### PR TITLE
GEODE-8659: Consolidating locator-wait-time tests

### DIFF
--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/MembershipIntegrationTest.java
@@ -187,99 +187,8 @@ public class MembershipIntegrationTest {
   }
 
   @Test
-  public void secondMembershipPausesForLocatorWaitTime()
-      throws IOException, MemberStartupException, InterruptedException {
-
-    /*
-     * Start a locator for the coordinator (membership) so we have a port for it.
-     *
-     * Its locator-wait-time is set to 0 so it eventually (soon after membership is started) forms a
-     * distributed system and becomes a coordinator.
-     */
-
-    final MembershipLocator<MemberIdentifier> coordinatorLocator = createLocator(0);
-    coordinatorLocator.start();
-    final int coordinatorLocatorPort = coordinatorLocator.getPort();
-
-    final Membership<MemberIdentifier> coordinatorMembership =
-        createMembership(coordinatorLocator, coordinatorLocatorPort);
-
-    /*
-     * We have not even started the membership yet — connection attempts will certainly fail until
-     * we do. This is a bit like the locator (host) not being present in DNS (yet).
-     */
-
-    /*
-     * Start a second locator and membership trying to join via the coordinator (membership) that
-     * hasn't yet started behind the port.
-     *
-     * Set its locator-wait-time so it'll not become a coordinator right away, allowing time for the
-     * other member to start and become a coordinator.
-     */
-
-    final MembershipLocator<MemberIdentifier> lateJoiningLocator = createLocator(0);
-    lateJoiningLocator.start();
-    final int lateJoiningLocatorPort = lateJoiningLocator.getPort();
-
-    final int[] locatorPorts = new int[] {coordinatorLocatorPort, lateJoiningLocatorPort};
-
-    // minimum duration a locator waits to become the coordinator, regardless of locatorWaitTime
-    final Duration minimumJoinWaitTime = Duration
-        // amount of sleep time per retry in GMSJoinLeave.join()
-        .ofMillis(JOIN_RETRY_SLEEP + FIND_LOCATOR_RETRY_SLEEP)
-        // expected number of retries in GMSJoinLeave.join()
-        .multipliedBy(getMinimumRetriesBeforeBecomingCoordinator(locatorPorts.length));
-
-    /*
-     * By setting locatorWaitTime to 10x the minimumJoinWaitTime, we are trying to make sure the
-     * locatorWaitTime is sufficiently larger than the minimum so we can reliably detect whether
-     * the lateJoiningMembership is waiting for the full locatorWaitTime and not just the minimum
-     * wait time.
-     */
-    final int locatorWaitTime = (int) (10 * minimumJoinWaitTime.getSeconds());
-
-    final MembershipConfig lateJoiningMembershipConfig =
-        createMembershipConfig(true, locatorWaitTime, locatorPorts);
-    final Membership<MemberIdentifier> lateJoiningMembership =
-        createMembership(lateJoiningMembershipConfig, lateJoiningLocator);
-
-    CompletableFuture<Void> lateJoiningMembershipStartup = executorServiceRule.runAsync(() -> {
-      try {
-        start(lateJoiningMembership);
-      } catch (MemberStartupException e) {
-        throw new RuntimeException(e);
-      }
-    });
-
-    /*
-     * By sleeping for 2x the minimumJoinWaitTime, we are trying to make sure we sleep for
-     * longer than the minimum but shorter than the locatorWaitTime so we can detect whether the
-     * lateJoiningMembership is waiting for the full locatorWaitTime and not just the minimum
-     * wait time.
-     */
-    Thread.sleep(2 * minimumJoinWaitTime.toMillis());
-
-    /*
-     * Now start the coordinator (membership), after waiting longer than the minimum wait time for
-     * connecting to a locator but shorter than the locator-wait-time.
-     */
-    start(coordinatorMembership);
-
-    await().untilAsserted(() -> assertThat(lateJoiningMembershipStartup).isCompleted());
-
-    await().untilAsserted(
-        () -> assertThat(coordinatorMembership.getView().getMembers()).hasSize(2));
-    await().untilAsserted(
-        () -> assertThat(lateJoiningMembership.getView().getMembers()).hasSize(2));
-
-    stop(coordinatorMembership, lateJoiningMembership);
-    stop(coordinatorLocator, lateJoiningLocator);
-  }
-
-  @Test
-  public void locatorsStopWaitingForLocatorWaitTimeIfAllLocatorsContacted()
-      throws IOException, MemberStartupException, InterruptedException, TimeoutException,
-      ExecutionException {
+  public void locatorWaitsForLocatorWaitTimeUntilAllLocatorsContacted()
+      throws InterruptedException, TimeoutException, ExecutionException {
 
     final Supplier<ExecutorService> executorServiceSupplier =
         () -> LoggingExecutors.newCachedThreadPool("membership", false);
@@ -290,15 +199,39 @@ public class MembershipIntegrationTest {
     final MembershipConfig config =
         createMembershipConfig(true, locatorWaitTime, locatorPorts[0], locatorPorts[1]);
 
+    /*
+     * Start a locator trying to contact the locator that hasn't started it's port
+     *
+     * Set its locator-wait-time so it'll not become a coordinator right away, allowing time for the
+     * other member to start and become a coordinator.
+     */
     CompletableFuture<Membership<MemberIdentifier>> createMembership0 =
         launchLocator(executorServiceSupplier, locatorPorts[0], config);
 
-    // Assert that membership 0 is waiting for the other locator to start
-    Thread.sleep(5000);
+    // minimum duration a locator waits to become the coordinator, regardless of locatorWaitTime
+    final Duration minimumJoinWaitTime = Duration
+        // amount of sleep time per retry in GMSJoinLeave.join()
+        .ofMillis(JOIN_RETRY_SLEEP + FIND_LOCATOR_RETRY_SLEEP)
+        // expected number of retries in GMSJoinLeave.join()
+        .multipliedBy(getMinimumRetriesBeforeBecomingCoordinator(locatorPorts.length));
+
+    /*
+     * By sleeping for 2x the minimumJoinWaitTime, we are trying to make sure we sleep for
+     * longer than the minimum but shorter than the locatorWaitTime so we can detect whether the
+     * lateJoiningMembership is waiting for the full locatorWaitTime and not just the minimum
+     * wait time.
+     */
+    Thread.sleep(2 * minimumJoinWaitTime.toMillis());
+
     assertThat(createMembership0.getNow(null)).isNull();
 
+    /*
+     * Now start the other locator, after waiting longer than the minimum wait time for
+     * connecting to a locator but shorter than the locator-wait-time.
+     */
     CompletableFuture<Membership<MemberIdentifier>> createMembership1 =
         launchLocator(executorServiceSupplier, locatorPorts[1], config);
+
 
     // Make sure the members are created in less than the locator-wait-time
     Membership<MemberIdentifier> membership0 = createMembership0.get(2, TimeUnit.MINUTES);
@@ -307,7 +240,10 @@ public class MembershipIntegrationTest {
     // Make sure the members see each other in the view
     await().untilAsserted(() -> assertThat(membership0.getView().getMembers()).hasSize(2));
     await().untilAsserted(() -> assertThat(membership1.getView().getMembers()).hasSize(2));
+
+    stop(membership0, membership1);
   }
+
 
   private CompletableFuture<Membership<MemberIdentifier>> launchLocator(
       Supplier<ExecutorService> executorServiceSupplier, int locatorPort, MembershipConfig config) {


### PR DESCRIPTION
We had two different tests of this functionality that were testing almost the
same thing. The first test had a slightly odd configuration - only one of the
locators knew about the other.

Combining these into a single test that locators wait for locator-wait-time and
stop waiting when all locators are found.