### PR TITLE
GEODE-8692: ArrayIndexOutOfBoundsException may be thrown in RegionAdvisor.processProfilesQueuedDuringInitialization

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
@@ -20,6 +20,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.AbstractSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -974,10 +975,15 @@ public class RegionAdvisor extends CacheDistributionAdvisor {
    * @return array of serial numbers for buckets created locally
    */
   public int[] getBucketSerials() {
+    int[] result;
     if (buckets == null) {
-      return new int[0];
+      PartitionedRegion p = getPartitionedRegion();
+      int numBuckets = p.getAttributes().getPartitionAttributes().getTotalNumBuckets();
+      result = new int[numBuckets];
+      Arrays.fill(result, ILLEGAL_SERIAL);
+      return result;
     }
-    int[] result = new int[buckets.length];
+    result = new int[buckets.length];
 
     for (int i = 0; i < result.length; i++) {
       ProxyBucketRegion pbr = buckets[i];

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/RegionAdvisor.java
@@ -97,12 +97,14 @@ public class RegionAdvisor extends CacheDistributionAdvisor {
   private volatile int numDataStores = 0;
   protected volatile ProxyBucketRegion[] buckets;
 
-  private Queue<QueuedBucketProfile> preInitQueue;
+  @VisibleForTesting
+  protected Queue<QueuedBucketProfile> preInitQueue;
   private final Object preInitQueueMonitor = new Object();
 
   private ConcurrentHashMap<Integer, Set<ServerBucketProfile>> clientBucketProfilesMap;
 
-  private RegionAdvisor(PartitionedRegion region) {
+  @VisibleForTesting
+  protected RegionAdvisor(PartitionedRegion region) {
     super(region);
     synchronized (preInitQueueMonitor) {
       preInitQueue = new ConcurrentLinkedQueue<>();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/RegionAdvisorJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/RegionAdvisorJUnitTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.partitioned;
+
+import static org.apache.geode.distributed.internal.DistributionAdvisor.ILLEGAL_SERIAL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.BucketAdvisor;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.ProxyBucketRegion;
+
+public class RegionAdvisorJUnitTest {
+
+  private PartitionedRegion partitionedRegion;
+  private RegionAdvisor regionAdvisor;
+  private final int[] serials = new int[] {ILLEGAL_SERIAL, ILLEGAL_SERIAL, ILLEGAL_SERIAL};
+
+  @Before
+  public void setUp() throws Exception {
+    partitionedRegion = mock(PartitionedRegion.class);
+    regionAdvisor = new RegionAdvisor(partitionedRegion);
+  }
+
+  @Test
+  public void getBucketSerials_shouldReturnAnArrayOfIllegalSerials_whenBucketsAreNull() {
+    RegionAttributes regionAttributes = mock(RegionAttributes.class);
+    PartitionAttributes partitionAttributes = mock(PartitionAttributes.class);
+    when(partitionedRegion.getAttributes()).thenReturn(regionAttributes);
+    when(regionAttributes.getPartitionAttributes()).thenReturn(partitionAttributes);
+    when(partitionAttributes.getTotalNumBuckets()).thenReturn(3);
+
+    assertThat(regionAdvisor.getBucketSerials()).containsExactly(serials);
+  }
+
+  @Test
+  public void processProfilesQueuedDuringInitialization_shouldNotThrowIndexOutOfBoundsException() {
+    RegionAdvisor.QueuedBucketProfile qbp =
+        new RegionAdvisor.QueuedBucketProfile(mock(InternalDistributedMember.class), serials, true);
+    DistributionManager distributionManager = mock(DistributionManager.class);
+    when(regionAdvisor.getDistributionManager()).thenReturn(distributionManager);
+    when(distributionManager.isCurrentMember(any())).thenReturn(true);
+    regionAdvisor.preInitQueue.add(qbp);
+
+    ProxyBucketRegion pbr = mock(ProxyBucketRegion.class);
+    when(pbr.getBucketAdvisor()).thenReturn(mock(BucketAdvisor.class));
+    regionAdvisor.buckets = new ProxyBucketRegion[] {pbr, pbr, pbr};
+
+    regionAdvisor.processProfilesQueuedDuringInitialization();
+  }
+}


### PR DESCRIPTION
If `RegionAdvisor.buckets == null` at the time the value of `serials` is generated, an `ArrayIndexOutOfBoundsException` may be thrown in `RegionAdvisor.processProfilesQueuedDuringInitialization` if buckets have been initialized at that point.

Code where `ArrayIndexOutOfBoundsException` might be thrown in `RegionAdvisor.processProfilesQueuedDuringInitialization()`:

```
for (int i = 0; i < buckets.length; i++) {
  BucketAdvisor ba = buckets[i].getBucketAdvisor();
  int serial = qbp.serials[i]; <<< Exception thrown here
  if (serial != ILLEGAL_SERIAL) {
    ba.removeIdWithSerial(qbp.memberId, serial, qbp.destroyed);
  }
}
```
We ultimately decided that if the buckets were not created at the time the value of `serials` is generated, there is no need to worry about their profiles getting deleted later.  To avoid the `ArrayIndexOutOfBoundsException`, `getBucketSerials()` was modified to return an array of `ILLEGAL_SERIAL` values if the buckets had not been created yet.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
