### PR TITLE
GEODE-8611: Fixes default KeyManagerFactory instantiation.

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLUtilIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLUtilIntegrationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.net;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.Security;
+
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.TrustManagerFactory;
+
+import org.junit.Test;
+
+public class SSLUtilIntegrationTest {
+
+  static final String SSL_KEY_MANAGER_FACTORY_ALGORITHM = "ssl.KeyManagerFactory.algorithm";
+  static final String SSL_TRUST_MANAGER_FACTORY_ALGORITHM = "ssl.TrustManagerFactory.algorithm";
+  static final String PKIX = "PKIX";
+  static final String SUN_X_509 = "SunX509";
+
+  @Test
+  public void getDefaultKeyManagerFactoryControlledBySystemProperty()
+      throws NoSuchAlgorithmException {
+    String original = Security.getProperty(SSL_KEY_MANAGER_FACTORY_ALGORITHM);
+    try {
+      Security.setProperty(SSL_KEY_MANAGER_FACTORY_ALGORITHM, PKIX);
+      final KeyManagerFactory pkixKeyManagerFactory = SSLUtil.getDefaultKeyManagerFactory();
+      assertThat(pkixKeyManagerFactory).isNotNull();
+      assertThat(pkixKeyManagerFactory.getAlgorithm()).isEqualTo(PKIX);
+
+      Security.setProperty(SSL_KEY_MANAGER_FACTORY_ALGORITHM, SUN_X_509);
+      final KeyManagerFactory x509KeyManagerFactory = SSLUtil.getDefaultKeyManagerFactory();
+      assertThat(x509KeyManagerFactory).isNotNull();
+      assertThat(x509KeyManagerFactory.getAlgorithm()).isEqualTo(SUN_X_509);
+    } finally {
+      Security.setProperty(SSL_KEY_MANAGER_FACTORY_ALGORITHM, original);
+    }
+  }
+
+  @Test
+  public void getDefaultTrustManagerFactoryControlledBySystemProperty()
+      throws NoSuchAlgorithmException {
+    String original = Security.getProperty(SSL_TRUST_MANAGER_FACTORY_ALGORITHM);
+    try {
+      Security.setProperty(SSL_TRUST_MANAGER_FACTORY_ALGORITHM, PKIX);
+      final TrustManagerFactory pkixTrustManagerFactory = SSLUtil.getDefaultTrustManagerFactory();
+      assertThat(pkixTrustManagerFactory).isNotNull();
+      assertThat(pkixTrustManagerFactory.getAlgorithm()).isEqualTo(PKIX);
+
+      Security.setProperty(SSL_TRUST_MANAGER_FACTORY_ALGORITHM, SUN_X_509);
+      final TrustManagerFactory x509TrustManagerFactory = SSLUtil.getDefaultTrustManagerFactory();
+      assertThat(x509TrustManagerFactory).isNotNull();
+      assertThat(x509TrustManagerFactory.getAlgorithm()).isEqualTo(SUN_X_509);
+    } finally {
+      Security.setProperty(SSL_TRUST_MANAGER_FACTORY_ALGORITHM, original);
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SSLUtil.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SSLUtil.java
@@ -120,8 +120,7 @@ public class SSLUtil {
         keyStoreStream = new FileInputStream(sslConfig.getKeystore());
         clientKeys.load(keyStoreStream, sslConfig.getKeystorePassword().toCharArray());
 
-        keyManagerFactory =
-            KeyManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        keyManagerFactory = getDefaultKeyManagerFactory();
         keyManagerFactory.init(clientKeys, sslConfig.getKeystorePassword().toCharArray());
       }
     } finally {
@@ -131,6 +130,10 @@ public class SSLUtil {
     }
 
     return keyManagerFactory != null ? keyManagerFactory.getKeyManagers() : null;
+  }
+
+  static KeyManagerFactory getDefaultKeyManagerFactory() throws NoSuchAlgorithmException {
+    return KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
   }
 
   private static TrustManager[] getTrustManagers(SSLConfig sslConfig, boolean skipSslVerification)
@@ -162,8 +165,7 @@ public class SSLUtil {
         KeyStore serverPub = KeyStore.getInstance(trustStoreType);
         trustStoreStream = new FileInputStream(sslConfig.getTruststore());
         serverPub.load(trustStoreStream, sslConfig.getTruststorePassword().toCharArray());
-        trustManagerFactory =
-            TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+        trustManagerFactory = getDefaultTrustManagerFactory();
         trustManagerFactory.init(serverPub);
       }
     } finally {
@@ -172,6 +174,11 @@ public class SSLUtil {
       }
     }
     return trustManagerFactory != null ? trustManagerFactory.getTrustManagers() : null;
+  }
+
+  static TrustManagerFactory getDefaultTrustManagerFactory()
+      throws NoSuchAlgorithmException {
+    return TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
   }
 
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SSLUtilTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SSLUtilTest.java
@@ -21,7 +21,9 @@ import static org.mockito.Mockito.when;
 
 import java.security.NoSuchAlgorithmException;
 
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManagerFactory;
 
 import org.junit.Test;
 
@@ -81,4 +83,18 @@ public class SSLUtilTest {
     assertThat(sslContextInstance.getProtocol().equalsIgnoreCase("TLSv1.1")).isTrue();
   }
 
+  @Test
+  public void getDefaultKeyManagerFactory() throws NoSuchAlgorithmException {
+    final KeyManagerFactory keyManagerFactory = SSLUtil.getDefaultKeyManagerFactory();
+    assertThat(keyManagerFactory).isNotNull();
+    assertThat(keyManagerFactory.getAlgorithm()).isEqualTo(KeyManagerFactory.getDefaultAlgorithm());
+  }
+
+  @Test
+  public void getDefaultTrustManagerFactory() throws NoSuchAlgorithmException {
+    final TrustManagerFactory trustManagerFactory = SSLUtil.getDefaultTrustManagerFactory();
+    assertThat(trustManagerFactory).isNotNull();
+    assertThat(trustManagerFactory.getAlgorithm())
+        .isEqualTo(TrustManagerFactory.getDefaultAlgorithm());
+  }
 }


### PR DESCRIPTION
* Uses the default KeyManagerFactory algorithm property.
* Adds unit test.
* Adds integration test.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
