### PR TITLE
GEODE-8645: Reduce netty threads used by PubSubIntegrationTest

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubIntegrationTest.java
@@ -20,6 +20,11 @@ import org.junit.ClassRule;
 import org.apache.geode.redis.GeodeRedisServerRule;
 
 public class PubSubIntegrationTest extends AbstractPubSubIntegrationTest {
+
+  static {
+    System.setProperty("io.netty.eventLoopThreads", "10");
+  }
+
   @ClassRule
   public static GeodeRedisServerRule server = new GeodeRedisServerRule();
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubIntegrationTest.java
@@ -16,17 +16,19 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import org.junit.ClassRule;
+import org.junit.contrib.java.lang.system.ProvideSystemProperty;
+import org.junit.rules.RuleChain;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 
 public class PubSubIntegrationTest extends AbstractPubSubIntegrationTest {
 
-  static {
-    System.setProperty("io.netty.eventLoopThreads", "10");
-  }
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
 
   @ClassRule
-  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+  public static RuleChain chain = RuleChain.outerRule(
+      new ProvideSystemProperty("io.netty.eventLoopThreads", "10"))
+      .around(server);
 
   @Override
   public int getPort() {


### PR DESCRIPTION
- Allows this test not to run out of memory when run under StressNewTest

Authored-by: Jens Deppe <jdeppe@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
