### PR TITLE
Geode-8677: Confirm binary data storage

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -167,7 +167,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.springframework.hateoas', name: 'spring-hateoas', version: '1.1.2.RELEASE')
         api(group: 'org.springframework.ldap', name: 'spring-ldap-core', version: '2.3.2.RELEASE')
         api(group: 'org.springframework.shell', name: 'spring-shell', version: '1.2.0.RELEASE')
-        api(group: 'org.testcontainers', name: 'testcontainers', version: '1.14.3')
+        api(group: 'org.testcontainers', name: 'testcontainers', version: '1.15.0-rc2')
         api(group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.0')
         api(group: 'redis.clients', name: 'jedis', version: '3.3.0')
         api(group: 'io.lettuce', name: 'lettuce-core', version: '5.3.4.RELEASE')

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -167,7 +167,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.springframework.hateoas', name: 'spring-hateoas', version: '1.1.2.RELEASE')
         api(group: 'org.springframework.ldap', name: 'spring-ldap-core', version: '2.3.2.RELEASE')
         api(group: 'org.springframework.shell', name: 'spring-shell', version: '1.2.0.RELEASE')
-        api(group: 'org.testcontainers', name: 'testcontainers', version: '1.15.0-rc2')
+        api(group: 'org.testcontainers', name: 'testcontainers', version: '1.14.3')
         api(group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.0')
         api(group: 'redis.clients', name: 'jedis', version: '3.3.0')
         api(group: 'io.lettuce', name: 'lettuce-core', version: '5.3.4.RELEASE')

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractAppendIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractAppendIntegrationTest.java
@@ -16,6 +16,9 @@ package org.apache.geode.redis.internal.executor.string;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -99,6 +102,22 @@ public abstract class AbstractAppendIntegrationTest implements RedisPortSupplier
     byte[] result = jedis.get(blob);
 
     assertThat(result).isEqualTo(doubleBlob);
+  }
+
+  @Test
+  public void testAppend_withUTF16KeyAndValue() throws IOException {
+    String test_utf16_string = "最𐐷𤭢";
+    byte[] testBytes = test_utf16_string.getBytes(StandardCharsets.UTF_16);
+
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    output.write(testBytes);
+    output.write(testBytes);
+    byte[] appendedBytes = output.toByteArray();
+
+    jedis.set(testBytes, testBytes);
+    jedis.append(testBytes, testBytes);
+    byte[] result = jedis.get(testBytes);
+    assertThat(result).isEqualTo(appendedBytes);
   }
 
   private String randString() {

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetRangeIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetRangeIntegrationTest.java
@@ -18,6 +18,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -143,6 +145,66 @@ public abstract class AbstractGetRangeIntegrationTest implements RedisPortSuppli
 
     String fromAfterStartToEndByNegativeOffset = jedis.getrange(key, 2, -1);
     assertThat(fromAfterStartToEndByNegativeOffset).isEqualTo("c123babyyouknowme");
+  }
+
+  @Test
+  public void testGetRange_whenValidSubrangeSpecified_binaryData_returnsAppropriateSubstring() {
+    byte[] keyWith13Chars =
+        new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'};
+
+    jedis.set(keyWith13Chars, keyWith13Chars);
+
+    byte[] fromStartToBeforeEnd = jedis.getrange(keyWith13Chars, 0, 10);
+    assertThat(fromStartToBeforeEnd).isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
+
+    byte[] fromStartByNegativeOffsetToBeforeEnd = jedis.getrange(keyWith13Chars, -19, 10);
+    assertThat(fromStartByNegativeOffsetToBeforeEnd).isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
+
+    byte[] fromStartToBeforeEndByNegativeOffset = jedis.getrange(keyWith13Chars, 0, -3);
+    assertThat(fromStartToBeforeEndByNegativeOffset).isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
+
+    byte[] fromAfterStartToBeforeEnd = jedis.getrange(keyWith13Chars, 2, 10);
+    assertThat(fromAfterStartToBeforeEnd).isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
+
+    byte[] fromAfterStartByNegativeOffsetToBeforeEndByNegativeOffset = jedis.getrange(keyWith13Chars, -10, -2);
+    assertThat(fromAfterStartByNegativeOffsetToBeforeEndByNegativeOffset)
+        .isEqualTo(new byte[] {4, 0, 5, 's', 't', 'r', 'i', 'n', 'g'});
+
+    byte[] fromAfterStartToEnd = jedis.getrange(keyWith13Chars, 2, 13);
+    assertThat(fromAfterStartToEnd).isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'});
+
+    byte[] fromAfterStartToEndByNegativeOffset = jedis.getrange(keyWith13Chars, 2, -1);
+    assertThat(fromAfterStartToEndByNegativeOffset).isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'});
+  }
+
+  @Test
+  public void testGetRange_whenValidSubrangeSpecified_utf16Data_returnsAppropriateSubstring() {
+    String utf16string = "最𐐷𤭢";
+    byte[] key = utf16string.getBytes(StandardCharsets.UTF_16);
+
+    jedis.set(key, key);
+
+    byte[] fromStartToBeforeEnd = jedis.getrange(key, 0, 4);
+    assertThat(fromStartToBeforeEnd).isEqualTo(new byte[] {-2, -1, 103, 0, -40});
+
+    byte[] fromStartByNegativeOffsetToBeforeEnd = jedis.getrange(key, -19, 4);
+    assertThat(fromStartByNegativeOffsetToBeforeEnd).isEqualTo(new byte[] {-2, -1, 103, 0, -40});
+
+    byte[] fromStartToBeforeEndByNegativeOffset = jedis.getrange(key, 0, -2);
+    assertThat(fromStartToBeforeEndByNegativeOffset).isEqualTo(new byte[] {-2, -1, 103, 0, -40, 1, -36, 55, -40, 82, -33});
+
+    byte[] fromAfterStartToBeforeEnd = jedis.getrange(key, 2, 4);
+    assertThat(fromAfterStartToBeforeEnd).isEqualTo(new byte[] {103, 0, -40});
+
+    byte[] fromAfterStartByNegativeOffsetToBeforeEndByNegativeOffset = jedis.getrange(key, -10, -2);
+    assertThat(fromAfterStartByNegativeOffsetToBeforeEndByNegativeOffset)
+        .isEqualTo(new byte[] {103, 0, -40, 1, -36, 55, -40, 82, -33});
+
+    byte[] fromAfterStartToEnd = jedis.getrange(key, 2, 10);
+    assertThat(fromAfterStartToEnd).isEqualTo(new byte[] {103, 0, -40, 1, -36, 55, -40, 82, -33});
+
+    byte[] fromAfterStartToEndByNegativeOffset = jedis.getrange(key, 2, -1);
+    assertThat(fromAfterStartToEndByNegativeOffset).isEqualTo(new byte[] {103, 0, -40, 1, -36, 55, -40, 82, -33, 98});
   }
 
   @Test

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetRangeIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetRangeIntegrationTest.java
@@ -155,26 +155,33 @@ public abstract class AbstractGetRangeIntegrationTest implements RedisPortSuppli
     jedis.set(keyWith13Chars, keyWith13Chars);
 
     byte[] fromStartToBeforeEnd = jedis.getrange(keyWith13Chars, 0, 10);
-    assertThat(fromStartToBeforeEnd).isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
+    assertThat(fromStartToBeforeEnd)
+        .isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
 
     byte[] fromStartByNegativeOffsetToBeforeEnd = jedis.getrange(keyWith13Chars, -19, 10);
-    assertThat(fromStartByNegativeOffsetToBeforeEnd).isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
+    assertThat(fromStartByNegativeOffsetToBeforeEnd)
+        .isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
 
     byte[] fromStartToBeforeEndByNegativeOffset = jedis.getrange(keyWith13Chars, 0, -3);
-    assertThat(fromStartToBeforeEndByNegativeOffset).isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
+    assertThat(fromStartToBeforeEndByNegativeOffset)
+        .isEqualTo(new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
 
     byte[] fromAfterStartToBeforeEnd = jedis.getrange(keyWith13Chars, 2, 10);
-    assertThat(fromAfterStartToBeforeEnd).isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
+    assertThat(fromAfterStartToBeforeEnd)
+        .isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n'});
 
-    byte[] fromAfterStartByNegativeOffsetToBeforeEndByNegativeOffset = jedis.getrange(keyWith13Chars, -10, -2);
+    byte[] fromAfterStartByNegativeOffsetToBeforeEndByNegativeOffset =
+        jedis.getrange(keyWith13Chars, -10, -2);
     assertThat(fromAfterStartByNegativeOffsetToBeforeEndByNegativeOffset)
         .isEqualTo(new byte[] {4, 0, 5, 's', 't', 'r', 'i', 'n', 'g'});
 
     byte[] fromAfterStartToEnd = jedis.getrange(keyWith13Chars, 2, 13);
-    assertThat(fromAfterStartToEnd).isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'});
+    assertThat(fromAfterStartToEnd)
+        .isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'});
 
     byte[] fromAfterStartToEndByNegativeOffset = jedis.getrange(keyWith13Chars, 2, -1);
-    assertThat(fromAfterStartToEndByNegativeOffset).isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'});
+    assertThat(fromAfterStartToEndByNegativeOffset)
+        .isEqualTo(new byte[] {0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'});
   }
 
   @Test
@@ -191,7 +198,8 @@ public abstract class AbstractGetRangeIntegrationTest implements RedisPortSuppli
     assertThat(fromStartByNegativeOffsetToBeforeEnd).isEqualTo(new byte[] {-2, -1, 103, 0, -40});
 
     byte[] fromStartToBeforeEndByNegativeOffset = jedis.getrange(key, 0, -2);
-    assertThat(fromStartToBeforeEndByNegativeOffset).isEqualTo(new byte[] {-2, -1, 103, 0, -40, 1, -36, 55, -40, 82, -33});
+    assertThat(fromStartToBeforeEndByNegativeOffset)
+        .isEqualTo(new byte[] {-2, -1, 103, 0, -40, 1, -36, 55, -40, 82, -33});
 
     byte[] fromAfterStartToBeforeEnd = jedis.getrange(key, 2, 4);
     assertThat(fromAfterStartToBeforeEnd).isEqualTo(new byte[] {103, 0, -40});
@@ -204,7 +212,8 @@ public abstract class AbstractGetRangeIntegrationTest implements RedisPortSuppli
     assertThat(fromAfterStartToEnd).isEqualTo(new byte[] {103, 0, -40, 1, -36, 55, -40, 82, -33});
 
     byte[] fromAfterStartToEndByNegativeOffset = jedis.getrange(key, 2, -1);
-    assertThat(fromAfterStartToEndByNegativeOffset).isEqualTo(new byte[] {103, 0, -40, 1, -36, 55, -40, 82, -33, 98});
+    assertThat(fromAfterStartToEndByNegativeOffset)
+        .isEqualTo(new byte[] {103, 0, -40, 1, -36, 55, -40, 82, -33, 98});
   }
 
   @Test

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractLettuceAppendIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractLettuceAppendIntegrationTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.string;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.lettuce.core.RedisClient;
+import io.lettuce.core.api.StatefulRedisConnection;
+import io.lettuce.core.api.sync.RedisCommands;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.rules.RedisPortSupplier;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+public abstract class AbstractLettuceAppendIntegrationTest implements RedisPortSupplier {
+
+  protected RedisClient client;
+
+  @ClassRule
+  public static ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  @Before
+  public void before() {
+    client = RedisClient.create("redis://localhost:" + getPort());
+  }
+
+  @After
+  public void after() {
+    client.shutdown();
+  }
+
+  @Test
+  public void testAppend_withUTF16KeyAndValue() {
+    String test_utf16_string = "最𐐷𤭢";
+    String double_utf16_string = test_utf16_string + test_utf16_string;
+
+    StatefulRedisConnection<String, String> redisConnection = client.connect();
+    RedisCommands<String, String> syncCommands = redisConnection.sync();
+
+    syncCommands.set(test_utf16_string, test_utf16_string);
+    syncCommands.append(test_utf16_string, test_utf16_string);
+    String result = syncCommands.get(test_utf16_string);
+    assertThat(result).isEqualTo(double_utf16_string);
+  }
+}

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractStrLenIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractStrLenIntegrationTest.java
@@ -17,6 +17,8 @@ package org.apache.geode.redis.internal.executor.string;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -97,6 +99,15 @@ public abstract class AbstractStrLenIntegrationTest implements RedisPortSupplier
     jedis.set(zero, zero);
 
     assertThat(jedis.strlen(zero)).isEqualTo(1);
+  }
+
+  @Test
+  public void testStrlen_withUTF16BinaryData() {
+    String test_utf16_string = "最𐐷𤭢";
+    byte[] testBytes = test_utf16_string.getBytes(StandardCharsets.UTF_16);
+    jedis.set(testBytes, testBytes);
+
+    assertThat(jedis.strlen(testBytes)).isEqualTo(12);
   }
 
   @Test

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/LettuceAppendIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/LettuceAppendIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.string;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+
+public class LettuceAppendIntegrationTest extends AbstractLettuceAppendIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
+
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -15,7 +15,6 @@
  */
 package org.apache.geode.redis.internal.netty;
 
-import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.util.Collection;
@@ -329,11 +328,7 @@ public class Coder {
     if (bytes == null) {
       return null;
     }
-    try {
-      return new String(bytes, CHARSET);
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
+    return new String(bytes);
   }
 
   public static String doubleToString(double d) {
@@ -355,11 +350,7 @@ public class Coder {
     if (string == null) {
       return null;
     }
-    try {
-      return string.getBytes(CHARSET);
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
+    return string.getBytes();
   }
 
   /*


### PR DESCRIPTION
Remove a forced encoding to UTF-8, and confirm that other forms of binary data are sent and received in the same way as native Redis.