### PR TITLE
GEODE-8603: fix StressNew for support branches

### DIFF
--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -50,7 +50,7 @@ function save_classpath() {
   echo "Building and saving classpath"
   pushd geode >> /dev/null
     # Do this twice since devBuild still dumps a warning string to stdout.
-    ./gradlew --console=plain -q compileTestJava devBuild 2>/dev/null
+    ./gradlew --console=plain -q compileTestJava compileIntegrationTestJava compileDistributedTestJava devBuild 2>/dev/null
     ./gradlew --console=plain -q printTestClasspath 2>/dev/null >/tmp/classpath.txt
   popd >> /dev/null
 }

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -50,7 +50,7 @@ function save_classpath() {
   echo "Building and saving classpath"
   pushd geode >> /dev/null
     # Do this twice since devBuild still dumps a warning string to stdout.
-    ./gradlew --console=plain -q devBuild 2>/dev/null
+    ./gradlew --console=plain -q compileTestJava devBuild 2>/dev/null
     ./gradlew --console=plain -q printTestClasspath 2>/dev/null >/tmp/classpath.txt
   popd >> /dev/null
 }


### PR DESCRIPTION
it seems that devBuild is not sufficient to ensure that StressNewTestHelper and all tests are built before running the helper.  Therefore, explicitly call `compileTestJava` to ensure that we do the needful regardless of branch.