### PR TITLE
GEODE-8585: Redis SCAN, HSCAN, and SSCAN do not detect illegal parameters

### DIFF
--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HScanNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HScanNativeRedisAcceptanceTest.java
@@ -11,29 +11,21 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- *
  */
-package org.apache.geode.redis.internal.executor.key;
+package org.apache.geode.redis.internal.executor.hash;
 
-import java.math.BigInteger;
-import java.util.regex.Pattern;
+import org.junit.ClassRule;
 
-import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.GlobPattern;
+import org.apache.geode.NativeRedisTestRule;
 
-public abstract class AbstractScanExecutor extends AbstractExecutor {
+public class HScanNativeRedisAcceptanceTest extends AbstractHScanIntegrationTest {
 
-  protected final BigInteger UNSIGNED_LONG_CAPACITY = new BigInteger("18446744073709551615");
-  protected final int DEFAULT_COUNT = 10;
+  @ClassRule
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
 
-  /**
-   * @param pattern A glob pattern.
-   * @return A regex pattern to recognize the given glob pattern.
-   */
-  protected Pattern convertGlobToRegex(String pattern) {
-    if (pattern == null) {
-      return null;
-    }
-    return GlobPattern.compile(pattern);
+  @Override
+  public int getPort() {
+    return redis.getPort();
   }
+
 }

--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SScanNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/set/SScanNativeRedisAcceptanceTest.java
@@ -11,29 +11,22 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
- *
  */
-package org.apache.geode.redis.internal.executor.key;
+package org.apache.geode.redis.internal.executor.set;
 
-import java.math.BigInteger;
-import java.util.regex.Pattern;
 
-import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.GlobPattern;
+import org.junit.ClassRule;
 
-public abstract class AbstractScanExecutor extends AbstractExecutor {
+import org.apache.geode.NativeRedisTestRule;
 
-  protected final BigInteger UNSIGNED_LONG_CAPACITY = new BigInteger("18446744073709551615");
-  protected final int DEFAULT_COUNT = 10;
+public class SScanNativeRedisAcceptanceTest extends AbstractSScanIntegrationTest {
 
-  /**
-   * @param pattern A glob pattern.
-   * @return A regex pattern to recognize the given glob pattern.
-   */
-  protected Pattern convertGlobToRegex(String pattern) {
-    if (pattern == null) {
-      return null;
-    }
-    return GlobPattern.compile(pattern);
+  @ClassRule
+  public static NativeRedisTestRule redis = new NativeRedisTestRule();
+
+  @Override
+  public int getPort() {
+    return redis.getPort();
   }
+
 }

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -1,0 +1,383 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.hash;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.rules.RedisPortSupplier;
+
+public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier {
+
+  protected Jedis jedis;
+  private static final int REDIS_CLIENT_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+
+  @Before
+  public void setUp() {
+    jedis = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void flushAll() {
+    jedis.flushAll();
+  }
+
+  @After
+  public void tearDown() {
+    jedis.close();
+  }
+
+  @Test
+  public void givenNoKeyArgument_returnsWrongNumberOfArgumentsError() {
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN))
+        .hasMessageContaining("ERR wrong number of arguments for 'hscan' command");
+  }
+
+  @Test
+  public void givenNoCursorArgument_returnsWrongNumberOfArgumentsError() {
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "key!"))
+        .hasMessageContaining("ERR wrong number of arguments for 'hscan' command");
+  }
+
+  @Test
+  public void givenArgumentsAreNotOddAndKeyExists_returnsSyntaxError() {
+    jedis.hset("a", "b", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "a*"))
+        .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void givenArgumentsAreNotOddAndKeyDoesNotExist_returnsEmptyArray() {
+    List<Object> result =
+        (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN, "key!", "0", "a*");
+
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((List<Object>) result.get(1)).isEmpty();
+  }
+
+  @Test
+  public void givenMatchOrCountKeywordNotSpecified_returnsSyntaxError() {
+    jedis.hset("a", "b", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "a*", "1"))
+        .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsNotAnInteger_returnsNotIntegerError() {
+    jedis.hset("a", "b", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "MATCH"))
+        .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsZero_returnsSyntaxError() {
+    jedis.hset("a", "b", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "0"))
+        .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsNegative_returnsSyntaxError() {
+    jedis.hset("a", "b", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "-37"))
+        .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenMultipleCounts_whenAnyCountParameterIsNotAnInteger_returnsNotIntegerError() {
+    jedis.hset("a", "b", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "3",
+        "COUNT", "sjlfs", "COUNT", "1"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void givenMultipleCounts_whenAnyCountParameterIsLessThanOne_returnsSyntaxError() {
+    jedis.hset("a", "b", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "3",
+        "COUNT", "0", "COUNT", "1"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenKeyIsNotAHash_returnsWrongTypeError() {
+    jedis.sadd("a", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "-37"))
+        .hasMessageContaining(ERROR_WRONG_TYPE);
+  }
+
+  @Test
+  public void givenKeyIsNotAHash_andCursorIsNotAnInteger_returnsCursorError() {
+    jedis.sadd("a", "b");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "sjfls"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenNonexistentKey_andCursorIsNotAnInteger_returnsCursorError() {
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "notReal", "sjfls"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenExistentHashKey_andCursorIsNotAnInteger_returnsCursorError() {
+    jedis.hset("a", "b", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "sjfls"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenNonexistentKey_returnsEmptyArray() {
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan("nonexistent", "0");
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(result.getResult()).isEmpty();
+  }
+
+  @Test
+  public void givenHashWithOneEntry_returnsEntry() {
+    jedis.hset("a", "1", "2");
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan("a", "0");
+
+    Map<String, String> expected = new HashMap<>();
+    expected.put("1", "2");
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(result.getResult()).containsExactly(expected.entrySet().iterator().next());
+  }
+
+  @Test
+  public void givenHashWithMultipleEntries_returnsAllEntries() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put("1", "yellow");
+    entryMap.put("2", "green");
+    entryMap.put("3", "orange");
+    jedis.hmset("colors", entryMap);
+
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan("colors", "0");
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(new HashSet<>(result.getResult())).isEqualTo(entryMap.entrySet());
+  }
+
+  @Test
+  public void givenCount_returnsAllEntriesWithoutDuplicates() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put("1", "yellow");
+    entryMap.put("2", "green");
+    entryMap.put("3", "orange");
+    jedis.hmset("colors", entryMap);
+
+    ScanParams scanParams = new ScanParams();
+    scanParams.count(1);
+    ScanResult<Map.Entry<String, String>> result;
+    List<Map.Entry<String, String>> allEntries = new ArrayList<>();
+    String cursor = "0";
+
+    do {
+      result = jedis.hscan("colors", cursor, scanParams);
+      allEntries.addAll(result.getResult());
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    assertThat(allEntries).hasSize(3);
+    assertThat(new HashSet<>(allEntries)).isEqualTo(entryMap.entrySet());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void givenMultipleCounts_returnsAllEntriesWithoutDuplicates() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put("1", "yellow");
+    entryMap.put("12", "green");
+    entryMap.put("3", "grey");
+    jedis.hmset("colors", entryMap);
+    List<Object> result;
+
+    List<byte[]> allEntries = new ArrayList<>();
+    String cursor = "0";
+
+    do {
+      result = (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN, "colors", cursor, "COUNT",
+          "2", "COUNT", "1");
+      allEntries.addAll((List<byte[]>) result.get(1));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(), "yellow".getBytes(),
+        "12".getBytes(), "green".getBytes(), "3".getBytes(), "grey".getBytes());
+  }
+
+  @Test
+  public void givenMatch_returnsAllMatchingEntriesWithoutDuplicates() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put("1", "yellow");
+    entryMap.put("12", "green");
+    entryMap.put("3", "grey");
+    jedis.hmset("colors", entryMap);
+
+    ScanParams scanParams = new ScanParams();
+    scanParams.match("1*");
+
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan("colors", "0", scanParams);
+
+    entryMap.remove("3");
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(new HashSet<>(result.getResult())).isEqualTo(entryMap.entrySet());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void givenMultipleMatches_returnsEntriesMatchingLastMatchParameter() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put("1", "yellow");
+    entryMap.put("12", "green");
+    entryMap.put("3", "grey");
+    jedis.hmset("colors", entryMap);
+
+    List<Object> result =
+        (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN, "colors", "0", "MATCH", "3*",
+            "MATCH", "1*");
+
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((List<Object>) result.get(1)).containsExactlyInAnyOrder("1".getBytes(),
+        "yellow".getBytes(), "12".getBytes(), "green".getBytes());
+  }
+
+  @Test
+  public void givenMatchAndCount_returnsAllMatchingKeysWithoutDuplicates() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put("1", "yellow");
+    entryMap.put("12", "green");
+    entryMap.put("3", "orange");
+    jedis.hmset("colors", entryMap);
+
+    ScanParams scanParams = new ScanParams();
+    scanParams.count(1);
+    scanParams.match("1*");
+    ScanResult<Map.Entry<String, String>> result;
+    List<Map.Entry<String, String>> allEntries = new ArrayList<>();
+    String cursor = "0";
+
+    do {
+      result = jedis.hscan("colors", cursor, scanParams);
+      allEntries.addAll(result.getResult());
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    entryMap.remove("3");
+    assertThat(allEntries).hasSize(2);
+    assertThat(new HashSet<>(allEntries)).isEqualTo(entryMap.entrySet());
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void givenMultipleCountsAndMatches_returnsEntriesMatchingLastMatchParameter() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put("1", "yellow");
+    entryMap.put("12", "green");
+    entryMap.put("3", "grey");
+    jedis.hmset("colors", entryMap);
+    List<Object> result;
+
+    List<byte[]> allEntries = new ArrayList<>();
+    String cursor = "0";
+
+    do {
+      result = (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN, "colors", cursor, "COUNT",
+          "37", "MATCH", "3*", "COUNT", "2", "COUNT", "1", "MATCH", "1*");
+      allEntries.addAll((List<byte[]>) result.get(1));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(), "yellow".getBytes(),
+        "12".getBytes(), "green".getBytes());
+  }
+
+  @Test
+  public void givenNegativeCursor_returnsEntriesUsingAbsoluteValueOfCursor() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put("1", "yellow");
+    entryMap.put("2", "green");
+    entryMap.put("3", "orange");
+    jedis.hmset("colors", entryMap);
+
+    String cursor = "-100";
+    ScanResult<Map.Entry<String, String>> result;
+    List<Map.Entry<String, String>> allEntries = new ArrayList<>();
+
+    do {
+      result = jedis.hscan("colors", cursor);
+      allEntries.addAll(result.getResult());
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    assertThat(allEntries).hasSize(3);
+    assertThat(new HashSet<>(allEntries)).isEqualTo(entryMap.entrySet());
+  }
+
+  @Test
+  public void givenCursorGreaterThanUnsignedLongCapacity_returnsCursorError() {
+    assertThatThrownBy(() -> jedis.hscan("a", "18446744073709551616"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenNegativeCursorGreaterThanUnsignedLongCapacity_returnsCursorError() {
+    assertThatThrownBy(() -> jedis.hscan("a", "-18446744073709551616"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenInvalidRegexSyntax_returnsEmptyArray() {
+    jedis.hset("a", "1", "green");
+    ScanParams scanParams = new ScanParams();
+    scanParams.count(1);
+    scanParams.match("\\p");
+
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan("a", "0", scanParams);
+
+    assertThat(result.getResult()).isEmpty();
+  }
+}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
@@ -1,0 +1,333 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.set;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.rules.RedisPortSupplier;
+
+public abstract class AbstractSScanIntegrationTest implements RedisPortSupplier {
+  protected Jedis jedis;
+  private static final int REDIS_CLIENT_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+
+  @Before
+  public void setUp() {
+    jedis = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    jedis.flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void givenNoKeyArgument_returnsWrongNumberOfArgumentsError() {
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN))
+        .hasMessageContaining("ERR wrong number of arguments for 'sscan' command");
+  }
+
+  @Test
+  public void givenNoCursorArgument_returnsWrongNumberOfArgumentsError() {
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "key!"))
+        .hasMessageContaining("ERR wrong number of arguments for 'sscan' command");
+  }
+
+  @Test
+  public void givenArgumentsAreNotOddAndKeyExists_returnsSyntaxError() {
+    jedis.sadd("a", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "0", "a*"))
+        .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void givenArgumentsAreNotOddAndKeyDoesNotExist_returnsEmptyArray() {
+    List<Object> result =
+        (List<Object>) jedis.sendCommand(Protocol.Command.SSCAN, "key!", "0", "a*");
+
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((List<Object>) result.get(1)).isEmpty();
+  }
+
+  @Test
+  public void givenMatchOrCountKeywordNotSpecified_returnsSyntaxError() {
+    jedis.sadd("a", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "0", "a*", "1"))
+        .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsNotAnInteger_returnsNotIntegerError() {
+    jedis.sadd("a", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "0", "COUNT", "MATCH"))
+        .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void givenMultipleCounts_whenAnyCountParameterIsNotAnInteger_returnsNotIntegerError() {
+    jedis.sadd("a", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "0", "COUNT", "2",
+        "COUNT", "sjlfs", "COUNT", "1"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void givenMultipleCounts_whenAnyCountParameterIsLessThanOne_returnsSyntaxError() {
+    jedis.sadd("a", "1");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "0", "COUNT", "2",
+        "COUNT", "0", "COUNT", "1"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsZero_returnsSyntaxError() {
+    jedis.sadd("a", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "0", "COUNT", "0"))
+        .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsNegative_returnsSyntaxError() {
+    jedis.sadd("a", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "0", "COUNT", "-37"))
+        .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenKeyIsNotASet_returnsWrongTypeError() {
+    jedis.hset("a", "b", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "0", "COUNT", "-37"))
+        .hasMessageContaining(ERROR_WRONG_TYPE);
+  }
+
+  @Test
+  public void givenKeyIsNotASet_andCursorIsNotAnInteger_returnsInvalidCursorError() {
+    jedis.hset("a", "b", "1");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "sjfls"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenNonexistentKey_andCursorIsNotInteger_returnsInvalidCursorError() {
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "notReal", "sjfls"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenExistentSetKey_andCursorIsNotAnInteger_returnsInvalidCursorError() {
+    jedis.set("a", "b");
+
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SSCAN, "a", "sjfls"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenNonexistentKey_returnsEmptyArray() {
+    ScanResult<String> result = jedis.sscan("nonexistent", "0");
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(result.getResult()).isEmpty();
+  }
+
+  @Test
+  public void givenSetWithOneMember_returnsMember() {
+    jedis.sadd("a", "1");
+    ScanResult<String> result = jedis.sscan("a", "0");
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(result.getResult()).containsExactly("1");
+  }
+
+  @Test
+  public void givenSetWithMultipleMembers_returnsAllMembers() {
+    jedis.sadd("a", "1", "2", "3");
+    ScanResult<String> result = jedis.sscan("a", "0");
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(result.getResult()).containsExactlyInAnyOrder("1", "2", "3");
+  }
+
+  @Test
+  public void givenCount_returnsAllMembersWithoutDuplicates() {
+    jedis.sadd("a", "1", "2", "3");
+
+    ScanParams scanParams = new ScanParams();
+    scanParams.count(1);
+    String cursor = "0";
+    ScanResult<String> result;
+    List<String> allMembersFromScan = new ArrayList<>();
+
+    do {
+      result = jedis.sscan("a", cursor, scanParams);
+      allMembersFromScan.addAll(result.getResult());
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    assertThat(allMembersFromScan).containsExactlyInAnyOrder("1", "2", "3");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void givenMultipleCounts_returnsAllEntriesWithoutDuplicates() {
+    jedis.sadd("a", "1", "12", "3");
+
+    List<Object> result;
+
+    List<byte[]> allEntries = new ArrayList<>();
+    String cursor = "0";
+
+    do {
+      result = (List<Object>) jedis.sendCommand(Protocol.Command.SSCAN, "a", cursor, "COUNT", "2",
+          "COUNT", "1");
+      allEntries.addAll((List<byte[]>) result.get(1));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(), "12".getBytes(),
+        "3".getBytes());
+  }
+
+  @Test
+  public void givenMatch_returnsAllMatchingMembersWithoutDuplicates() {
+    jedis.sadd("a", "1", "12", "3");
+
+    ScanParams scanParams = new ScanParams();
+    scanParams.match("1*");
+
+    ScanResult<String> result = jedis.sscan("a", "0", scanParams);
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(result.getResult()).containsExactlyInAnyOrder("1", "12");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void givenMultipleMatches_returnsMembersMatchingLastMatchParameter() {
+    jedis.sadd("a", "1", "12", "3");
+
+    List<Object> result = (List<Object>) jedis.sendCommand(Protocol.Command.SSCAN, "a", "0",
+        "MATCH", "3*", "MATCH", "1*");
+
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((List<byte[]>) result.get(1)).containsExactlyInAnyOrder("1".getBytes(),
+        "12".getBytes());
+  }
+
+  @Test
+  public void givenMatchAndCount_returnsAllMembersWithoutDuplicates() {
+    jedis.sadd("a", "1", "12", "3");
+
+    ScanParams scanParams = new ScanParams();
+    scanParams.count(1);
+    scanParams.match("1*");
+    ScanResult<String> result;
+    List<String> allMembersFromScan = new ArrayList<>();
+    String cursor = "0";
+
+    do {
+      result = jedis.sscan("a", cursor, scanParams);
+      allMembersFromScan.addAll(result.getResult());
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    assertThat(allMembersFromScan).containsExactlyInAnyOrder("1", "12");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void givenMultipleCountsAndMatches_returnsAllEntriesWithoutDuplicates() {
+    jedis.sadd("a", "1", "12", "3");
+
+    List<Object> result;
+    List<byte[]> allEntries = new ArrayList<>();
+    String cursor = "0";
+
+    do {
+      result = (List<Object>) jedis.sendCommand(Protocol.Command.SSCAN, "a", cursor, "COUNT", "37",
+          "MATCH", "3*", "COUNT", "2", "COUNT", "1", "MATCH", "1*");
+      allEntries.addAll((List<byte[]>) result.get(1));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(), "12".getBytes());
+  }
+
+  @Test
+  public void givenNegativeCursor_returnsMembersUsingAbsoluteValueOfCursor() {
+    jedis.sadd("b", "green", "orange", "yellow");
+
+    List<String> allEntries = new ArrayList<>();
+
+    String cursor = "-100";
+    ScanResult<String> result;
+    do {
+      result = jedis.sscan("b", cursor);
+      allEntries.addAll(result.getResult());
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    assertThat(allEntries).containsExactlyInAnyOrder("green", "orange", "yellow");
+  }
+
+  @Test
+  public void givenCursorGreaterThanUnsignedLongCapacity_returnsCursorError() {
+    assertThatThrownBy(() -> jedis.sscan("a", "18446744073709551616"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenNegativeCursorGreaterThanUnsignedLongCapacity_returnsCursorError() {
+    assertThatThrownBy(() -> jedis.sscan("a", "-18446744073709551616"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenInvalidRegexSyntax_returnsEmptyArray() {
+    jedis.sadd("a", "1");
+    ScanParams scanParams = new ScanParams();
+    scanParams.count(1);
+    scanParams.match("\\p");
+
+    ScanResult<String> result = jedis.sscan("a", "0", scanParams);
+
+    assertThat(result.getResult()).isEmpty();
+  }
+}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
@@ -12,8 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
-package org.apache.geode.redis.internal.executor.key;
+package org.apache.geode.redis.internal.executor.set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -27,7 +26,7 @@ import redis.clients.jedis.ScanResult;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 
-public class ScanIntegrationTest extends AbstractScanIntegrationTest {
+public class SScanIntegrationTest extends AbstractSScanIntegrationTest {
 
   @ClassRule
   public static GeodeRedisServerRule server = new GeodeRedisServerRule();
@@ -38,20 +37,20 @@ public class ScanIntegrationTest extends AbstractScanIntegrationTest {
   }
 
   @Test
-  public void givenDifferentCursorThanSpecifiedByPreviousScan_returnsAllKeys() {
-    List<String> keyList = new ArrayList<>();
+  public void givenDifferentCursorThanSpecifiedByPreviousSscan_returnsAllMembers() {
+    List<String> memberList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
-      jedis.set(String.valueOf(i), "a");
-      keyList.add(String.valueOf(i));
+      jedis.sadd("a", String.valueOf(i));
+      memberList.add(String.valueOf(i));
     }
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(5);
-    ScanResult<String> result = jedis.scan("0", scanParams);
+    ScanResult<String> result = jedis.sscan("a", "0", scanParams);
     assertThat(result.isCompleteIteration()).isFalse();
 
-    result = jedis.scan("100");
+    result = jedis.sscan("a", "100");
 
-    assertThat(result.getResult()).containsExactlyInAnyOrder(keyList.toArray(new String[0]));
+    assertThat(result.getResult()).containsExactlyInAnyOrder(memberList.toArray(new String[0]));
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/OddParameterRequirements.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/OddParameterRequirements.java
@@ -18,27 +18,26 @@ package org.apache.geode.redis.internal.ParameterRequirements;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class EvenParameterRequirements implements ParameterRequirements {
-
+public class OddParameterRequirements implements ParameterRequirements {
   private final String errorMessage;
 
-  public EvenParameterRequirements() {
-    this.errorMessage = null;
+  public OddParameterRequirements() {
+    this(null);
   }
 
-  public EvenParameterRequirements(String errorMessage) {
+  public OddParameterRequirements(String errorMessage) {
     this.errorMessage = errorMessage;
   }
 
   @Override
   public void checkParameters(Command command, ExecutionHandlerContext executionHandlerContext) {
-    if (!isEven(command.getProcessedCommand().size())) {
+    if (!isOdd(command.getProcessedCommand().size())) {
       throw new RedisParametersMismatchException(getErrorMessage(command));
     }
   }
 
-  private boolean isEven(int n) {
-    return n % 2 == 0;
+  private boolean isOdd(int n) {
+    return n % 2 == 1;
   }
 
   private String getErrorMessage(Command command) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -31,9 +31,9 @@ public class RedisConstants {
       "The server had an internal error please try again";
   public static final String SERVER_ERROR_SHUTDOWN = "The server is shutting down";
   public static final String ERROR_UNKNOWN_COMMAND = "Unable to process unknown command";
+  public static final String ERROR_CURSOR = "invalid cursor";
   public static final String ERROR_UNSUPPORTED_COMMAND =
       " is not supported. To enable all unsupported commands use GFSH to execute: 'redis --enable-unsupported-commands'. Unsupported commands have not been fully tested.";
-  public static final String ERROR_ILLEGAL_GLOB = "Incorrect syntax for given glob regex";
   public static final String ERROR_OUT_OF_RANGE = "The number provided is out of range";
   public static final String ERROR_NO_PASS = "Client sent AUTH, but no password is set";
   public static final String ERROR_INVALID_PWD = "invalid password";
@@ -55,9 +55,6 @@ public class RedisConstants {
         "The wrong number of arguments or syntax was provided, the format for the ECHO command is \"ECHO message\"";
     public static final String PERSIST =
         "The wrong number of arguments or syntax was provided, the format for the PERSIST command is \"PERSIST key\"";
-    public static final String SCAN =
-        "The wrong number of arguments or syntax was provided, the format for the SCAN command is \"SCAN cursor [MATCH pattern] [COUNT count]\"";
-
     /*
      * String
      */

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSet.java
@@ -22,9 +22,7 @@ import static java.util.Collections.emptySet;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Region;
@@ -40,11 +38,6 @@ class NullRedisSet extends RedisSet {
   @Override
   public boolean isNull() {
     return true;
-  }
-
-  @Override
-  List<Object> sscan(Pattern matchPattern, int count, int cursor) {
-    return emptyList();
   }
 
   @Override

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
@@ -16,9 +16,12 @@
 
 package org.apache.geode.redis.internal.data;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
 
@@ -87,7 +90,8 @@ public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunction
   }
 
   @Override
-  public List<Object> hscan(ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
+  public Pair<BigInteger, List<Object>> hscan(ByteArrayWrapper key, Pattern matchPattern, int count,
+      BigInteger cursor) {
     return stripedExecute(key, () -> getRedisHash(key).hscan(matchPattern, count, cursor));
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSetCommandsFunctionExecutor.java
@@ -18,11 +18,14 @@ package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.data.RedisSet.NULL_REDIS_SET;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.executor.set.RedisSetCommands;
 
@@ -103,8 +106,8 @@ public class RedisSetCommandsFunctionExecutor extends RedisDataCommandsFunctionE
   }
 
   @Override
-  public List<Object> sscan(
-      ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
+  public Pair<BigInteger, List<Object>> sscan(ByteArrayWrapper key, Pattern matchPattern, int count,
+      BigInteger cursor) {
     return stripedExecute(key, () -> getRedisSet(key).sscan(matchPattern, count, cursor));
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal.executor;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -198,7 +199,7 @@ public class CommandFunction extends SingleResultRedisFunction {
       case SSCAN: {
         Pattern matchPattern = (Pattern) args[1];
         int count = (int) args[2];
-        int cursor = (int) args[3];
+        BigInteger cursor = (BigInteger) args[3];
         return setCommands.sscan(key, matchPattern, count, cursor);
       }
       case SUNIONSTORE: {
@@ -249,7 +250,7 @@ public class CommandFunction extends SingleResultRedisFunction {
       case HSCAN: {
         Pattern pattern = (Pattern) args[1];
         int count = (int) args[2];
-        int cursor = (int) args[3];
+        BigInteger cursor = (BigInteger) args[3];
         return hashCommands.hscan(key, pattern, count, cursor);
       }
       case HINCRBY: {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
@@ -16,7 +16,9 @@
 
 package org.apache.geode.redis.internal.executor;
 
+import java.math.BigInteger;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
@@ -24,6 +26,8 @@ import java.util.function.Function;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.CoderException;
@@ -126,8 +130,12 @@ public class RedisResponse {
     return new RedisResponse((bba) -> Coder.getWrongTypeResponse(bba, error));
   }
 
-  public static RedisResponse scan(List<?> items) {
-    return new RedisResponse((bba) -> Coder.getScanResponse(bba, items));
+  public static RedisResponse scan(Pair<BigInteger, List<Object>> scanResult) {
+    return new RedisResponse((bba) -> Coder.getScanResponse(bba, scanResult));
+  }
+
+  public static RedisResponse emptyScan() {
+    return scan(new ImmutablePair<>(new BigInteger("0"), new ArrayList<>()));
   }
 
   /**

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
@@ -26,8 +26,6 @@ import java.util.function.Function;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.buffer.UnpooledByteBufAllocator;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.CoderException;
@@ -130,12 +128,12 @@ public class RedisResponse {
     return new RedisResponse((bba) -> Coder.getWrongTypeResponse(bba, error));
   }
 
-  public static RedisResponse scan(Pair<BigInteger, List<Object>> scanResult) {
-    return new RedisResponse((bba) -> Coder.getScanResponse(bba, scanResult));
+  public static RedisResponse scan(BigInteger cursor, List<Object> scanResult) {
+    return new RedisResponse((bba) -> Coder.getScanResponse(bba, cursor, scanResult));
   }
 
   public static RedisResponse emptyScan() {
-    return scan(new ImmutablePair<>(new BigInteger("0"), new ArrayList<>()));
+    return scan(new BigInteger("0"), new ArrayList<>());
   }
 
   /**

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -14,13 +14,22 @@
  */
 package org.apache.geode.redis.internal.executor.hash;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_ILLEGAL_GLOB;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_HASH;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
+import org.apache.commons.lang3.tuple.Pair;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
+import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
 import org.apache.geode.redis.internal.netty.Coder;
@@ -37,75 +46,77 @@ public class HScanExecutor extends AbstractScanExecutor {
       ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
 
-    ByteArrayWrapper key = command.getKey();
-
-    byte[] cAr = commandElems.get(2);
-    String cursorString = Coder.bytesToString(cAr);
-
-    int cursor = 0;
-    Pattern matchPattern = null;
-    String globMatchPattern = null;
+    String cursorString = Coder.bytesToString(commandElems.get(2));
+    BigInteger cursor;
+    Pattern matchPattern;
+    String globPattern = null;
     int count = DEFAULT_COUNT;
+
     try {
-      cursor = Integer.parseInt(cursorString);
+      cursor = new BigInteger(cursorString).abs();
     } catch (NumberFormatException e) {
       return RedisResponse.error(ERROR_CURSOR);
     }
 
-    if (cursor < 0) {
+    if (cursor.compareTo(UNSIGNED_LONG_CAPACITY) > 0) {
       return RedisResponse.error(ERROR_CURSOR);
     }
 
-    if (commandElems.size() > 4) {
-      try {
-        byte[] bytes = commandElems.get(3);
-        String tmp = Coder.bytesToString(bytes);
-        if (tmp.equalsIgnoreCase("MATCH")) {
-          bytes = commandElems.get(4);
-          globMatchPattern = Coder.bytesToString(bytes);
-        } else if (tmp.equalsIgnoreCase("COUNT")) {
-          bytes = commandElems.get(4);
-          count = Coder.bytesToInt(bytes);
-        }
-      } catch (NumberFormatException e) {
-        return RedisResponse.error(ERROR_COUNT);
-      }
+    if (!cursor.equals(context.getHscanCursor())) {
+      cursor = new BigInteger("0");
     }
 
-    if (commandElems.size() > 6) {
-      try {
-        byte[] bytes = commandElems.get(5);
-        String tmp = Coder.bytesToString(bytes);
-        if (tmp.equalsIgnoreCase("MATCH")) {
-          bytes = commandElems.get(6);
-          globMatchPattern = Coder.bytesToString(bytes);
-        } else if (tmp.equalsIgnoreCase("COUNT")) {
-          bytes = commandElems.get(6);
-          count = Coder.bytesToInt(bytes);
-        }
-      } catch (NumberFormatException e) {
-        return RedisResponse.error(ERROR_COUNT);
-      }
+    ByteArrayWrapper key = command.getKey();
+    if (!getDataRegion(context).containsKey(key)) {
+      return RedisResponse.emptyScan();
     }
 
-    if (count < 0) {
-      return RedisResponse.error(ERROR_COUNT);
+    if (getDataRegion(context).get(key).getType() != REDIS_HASH) {
+      throw new RedisDataTypeMismatchException(ERROR_WRONG_TYPE);
+    }
+
+    command.getCommandType().checkDeferredParameters(command, context);
+
+    for (int i = 3; i < commandElems.size(); i = i + 2) {
+      byte[] commandElemBytes = commandElems.get(i);
+      String keyword = Coder.bytesToString(commandElemBytes);
+      if (keyword.equalsIgnoreCase("MATCH")) {
+        commandElemBytes = commandElems.get(i + 1);
+        globPattern = Coder.bytesToString(commandElemBytes);
+
+      } else if (keyword.equalsIgnoreCase("COUNT")) {
+        commandElemBytes = commandElems.get(i + 1);
+        try {
+          count = Coder.bytesToInt(commandElemBytes);
+        } catch (NumberFormatException e) {
+          return RedisResponse.error(ERROR_NOT_INTEGER);
+        }
+
+        if (count < 1) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+
+      } else {
+        return RedisResponse.error(ERROR_SYNTAX);
+      }
     }
 
     try {
-      matchPattern = convertGlobToRegex(globMatchPattern);
+      matchPattern = convertGlobToRegex(globPattern);
     } catch (PatternSyntaxException e) {
-      return RedisResponse.error(ERROR_ILLEGAL_GLOB);
+      LogService.getLogger().warn(
+          "Could not compile the pattern: '{}' due to the following exception: '{}'. HSCAN will return an empty list.",
+          globPattern, e.getMessage());
+      return RedisResponse.emptyScan();
     }
 
     RedisHashCommands redisHashCommands =
         new RedisHashCommandsFunctionInvoker(context.getRegionProvider().getDataRegion());
-    List<Object> returnList = redisHashCommands.hscan(key, matchPattern, count, cursor);
+    Pair<BigInteger, List<Object>> scanResult =
+        redisHashCommands.hscan(key, matchPattern, count, cursor);
 
-    if (returnList.isEmpty()) {
-      return RedisResponse.error(ERROR_CURSOR);
-    } else {
-      return RedisResponse.scan(returnList);
-    }
+    context.setHscanCursor(scanResult.getLeft());
+
+    return RedisResponse.scan(scanResult);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -117,6 +117,6 @@ public class HScanExecutor extends AbstractScanExecutor {
 
     context.setHscanCursor(scanResult.getLeft());
 
-    return RedisResponse.scan(scanResult);
+    return RedisResponse.scan(scanResult.getLeft(), scanResult.getRight());
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
@@ -15,9 +15,12 @@
 
 package org.apache.geode.redis.internal.executor.hash;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 
@@ -42,7 +45,8 @@ public interface RedisHashCommands {
 
   Collection<ByteArrayWrapper> hkeys(ByteArrayWrapper key);
 
-  List<Object> hscan(ByteArrayWrapper key, Pattern matchPattern, int count, int cursor);
+  Pair<BigInteger, List<Object>> hscan(ByteArrayWrapper key, Pattern matchPattern, int count,
+      BigInteger cursor);
 
   long hincrby(ByteArrayWrapper key, ByteArrayWrapper field, long increment);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommandsFunctionInvoker.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommandsFunctionInvoker.java
@@ -29,9 +29,12 @@ import static org.apache.geode.redis.internal.RedisCommandType.HSET;
 import static org.apache.geode.redis.internal.RedisCommandType.HSTRLEN;
 import static org.apache.geode.redis.internal.RedisCommandType.HVALS;
 
+import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
@@ -102,7 +105,8 @@ public class RedisHashCommandsFunctionInvoker extends RedisCommandsFunctionInvok
   }
 
   @Override
-  public List<Object> hscan(ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
+  public Pair<BigInteger, List<Object>> hscan(ByteArrayWrapper key, Pattern matchPattern, int count,
+      BigInteger cursor) {
     return invokeCommandFunction(key, HSCAN, matchPattern, count, cursor);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
@@ -96,11 +96,10 @@ public class ScanExecutor extends AbstractScanExecutor {
     }
 
     Pair<BigInteger, List<Object>> scanResult =
-        scan(getDataRegion(context).keySet(), matchPattern, count,
-            cursor);
+        scan(getDataRegion(context).keySet(), matchPattern, count, cursor);
     context.setScanCursor(scanResult.getLeft());
 
-    return RedisResponse.scan(scanResult);
+    return RedisResponse.scan(scanResult.getLeft(), scanResult.getRight());
   }
 
   private Pair<BigInteger, List<Object>> scan(Collection<ByteArrayWrapper> list,

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -15,11 +15,14 @@
 
 package org.apache.geode.redis.internal.executor.set;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 
@@ -39,7 +42,8 @@ public interface RedisSetCommands {
 
   Collection<ByteArrayWrapper> spop(ByteArrayWrapper key, int popCount);
 
-  List<Object> sscan(ByteArrayWrapper key, Pattern matchPattern, int count, int cursor);
+  Pair<BigInteger, List<Object>> sscan(ByteArrayWrapper key, Pattern matchPattern, int count,
+      BigInteger cursor);
 
   int sunionstore(ByteArrayWrapper destination, ArrayList<ByteArrayWrapper> setKeys);
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionInvoker.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommandsFunctionInvoker.java
@@ -27,11 +27,14 @@ import static org.apache.geode.redis.internal.RedisCommandType.SREM;
 import static org.apache.geode.redis.internal.RedisCommandType.SSCAN;
 import static org.apache.geode.redis.internal.RedisCommandType.SUNIONSTORE;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
@@ -86,7 +89,8 @@ public class RedisSetCommandsFunctionInvoker extends RedisCommandsFunctionInvoke
   }
 
   @Override
-  public List<Object> sscan(ByteArrayWrapper key, Pattern matchPattern, int count, int cursor) {
+  public Pair<BigInteger, List<Object>> sscan(ByteArrayWrapper key, Pattern matchPattern, int count,
+      BigInteger cursor) {
     return invokeCommandFunction(key, SSCAN, matchPattern, count, cursor);
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -116,6 +116,6 @@ public class SScanExecutor extends AbstractScanExecutor {
 
     context.setSscanCursor(scanResult.getLeft());
 
-    return RedisResponse.scan(scanResult);
+    return RedisResponse.scan(scanResult.getLeft(), scanResult.getRight());
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -15,12 +15,22 @@
 package org.apache.geode.redis.internal.executor.set;
 
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SET;
+
+import java.math.BigInteger;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.geode.redis.internal.RedisConstants;
+import org.apache.commons.lang3.tuple.Pair;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
+import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
 import org.apache.geode.redis.internal.netty.Coder;
@@ -34,68 +44,78 @@ public class SScanExecutor extends AbstractScanExecutor {
       ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
 
-    ByteArrayWrapper key = command.getKey();
-
-    byte[] cAr = commandElems.get(2);
-    String cursorString = Coder.bytesToString(cAr);
-    int cursor = 0;
-    Pattern matchPattern = null;
-    String globMatchPattern = null;
+    String cursorString = Coder.bytesToString(commandElems.get(2));
+    BigInteger cursor;
+    Pattern matchPattern;
+    String globPattern = null;
     int count = DEFAULT_COUNT;
 
     try {
-      cursor = Integer.parseInt(cursorString);
+      cursor = new BigInteger(cursorString).abs();
     } catch (NumberFormatException e) {
       return RedisResponse.error(ERROR_CURSOR);
     }
 
-    if (cursor < 0) {
+    if (cursor.compareTo(UNSIGNED_LONG_CAPACITY) > 0) {
       return RedisResponse.error(ERROR_CURSOR);
     }
 
-    if (commandElems.size() > 4) {
-      try {
-        byte[] bytes = commandElems.get(3);
-        String tmp = Coder.bytesToString(bytes);
-        if (tmp.equalsIgnoreCase("MATCH")) {
-          bytes = commandElems.get(4);
-          globMatchPattern = Coder.bytesToString(bytes);
-        } else if (tmp.equalsIgnoreCase("COUNT")) {
-          bytes = commandElems.get(4);
-          count = Coder.bytesToInt(bytes);
-        }
-      } catch (NumberFormatException e) {
-        return RedisResponse.error(ERROR_COUNT);
-      }
+    ByteArrayWrapper key = command.getKey();
+
+    if (!getDataRegion(context).containsKey(key)) {
+      return RedisResponse.emptyScan();
     }
 
-    if (commandElems.size() > 6) {
-      try {
-        byte[] bytes = commandElems.get(5);
-        String tmp = Coder.bytesToString(bytes);
-        if (tmp.equalsIgnoreCase("COUNT")) {
-          bytes = commandElems.get(6);
-          count = Coder.bytesToInt(bytes);
-        }
-      } catch (NumberFormatException e) {
-        return RedisResponse.error(ERROR_COUNT);
-      }
+    if (getDataRegion(context).get(key).getType() != REDIS_SET) {
+      throw new RedisDataTypeMismatchException(ERROR_WRONG_TYPE);
     }
 
-    if (count < 0) {
-      return RedisResponse.error(ERROR_COUNT);
+    command.getCommandType().checkDeferredParameters(command, context);
+
+    if (!cursor.equals(context.getSscanCursor())) {
+      cursor = new BigInteger("0");
+    }
+
+    for (int i = 3; i < commandElems.size(); i = i + 2) {
+      byte[] commandElemBytes = commandElems.get(i);
+      String keyword = Coder.bytesToString(commandElemBytes);
+      if (keyword.equalsIgnoreCase("MATCH")) {
+        commandElemBytes = commandElems.get(i + 1);
+        globPattern = Coder.bytesToString(commandElemBytes);
+
+      } else if (keyword.equalsIgnoreCase("COUNT")) {
+        commandElemBytes = commandElems.get(i + 1);
+        try {
+          count = Coder.bytesToInt(commandElemBytes);
+        } catch (NumberFormatException e) {
+          return RedisResponse.error(ERROR_NOT_INTEGER);
+        }
+
+        if (count < 1) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+
+      } else {
+        return RedisResponse.error(ERROR_SYNTAX);
+      }
     }
 
     try {
-      matchPattern = convertGlobToRegex(globMatchPattern);
+      matchPattern = convertGlobToRegex(globPattern);
     } catch (PatternSyntaxException e) {
-      return RedisResponse.error(RedisConstants.ERROR_ILLEGAL_GLOB);
+      LogService.getLogger().warn(
+          "Could not compile the pattern: '{}' due to the following exception: '{}'. SSCAN will return an empty list.",
+          globPattern, e.getMessage());
+      return RedisResponse.emptyScan();
     }
 
     RedisSetCommands redisSetCommands =
         new RedisSetCommandsFunctionInvoker(context.getRegionProvider().getDataRegion());
-    List<Object> returnList = redisSetCommands.sscan(key, matchPattern, count, cursor);
+    Pair<BigInteger, List<Object>> scanResult =
+        redisSetCommands.sscan(key, matchPattern, count, cursor);
 
-    return RedisResponse.scan(returnList);
+    context.setSscanCursor(scanResult.getLeft());
+
+    return RedisResponse.scan(scanResult);
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -16,12 +16,14 @@
 package org.apache.geode.redis.internal.netty;
 
 import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.util.Collection;
 import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.annotations.internal.MakeImmutable;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
@@ -207,8 +209,9 @@ public class Coder {
     }
   }
 
-  public static ByteBuf getScanResponse(ByteBufAllocator alloc, List<?> items) {
-    if (items == null || items.isEmpty()) {
+  public static ByteBuf getScanResponse(ByteBufAllocator alloc,
+      Pair<BigInteger, List<Object>> scanResult) {
+    if (scanResult == null) {
       return null;
     }
 
@@ -218,12 +221,12 @@ public class Coder {
     response.writeBytes(intToBytes(2));
     response.writeBytes(CRLFar);
     response.writeByte(BULK_STRING_ID);
-    byte[] cursor = stringToBytes((String) items.get(0));
+    byte[] cursor = stringToBytes(scanResult.getLeft().toString());
     response.writeBytes(intToBytes(cursor.length));
     response.writeBytes(CRLFar);
     response.writeBytes(cursor);
     response.writeBytes(CRLFar);
-    items = items.subList(1, items.size());
+    List<Object> items = scanResult.getRight();
     response.writeByte(ARRAY_ID);
     response.writeBytes(intToBytes(items.size()));
     response.writeBytes(CRLFar);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -23,7 +23,6 @@ import java.util.List;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.annotations.internal.MakeImmutable;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
@@ -209,9 +208,9 @@ public class Coder {
     }
   }
 
-  public static ByteBuf getScanResponse(ByteBufAllocator alloc,
-      Pair<BigInteger, List<Object>> scanResult) {
-    if (scanResult == null) {
+  public static ByteBuf getScanResponse(ByteBufAllocator alloc, BigInteger cursor,
+      List<Object> scanResult) {
+    if (scanResult == null && cursor == null) {
       return null;
     }
 
@@ -221,17 +220,16 @@ public class Coder {
     response.writeBytes(intToBytes(2));
     response.writeBytes(CRLFar);
     response.writeByte(BULK_STRING_ID);
-    byte[] cursor = stringToBytes(scanResult.getLeft().toString());
-    response.writeBytes(intToBytes(cursor.length));
+    byte[] cursorBytes = stringToBytes(cursor.toString());
+    response.writeBytes(intToBytes(cursorBytes.length));
     response.writeBytes(CRLFar);
-    response.writeBytes(cursor);
+    response.writeBytes(cursorBytes);
     response.writeBytes(CRLFar);
-    List<Object> items = scanResult.getRight();
     response.writeByte(ARRAY_ID);
-    response.writeBytes(intToBytes(items.size()));
+    response.writeBytes(intToBytes(scanResult.size()));
     response.writeBytes(CRLFar);
 
-    for (Object nextObject : items) {
+    for (Object nextObject : scanResult) {
       if (nextObject instanceof String) {
         String next = (String) nextObject;
         response.writeByte(BULK_STRING_ID);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -210,10 +210,6 @@ public class Coder {
 
   public static ByteBuf getScanResponse(ByteBufAllocator alloc, BigInteger cursor,
       List<Object> scanResult) {
-    if (scanResult == null && cursor == null) {
-      return null;
-    }
-
     ByteBuf response = alloc.buffer();
 
     response.writeByte(ARRAY_ID);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.netty;
 
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -78,6 +79,9 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   private final Runnable shutdownInvoker;
   private final RedisStats redisStats;
   private final EventLoopGroup subscriberGroup;
+  private BigInteger scanCursor;
+  private BigInteger sscanCursor;
+  private BigInteger hscanCursor;
   private final AtomicBoolean channelInactive = new AtomicBoolean();
   private final int MAX_QUEUED_COMMANDS =
       Integer.getInteger("geode.redis.commandQueueSize", 1000);
@@ -117,6 +121,9 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     this.authPassword = password;
     this.isAuthenticated = password == null;
     this.serverPort = serverPort;
+    this.scanCursor = new BigInteger("0");
+    this.sscanCursor = new BigInteger("0");
+    this.hscanCursor = new BigInteger("0");
     redisStats.addClient();
 
     backgroundExecutor.submit(this::processCommandQueue);
@@ -396,6 +403,30 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
 
   public PubSub getPubSub() {
     return pubsub;
+  }
+
+  public BigInteger getScanCursor() {
+    return scanCursor;
+  }
+
+  public void setScanCursor(BigInteger scanCursor) {
+    this.scanCursor = scanCursor;
+  }
+
+  public BigInteger getSscanCursor() {
+    return sscanCursor;
+  }
+
+  public void setSscanCursor(BigInteger sscanCursor) {
+    this.sscanCursor = sscanCursor;
+  }
+
+  public BigInteger getHscanCursor() {
+    return hscanCursor;
+  }
+
+  public void setHscanCursor(BigInteger hscanCursor) {
+    this.hscanCursor = hscanCursor;
   }
 
   /**

--- a/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
+++ b/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
@@ -1,6 +1,6 @@
 org/apache/geode/redis/internal/ParameterRequirements/RedisParametersMismatchException,true,-643700717871858072
 org/apache/geode/redis/internal/RedisCommandSupportLevel,false
-org/apache/geode/redis/internal/RedisCommandType,false,executor:org/apache/geode/redis/internal/executor/Executor,parameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,supportLevel:org/apache/geode/redis/internal/RedisCommandSupportLevel
+org/apache/geode/redis/internal/RedisCommandType,false,deferredParameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,executor:org/apache/geode/redis/internal/executor/Executor,parameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,supportLevel:org/apache/geode/redis/internal/RedisCommandSupportLevel
 org/apache/geode/redis/internal/data/NullRedisSet$SetOp,false
 org/apache/geode/redis/internal/data/NullRedisString$BitOp,false
 org/apache/geode/redis/internal/data/RedisDataType,false,toStringValue:java/lang/String


### PR DESCRIPTION
Add integration tests and functionality to match native Redis.
