### PR TITLE
GEODE-8584: AutoCloseable for ByteBuffer Locking

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketHostNameVerificationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketHostNameVerificationIntegrationTest.java
@@ -215,7 +215,9 @@ public class SSLSocketHostNameVerificationIntegrationTest {
           final NioSslEngine nioSslEngine = engine;
           engine.close(socket.getChannel());
           assertThatThrownBy(() -> {
-            nioSslEngine.unwrap(ByteBuffer.wrap(new byte[0]));
+            try (final ByteBufferSharing unused =
+                nioSslEngine.unwrap(ByteBuffer.wrap(new byte[0]))) {
+            }
           })
               .isInstanceOf(IOException.class);
         }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -256,11 +256,13 @@ public class SSLSocketIntegrationTest {
     ByteBuffer buffer = bbos.getContentBuffer();
     System.out.println(
         "client buffer position is " + buffer.position() + " and limit is " + buffer.limit());
-    ByteBuffer wrappedBuffer = engine.wrap(buffer);
-    System.out.println("client wrapped buffer position is " + wrappedBuffer.position()
-        + " and limit is " + wrappedBuffer.limit());
-    int bytesWritten = clientChannel.write(wrappedBuffer);
-    System.out.println("client bytes written is " + bytesWritten);
+    try (final ByteBufferSharing outputSharing = engine.wrap(buffer)) {
+      ByteBuffer wrappedBuffer = outputSharing.getBuffer();
+      System.out.println("client wrapped buffer position is " + wrappedBuffer.position()
+          + " and limit is " + wrappedBuffer.limit());
+      int bytesWritten = clientChannel.write(wrappedBuffer);
+      System.out.println("client bytes written is " + bytesWritten);
+    }
   }
 
   private Thread startServerNIO(final ServerSocket serverSocket, int timeoutMillis)
@@ -299,7 +301,9 @@ public class SSLSocketIntegrationTest {
           final NioSslEngine nioSslEngine = engine;
           engine.close(socket.getChannel());
           assertThatThrownBy(() -> {
-            nioSslEngine.unwrap(ByteBuffer.wrap(new byte[0]));
+            try (final ByteBufferSharing unused =
+                nioSslEngine.unwrap(ByteBuffer.wrap(new byte[0]))) {
+            }
           })
               .isInstanceOf(IOException.class);
         }
@@ -313,24 +317,35 @@ public class SSLSocketIntegrationTest {
   private void readMessageFromNIOSSLClient(Socket socket, ByteBuffer buffer, NioSslEngine engine)
       throws IOException {
 
-    ByteBuffer unwrapped = engine.getUnwrappedBuffer(buffer);
-    // if we already have unencrypted data skip unwrapping
-    if (unwrapped.position() == 0) {
-      int bytesRead;
-      // if we already have encrypted data skip reading from the socket
-      if (buffer.position() == 0) {
-        bytesRead = socket.getChannel().read(buffer);
-        buffer.flip();
+    try (final ByteBufferSharing sharedBuffer = engine.getUnwrappedBuffer(buffer)) {
+      final ByteBuffer unwrapped = sharedBuffer.getBuffer();
+      // if we already have unencrypted data skip unwrapping
+      if (unwrapped.position() == 0) {
+        int bytesRead;
+        // if we already have encrypted data skip reading from the socket
+        if (buffer.position() == 0) {
+          bytesRead = socket.getChannel().read(buffer);
+          buffer.flip();
+        } else {
+          bytesRead = buffer.remaining();
+        }
+        System.out.println("server bytes read is " + bytesRead + ": buffer position is "
+            + buffer.position() + " and limit is " + buffer.limit());
+        try (final ByteBufferSharing sharedBuffer2 = engine.unwrap(buffer)) {
+          final ByteBuffer unwrapped2 = sharedBuffer2.getBuffer();
+
+          unwrapped2.flip();
+          System.out.println("server unwrapped buffer position is " + unwrapped2.position()
+              + " and limit is " + unwrapped2.limit());
+          finishReadMessageFromNIOSSLClient(unwrapped2);
+        }
       } else {
-        bytesRead = buffer.remaining();
+        finishReadMessageFromNIOSSLClient(unwrapped);
       }
-      System.out.println("server bytes read is " + bytesRead + ": buffer position is "
-          + buffer.position() + " and limit is " + buffer.limit());
-      unwrapped = engine.unwrap(buffer);
-      unwrapped.flip();
-      System.out.println("server unwrapped buffer position is " + unwrapped.position()
-          + " and limit is " + unwrapped.limit());
     }
+  }
+
+  private void finishReadMessageFromNIOSSLClient(final ByteBuffer unwrapped) throws IOException {
     ByteBufferInputStream bbis = new ByteBufferInputStream(unwrapped);
     DataInputStream dis = new DataInputStream(bbis);
     String welcome = dis.readUTF();

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -104,3 +104,4 @@ org/apache/geode/cache/query/internal/xml/ElementType
 org/apache/geode/cache/query/internal/xml/ElementType$1
 org/apache/geode/cache/query/internal/xml/ElementType$2
 org/apache/geode/cache/query/internal/xml/ElementType$3
+org/apache/geode/internal/net/ByteBufferSharingImpl$LockAttemptTimedOut

--- a/geode-core/src/main/java/org/apache/geode/internal/net/ByteBufferReferencing.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/ByteBufferReferencing.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.net;
+
+
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.annotations.internal.MakeImmutable;
+import org.apache.geode.internal.net.BufferPool.BufferType;
+
+/**
+ * Reference counting for a pooled ByteBuffer. Releases buffer back to pool after last reference is
+ * dropped.
+ */
+class ByteBufferReferencing {
+
+  // this variable requires the MakeImmutable annotation but the buffer is empty and
+  // not really modifiable
+  @MakeImmutable
+  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
+
+  private final AtomicBoolean isClosed;
+  // mutable because in general our ByteBuffer may need to be resized (grown or compacted)
+  private ByteBuffer buffer;
+  private final BufferType bufferType;
+  private final AtomicInteger counter;
+  private final BufferPool bufferPool;
+
+  /**
+   * Construct with a single reference. You must call {@link #dropReference()} at least one time to
+   * return this buffer to the pool.
+   */
+  ByteBufferReferencing(final ByteBuffer buffer, final BufferType bufferType,
+      final BufferPool bufferPool) {
+    this.buffer = buffer;
+    this.bufferType = bufferType;
+    this.bufferPool = bufferPool;
+    counter = new AtomicInteger(1);
+    isClosed = new AtomicBoolean(false);
+  }
+
+  /**
+   * The destructor. Called by the resource owner to undo the work of the constructor.
+   */
+  void close() {
+    if (isClosed.compareAndSet(false, true)) {
+      dropReference();
+    }
+  }
+
+  int addReference() {
+    return counter.incrementAndGet();
+  }
+
+  int dropReference() {
+    final int usages = counter.decrementAndGet();
+    if (usages == 0) {
+      bufferPool.releaseBuffer(bufferType, buffer);
+    }
+    return usages;
+  }
+
+  ByteBuffer getBuffer() throws IOException {
+    if (isClosed.get()) {
+      throw new IOException("NioSslEngine has been closed");
+    } else {
+      return buffer;
+    }
+  }
+
+  ByteBuffer expandWriteBufferIfNeeded(final int newCapacity) {
+    return buffer = bufferPool.expandWriteBufferIfNeeded(bufferType, buffer, newCapacity);
+  }
+
+  ByteBuffer expandReadBufferIfNeeded(final int newCapacity) {
+    return buffer = bufferPool.expandReadBufferIfNeeded(bufferType, buffer, newCapacity);
+  }
+
+  @VisibleForTesting
+  void setBufferForTestingOnly(final ByteBuffer newBufferForTesting) {
+    buffer = newBufferForTesting;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/net/ByteBufferSharing.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/ByteBufferSharing.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.net;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * When a {@link ByteBufferSharing} is acquired in a try-with-resources the buffer
+ * is available (for reading and modification) within the scope of that try block.
+ */
+public interface ByteBufferSharing extends AutoCloseable {
+
+  /**
+   * Call this method only within a try-with-resource in which this {@link ByteBufferSharing}
+   * was acquired. Retain the reference only within the scope of that try-with-resources.
+   *
+   * @return the buffer: manipulable only within the scope of the try-with-resources
+   */
+  ByteBuffer getBuffer() throws IOException;
+
+  /**
+   * Override {@link AutoCloseable#close()} without throws clause since we don't need one.
+   */
+  @Override
+  void close();
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/net/ByteBufferSharingImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/ByteBufferSharingImpl.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.net;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
+
+/**
+ * An {@link AutoCloseable} meant to be acquired in a try-with-resources statement. The resource (a
+ * {@link ByteBuffer}) is available (for reading and modification) in the scope of the
+ * try-with-resources. Collaborates with {@link ByteBufferReferencing} to ensure final dereference
+ * returns the {@link ByteBuffer} to the pool.
+ */
+class ByteBufferSharingImpl implements ByteBufferSharing {
+  private static final Logger logger = LogService.getLogger();
+
+  static class LockAttemptTimedOut extends Exception {
+  }
+
+  private final Lock lock;
+  private final ByteBufferReferencing referencing;
+
+  /**
+   * This constructor is for use only by the owner of the shared resource (a {@link ByteBuffer}).
+   *
+   * A resource owner must invoke {@link #alias()} once for each reference that escapes (is passed
+   * to an external object or is returned to an external caller.)
+   *
+   * This constructor acquires no lock and does not modify the reference count through the {@link
+   * ByteBufferReferencing} (passed in here.) Usually, the referencing object will have been set to
+   * a reference of 1 before calling this method.
+   */
+  ByteBufferSharingImpl(final ByteBufferReferencing referencing) {
+    this(new ReentrantLock(), referencing);
+  }
+
+  /**
+   * This method is for use only by the owner of the shared resource. It's used for handing out
+   * references to the shared resource. So it does reference counting and also acquires a lock.
+   *
+   * Resource owners call this method as the last thing before returning a reference to the caller.
+   * That caller binds that reference to a variable in a try-with-resources statement and relies on
+   * the AutoCloseable protocol to invoke close() on the object at the end of the block.
+   */
+  ByteBufferSharing alias() {
+    lock.lock();
+    referencing.addReference();
+    return this;
+  }
+
+  ByteBufferSharing alias(final long time, final TimeUnit unit) throws LockAttemptTimedOut {
+    try {
+      if (!lock.tryLock(time, unit)) {
+        throw new LockAttemptTimedOut();
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new LockAttemptTimedOut();
+    }
+    final int refcount = referencing.addReference();
+    return this;
+  }
+
+  private ByteBufferSharingImpl(final Lock lock,
+      final ByteBufferReferencing referencing) {
+    this.lock = lock;
+    this.referencing = referencing;
+  }
+
+  @Override
+  public ByteBuffer getBuffer() throws IOException {
+    return referencing.getBuffer();
+  }
+
+  @Override
+  public void close() {
+    referencing.dropReference();
+    lock.unlock();
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/net/ByteBufferSharingNoOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/ByteBufferSharingNoOp.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.net;
+
+import java.nio.ByteBuffer;
+
+/**
+ * An {@link AutoCloseable} meant to be acquired in a try-with-resources statement. The resource (a
+ * {@link ByteBuffer}) is available (for reading and modification) in the scope of the
+ * try-with-resources.
+ *
+ * This implementation is a "no-op". It performs no actual locking and no reference counting. It's
+ * meant for use with the {@link NioPlainEngine} only, since that engine keeps no buffers and so,
+ * needs no reference counting on buffers, nor any synchronization around access to buffers.
+ *
+ * See also {@link ByteBufferSharingImpl}
+ */
+class ByteBufferSharingNoOp implements ByteBufferSharing {
+
+  private final ByteBuffer buffer;
+
+  ByteBufferSharingNoOp(final ByteBuffer buffer) {
+    this.buffer = buffer;
+  }
+
+  @Override
+  public ByteBuffer getBuffer() {
+    return buffer;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
@@ -33,15 +33,21 @@ public interface NioFilter {
 
   /**
    * wrap bytes for transmission to another process
+   *
+   * Be sure to call close() on the returned {@link ByteBufferSharing}. The best
+   * way to do that is to call this method in a try-with-resources statement.
    */
-  ByteBuffer wrap(ByteBuffer buffer) throws IOException;
+  ByteBufferSharing wrap(ByteBuffer buffer) throws IOException;
 
   /**
    * unwrap bytes received from another process. The unwrapped
    * buffer should be flipped before reading. When done reading invoke
    * doneReading() to reset for future read ops
+   *
+   * Be sure to call close() on the returned {@link ByteBufferSharing}. The best
+   * way to do that is to call this method in a try-with-resources statement.
    */
-  ByteBuffer unwrap(ByteBuffer wrappedBuffer) throws IOException;
+  ByteBufferSharing unwrap(ByteBuffer wrappedBuffer) throws IOException;
 
   /**
    * ensure that the wrapped buffer has enough room to read the given amount of data.
@@ -58,8 +64,11 @@ public interface NioFilter {
    * <br>
    * wrappedBuffer = filter.ensureWrappedCapacity(amount, wrappedBuffer, etc.);<br>
    * unwrappedBuffer = filter.readAtLeast(channel, amount, wrappedBuffer, etc.)
+   *
+   * Be sure to call close() on the returned {@link ByteBufferSharing}. The best
+   * way to do that is to call this method in a try-with-resources statement.
    */
-  ByteBuffer readAtLeast(SocketChannel channel, int amount, ByteBuffer wrappedBuffer)
+  ByteBufferSharing readAtLeast(SocketChannel channel, int amount, ByteBuffer wrappedBuffer)
       throws IOException;
 
   /**
@@ -81,10 +90,6 @@ public interface NioFilter {
     }
   }
 
-  default boolean isClosed() {
-    return false;
-  }
-
   /**
    * invoke this method when you are done using the NioFilter
    *
@@ -95,14 +100,9 @@ public interface NioFilter {
 
   /**
    * returns the unwrapped byte buffer associated with the given wrapped buffer.
+   *
+   * Be sure to call close() on the returned {@link ByteBufferSharing}. The best
+   * way to do that is to call this method in a try-with-resources statement.
    */
-  ByteBuffer getUnwrappedBuffer(ByteBuffer wrappedBuffer);
-
-  /**
-   * returns an object to be used in synchronizing on the use of buffers returned by
-   * a NioFilter.
-   */
-  default Object getSynchObject() {
-    return this;
-  }
+  ByteBufferSharing getUnwrappedBuffer(ByteBuffer wrappedBuffer);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
@@ -38,14 +38,14 @@ public class NioPlainEngine implements NioFilter {
   }
 
   @Override
-  public ByteBuffer wrap(ByteBuffer buffer) {
-    return buffer;
+  public ByteBufferSharing wrap(ByteBuffer buffer) {
+    return shareBuffer(buffer);
   }
 
   @Override
-  public ByteBuffer unwrap(ByteBuffer wrappedBuffer) {
+  public ByteBufferSharing unwrap(ByteBuffer wrappedBuffer) {
     wrappedBuffer.position(wrappedBuffer.limit());
-    return wrappedBuffer;
+    return shareBuffer(wrappedBuffer);
   }
 
   @Override
@@ -82,7 +82,7 @@ public class NioPlainEngine implements NioFilter {
   }
 
   @Override
-  public ByteBuffer readAtLeast(SocketChannel channel, int bytes, ByteBuffer wrappedBuffer)
+  public ByteBufferSharing readAtLeast(SocketChannel channel, int bytes, ByteBuffer wrappedBuffer)
       throws IOException {
     ByteBuffer buffer = wrappedBuffer;
 
@@ -108,7 +108,7 @@ public class NioPlainEngine implements NioFilter {
     buffer.position(lastProcessedPosition);
     lastProcessedPosition += bytes;
 
-    return buffer;
+    return shareBuffer(buffer);
   }
 
   public void doneReading(ByteBuffer unwrappedBuffer) {
@@ -121,8 +121,16 @@ public class NioPlainEngine implements NioFilter {
   }
 
   @Override
-  public ByteBuffer getUnwrappedBuffer(ByteBuffer wrappedBuffer) {
-    return wrappedBuffer;
+  public ByteBufferSharing getUnwrappedBuffer(ByteBuffer wrappedBuffer) {
+    return shareBuffer(wrappedBuffer);
+  }
+
+  public ByteBufferSharing shareInputBuffer() {
+    return shareBuffer(null); // calling getBuffer() on result will return null natch'
+  }
+
+  private ByteBufferSharingNoOp shareBuffer(final ByteBuffer wrappedBuffer) {
+    return new ByteBufferSharingNoOp(wrappedBuffer);
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -40,23 +40,18 @@ import javax.net.ssl.SSLSession;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.GemFireIOException;
-import org.apache.geode.annotations.internal.MakeImmutable;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.net.BufferPool.BufferType;
+import org.apache.geode.internal.net.ByteBufferSharingImpl.LockAttemptTimedOut;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 
 /**
- * NioSslEngine uses an SSLEngine to bind SSL logic to a data source. This class is not thread
- * safe. Its use should be confined to one thread or should be protected by external
- * synchronization.
+ * NioSslEngine uses an SSLEngine to bind SSL logic to a data source. This class is not thread safe.
+ * Its use should be confined to one thread or should be protected by external synchronization.
  */
 public class NioSslEngine implements NioFilter {
   private static final Logger logger = LogService.getLogger();
-
-  // this variable requires the MakeImmutable annotation but the buffer is empty and
-  // not really modifiable
-  @MakeImmutable
-  private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.allocate(0);
 
   private final BufferPool bufferPool;
 
@@ -65,23 +60,32 @@ public class NioSslEngine implements NioFilter {
   SSLEngine engine;
 
   /**
-   * myNetData holds bytes wrapped by the SSLEngine
+   * holds bytes wrapped by the SSLEngine; a.k.a. myNetData
    */
-  ByteBuffer myNetData;
+  private final ByteBufferReferencing outputReferencing;
+  private final ByteBufferSharingImpl outputSharing;
 
   /**
-   * peerAppData holds the last unwrapped data from a peer
+   * holds the last unwrapped data from a peer; a.k.a. peerAppData
    */
-  ByteBuffer peerAppData;
+  private final ByteBufferReferencing inputReferencing;
+  private final ByteBufferSharingImpl inputSharing;
 
   NioSslEngine(SSLEngine engine, BufferPool bufferPool) {
     SSLSession session = engine.getSession();
     int appBufferSize = session.getApplicationBufferSize();
     int packetBufferSize = engine.getSession().getPacketBufferSize();
+    closed = false;
     this.engine = engine;
     this.bufferPool = bufferPool;
-    this.myNetData = bufferPool.acquireDirectSenderBuffer(packetBufferSize);
-    this.peerAppData = bufferPool.acquireNonDirectReceiveBuffer(appBufferSize);
+    outputReferencing =
+        new ByteBufferReferencing(bufferPool.acquireDirectSenderBuffer(packetBufferSize),
+            TRACKED_SENDER, bufferPool);
+    outputSharing = new ByteBufferSharingImpl(outputReferencing);
+    inputReferencing =
+        new ByteBufferReferencing(bufferPool.acquireNonDirectReceiveBuffer(appBufferSize),
+            TRACKED_RECEIVER, bufferPool);
+    inputSharing = new ByteBufferSharingImpl(inputReferencing);
   }
 
   /**
@@ -134,12 +138,15 @@ public class NioSslEngine implements NioFilter {
       }
 
       switch (status) {
-        case NEED_UNWRAP:
+        case NEED_UNWRAP: { // notice we have made a block here to limit scope of peerAppData
           // Receive handshaking data from peer
           int dataRead = socketChannel.read(handshakeBuffer);
 
           // Process incoming handshaking data
           handshakeBuffer.flip();
+
+          final ByteBuffer peerAppData = inputReferencing.getBuffer();
+
           engineResult = engine.unwrap(handshakeBuffer, peerAppData);
           handshakeBuffer.compact();
           status = engineResult.getHandshakeStatus();
@@ -151,12 +158,14 @@ public class NioSslEngine implements NioFilter {
           }
 
           if (engineResult.getStatus() == BUFFER_OVERFLOW) {
-            peerAppData =
-                expandWriteBuffer(TRACKED_RECEIVER, peerAppData, peerAppData.capacity() * 2);
+            inputReferencing.expandWriteBufferIfNeeded(peerAppData.capacity() * 2);
           }
           break;
+        }
 
-        case NEED_WRAP:
+        case NEED_WRAP: { // notice we have made a block here to limit scope of myNetData
+          final ByteBuffer myNetData = outputReferencing.getBuffer();
+
           // Empty the local network packet buffer.
           myNetData.clear();
 
@@ -167,9 +176,8 @@ public class NioSslEngine implements NioFilter {
           // Check status
           switch (engineResult.getStatus()) {
             case BUFFER_OVERFLOW:
-              myNetData =
-                  expandWriteBuffer(TRACKED_SENDER, myNetData,
-                      myNetData.capacity() * 2);
+              // no need to assign return value because we will never reference it
+              outputReferencing.expandWriteBufferIfNeeded(myNetData.capacity() * 2);
               break;
             case OK:
               myNetData.flip();
@@ -186,6 +194,7 @@ public class NioSslEngine implements NioFilter {
                   "Unknown SSLEngineResult status: " + engineResult.getStatus());
           }
           break;
+        }
         case NEED_TASK:
           // Handle blocking tasks
           handleBlockingTasks();
@@ -213,17 +222,6 @@ public class NioSslEngine implements NioFilter {
     return true;
   }
 
-  ByteBuffer expandWriteBuffer(BufferType type, ByteBuffer existing,
-      int desiredCapacity) {
-    return bufferPool.expandWriteBufferIfNeeded(type, existing, desiredCapacity);
-  }
-
-  synchronized void checkClosed() throws IOException {
-    if (closed) {
-      throw new IOException("NioSslEngine has been closed");
-    }
-  }
-
   void handleBlockingTasks() {
     Runnable task;
     while ((task = engine.getDelegatedTask()) != null) {
@@ -233,72 +231,77 @@ public class NioSslEngine implements NioFilter {
   }
 
   @Override
-  public synchronized ByteBuffer wrap(ByteBuffer appData) throws IOException {
-    checkClosed();
+  public ByteBufferSharing wrap(ByteBuffer appData) throws IOException {
+    try (final ByteBufferSharing outputSharing = shareOutputBuffer()) {
 
-    myNetData.clear();
+      ByteBuffer myNetData = outputSharing.getBuffer();
 
-    while (appData.hasRemaining()) {
-      // ensure we have lots of capacity since encrypted data might
-      // be larger than the app data
-      int remaining = myNetData.capacity() - myNetData.position();
+      myNetData.clear();
 
-      if (remaining < (appData.remaining() * 2)) {
-        int newCapacity = expandedCapacity(appData, myNetData);
-        myNetData = expandWriteBuffer(TRACKED_SENDER, myNetData, newCapacity);
+      while (appData.hasRemaining()) {
+        // ensure we have lots of capacity since encrypted data might
+        // be larger than the app data
+        int remaining = myNetData.capacity() - myNetData.position();
+
+        if (remaining < (appData.remaining() * 2)) {
+          int newCapacity = expandedCapacity(appData, myNetData);
+          myNetData = outputReferencing.expandWriteBufferIfNeeded(newCapacity);
+        }
+
+        SSLEngineResult wrapResult = engine.wrap(appData, myNetData);
+
+        if (wrapResult.getHandshakeStatus() == NEED_TASK) {
+          handleBlockingTasks();
+        }
+
+        if (wrapResult.getStatus() != OK) {
+          throw new SSLException("Error encrypting data: " + wrapResult);
+        }
       }
 
-      SSLEngineResult wrapResult = engine.wrap(appData, myNetData);
+      myNetData.flip();
 
-      if (wrapResult.getHandshakeStatus() == NEED_TASK) {
-        handleBlockingTasks();
-      }
-
-      if (wrapResult.getStatus() != OK) {
-        throw new SSLException("Error encrypting data: " + wrapResult);
-      }
+      return shareOutputBuffer();
     }
-
-    myNetData.flip();
-
-    return myNetData;
   }
 
   @Override
-  public synchronized ByteBuffer unwrap(ByteBuffer wrappedBuffer) throws IOException {
-    checkClosed();
+  public ByteBufferSharing unwrap(ByteBuffer wrappedBuffer) throws IOException {
+    try (final ByteBufferSharing inputSharing = shareInputBuffer()) {
 
-    // note that we do not clear peerAppData as it may hold a partial
-    // message. TcpConduit, for instance, uses message chunking to
-    // transmit large payloads and we may have read a partial chunk
-    // during the previous unwrap
+      ByteBuffer peerAppData = inputSharing.getBuffer();
 
-    peerAppData.limit(peerAppData.capacity());
-    while (wrappedBuffer.hasRemaining()) {
-      SSLEngineResult unwrapResult = engine.unwrap(wrappedBuffer, peerAppData);
-      switch (unwrapResult.getStatus()) {
-        case BUFFER_OVERFLOW:
-          // buffer overflow expand and try again - double the available decryption space
-          int newCapacity =
-              (peerAppData.capacity() - peerAppData.position()) * 2 + peerAppData.position();
-          newCapacity = Math.max(newCapacity, peerAppData.capacity() / 2 * 3);
-          peerAppData =
-              bufferPool.expandWriteBufferIfNeeded(TRACKED_RECEIVER, peerAppData, newCapacity);
-          peerAppData.limit(peerAppData.capacity());
-          break;
-        case BUFFER_UNDERFLOW:
-          // partial data - need to read more. When this happens the SSLEngine will not have
-          // changed the buffer position
-          wrappedBuffer.compact();
-          return peerAppData;
-        case OK:
-          break;
-        default:
-          throw new SSLException("Error decrypting data: " + unwrapResult);
+      // note that we do not clear peerAppData as it may hold a partial
+      // message. TcpConduit, for instance, uses message chunking to
+      // transmit large payloads and we may have read a partial chunk
+      // during the previous unwrap
+
+      peerAppData.limit(peerAppData.capacity());
+      while (wrappedBuffer.hasRemaining()) {
+        SSLEngineResult unwrapResult = engine.unwrap(wrappedBuffer, peerAppData);
+        switch (unwrapResult.getStatus()) {
+          case BUFFER_OVERFLOW:
+            // buffer overflow expand and try again - double the available decryption space
+            int newCapacity =
+                (peerAppData.capacity() - peerAppData.position()) * 2 + peerAppData.position();
+            newCapacity = Math.max(newCapacity, peerAppData.capacity() / 2 * 3);
+            peerAppData = inputReferencing.expandWriteBufferIfNeeded(newCapacity);
+            peerAppData.limit(peerAppData.capacity());
+            break;
+          case BUFFER_UNDERFLOW:
+            // partial data - need to read more. When this happens the SSLEngine will not have
+            // changed the buffer position
+            wrappedBuffer.compact();
+            return shareInputBuffer();
+          case OK:
+            break;
+          default:
+            throw new SSLException("Error decrypting data: " + unwrapResult);
+        }
       }
+      wrappedBuffer.clear();
+      return shareInputBuffer();
     }
-    wrappedBuffer.clear();
-    return peerAppData;
   }
 
   @Override
@@ -315,50 +318,48 @@ public class NioSslEngine implements NioFilter {
   }
 
   @Override
-  public ByteBuffer readAtLeast(SocketChannel channel, int bytes,
+  public ByteBufferSharing readAtLeast(SocketChannel channel, int bytes,
       ByteBuffer wrappedBuffer) throws IOException {
-    if (peerAppData.capacity() > bytes) {
-      // we already have a buffer that's big enough
-      if (peerAppData.capacity() - peerAppData.position() < bytes) {
-        peerAppData.compact();
-        peerAppData.flip();
-      }
-    }
+    try (final ByteBufferSharing inputSharing = shareInputBuffer()) {
 
-    while (peerAppData.remaining() < bytes) {
-      wrappedBuffer.limit(wrappedBuffer.capacity());
-      int amountRead = channel.read(wrappedBuffer);
-      if (amountRead < 0) {
-        throw new EOFException();
+      ByteBuffer peerAppData = inputSharing.getBuffer();
+
+      if (peerAppData.capacity() > bytes) {
+        // we already have a buffer that's big enough
+        if (peerAppData.capacity() - peerAppData.position() < bytes) {
+          peerAppData.compact();
+          peerAppData.flip();
+        }
       }
-      if (amountRead > 0) {
-        wrappedBuffer.flip();
-        // prep the decoded buffer for writing
-        peerAppData.compact();
-        peerAppData = unwrap(wrappedBuffer);
-        // done writing to the decoded buffer - prep it for reading again
-        peerAppData.flip();
+
+      while (peerAppData.remaining() < bytes) {
+        wrappedBuffer.limit(wrappedBuffer.capacity());
+        int amountRead = channel.read(wrappedBuffer);
+        if (amountRead < 0) {
+          throw new EOFException();
+        }
+        if (amountRead > 0) {
+          wrappedBuffer.flip();
+          // prep the decoded buffer for writing
+          peerAppData.compact();
+          try (final ByteBufferSharing inputSharing2 = unwrap(wrappedBuffer)) {
+            // done writing to the decoded buffer - prep it for reading again
+            final ByteBuffer peerAppDataNew = inputSharing2.getBuffer();
+            peerAppDataNew.flip();
+            peerAppData = peerAppDataNew; // loop needs new reference!
+          }
+        }
       }
+      return shareInputBuffer();
     }
-    return peerAppData;
   }
 
   @Override
-  public ByteBuffer getUnwrappedBuffer(ByteBuffer wrappedBuffer) {
-    return peerAppData;
-  }
-
-  /**
-   * ensures that the unwrapped buffer associated with the given wrapped buffer has
-   * sufficient capacity for the given amount of bytes. This may compact the
-   * buffer or it may return a new buffer.
-   */
-  public ByteBuffer ensureUnwrappedCapacity(int amount) {
-    // for TTLS the app-data buffers do not need to be tracked direct-buffers since we
-    // do not use them for I/O operations
-    peerAppData =
-        bufferPool.expandReadBufferIfNeeded(TRACKED_RECEIVER, peerAppData, amount);
-    return peerAppData;
+  public ByteBufferSharing getUnwrappedBuffer(ByteBuffer wrappedBuffer) {
+    /*
+     * TODO: it can't be right that we ignore the wrappedBuffer parameter here!
+     */
+    return shareInputBuffer();
   }
 
   @Override
@@ -369,16 +370,14 @@ public class NioSslEngine implements NioFilter {
   }
 
   @Override
-  public synchronized boolean isClosed() {
-    return closed;
-  }
-
-  @Override
   public synchronized void close(SocketChannel socketChannel) {
     if (closed) {
       return;
     }
-    try {
+    closed = true;
+    inputReferencing.close();
+    try (final ByteBufferSharing outputSharing = shareOutputBuffer(1, TimeUnit.MINUTES)) {
+      final ByteBuffer myNetData = outputSharing.getBuffer();
 
       if (!engine.isOutboundDone()) {
         ByteBuffer empty = ByteBuffer.wrap(new byte[0]);
@@ -405,14 +404,13 @@ public class NioSslEngine implements NioFilter {
       // we can't send a close message if the channel is closed
     } catch (IOException e) {
       throw new GemFireIOException("exception closing SSL session", e);
+    } catch (final LockAttemptTimedOut _unused) {
+      logger.info(String.format("Couldn't get output lock in time, eliding TLS close message"));
+      if (!engine.isOutboundDone()) {
+        engine.closeOutbound();
+      }
     } finally {
-      ByteBuffer netData = myNetData;
-      ByteBuffer appData = peerAppData;
-      myNetData = null;
-      peerAppData = EMPTY_BUFFER;
-      bufferPool.releaseBuffer(TRACKED_SENDER, netData);
-      bufferPool.releaseBuffer(TRACKED_RECEIVER, appData);
-      this.closed = true;
+      outputReferencing.close();
     }
   }
 
@@ -421,4 +419,26 @@ public class NioSslEngine implements NioFilter {
         targetBuffer.capacity() * 2);
   }
 
+  private ByteBufferSharing shareOutputBuffer() {
+    return outputSharing.alias();
+  }
+
+  private ByteBufferSharing shareOutputBuffer(final long time, final TimeUnit unit)
+      throws LockAttemptTimedOut {
+    return outputSharing.alias(time, unit);
+  }
+
+  public ByteBufferSharing shareInputBuffer() {
+    return inputSharing.alias();
+  }
+
+  @VisibleForTesting
+  ByteBufferReferencing getOutputReferencing() {
+    return outputReferencing;
+  }
+
+  @VisibleForTesting
+  ByteBufferReferencing getInputReferencing() {
+    return inputReferencing;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCloser.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCloser.java
@@ -25,8 +25,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 
+import org.apache.logging.log4j.Logger;
+
 import org.apache.geode.SystemFailure;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
+import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * This class allows sockets to be closed without blocking. In some cases we have seen a call of
@@ -41,6 +44,7 @@ import org.apache.geode.logging.internal.executors.LoggingExecutors;
  * This max threads can be configured using the "p2p.ASYNC_CLOSE_POOL_MAX_THREADS" system property.
  */
 public class SocketCloser {
+  private static final Logger logger = LogService.getLogger();
 
   /**
    * Number of seconds to wait before timing out an unused async close thread. Default is 120 (2

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -78,6 +78,7 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.SystemTimer;
 import org.apache.geode.internal.SystemTimer.SystemTimerTask;
 import org.apache.geode.internal.net.BufferPool;
+import org.apache.geode.internal.net.ByteBufferSharing;
 import org.apache.geode.internal.net.NioFilter;
 import org.apache.geode.internal.net.NioPlainEngine;
 import org.apache.geode.internal.net.SocketCreator;
@@ -801,11 +802,12 @@ public class Connection implements Runnable {
 
   private void notifyHandshakeWaiter(boolean success) {
     if (getConduit().useSSL() && ioFilter != null) {
-      synchronized (ioFilter.getSynchObject()) {
-        if (!ioFilter.isClosed()) {
-          // clear out any remaining handshake bytes
-          ByteBuffer buffer = ioFilter.getUnwrappedBuffer(inputBuffer);
-          buffer.position(0).limit(0);
+      try (final ByteBufferSharing sharedBuffer = ioFilter.getUnwrappedBuffer(inputBuffer)) {
+        // clear out any remaining handshake bytes
+        try {
+          sharedBuffer.getBuffer().position(0).limit(0);
+        } catch (IOException e) {
+          // means the NioFilter was already closed
         }
       }
     }
@@ -2441,8 +2443,9 @@ public class Connection implements Runnable {
         long queueTimeoutTarget = now + asyncQueueTimeout;
         channel.configureBlocking(false);
         try {
-          synchronized (ioFilter.getSynchObject()) {
-            ByteBuffer wrappedBuffer = ioFilter.wrap(buffer);
+          try (final ByteBufferSharing outputSharing = ioFilter.wrap(buffer)) {
+            final ByteBuffer wrappedBuffer = outputSharing.getBuffer();
+
             int waitTime = 1;
             do {
               owner.getConduit().getCancelCriterion().checkCancelInProgress(null);
@@ -2595,9 +2598,9 @@ public class Connection implements Runnable {
           }
           // fall through
         }
-        // synchronize on the ioFilter while using its network buffer
-        synchronized (ioFilter.getSynchObject()) {
-          ByteBuffer wrappedBuffer = ioFilter.wrap(buffer);
+        try (final ByteBufferSharing outputSharing = ioFilter.wrap(buffer)) {
+          final ByteBuffer wrappedBuffer = outputSharing.getBuffer();
+
           while (wrappedBuffer.remaining() > 0) {
             int amtWritten = 0;
             long start = stats.startSocketWrite(true);
@@ -2650,23 +2653,27 @@ public class Connection implements Runnable {
     try {
       msgReader = new MsgReader(this, ioFilter, version);
 
-      Header header = msgReader.readHeader();
-
       ReplyMessage msg;
       int len;
-      if (header.getMessageType() == NORMAL_MSG_TYPE) {
-        msg = (ReplyMessage) msgReader.readMessage(header);
-        len = header.getMessageLength();
-      } else {
-        MsgDestreamer destreamer = obtainMsgDestreamer(header.getMessageId(), version);
-        while (header.getMessageType() == CHUNKED_MSG_TYPE) {
+
+      // we have to lock here to protect between reading header and message body
+      try (final ByteBufferSharing _unused = ioFilter.getUnwrappedBuffer(null)) {
+        Header header = msgReader.readHeader();
+
+        if (header.getMessageType() == NORMAL_MSG_TYPE) {
+          msg = (ReplyMessage) msgReader.readMessage(header);
+          len = header.getMessageLength();
+        } else {
+          MsgDestreamer destreamer = obtainMsgDestreamer(header.getMessageId(), version);
+          while (header.getMessageType() == CHUNKED_MSG_TYPE) {
+            msgReader.readChunk(header, destreamer);
+            header = msgReader.readHeader();
+          }
           msgReader.readChunk(header, destreamer);
-          header = msgReader.readHeader();
+          msg = (ReplyMessage) destreamer.getMessage();
+          releaseMsgDestreamer(header.getMessageId(), destreamer);
+          len = destreamer.size();
         }
-        msgReader.readChunk(header, destreamer);
-        msg = (ReplyMessage) destreamer.getMessage();
-        releaseMsgDestreamer(header.getMessageId(), destreamer);
-        len = destreamer.size();
       }
       // I'd really just like to call dispatchMessage here. However,
       // that call goes through a bunch of checks that knock about
@@ -2734,8 +2741,9 @@ public class Connection implements Runnable {
   private void processInputBuffer() throws ConnectionException, IOException {
     inputBuffer.flip();
 
-    synchronized (ioFilter.getSynchObject()) {
-      ByteBuffer peerDataBuffer = ioFilter.unwrap(inputBuffer);
+    try (final ByteBufferSharing sharedBuffer = ioFilter.unwrap(inputBuffer)) {
+      final ByteBuffer peerDataBuffer = sharedBuffer.getBuffer();
+
       peerDataBuffer.flip();
 
       boolean done = false;


### PR DESCRIPTION
A third attempt at fixing GEODE-8584 locking granularity.

In this PR we have fine-grained locking (read has its own lock, write has its own lock, and `NioSslEngine.close()` has a completely separate lock). Also in the place where we acquire the write lock in `close()` we have a finite wait time (1 minute.) so we don't prevent `Connection` from closing the socket.

This is a refinement of the [Finer-Grained Locking PR](https://github.com/apache/geode/pull/5632). That PR split the single lock into two (but does not have the timeout on write lock acquisition that this PR has.)  With that other PR, client code in e.g. .`MsgReader` had to do all this ceremony:

```
synchronized (ioFilter.getInputSyncObject()) {
  ioFilter.setInputInUse(true);
  try {
    ByteBuffer unwrappedBuffer = readAtLeast(Connection.MSG_HEADER_BYTES);

    // do stuff with unwrappedBuffer

  } finally {
	ioFilter.setInputInUse(false);
  }
}
```

@dschneider-pivotal noticed that this followed the `AutoCloseable` pattern. So this PR makes good on that observation and introduces the auto-closeable `ByteBufferSharing`. We now return a `ByteBufferSharing` from methods that used to return the input `ByteBuffer`. Callers acquire it in a try-with-resources and rely on the `AutoCloseable` protocol to take care of lock closing and reference counting (decrement).

With this PR that same `MsgReader` code looks like this:

```
try (final ByteBufferSharing sharedBuffer = readAtLeast(Connection.MSG_HEADER_BYTES)) {
  ByteBuffer unwrappedBuffer = sharedBuffer.getBuffer();

  // do stuff with unwrappedBuffer
  
}
```      

The value of this approach goes beyond mere concision. It helped me find places where we were failing to properly follow the locking and ref-counting protocol in the previous PR. Now the methods that require the special treatment are much more self-documenting. There is no danger of failing to lock now. The only risk is a failure to acquire the resource in a try-with-resources, resulting in a failure to release the lock and release the reference.

# TODO

- [ ] in `NioSslEngine` use `Lock` for `myNetData` (output) sync (shall we reuse `ByteBufferSharing`+`ByteBufferReferencing` for this?)
- [ ] change `close()` sync to time out if `Lock` can't be acquired so that `close()` is no longer blocked on readers

# Boilerplate TODO

- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
