### PR TITLE
GEODE-8685: change export to not deserialize region values

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntrySnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntrySnapshot.java
@@ -123,6 +123,20 @@ public class EntrySnapshot implements Region.Entry, DataSerializable {
     return v;
   }
 
+  /**
+   * If the value is available as a CachedDeserializable instance then return it.
+   * Otherwise behave as if getValue() was called.
+   */
+  public Object getValuePreferringCachedDeserializable() {
+    checkEntryDestroyed();
+    Object v = this.regionEntry.getValue(null);
+    if (v instanceof CachedDeserializable) {
+      return v;
+    } else {
+      return getRawValue();
+    }
+  }
+
   @Override
   public Object getValue() {
     checkEntryDestroyed();
@@ -281,5 +295,4 @@ public class EntrySnapshot implements Region.Entry, DataSerializable {
     }
     this.regionEntry.fromData(in);
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntrySnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntrySnapshot.java
@@ -129,9 +129,9 @@ public class EntrySnapshot implements Region.Entry, DataSerializable {
    */
   public Object getValuePreferringCachedDeserializable() {
     checkEntryDestroyed();
-    Object v = this.regionEntry.getValue(null);
-    if (v instanceof CachedDeserializable) {
-      return v;
+    Object value = regionEntry.getValue(null);
+    if (value instanceof CachedDeserializable) {
+      return value;
     } else {
       return getRawValue();
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotPacket.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotPacket.java
@@ -79,6 +79,7 @@ public class SnapshotPacket implements DataSerializableFixedID {
       } else if (entry instanceof EntrySnapshot) {
         EntrySnapshot entrySnapshot = (EntrySnapshot) entry;
         Object entryValue = entrySnapshot.getValuePreferringCachedDeserializable();
+        value = convertToBytes(entryValue);
       } else {
         value = convertToBytes(entry.getValue());
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotPacket.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotPacket.java
@@ -25,6 +25,7 @@ import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.CachedDeserializable;
+import org.apache.geode.internal.cache.EntrySnapshot;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.NonTXEntry;
 import org.apache.geode.internal.cache.Token;
@@ -75,6 +76,9 @@ public class SnapshotPacket implements DataSerializableFixedID {
         } finally {
           OffHeapHelper.release(v);
         }
+      } else if (entry instanceof EntrySnapshot) {
+        EntrySnapshot entrySnapshot = (EntrySnapshot) entry;
+        Object entryValue = entrySnapshot.getValuePreferringCachedDeserializable();
       } else {
         value = convertToBytes(entry.getValue());
       }

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ExportDataIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ExportDataIntegrationTest.java
@@ -85,7 +85,7 @@ public class ExportDataIntegrationTest {
   public void setup() throws Exception {
     gfsh.connectAndVerify(server.getEmbeddedLocatorPort(), GfshCommandRule.PortType.locator);
     region = server.getCache().getRegion(TEST_REGION_NAME);
-    loadRegion(new StringWrapper("value"));
+    loadRegion("value");
     Path basePath = tempDir.getRoot().toPath();
     snapshotFile = basePath.resolve(SNAPSHOT_FILE);
     snapshotDir = basePath.resolve(SNAPSHOT_DIR);
@@ -93,6 +93,7 @@ public class ExportDataIntegrationTest {
 
   @Test
   public void testExport() {
+    loadRegion(new StringWrapper("value"));
     String exportCommand = buildBaseExportCommand()
         .addOption(CliStrings.EXPORT_DATA__FILE, snapshotFile.toString()).getCommandString();
     gfsh.executeAndAssertThat(exportCommand).statusIsSuccess();

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ExportDataIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ExportDataIntegrationTest.java
@@ -66,8 +66,8 @@ public class ExportDataIntegrationTest {
 
     private String value;
 
-    public StringWrapper(String v) {
-      value = v;
+    public StringWrapper(String string) {
+      value = string;
     }
 
     @Override


### PR DESCRIPTION
Modified test to fail if it attempts to deserialize values during export.
Fixed product export code to no longer deserialize and test now passes.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
