### PR TITLE
GEODE-8612: Remove unused Redis constants

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -35,11 +35,8 @@ public class RedisConstants {
       " is not supported. To enable all unsupported commands use GFSH to execute: 'redis --enable-unsupported-commands'. Unsupported commands have not been fully tested.";
   public static final String ERROR_ILLEGAL_GLOB = "Incorrect syntax for given glob regex";
   public static final String ERROR_OUT_OF_RANGE = "The number provided is out of range";
-  public static final String ERROR_NAN_INF_INCR = "increment would produce NaN or Infinity";
-  public static final String ERROR_NO_PASS =
-      "Client sent AUTH, but no password is set";
-  public static final String ERROR_INVALID_PWD =
-      "invalid password";
+  public static final String ERROR_NO_PASS = "Client sent AUTH, but no password is set";
+  public static final String ERROR_INVALID_PWD = "invalid password";
   public static final String ERROR_NOT_AUTH = "NOAUTH Authentication required.";
   public static final String ERROR_WRONG_TYPE =
       "Operation against a key holding the wrong kind of value";
@@ -54,44 +51,16 @@ public class RedisConstants {
     /*
      * General
      */
-    public static final int DBSIZE_ARITY = 0;
-    public static final String AUTH =
-        "The wrong number of arguments or syntax was provided, the format for the AUTH command is \"AUTH password\"";
-    public static final String DBSIZE = null;
     public static final String ECHO =
         "The wrong number of arguments or syntax was provided, the format for the ECHO command is \"ECHO message\"";
-    public static final String EXPIREAT =
-        "The wrong number of arguments or syntax was provided, the format for the EXPIREAT command is \"EXPIREAT key timestamp\"";
-    public static final String EXPIRE =
-        "The wrong number of arguments or syntax was provided, the format for the EXPIRE command is \"EXPIRE key seconds\"";
-    public static final String FLUSHALL = null;
-    public static final String KEYS =
-        "The wrong number of arguments or syntax was provided, the format for the KEYS command is \"KEYS pattern\"";
     public static final String PERSIST =
         "The wrong number of arguments or syntax was provided, the format for the PERSIST command is \"PERSIST key\"";
-    public static final String PEXPIREAT =
-        "The wrong number of arguments or syntax was provided, the format for the PEXPIREAT command is \"PEXPIREAT key milliseconds-timestamp\"";
-    public static final String PEXPIRE =
-        "The wrong number of arguments or syntax was provided, the format for the PEXPIRE command is \"PEXPIRE key milliseconds\"";
-    public static final String PING = null;
-    public static final String PTTL =
-        "The wrong number of arguments or syntax was provided, the format for the PTTL command is \"PTTL key\"";
-    public static final String QUIT = null;
     public static final String SCAN =
         "The wrong number of arguments or syntax was provided, the format for the SCAN command is \"SCAN cursor [MATCH pattern] [COUNT count]\"";
-    public static final String SHUTDOWN = null;
-    public static final String TIME = null;
-    public static final String TTL =
-        "The wrong number of arguments or syntax was provided, the format for the TTL command is \"TTL key\"";
-    public static final String TYPE =
-        "The wrong number of arguments or syntax was provided, the format for the TYPE command is \"TYPE key\"";
-    public static final String UNKNOWN = null;
 
     /*
      * String
      */
-    public static final String APPEND =
-        "The wrong number of arguments or syntax was provided, the format for the APPEND command is \"APPEND key value\"";
     public static final String BITCOUNT =
         "The wrong number of arguments or syntax was provided, the format for the BITCOUNT command is \"BITCOUNT key [start end]\"";
     public static final String BITOP =
@@ -104,8 +73,6 @@ public class RedisConstants {
         "The wrong number of arguments or syntax was provided, the format for the DECR command is \"DECR key\"";
     public static final String GETBIT =
         "The wrong number of arguments or syntax was provided, the format for the GETBIT command is \"GETBIT key offset\"";
-    public static final String GETEXECUTOR =
-        "The wrong number of arguments or syntax was provided, the format for the GET command is \"GET key\"";
     public static final String GETRANGE =
         "The wrong number of arguments or syntax was provided, the format for the GETRANGE command is \"GETRANGE key start end\"";
     public static final String GETSET =
@@ -124,12 +91,8 @@ public class RedisConstants {
         "The wrong number of arguments or syntax was provided, the format for the MSETNX command is \"MSETNX key value [key value ...]\", or not every key matches a value";
     public static final String PSETEX =
         "The wrong number of arguments or syntax was provided, the format for the PSETEX command is \"PSETEX key milliseconds value\"";
-    public static final String PUBLISH =
-        "The wrong number of arguments or syntax was provided, the format for the PUBLISH command is \"PUBLISH channel message\"";
     public static final String SETBIT =
         "The wrong number of arguments or syntax was provided, the format for the SETBIT command is \"SETBIT key offset value\"";
-    public static final String SET =
-        "The wrong number of arguments or syntax was provided, the format for the SET command is \"SET key value [EX seconds] [PX milliseconds] [NX|XX]\"";
     public static final String SETEX =
         "The wrong number of arguments or syntax was provided, the format for the SETEX command is \"SETEX key seconds value\"";
     public static final String SETNX =

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ExpireAtExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ExpireAtExecutor.java
@@ -20,16 +20,14 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 
 import java.util.List;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.Extendable;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
+public class ExpireAtExecutor extends AbstractExecutor {
 
   @Override
   public RedisResponse executeCommand(Command command,
@@ -60,10 +58,4 @@ public class ExpireAtExecutor extends AbstractExecutor implements Extendable {
   protected boolean timeUnitMillis() {
     return false;
   }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.EXPIREAT;
-  }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ExpireExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ExpireExecutor.java
@@ -20,16 +20,14 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 
 import java.util.List;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.Extendable;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ExpireExecutor extends AbstractExecutor implements Extendable {
+public class ExpireExecutor extends AbstractExecutor {
 
   @Override
   public RedisResponse executeCommand(Command command,
@@ -65,10 +63,4 @@ public class ExpireExecutor extends AbstractExecutor implements Extendable {
   protected boolean timeUnitMillis() {
     return false;
   }
-
-  @Override
-  public String getArgsError() {
-    return ArityDef.EXPIRE;
-  }
-
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/PExpireAtExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/PExpireAtExecutor.java
@@ -15,7 +15,6 @@
  */
 package org.apache.geode.redis.internal.executor.key;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 public class PExpireAtExecutor extends ExpireAtExecutor {
 
@@ -24,8 +23,4 @@ public class PExpireAtExecutor extends ExpireAtExecutor {
     return true;
   }
 
-  @Override
-  public String getArgsError() {
-    return ArityDef.PEXPIREAT;
-  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/PExpireExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/PExpireExecutor.java
@@ -15,7 +15,6 @@
  */
 package org.apache.geode.redis.internal.executor.key;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 
 public class PExpireExecutor extends ExpireExecutor {
 
@@ -24,8 +23,4 @@ public class PExpireExecutor extends ExpireExecutor {
     return true;
   }
 
-  @Override
-  public String getArgsError() {
-    return ArityDef.PEXPIRE;
-  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/PTTLExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/PTTLExecutor.java
@@ -15,8 +15,6 @@
  */
 package org.apache.geode.redis.internal.executor.key;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
-
 public class PTTLExecutor extends TTLExecutor {
 
 
@@ -25,8 +23,4 @@ public class PTTLExecutor extends TTLExecutor {
     return true;
   }
 
-  @Override
-  public String getArgsError() {
-    return ArityDef.PTTL;
-  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/TTLExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/key/TTLExecutor.java
@@ -17,15 +17,13 @@ package org.apache.geode.redis.internal.executor.key;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
-import org.apache.geode.redis.internal.RedisConstants.ArityDef;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.Extendable;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class TTLExecutor extends AbstractExecutor implements Extendable {
+public class TTLExecutor extends AbstractExecutor {
 
   @Override
   public RedisResponse executeCommand(Command command,
@@ -45,8 +43,4 @@ public class TTLExecutor extends AbstractExecutor implements Extendable {
     return false;
   }
 
-  @Override
-  public String getArgsError() {
-    return ArityDef.TTL;
-  }
 }


### PR DESCRIPTION
Remove constants we no longer use in `RedisConstants`
