### PR TITLE
GEODE-8687: Fix for handling of PdxSerializationException on client

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientUpdater.java
@@ -87,6 +87,7 @@ import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.statistics.StatisticsTypeFactoryImpl;
 import org.apache.geode.logging.internal.executors.LoggingThread;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.pdx.PdxSerializationException;
 import org.apache.geode.security.AuthenticationFailedException;
 import org.apache.geode.security.AuthenticationRequiredException;
 import org.apache.geode.security.GemFireSecurityException;
@@ -1793,7 +1794,7 @@ public class CacheClientUpdater extends LoggingThread implements ClientUpdater, 
     // This is a debugging method so ignore all exceptions like ClassNotFoundException
     try (ByteArrayDataInput dis = new ByteArrayDataInput(serializedBytes)) {
       deserializedObject = DataSerializer.readObject(dis);
-    } catch (ClassNotFoundException | IOException ignore) {
+    } catch (ClassNotFoundException | IOException | PdxSerializationException e) {
     }
     return deserializedObject;
   }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQAutoSerializer.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQAutoSerializer.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.Serializable;
+import java.util.Iterator;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.client.internal.PoolImpl;
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqQuery;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.internal.cache.CacheServerImpl;
+import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
+import org.apache.geode.pdx.internal.AutoSerializableManager;
+import org.apache.geode.test.dunit.Invoke;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
+import org.apache.geode.test.junit.categories.SerializationTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+@Category({ClientSubscriptionTest.class, SerializationTest.class})
+public class DurableClientCQAutoSerializer implements Serializable {
+  private static final String REPLICATE_REGION_NAME = "ReplicateRegion";
+  private static final String PARTITION_REGION_NAME = "PartitionRegion";
+
+  private MemberVM server;
+  private MemberVM server2;
+  private MemberVM locator;
+  private ClientVM client;
+  private ClientVM client2;
+
+  private static TestAutoSerializerCqListener cqListener = null;
+
+  private static final String TEST_OBJECT1_CLASS_PATH =
+      "org.apache.geode.internal.cache.tier.sockets.TestAutoSerializerObject1";
+  private static final String TEST_OBJECT2_CLASS_PATH =
+      "org.apache.geode.internal.cache.tier.sockets.TestAutoSerializerObject2";
+  private static final String TEST_FAULTY_CLASS_PATH =
+      "org.apache.geode.internal.cache.tier.sockets.TestAutoSerializerObject2Faulty";
+  private static final String DURABLE_CLIENT_ID = "durableClient";
+
+  // Traffic data
+  static final Map<String, TestAutoSerializerObject1> LIST_TEST_OBJECT1 = ImmutableMap.of(
+      "key1", new TestAutoSerializerObject1("aa", "bb", 300),
+      "key2", new TestAutoSerializerObject1("aa", "bb", 600),
+      "key3", new TestAutoSerializerObject1("aaa", "bbb", 500));
+
+  static final Map<String, TestAutoSerializerObject2> LIST_TEST_OBJECT2 = ImmutableMap.of(
+      "key1", new TestAutoSerializerObject2("cc", "ddd", 300),
+      "key2", new TestAutoSerializerObject2("cc", "dddd", 400));
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule(5);
+
+  @Before
+  public void setUp() throws Exception {
+    Invoke.invokeInEveryVM(
+        () -> System.setProperty(AutoSerializableManager.NO_HARDCODED_EXCLUDES_PARAM, "true"));
+
+    locator =
+        cluster.startLocatorVM(0);
+    int locatorPort = locator.getPort();
+    server = cluster.startServerVM(1,
+        s -> s.withConnectionToLocator(locatorPort));
+
+    server2 = cluster.startServerVM(2,
+        s -> s.withConnectionToLocator(locatorPort));
+
+    gfsh.connectAndVerify(locator);
+    gfsh.executeAndAssertThat(
+        "configure pdx --auto-serializable-classes='" + TEST_OBJECT1_CLASS_PATH + ", "
+            + TEST_OBJECT2_CLASS_PATH + "'")
+        .statusIsSuccess();
+    gfsh.executeAndAssertThat("create region --name=" + REPLICATE_REGION_NAME + " --type=REPLICATE")
+        .statusIsSuccess();
+    gfsh.executeAndAssertThat("create region --name=" + PARTITION_REGION_NAME + " --type=PARTITION")
+        .statusIsSuccess();
+
+    locator.invoke(() -> {
+      ClusterStartupRule.memberStarter
+          .waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + REPLICATE_REGION_NAME, 2);
+      ClusterStartupRule.memberStarter
+          .waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + PARTITION_REGION_NAME, 2);
+    });
+  }
+
+  private void startTrafficClient(String... patterns) throws Exception {
+    int locatorPort = locator.getPort();
+    client2 = cluster.startClientVM(4, ccf -> ccf
+        .withLocatorConnection(locatorPort).withCacheSetup(c -> c
+            .setPdxSerializer(new ReflectionBasedAutoSerializer(patterns))));
+  }
+
+  private void startDurableClientCq(String... patterns)
+      throws Exception {
+    int locatorPort = locator.getPort();
+    client = cluster.startClientVM(3, ccf -> ccf
+        .withPoolSubscription(true).withLocatorConnection(locatorPort).withCacheSetup(c -> c
+            .setPdxSerializer(new ReflectionBasedAutoSerializer(patterns))
+            .set("durable-client-id", DURABLE_CLIENT_ID)));
+  }
+
+  private void createDurableCQs(String... queries) {
+    client.invoke(() -> {
+      TestAutoSerializerCqListener cqListener = new TestAutoSerializerCqListener();
+      DurableClientCQAutoSerializer.cqListener = cqListener;
+      assertThat(ClusterStartupRule.getClientCache()).isNotNull();
+      QueryService queryService = ClusterStartupRule.getClientCache().getQueryService();
+      CqAttributesFactory cqAttributesFactory = new CqAttributesFactory();
+      cqAttributesFactory.addCqListener(cqListener);
+
+      for (String query : queries) {
+        CqQuery cq = queryService.newCq(query, cqAttributesFactory.create(), true);
+        cq.execute();
+      }
+      ClusterStartupRule.getClientCache().readyForEvents();
+    });
+  }
+
+  private static void verifyDurableClientOnServer(MemberVM server, boolean isExpected) {
+    server.invoke(() -> {
+      CacheServerImpl cacheServer =
+          (CacheServerImpl) ClusterStartupRule.getCache().getCacheServers().iterator().next();
+      assertNotNull(cacheServer);
+
+      // Get the CacheClientNotifier
+      CacheClientNotifier notifier = cacheServer.getAcceptor().getCacheClientNotifier();
+
+      // Get the CacheClientProxy or not (if proxy set is empty)
+      CacheClientProxy proxy = null;
+      Iterator i = notifier.getClientProxies().iterator();
+      if (i.hasNext()) {
+        proxy = (CacheClientProxy) i.next();
+      }
+
+      if (isExpected) {
+        assertNotNull(proxy);
+        assertThat(proxy.getDurableId().equals(DURABLE_CLIENT_ID));
+      } else {
+        if (proxy != null) {
+          assertNotEquals(proxy.getDurableId(), DURABLE_CLIENT_ID);
+        }
+      }
+    });
+  }
+
+  boolean isPrimaryServer(int primaryPort, MemberVM member) {
+    return primaryPort == member.getPort();
+  }
+
+  private void verifyOnlyPrimaryServerHostDurableSubscription() {
+    int primPort = getPrimaryServerPort(client);
+
+    verifyDurableClientOnServer(server, isPrimaryServer(primPort, server));
+    verifyDurableClientOnServer(server2, isPrimaryServer(primPort, server2));
+  }
+
+  private void checkCqEvents(int expectedTestAutoSerializerObject1,
+      int expectedTestAutoSerializerObject2) {
+    // Check if number of events is correct
+    client.invoke(() -> {
+      await().untilAsserted(() -> assertThat(
+          DurableClientCQAutoSerializer.cqListener.getNumEvents())
+              .isEqualTo(expectedTestAutoSerializerObject1 + expectedTestAutoSerializerObject2));
+
+      // Check if events are deserialized correctly
+      if (expectedTestAutoSerializerObject1 != 0) {
+        assertEquals(DurableClientCQAutoSerializer.cqListener.testAutoSerializerObject1,
+            LIST_TEST_OBJECT1);
+      }
+      if (expectedTestAutoSerializerObject2 != 0) {
+        assertEquals(DurableClientCQAutoSerializer.cqListener.testAutoSerializerObject2,
+            LIST_TEST_OBJECT2);
+      }
+    });
+  }
+
+  private void provisionRegionsWithData() {
+    client2.invoke(() -> {
+      ClientRegionFactory factory =
+          ClusterStartupRule.getClientCache().createClientRegionFactory(ClientRegionShortcut.PROXY);
+      Region<String, TestAutoSerializerObject1> region = factory.create(REPLICATE_REGION_NAME);
+
+      // provision TestAutoSerializerObject1 data
+      for (Map.Entry<String, TestAutoSerializerObject1> entry : LIST_TEST_OBJECT1.entrySet()) {
+        region.put(entry.getKey(), entry.getValue());
+      }
+
+      Region<String, TestAutoSerializerObject2> region2 = factory.create(PARTITION_REGION_NAME);
+      // provision TestAutoSerializerObject2 data
+      for (Map.Entry<String, TestAutoSerializerObject2> entry : LIST_TEST_OBJECT2.entrySet()) {
+        region2.put(entry.getKey(), entry.getValue());
+      }
+    });
+  }
+
+  private int getPrimaryServerPort(ClientVM client) {
+    return client.invoke(() -> {
+      ClientCache cache = ClusterStartupRule.getClientCache();
+      PoolImpl pool = (PoolImpl) cache.getDefaultPool();
+      return pool.getPrimaryPort();
+    });
+  }
+
+  @Test
+  public void correctClassPathsAutoSerialize()
+      throws Exception {
+
+    String query1 = "SELECT * FROM " + SEPARATOR + REPLICATE_REGION_NAME;
+    String query2 = "SELECT * FROM " + SEPARATOR + PARTITION_REGION_NAME;
+    startDurableClientCq(TEST_OBJECT1_CLASS_PATH, TEST_OBJECT2_CLASS_PATH);
+    createDurableCQs(query1, query2);
+
+    startTrafficClient(TEST_OBJECT1_CLASS_PATH, TEST_OBJECT2_CLASS_PATH);
+    provisionRegionsWithData();
+
+    checkCqEvents(LIST_TEST_OBJECT1.size(), LIST_TEST_OBJECT2.size());
+    verifyOnlyPrimaryServerHostDurableSubscription();
+  }
+
+  @Test
+  public void faultyClassPathAutoSerializer()
+      throws Exception {
+    String query1 = "SELECT * FROM " + SEPARATOR + REPLICATE_REGION_NAME;
+    String query2 = "SELECT * FROM " + SEPARATOR + PARTITION_REGION_NAME;
+    startDurableClientCq(TEST_FAULTY_CLASS_PATH, TEST_OBJECT2_CLASS_PATH);
+    createDurableCQs(query1, query2);
+
+    startTrafficClient(TEST_OBJECT1_CLASS_PATH, TEST_OBJECT2_CLASS_PATH);
+    provisionRegionsWithData();
+
+    checkCqEvents(0, LIST_TEST_OBJECT2.size());
+    verifyOnlyPrimaryServerHostDurableSubscription();
+  }
+}

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQAutoSerializerDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQAutoSerializerDUnitTest.java
@@ -50,7 +50,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 
 @Category({ClientSubscriptionTest.class, SerializationTest.class})
-public class DurableClientCQAutoSerializer implements Serializable {
+public class DurableClientCQAutoSerializerDUnitTest implements Serializable {
   private static final String REPLICATE_REGION_NAME = "ReplicateRegion";
   private static final String PARTITION_REGION_NAME = "PartitionRegion";
 
@@ -119,7 +119,7 @@ public class DurableClientCQAutoSerializer implements Serializable {
   }
 
   @Test
-  public void correctClassPathsAutoSerializer()
+  public void testCorrectClassPathsAutoSerializer()
       throws Exception {
 
     String query1 = "SELECT * FROM " + SEPARATOR + REPLICATE_REGION_NAME;
@@ -139,7 +139,7 @@ public class DurableClientCQAutoSerializer implements Serializable {
   }
 
   @Test
-  public void faultyClassPathAutoSerializer()
+  public void testFaultyClassPathAutoSerializer()
       throws Exception {
     String query1 = "SELECT * FROM " + SEPARATOR + REPLICATE_REGION_NAME;
     String query2 = "SELECT * FROM " + SEPARATOR + PARTITION_REGION_NAME;
@@ -176,7 +176,7 @@ public class DurableClientCQAutoSerializer implements Serializable {
   private void createDurableCQs(String... queries) {
     client.invoke(() -> {
       TestAutoSerializerCqListener cqListener = new TestAutoSerializerCqListener();
-      DurableClientCQAutoSerializer.cqListener = cqListener;
+      DurableClientCQAutoSerializerDUnitTest.cqListener = cqListener;
       assertThat(ClusterStartupRule.getClientCache()).isNotNull();
       QueryService queryService = ClusterStartupRule.getClientCache().getQueryService();
       CqAttributesFactory cqAttributesFactory = new CqAttributesFactory();
@@ -205,16 +205,16 @@ public class DurableClientCQAutoSerializer implements Serializable {
     // Check if number of events is correct
     client.invoke(() -> {
       await().untilAsserted(() -> assertThat(
-          DurableClientCQAutoSerializer.cqListener.getNumEvents())
+          DurableClientCQAutoSerializerDUnitTest.cqListener.getNumEvents())
               .isEqualTo(expectedTestAutoSerializerObject1 + expectedTestAutoSerializerObject2));
 
       // Check if events are deserialized correctly
       if (expectedTestAutoSerializerObject1 != 0) {
-        assertEquals(DurableClientCQAutoSerializer.cqListener.testAutoSerializerObject1,
+        assertEquals(DurableClientCQAutoSerializerDUnitTest.cqListener.testAutoSerializerObject1,
             LIST_TEST_OBJECT1);
       }
       if (expectedTestAutoSerializerObject2 != 0) {
-        assertEquals(DurableClientCQAutoSerializer.cqListener.testAutoSerializerObject2,
+        assertEquals(DurableClientCQAutoSerializerDUnitTest.cqListener.testAutoSerializerObject2,
             LIST_TEST_OBJECT2);
       }
     });

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerCqListener.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerCqListener.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqListener;
+
+public class TestAutoSerializerCqListener implements CqListener {
+  private int numEvents = 0;
+  private int numErrors = 0;
+  public Map<String, TestAutoSerializerObject1> testAutoSerializerObject1 = new HashMap<>();
+  public Map<String, TestAutoSerializerObject2> testAutoSerializerObject2 = new HashMap<>();
+
+  public int getNumEvents() {
+    return numEvents;
+  }
+
+  public int getNumErrors() {
+    return numErrors;
+  }
+
+  @Override
+  public void onEvent(CqEvent aCqEvent) {
+    Object obj = aCqEvent.getNewValue();
+    if (obj instanceof TestAutoSerializerObject1) {
+      testAutoSerializerObject1.put((String) aCqEvent.getKey(),
+          (TestAutoSerializerObject1) aCqEvent.getNewValue());
+    } else if (obj instanceof TestAutoSerializerObject2) {
+      testAutoSerializerObject2.put((String) aCqEvent.getKey(),
+          (TestAutoSerializerObject2) aCqEvent.getNewValue());
+    }
+    numEvents++;
+  }
+
+  @Override
+  public void onError(CqEvent aCqEvent) {
+    numErrors++;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerObject1.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerObject1.java
@@ -25,16 +25,16 @@ import org.apache.geode.internal.PdxSerializerObject;
 public class TestAutoSerializerObject1 implements PdxSerializerObject {
   protected String data1;
   protected String data2;
-  protected int numData3;
+  protected int numData;
 
   public TestAutoSerializerObject1() {
     this("", "", 0);
   }
 
-  protected TestAutoSerializerObject1(String data1, String data2, int numData3) {
+  protected TestAutoSerializerObject1(String data1, String data2, int numData) {
     this.data1 = data1;
     this.data2 = data2;
-    this.numData3 = numData3;
+    this.numData = numData;
   }
 
   public String getData1() {
@@ -49,12 +49,12 @@ public class TestAutoSerializerObject1 implements PdxSerializerObject {
     this.data2 = data2;
   }
 
-  public int getNumData3() {
-    return numData3;
+  public int getNumData() {
+    return numData;
   }
 
-  public void setNumData3(int numData3) {
-    this.numData3 = numData3;
+  public void setNumData(int numData) {
+    this.numData = numData;
   }
 
   public String toString() {
@@ -71,12 +71,12 @@ public class TestAutoSerializerObject1 implements PdxSerializerObject {
         builder.append(data2);
       }
 
-      if (0 < numData3) {
+      if (0 < numData) {
         if (0 < builder.length() && '(' != builder.charAt(builder.length() - 1)) {
           builder.append(", ");
         }
-        builder.append("numData3: ");
-        builder.append(numData3);
+        builder.append("numData: ");
+        builder.append(numData);
       }
 
       builder.append(")");
@@ -86,19 +86,16 @@ public class TestAutoSerializerObject1 implements PdxSerializerObject {
 
   @Override
   public boolean equals(Object o) {
-
     if (this == o)
       return true;
 
-    if (o == null)
+    if (o == null || getClass() != o.getClass())
       return false;
 
-    if (getClass() != o.getClass())
-      return false;
     TestAutoSerializerObject1 test = (TestAutoSerializerObject1) o;
     // field comparison
     return Objects.equals(data1, test.data1)
-        && Objects.equals(data2, test.data2) && Objects.equals(numData3, test.numData3);
+        && Objects.equals(data2, test.data2) && Objects.equals(numData, test.numData);
   }
 
   @Override
@@ -106,7 +103,7 @@ public class TestAutoSerializerObject1 implements PdxSerializerObject {
     int result = 17;
     result = 31 * result + data1.hashCode();
     result = 31 * result + data2.hashCode();
-    result = 31 * result + numData3;
+    result = 31 * result + numData;
     return result;
   }
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerObject1.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerObject1.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.util.Objects;
+
+import org.apache.geode.internal.PdxSerializerObject;
+
+/**
+ * <strong>Explicitly</strong> not serializable by java.io.Serializable,
+ * org.apache.geode.DataSerializable, or org.apache.geode.pdx.PdxSerializable.
+ */
+public class TestAutoSerializerObject1 implements PdxSerializerObject {
+  protected String data1;
+  protected String data2;
+  protected int numData3;
+
+  public TestAutoSerializerObject1() {
+    this("", "", 0);
+  }
+
+  protected TestAutoSerializerObject1(String data1, String data2, int numData3) {
+    this.data1 = data1;
+    this.data2 = data2;
+    this.numData3 = numData3;
+  }
+
+  public String getData1() {
+    return data1;
+  }
+
+  public String getData2() {
+    return data2;
+  }
+
+  public void setData2(String data2) {
+    this.data2 = data2;
+  }
+
+  public int getNumData3() {
+    return numData3;
+  }
+
+  public void setNumData3(int numData3) {
+    this.numData3 = numData3;
+  }
+
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    if (data1 != null && !data1.isEmpty()) {
+      builder.append(data1);
+      builder.append(" (");
+
+      if (data2 != null && !data2.isEmpty()) {
+        if (0 < builder.length() && '(' != builder.charAt(builder.length() - 1)) {
+          builder.append(", ");
+        }
+        builder.append("data2: ");
+        builder.append(data2);
+      }
+
+      if (0 < numData3) {
+        if (0 < builder.length() && '(' != builder.charAt(builder.length() - 1)) {
+          builder.append(", ");
+        }
+        builder.append("numData3: ");
+        builder.append(numData3);
+      }
+
+      builder.append(")");
+    }
+    return builder.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+
+    if (this == o)
+      return true;
+
+    if (o == null)
+      return false;
+
+    if (getClass() != o.getClass())
+      return false;
+    TestAutoSerializerObject1 test = (TestAutoSerializerObject1) o;
+    // field comparison
+    return Objects.equals(data1, test.data1)
+        && Objects.equals(data2, test.data2) && Objects.equals(numData3, test.numData3);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + data1.hashCode();
+    result = 31 * result + data2.hashCode();
+    result = 31 * result + numData3;
+    return result;
+  }
+
+}

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerObject2.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerObject2.java
@@ -25,16 +25,16 @@ import org.apache.geode.internal.PdxSerializerObject;
 public class TestAutoSerializerObject2 implements PdxSerializerObject {
   protected String data1;
   protected String data2;
-  protected int numData3;
+  protected int numData;
 
   public TestAutoSerializerObject2() {
     this("", "", 0);
   }
 
-  protected TestAutoSerializerObject2(String data1, String data2, int numData3) {
+  protected TestAutoSerializerObject2(String data1, String data2, int numData) {
     this.data1 = data1;
     this.data2 = data2;
-    this.numData3 = numData3;
+    this.numData = numData;
   }
 
   public String getData1() {
@@ -49,12 +49,12 @@ public class TestAutoSerializerObject2 implements PdxSerializerObject {
     this.data2 = data2;
   }
 
-  public int getNumData3() {
-    return numData3;
+  public int getNumData() {
+    return numData;
   }
 
-  public void setNumData3(int numData3) {
-    this.numData3 = numData3;
+  public void setNumData(int numData) {
+    this.numData = numData;
   }
 
   public String toString() {
@@ -71,12 +71,12 @@ public class TestAutoSerializerObject2 implements PdxSerializerObject {
         builder.append(data2);
       }
 
-      if (0 < numData3) {
+      if (0 < numData) {
         if (0 < builder.length() && '(' != builder.charAt(builder.length() - 1)) {
           builder.append(", ");
         }
-        builder.append("numData3: ");
-        builder.append(numData3);
+        builder.append("numData: ");
+        builder.append(numData);
       }
 
       builder.append(")");
@@ -89,15 +89,13 @@ public class TestAutoSerializerObject2 implements PdxSerializerObject {
     if (this == o)
       return true;
 
-    if (o == null)
+    if (o == null || getClass() != o.getClass())
       return false;
 
-    if (getClass() != o.getClass())
-      return false;
     TestAutoSerializerObject2 test = (TestAutoSerializerObject2) o;
     // field comparison
     return Objects.equals(data1, test.data1)
-        && Objects.equals(data2, test.data2) && Objects.equals(numData3, test.numData3);
+        && Objects.equals(data2, test.data2) && Objects.equals(numData, test.numData);
   }
 
   @Override
@@ -105,7 +103,7 @@ public class TestAutoSerializerObject2 implements PdxSerializerObject {
     int result = 17;
     result = 31 * result + data1.hashCode();
     result = 31 * result + data2.hashCode();
-    result = 31 * result + numData3;
+    result = 31 * result + numData;
     return result;
   }
 }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerObject2.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/TestAutoSerializerObject2.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.util.Objects;
+
+import org.apache.geode.internal.PdxSerializerObject;
+
+/**
+ * <strong>Explicitly</strong> not serializable by java.io.Serializable,
+ * org.apache.geode.DataSerializable, or org.apache.geode.pdx.PdxSerializable.
+ */
+public class TestAutoSerializerObject2 implements PdxSerializerObject {
+  protected String data1;
+  protected String data2;
+  protected int numData3;
+
+  public TestAutoSerializerObject2() {
+    this("", "", 0);
+  }
+
+  protected TestAutoSerializerObject2(String data1, String data2, int numData3) {
+    this.data1 = data1;
+    this.data2 = data2;
+    this.numData3 = numData3;
+  }
+
+  public String getData1() {
+    return data1;
+  }
+
+  public String getData2() {
+    return data2;
+  }
+
+  public void setData2(String data2) {
+    this.data2 = data2;
+  }
+
+  public int getNumData3() {
+    return numData3;
+  }
+
+  public void setNumData3(int numData3) {
+    this.numData3 = numData3;
+  }
+
+  public String toString() {
+    StringBuilder builder = new StringBuilder();
+    if (data1 != null && !data1.isEmpty()) {
+      builder.append(data1);
+      builder.append(" (");
+
+      if (data2 != null && !data2.isEmpty()) {
+        if (0 < builder.length() && '(' != builder.charAt(builder.length() - 1)) {
+          builder.append(", ");
+        }
+        builder.append("data2: ");
+        builder.append(data2);
+      }
+
+      if (0 < numData3) {
+        if (0 < builder.length() && '(' != builder.charAt(builder.length() - 1)) {
+          builder.append(", ");
+        }
+        builder.append("numData3: ");
+        builder.append(numData3);
+      }
+
+      builder.append(")");
+    }
+    return builder.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+
+    if (o == null)
+      return false;
+
+    if (getClass() != o.getClass())
+      return false;
+    TestAutoSerializerObject2 test = (TestAutoSerializerObject2) o;
+    // field comparison
+    return Objects.equals(data1, test.data1)
+        && Objects.equals(data2, test.data2) && Objects.equals(numData3, test.numData3);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+    result = 31 * result + data1.hashCode();
+    result = 31 * result + data2.hashCode();
+    result = 31 * result + numData3;
+    return result;
+  }
+}


### PR DESCRIPTION
* Whenever PdxSerializationException is thrown on client for problematic CQ event, client will try to log that exception
  together with the problematic event value. But the problem is that client has to de-serialize event value in order to log it.
  When client tries to do that, it gets another PdxSerializationException which is now catched at higher level and cause
  shutdown of CacheClientUpdater and subscription queue connection.

* Behavior with this fix: At the reception of event that provoke
  PdxSerializationException client will only log the exception and ignore
  PdxSerializationException that happen during logging

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
