### PR TITLE
GEODE-8627: Redis not unsubscribing and punsubscribing correctly when no channel/pattern provided

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
@@ -17,13 +17,10 @@ package org.apache.geode.redis.internal;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.experimental.categories.Category;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.GeodeRedisServerRule;
-import org.apache.geode.test.junit.categories.RedisTest;
 
-@Category({RedisTest.class})
 public class GeodeServerRunTest {
   @ClassRule
   public static GeodeRedisServerRule server = new GeodeRedisServerRule();

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
@@ -17,10 +17,13 @@ package org.apache.geode.redis.internal;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.GeodeRedisServerRule;
+import org.apache.geode.test.junit.categories.RedisTest;
 
+@Category({RedisTest.class})
 public class GeodeServerRunTest {
   @ClassRule
   public static GeodeRedisServerRule server = new GeodeRedisServerRule();

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
@@ -395,35 +395,6 @@ public abstract class AbstractPubSubIntegrationTest implements RedisPortSupplier
   }
 
   @Test
-  public void testUnsubscribingImplicitlyFromAllChannels() {
-    MockSubscriber mockSubscriber = new MockSubscriber();
-
-    Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "salutations", "yuletide");
-
-    Thread subscriberThread = new Thread(runnable);
-    subscriberThread.start();
-
-    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
-
-    mockSubscriber.unsubscribe();
-    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
-    waitFor(() -> !subscriberThread.isAlive());
-
-    List<String> unsubscribedChannels = mockSubscriber.unsubscribeInfos.stream()
-        .map(x -> x.channel)
-        .collect(Collectors.toList());
-    assertThat(unsubscribedChannels).containsExactlyInAnyOrder("salutations", "yuletide");
-
-    List<Integer> channelCounts = mockSubscriber.unsubscribeInfos.stream()
-        .map(x -> x.count)
-        .collect(Collectors.toList());
-    assertThat(channelCounts).containsExactlyInAnyOrder(1, 0);
-
-    Long result = publisher.publish("salutations", "greetings");
-    assertThat(result).isEqualTo(0);
-  }
-
-  @Test
   public void testPsubscribingAndPunsubscribingFromMultipleChannels() {
     MockSubscriber mockSubscriber = new MockSubscriber();
 
@@ -519,7 +490,6 @@ public abstract class AbstractPubSubIntegrationTest implements RedisPortSupplier
 
     return mockSubscriber.getReceivedEvents();
   }
-
 
   @Test
   public void testTwoSubscribersOneChannel() {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/DummySubscription.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/DummySubscription.java
@@ -25,6 +25,11 @@ import org.apache.geode.redis.internal.pubsub.Subscription;
 public class DummySubscription implements Subscription {
 
   @Override
+  public Type getType() {
+    return Type.CHANNEL;
+  }
+
+  @Override
   public boolean isEqualTo(Object channelOrPattern, Client client) {
     return false;
   }
@@ -49,12 +54,7 @@ public class DummySubscription implements Subscription {
   }
 
   @Override
-  public byte[] getChannelName() {
-    return null;
-  }
-
-  @Override
-  public byte[] getPatternName() {
+  public byte[] getSubscriptionName() {
     return null;
   }
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/DummySubscription.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/mocks/DummySubscription.java
@@ -54,6 +54,11 @@ public class DummySubscription implements Subscription {
   }
 
   @Override
+  public byte[] getPatternName() {
+    return null;
+  }
+
+  @Override
   public void readyToPublish() {}
 
   @Override

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -34,7 +34,7 @@ public class PingExecutor extends AbstractExecutor {
 
     context.eventLoopReady();
 
-    if (context.getPubSub().findSubscriptionsNames(context.getClient()).isEmpty()) {
+    if (context.getPubSub().findSubscriptionNames(context.getClient()).isEmpty()) {
       byte[] result;
       if (commandElems.size() > 1) {
         result = commandElems.get(1);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -34,8 +34,7 @@ public class PingExecutor extends AbstractExecutor {
 
     context.eventLoopReady();
 
-    if (context.getPubSub().findSubscribedChannels(context.getClient()).isEmpty()
-        && context.getPubSub().findSubscribedPatterns(context.getClient()).isEmpty()) {
+    if (context.getPubSub().findSubscriptionsNames(context.getClient()).isEmpty()) {
       byte[] result;
       if (commandElems.size() > 1) {
         result = commandElems.get(1);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -34,7 +34,8 @@ public class PingExecutor extends AbstractExecutor {
 
     context.eventLoopReady();
 
-    if (context.getPubSub().findSubscribedChannels(context.getClient()).isEmpty()) {
+    if (context.getPubSub().findSubscribedChannels(context.getClient()).isEmpty()
+        && context.getPubSub().findSubscribedPatterns(context.getClient()).isEmpty()) {
       byte[] result;
       if (commandElems.size() > 1) {
         result = commandElems.get(1);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PunsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PunsubscribeExecutor.java
@@ -30,6 +30,7 @@ import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.pubsub.Subscription;
 
 public class PunsubscribeExecutor extends AbstractExecutor {
   private static final Logger logger = LogService.getLogger();
@@ -42,7 +43,8 @@ public class PunsubscribeExecutor extends AbstractExecutor {
 
     List<byte[]> patternNames = extractPatternNames(command);
     if (patternNames.isEmpty()) {
-      patternNames = context.getPubSub().findSubscribedPatterns(context.getClient());
+      patternNames = context.getPubSub().findSubscriptionsNames(context.getClient(),
+          Subscription.Type.PATTERN);
     }
 
     Collection<Collection<?>> response = punsubscribe(context, patternNames);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PunsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PunsubscribeExecutor.java
@@ -43,7 +43,7 @@ public class PunsubscribeExecutor extends AbstractExecutor {
 
     List<byte[]> patternNames = extractPatternNames(command);
     if (patternNames.isEmpty()) {
-      patternNames = context.getPubSub().findSubscriptionsNames(context.getClient(),
+      patternNames = context.getPubSub().findSubscriptionNames(context.getClient(),
           Subscription.Type.PATTERN);
     }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
@@ -25,6 +25,7 @@ import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+import org.apache.geode.redis.internal.pubsub.Subscription;
 
 public class UnsubscribeExecutor extends AbstractExecutor {
 
@@ -36,7 +37,8 @@ public class UnsubscribeExecutor extends AbstractExecutor {
 
     List<byte[]> channelNames = extractChannelNames(command);
     if (channelNames.isEmpty()) {
-      channelNames = context.getPubSub().findSubscribedChannels(context.getClient());
+      channelNames = context.getPubSub().findSubscriptionsNames(context.getClient(),
+          Subscription.Type.CHANNEL);
     }
 
     Collection<Collection<?>> response = unsubscribe(context, channelNames);

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/UnsubscribeExecutor.java
@@ -37,7 +37,7 @@ public class UnsubscribeExecutor extends AbstractExecutor {
 
     List<byte[]> channelNames = extractChannelNames(command);
     if (channelNames.isEmpty()) {
-      channelNames = context.getPubSub().findSubscriptionsNames(context.getClient(),
+      channelNames = context.getPubSub().findSubscriptionNames(context.getClient(),
           Subscription.Type.CHANNEL);
     }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -298,7 +298,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
         return;
       }
 
-      if (!getPubSub().findSubscribedChannels(getClient()).isEmpty()) {
+      if (!getPubSub().findSubscribedChannels(getClient()).isEmpty()
+          || !getPubSub().findSubscribedPatterns(getClient()).isEmpty()) {
         if (!command.getCommandType().isAllowedWhileSubscribed()) {
           writeToChannel(RedisResponse
               .error("only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context"));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -298,8 +298,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
         return;
       }
 
-      if (!getPubSub().findSubscribedChannels(getClient()).isEmpty()
-          || !getPubSub().findSubscribedPatterns(getClient()).isEmpty()) {
+      if (!getPubSub().findSubscriptionsNames(getClient()).isEmpty()) {
         if (!command.getCommandType().isAllowedWhileSubscribed()) {
           writeToChannel(RedisResponse
               .error("only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context"));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -298,7 +298,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
         return;
       }
 
-      if (!getPubSub().findSubscriptionsNames(getClient()).isEmpty()) {
+      if (!getPubSub().findSubscriptionNames(getClient()).isEmpty()) {
         if (!command.getCommandType().isAllowedWhileSubscribed()) {
           writeToChannel(RedisResponse
               .error("only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT allowed in this context"));

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelSubscription.java
@@ -60,4 +60,9 @@ class ChannelSubscription extends AbstractSubscription {
   public byte[] getChannelName() {
     return channel;
   }
+
+  @Override
+  public byte[] getPatternName() {
+    return null;
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelSubscription.java
@@ -39,6 +39,11 @@ class ChannelSubscription extends AbstractSubscription {
   }
 
   @Override
+  public Type getType() {
+    return Type.CHANNEL;
+  }
+
+  @Override
   public List<Object> createResponse(byte[] channel, byte[] message) {
     return Arrays.asList("message", channel, message);
   }
@@ -57,12 +62,7 @@ class ChannelSubscription extends AbstractSubscription {
   }
 
   @Override
-  public byte[] getChannelName() {
+  public byte[] getSubscriptionName() {
     return channel;
-  }
-
-  @Override
-  public byte[] getPatternName() {
-    return null;
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
@@ -57,6 +57,11 @@ class PatternSubscription extends AbstractSubscription {
 
   @Override
   public byte[] getChannelName() {
+    return null;
+  }
+
+  @Override
+  public byte[] getPatternName() {
     return pattern.globPattern().getBytes();
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
@@ -40,6 +40,11 @@ class PatternSubscription extends AbstractSubscription {
   }
 
   @Override
+  public Type getType() {
+    return Type.PATTERN;
+  }
+
+  @Override
   public List<Object> createResponse(byte[] channel, byte[] message) {
     return Arrays.asList("pmessage", pattern.globPattern(), channel, message);
   }
@@ -56,12 +61,7 @@ class PatternSubscription extends AbstractSubscription {
   }
 
   @Override
-  public byte[] getChannelName() {
-    return null;
-  }
-
-  @Override
-  public byte[] getPatternName() {
+  public byte[] getSubscriptionName() {
     return pattern.globPattern().getBytes();
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -88,4 +88,12 @@ public interface PubSub {
    */
   List<byte[]> findSubscribedChannels(Client client);
 
+  /**
+   * Return a list of pattern names that a client has subscribed to
+   *
+   * @param client the Client which is to be queried
+   * @return the list of patterns
+   */
+  List<byte[]> findSubscribedPatterns(Client client);
+
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -86,7 +86,7 @@ public interface PubSub {
    * @param client the Client which is to be queried
    * @return the list of channels or patterns
    */
-  List<byte[]> findSubscriptionsNames(Client client, Subscription.Type type);
+  List<byte[]> findSubscriptionNames(Client client, Subscription.Type type);
 
   /**
    * Return a list of channel names and patterns that a client has subscribed to
@@ -94,6 +94,6 @@ public interface PubSub {
    * @param client the Client which is to be queried
    * @return the list of channels and patterns
    */
-  List<byte[]> findSubscriptionsNames(Client client);;
+  List<byte[]> findSubscriptionNames(Client client);;
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -81,19 +81,19 @@ public interface PubSub {
   long punsubscribe(GlobPattern pattern, Client client);
 
   /**
-   * Return a list of channel names that a client has subscribed to
+   * Return a list of channel names or patterns that a client has subscribed to
    *
    * @param client the Client which is to be queried
-   * @return the list of channels
+   * @return the list of channels or patterns
    */
-  List<byte[]> findSubscribedChannels(Client client);
+  List<byte[]> findSubscriptionsNames(Client client, Subscription.Type type);
 
   /**
-   * Return a list of pattern names that a client has subscribed to
+   * Return a list of channel names and patterns that a client has subscribed to
    *
    * @param client the Client which is to be queried
-   * @return the list of patterns
+   * @return the list of channels and patterns
    */
-  List<byte[]> findSubscribedPatterns(Client client);
+  List<byte[]> findSubscriptionsNames(Client client);;
 
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -139,16 +139,16 @@ public class PubSubImpl implements PubSub {
   }
 
   @Override
-  public List<byte[]> findSubscriptionsNames(Client client) {
+  public List<byte[]> findSubscriptionNames(Client client) {
     return subscriptions.findSubscriptions(client).stream()
         .map(Subscription::getSubscriptionName)
         .collect(Collectors.toList());
   }
 
   @Override
-  public List<byte[]> findSubscriptionsNames(Client client, Subscription.Type type) {
+  public List<byte[]> findSubscriptionNames(Client client, Subscription.Type type) {
     return subscriptions.findSubscriptions(client).stream()
-        .filter(s -> s.getType().equals(type))
+        .filter(s -> s.getType() == (type))
         .map(Subscription::getSubscriptionName)
         .collect(Collectors.toList());
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -18,7 +18,6 @@ package org.apache.geode.redis.internal.pubsub;
 
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -140,18 +139,17 @@ public class PubSubImpl implements PubSub {
   }
 
   @Override
-  public List<byte[]> findSubscribedChannels(Client client) {
+  public List<byte[]> findSubscriptionsNames(Client client) {
     return subscriptions.findSubscriptions(client).stream()
-        .map(Subscription::getChannelName)
-        .filter(Objects::nonNull)
+        .map(Subscription::getSubscriptionName)
         .collect(Collectors.toList());
   }
 
   @Override
-  public List<byte[]> findSubscribedPatterns(Client client) {
+  public List<byte[]> findSubscriptionsNames(Client client, Subscription.Type type) {
     return subscriptions.findSubscriptions(client).stream()
-        .map(Subscription::getPatternName)
-        .filter(Objects::nonNull)
+        .filter(s -> s.getType().equals(type))
+        .map(Subscription::getSubscriptionName)
         .collect(Collectors.toList());
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.pubsub;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -142,6 +143,15 @@ public class PubSubImpl implements PubSub {
   public List<byte[]> findSubscribedChannels(Client client) {
     return subscriptions.findSubscriptions(client).stream()
         .map(Subscription::getChannelName)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<byte[]> findSubscribedPatterns(Client client) {
+    return subscriptions.findSubscriptions(client).stream()
+        .map(Subscription::getPatternName)
+        .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscription.java
@@ -53,10 +53,14 @@ public interface Subscription {
   List<Object> createResponse(byte[] channel, byte[] message);
 
   /**
-   * Return the subscription name. In the case of a pattern the string representation of the
-   * pattern is returned.
+   * Return the channel name. In the case of a pattern null is returned.
    */
   byte[] getChannelName();
+
+  /**
+   * Return the pattern name. In the case of a channel null is returned.
+   */
+  byte[] getPatternName();
 
   /**
    * Called once this subscriber is ready to have publishMessage called

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscription.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscription.java
@@ -25,6 +25,13 @@ import org.apache.geode.redis.internal.netty.Client;
  * Interface that represents the relationship between a channel or pattern and client.
  */
 public interface Subscription {
+  enum Type {
+    CHANNEL,
+    PATTERN;
+  }
+
+  Type getType();
+
   /**
    * Equality of a subscription is represented by a combination of client and one of channel or
    * pattern
@@ -53,14 +60,9 @@ public interface Subscription {
   List<Object> createResponse(byte[] channel, byte[] message);
 
   /**
-   * Return the channel name. In the case of a pattern null is returned.
+   * Return the channel or pattern name.
    */
-  byte[] getChannelName();
-
-  /**
-   * Return the pattern name. In the case of a channel null is returned.
-   */
-  byte[] getPatternName();
+  byte[] getSubscriptionName();
 
   /**
    * Called once this subscriber is ready to have publishMessage called

--- a/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
+++ b/geode-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-redis-serializables.txt
@@ -15,3 +15,4 @@ org/apache/geode/redis/internal/gfsh/RedisCommandFunction,false
 org/apache/geode/redis/internal/netty/CoderException,true,4707944288714910949
 org/apache/geode/redis/internal/netty/RedisCommandParserException,true,4707944288714910949
 org/apache/geode/redis/internal/pubsub/PubSubImpl$1,false,this$0:org/apache/geode/redis/internal/pubsub/PubSubImpl
+org/apache/geode/redis/internal/pubsub/Subscription$Type,false


### PR DESCRIPTION
Geode Redis should unsubscribe from all channels (not including patterns) when no channel is provided and punsubscribe from all patterns (not including channels) when no pattern is provided.