### PR TITLE
GEODE-8621: Redis SPOP can return incorrect string type

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
@@ -46,7 +46,7 @@ public class SPopExecutor extends SetExecutor {
     }
 
     if (!isCountPassed) {
-      return RedisResponse.string(popped.iterator().next().toString());
+      return RedisResponse.bulkString(popped.iterator().next().toString());
     }
 
     return RedisResponse.array(popped);


### PR DESCRIPTION
- Without a count argument, SPOP should return the result as a bulk
  string.

Authored-by: Jens Deppe <jdeppe@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
