### PR TITLE
ByteBufferSharingImpl: only ever return buffer to pool once

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
@@ -100,6 +100,6 @@ public interface NioFilter {
    * Be sure to call close() on the returned {@link ByteBufferSharing}. The best way to do that is
    * to call this method in a try-with-resources statement.
    */
-  ByteBufferSharing getUnwrappedBuffer();
+  ByteBufferSharing getUnwrappedBuffer() throws IOException;
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -354,7 +354,7 @@ public class NioSslEngine implements NioFilter {
   }
 
   @Override
-  public ByteBufferSharing getUnwrappedBuffer() {
+  public ByteBufferSharing getUnwrappedBuffer() throws IOException {
     return shareInputBuffer();
   }
 
@@ -416,16 +416,16 @@ public class NioSslEngine implements NioFilter {
   }
 
   @VisibleForTesting
-  public ByteBufferSharing shareOutputBuffer() {
+  public ByteBufferSharing shareOutputBuffer() throws IOException {
     return outputSharing.open();
   }
 
   private ByteBufferSharing shareOutputBuffer(final long time, final TimeUnit unit)
-      throws OpenAttemptTimedOut {
+      throws OpenAttemptTimedOut, IOException {
     return outputSharing.open(time, unit);
   }
 
-  public ByteBufferSharing shareInputBuffer() {
+  public ByteBufferSharing shareInputBuffer() throws IOException {
     return inputSharing.open();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -805,11 +805,9 @@ public class Connection implements Runnable {
     if (getConduit().useSSL() && ioFilter != null) {
       try (final ByteBufferSharing sharedBuffer = ioFilter.getUnwrappedBuffer()) {
         // clear out any remaining handshake bytes
-        try {
-          sharedBuffer.getBuffer().position(0).limit(0);
-        } catch (IOException e) {
-          // means the NioFilter was already closed
-        }
+        sharedBuffer.getBuffer().position(0).limit(0);
+      } catch (IOException e) {
+        // means the NioFilter was already closed
       }
     }
   }


### PR DESCRIPTION
Fix data race in `ByteBufferSharingImpl` that was causing us to re-pool a `ByteBuffer` more than once.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
