### PR TITLE
GEODE-8632: Redis Unknown command error message should have trailing space

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
@@ -45,13 +45,20 @@ public abstract class AbstractUnknownIntegrationTest implements RedisPortSupplie
   @Test
   public void givenUnknownCommand_returnsUnknownCommandError() {
     assertThatThrownBy(() -> jedis.sendCommand("fhqwhgads"::getBytes))
-        .hasMessageContaining("ERR unknown command `fhqwhgads`, with args beginning with:");
+        .hasMessage("ERR unknown command `fhqwhgads`, with args beginning with: ");
   }
 
   @Test
   public void givenUnknownCommand_withArguments_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(() -> jedis.sendCommand("fhqwhgads"::getBytes, "EVERYBODY", "TO THE LIMIT"))
-        .hasMessageContaining(
-            "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, `TO THE LIMIT`,");
+        .hasMessage(
+            "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, `TO THE LIMIT`, ");
+  }
+
+  @Test
+  public void givenUnknownCommand_withEmptyStringArgument_returnsUnknownCommandErrorWithArgumentsListed() {
+    assertThatThrownBy(() -> jedis.sendCommand("fhqwhgads"::getBytes, "EVERYBODY", ""))
+        .hasMessage(
+            "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, ``, ");
   }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -32,7 +32,7 @@ public class RedisConstants {
   public static final String SERVER_ERROR_SHUTDOWN = "The server is shutting down";
   public static final String ERROR_CURSOR = "invalid cursor";
   public static final String ERROR_UNKNOWN_COMMAND =
-      "unknown command `%s`, with args beginning with:%s";
+      "unknown command `%s`, with args beginning with: %s";
   public static final String ERROR_UNSUPPORTED_COMMAND =
       " is not supported. To enable all unsupported commands use GFSH to execute: 'redis --enable-unsupported-commands'. Unsupported commands have not been fully tested.";
   public static final String ERROR_OUT_OF_RANGE = "The number provided is out of range";

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/UnknownExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/UnknownExecutor.java
@@ -38,11 +38,11 @@ public class UnknownExecutor extends AbstractExecutor {
 
       if (commandElems.size() > 1) {
         for (int i = 1; i < commandElems.size(); i++) {
-          if (commandElems.get(i) == null || commandElems.get(i).length == 0) {
-            continue; // skip blanks
+          if (commandElems.get(i) == null) {
+            continue;
           }
-          commandArguments.append(" `").append(Coder.bytesToString(commandElems.get(i)))
-              .append("`,");
+          commandArguments.append("`").append(Coder.bytesToString(commandElems.get(i)))
+              .append("`, ");
         }
       }
     }


### PR DESCRIPTION
Unknown command error message should have trailing space like native Redis.