### PR TITLE
GEODE-8683: Honor maximum-time-between-pings in gateway receiver

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/Acceptor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/Acceptor.java
@@ -105,4 +105,6 @@ public interface Acceptor extends CommBufferPool {
   void unregisterServerConnection(ServerConnection serverConnection);
 
   void decClientServerConnectionCount();
+
+  int getMaximumTimeBetweenPings();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/AcceptorImpl.java
@@ -121,6 +121,7 @@ public class AcceptorImpl implements Acceptor, Runnable {
   private final CacheServerStats stats;
   private final int maxConnections;
   private final int maxThreads;
+  private final int maximumTimeBetweenPings;
 
   private final ExecutorService pool;
   /**
@@ -635,6 +636,7 @@ public class AcceptorImpl implements Acceptor, Runnable {
     this.socketBufferSize = socketBufferSize;
 
     // Create the singleton ClientHealthMonitor
+    this.maximumTimeBetweenPings = maximumTimeBetweenPings;
     healthMonitor = clientHealthMonitorProvider.get(internalCache, maximumTimeBetweenPings,
         clientNotifier.getStats());
 
@@ -1861,6 +1863,11 @@ public class AcceptorImpl implements Acceptor, Runnable {
     }
 
     releaseCommBuffer(Message.setTLCommBuffer(null));
+  }
+
+  @Override
+  public int getMaximumTimeBetweenPings() {
+    return maximumTimeBetweenPings;
   }
 
   private static class ClientQueueInitializerTask implements Runnable {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientHealthMonitor.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.cache.tier.sockets;
 
+
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -69,6 +70,12 @@ public class ClientHealthMonitor {
       new ConcurrentHashMap<>();
 
   /**
+   * The map of known clients and maximum time between pings.
+   */
+  private ConcurrentMap<ClientProxyMembershipID, Integer> clientMaximumTimeBetweenPings =
+      new ConcurrentHashMap<>();
+
+  /**
    * THe GemFire <code>Cache</code>
    */
   private final InternalCache cache;
@@ -77,7 +84,7 @@ public class ClientHealthMonitor {
     return maximumTimeBetweenPings;
   }
 
-  private final int maximumTimeBetweenPings;
+  private volatile int maximumTimeBetweenPings;
 
   /**
    * A thread that validates client connections
@@ -191,12 +198,19 @@ public class ClientHealthMonitor {
     refCount = 0;
   }
 
+  public void registerClient(ClientProxyMembershipID proxyID) {
+    registerClient(proxyID, maximumTimeBetweenPings);
+  }
+
   /**
    * Registers a new client to be monitored.
    *
    * @param proxyID The id of the client to be registered
    */
-  public void registerClient(ClientProxyMembershipID proxyID) {
+  public void registerClient(ClientProxyMembershipID proxyID, int maximumTimeBetweenPings) {
+    if (!clientMaximumTimeBetweenPings.containsKey(proxyID)) {
+      clientMaximumTimeBetweenPings.putIfAbsent(proxyID, maximumTimeBetweenPings);
+    }
     if (!clientHeartbeats.containsKey(proxyID)) {
       if (null == clientHeartbeats.putIfAbsent(proxyID,
           new AtomicLong(System.currentTimeMillis()))) {
@@ -233,6 +247,7 @@ public class ClientHealthMonitor {
       }
       expireTXStates(proxyID);
     }
+    clientMaximumTimeBetweenPings.remove(proxyID);
   }
 
   /**
@@ -349,7 +364,7 @@ public class ClientHealthMonitor {
 
     AtomicLong heartbeat = clientHeartbeats.get(proxyID);
     if (null == heartbeat) {
-      registerClient(proxyID);
+      registerClient(proxyID, getMaximumTimeBetweenPings(proxyID));
     } else {
       heartbeat.set(System.currentTimeMillis());
     }
@@ -581,6 +596,7 @@ public class ClientHealthMonitor {
    *
    * @param cache The GemFire <code>Cache</code>
    * @param maximumTimeBetweenPings The maximum time allowed between pings before determining the
+   *        client has died and interrupting its sockets
    */
   protected static synchronized void createInstance(InternalCache cache,
       int maximumTimeBetweenPings, CacheClientNotifierStats stats) {
@@ -597,6 +613,7 @@ public class ClientHealthMonitor {
    *
    * @param cache The GemFire <code>Cache</code>
    * @param maximumTimeBetweenPings The maximum time allowed between pings before determining the
+   *        client has died and interrupting its sockets
    */
   private ClientHealthMonitor(InternalCache cache, int maximumTimeBetweenPings,
       CacheClientNotifierStats stats) {
@@ -658,6 +675,10 @@ public class ClientHealthMonitor {
 
   public boolean hasDeltaClients() {
     return getNumberOfClientsAtOrAboveVersion(KnownVersion.GFE_61) > 0;
+  }
+
+  private int getMaximumTimeBetweenPings(ClientProxyMembershipID proxyID) {
+    return clientMaximumTimeBetweenPings.getOrDefault(proxyID, maximumTimeBetweenPings);
   }
 
   /**
@@ -786,8 +807,9 @@ public class ClientHealthMonitor {
                     (currentTime - latestHeartbeat), proxyID);
               }
 
+              int maximumTimeBetweenPingsForClient = getMaximumTimeBetweenPings(proxyID);
               if (checkHeartbeat.timedOut(currentTime, latestHeartbeat,
-                  _maximumTimeBetweenPings)) {
+                  maximumTimeBetweenPingsForClient)) {
                 // This client has been idle for too long. Determine whether
                 // any of its ServerConnection threads are currently processing
                 // a message. If so, let it go. If not, disconnect it.
@@ -795,7 +817,8 @@ public class ClientHealthMonitor {
                   if (cleanupClientThreads(proxyID, true)) {
                     logger.warn(
                         "Monitoring client with member id {}. It had been {} ms since the latest heartbeat. Max interval is {}. Terminated client.",
-                        entry.getKey(), currentTime - latestHeartbeat, _maximumTimeBetweenPings);
+                        entry.getKey(), currentTime - latestHeartbeat,
+                        maximumTimeBetweenPingsForClient);
                   }
                 } else {
                   if (logger.isDebugEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -634,7 +634,7 @@ public abstract class ServerConnection implements Runnable {
         chmRegistered = true;
       }
       if (registerClient) {
-        chm.registerClient(proxyId);
+        chm.registerClient(proxyId, acceptor.getMaximumTimeBetweenPings());
       }
       serverConnectionCollection = chm.addConnection(proxyId, this);
       acceptor.getConnectionListener().connectionOpened(registerClient, communicationMode);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientHealthMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientHealthMonitorTest.java
@@ -63,6 +63,7 @@ public class ClientHealthMonitorTest {
     ClientProxyMembershipID mockId = mock(ClientProxyMembershipID.class);
     ServerConnection mockConnection = mock(ServerConnection.class);
 
+    clientHealthMonitor.registerClient(mockId);
     clientHealthMonitor.addConnection(mockId, mockConnection);
     clientHealthMonitor.receivedPing(mockId);
     clientHealthMonitor.testUseCustomHeartbeatCheck((a, b, c) -> true); // Fail all heartbeats
@@ -86,6 +87,7 @@ public class ClientHealthMonitorTest {
     ClientProxyMembershipID mockId = mock(ClientProxyMembershipID.class);
     ServerConnection mockConnection = mock(ServerConnection.class);
 
+    clientHealthMonitor.registerClient(mockId);
     clientHealthMonitor.addConnection(mockId, mockConnection);
     clientHealthMonitor.receivedPing(mockId);
 
@@ -149,6 +151,7 @@ public class ClientHealthMonitorTest {
   @Test
   public void receivedPingNewClientRegistersWithCurrentTimeAndIncrementsStat() {
     ClientProxyMembershipID mockId = mock(ClientProxyMembershipID.class);
+    clientHealthMonitor.registerClient(mockId);
     clientHealthMonitor.receivedPing(mockId);
     assertThat(clientHealthMonitor.getClientHeartbeats().get(mockId)).isNotNull()
         .isLessThanOrEqualTo(System.currentTimeMillis());
@@ -158,6 +161,7 @@ public class ClientHealthMonitorTest {
   @Test
   public void receivedPingExistingClientUpdatesTimeOnly() throws InterruptedException {
     ClientProxyMembershipID mockId = mock(ClientProxyMembershipID.class);
+    clientHealthMonitor.registerClient(mockId);
     clientHealthMonitor.receivedPing(mockId);
     Long expectedTime = clientHealthMonitor.getClientHeartbeats().get(mockId);
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -142,6 +142,7 @@ import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCacheBuilder;
 import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PoolStats;
 import org.apache.geode.internal.cache.RegionQueue;
 import org.apache.geode.internal.cache.execute.data.CustId;
 import org.apache.geode.internal.cache.execute.data.Customer;
@@ -1254,6 +1255,16 @@ public class WANTestBase extends DistributedTestCase {
     return stats;
   }
 
+  public static int getGatewaySenderPoolDisconnects(String senderId) {
+    AbstractGatewaySender sender =
+        (AbstractGatewaySender) CacheFactory.getAnyInstance().getGatewaySender(senderId);
+    assertNotNull(sender);
+
+    PoolStats poolStats = sender.getProxy().getStats();
+
+    return poolStats.getDisConnects();
+  }
+
   protected static int getTotalBucketQueueSize(PartitionedRegion prQ, boolean isPrimary) {
     int size = 0;
     if (prQ != null) {
@@ -2053,18 +2064,30 @@ public class WANTestBase extends DistributedTestCase {
     }
   }
 
-  public static void createReceiverInVMs(VM... vms) {
+  public static void createReceiverInVMs(int maximumTimeBetweenPings, VM... vms) {
     for (VM vm : vms) {
-      vm.invoke(() -> createReceiver());
+      vm.invoke(() -> createReceiverWithMaximumTimeBetweenPings(maximumTimeBetweenPings));
     }
   }
 
+
+  public static void createReceiverInVMs(VM... vms) {
+    createReceiverInVMs(-1, vms);
+  }
+
   public static int createReceiver() {
+    return createReceiverWithMaximumTimeBetweenPings(-1);
+  }
+
+  public static int createReceiverWithMaximumTimeBetweenPings(int maximumTimeBetweenPings) {
     GatewayReceiverFactory fact = cache.createGatewayReceiverFactory();
     int port = AvailablePortHelper.getRandomAvailableTCPPort();
     fact.setStartPort(port);
     fact.setEndPort(port);
     fact.setManualStart(true);
+    if (maximumTimeBetweenPings > 0) {
+      fact.setMaximumTimeBetweenPings(maximumTimeBetweenPings);
+    }
     GatewayReceiver receiver = fact.create();
     try {
       receiver.start();
@@ -2149,6 +2172,10 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static int createServer(int locPort) {
+    return createServer(locPort, -1);
+  }
+
+  public static int createServer(int locPort, int maximumTimeBetweenPings) {
     WANTestBase test = new WANTestBase();
     Properties props = test.getDistributedSystemProperties();
     props.setProperty(MCAST_PORT, "0");
@@ -2160,6 +2187,9 @@ public class WANTestBase extends DistributedTestCase {
     int port = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
     server.setPort(port);
     server.setHostnameForClients("localhost");
+    if (maximumTimeBetweenPings > 0) {
+      server.setMaximumTimeBetweenPings(maximumTimeBetweenPings);
+    }
     try {
       server.start();
     } catch (IOException e) {


### PR DESCRIPTION
The maximum-time-between-pings set when creating a gateway receiver
was not honored because the ClientHealthMonitor, that is the singleton
class monitoring all clients, supported just one value for maximum
time between pings for all clients. This value is set
when the server in which the receiver is running is started
and when the gateway receiver provides a different value
it is ignored.

With this fix, it is allowed to have different values
for maximum-time-between-clients for different clients.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
