### PR TITLE
GEODE-8664: Nest errors in DistributionImpl.start

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -181,9 +181,9 @@ public class DistributionImpl implements Distribution {
       throw new GemFireSecurityException(e.getMessage(),
           e);
     } catch (MembershipConfigurationException e) {
-      throw new GemFireConfigException(e.getMessage());
+      throw new GemFireConfigException(e.getMessage(), e.getCause());
     } catch (MemberStartupException e) {
-      throw new SystemConnectException(e.getMessage());
+      throw new SystemConnectException(e.getMessage(), e.getCause());
     } catch (RuntimeException e) {
       logger.error("Unexpected problem starting up membership services", e);
       throw new SystemConnectException("Problem starting up membership services: " + e.getMessage()

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -181,9 +181,9 @@ public class DistributionImpl implements Distribution {
       throw new GemFireSecurityException(e.getMessage(),
           e);
     } catch (MembershipConfigurationException e) {
-      throw new GemFireConfigException(e.getMessage(), e.getCause());
+      throw new GemFireConfigException("Problem configuring membership services", e);
     } catch (MemberStartupException e) {
-      throw new SystemConnectException(e.getMessage(), e.getCause());
+      throw new SystemConnectException("Problem starting up membership services", e);
     } catch (RuntimeException e) {
       logger.error("Unexpected problem starting up membership services", e);
       throw new SystemConnectException("Problem starting up membership services: " + e.getMessage()

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.distributed.internal;
 
 import static org.apache.geode.distributed.internal.DistributionImpl.EMPTY_MEMBER_ARRAY;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -213,12 +214,10 @@ public class DistributionTest {
     Throwable cause = new RuntimeException("Exception cause");
     Throwable exception = new MembershipConfigurationException("Test exception", cause);
     doThrow(exception).when(membership).start();
-    try {
-      distribution.start();
-      fail("expected start to throw an exception");
-    } catch (GemFireConfigException e) {
-      assertEquals(e.getCause(), cause);
-    }
+
+    assertThatThrownBy(() -> distribution.start())
+        .isInstanceOf(GemFireConfigException.class)
+        .hasCauseInstanceOf(cause.getClass());
   }
 
   @Test
@@ -226,11 +225,9 @@ public class DistributionTest {
     Throwable cause = new RuntimeException("Exception cause");
     Throwable exception = new MemberStartupException("Test exception", cause);
     doThrow(exception).when(membership).start();
-    try {
-      distribution.start();
-      fail("expected start to throw an exception");
-    } catch (SystemConnectException e) {
-      assertEquals(e.getCause(), cause);
-    }
+
+    assertThatThrownBy(() -> distribution.start())
+        .isInstanceOf(SystemConnectException.class)
+        .hasCauseInstanceOf(cause.getClass());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionTest.java
@@ -211,23 +211,21 @@ public class DistributionTest {
 
   @Test
   public void testExceptionNestedOnStartConfigError() throws Exception {
-    Throwable cause = new RuntimeException("Exception cause");
-    Throwable exception = new MembershipConfigurationException("Test exception", cause);
+    Throwable exception = new MembershipConfigurationException("Test exception");
     doThrow(exception).when(membership).start();
 
     assertThatThrownBy(() -> distribution.start())
         .isInstanceOf(GemFireConfigException.class)
-        .hasCauseInstanceOf(cause.getClass());
+        .hasCause(exception);
   }
 
   @Test
   public void testExceptionNestedOnStartStartupError() throws Exception {
-    Throwable cause = new RuntimeException("Exception cause");
-    Throwable exception = new MemberStartupException("Test exception", cause);
+    Throwable exception = new MemberStartupException("Test exception");
     doThrow(exception).when(membership).start();
 
     assertThatThrownBy(() -> distribution.start())
         .isInstanceOf(SystemConnectException.class)
-        .hasCauseInstanceOf(cause.getClass());
+        .hasCause(exception);
   }
 }


### PR DESCRIPTION
 - If while calling DistributionImpl.start there was either a
   MembershipConfigurationException or MemberStartupException exceptions, its
   original cause was not propagated, therefore being unable to properly
   tackling issues on startup.
 - This commit propagates the cause for both exceptions.
 - Also 2 JUint test were added to make sure this is working.

---

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] **(N/A)** If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
