### PR TITLE
GEODE-8697: Propagate ForcedDisconnectException to the user application

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -2362,7 +2362,7 @@ public class ClusterDistributionManager implements DistributionManager {
                                                               // so
           // don't issue a warning
           message.setRecipient(dm.getDistributionManagerId());
-          message.setReason(reason); // added for #37950
+          message.setReason(reason);
           dm.handleIncomingDMsg(message);
         }
         dm.handleManagerDeparture(theId, crashed, reason);

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/ClusterDistributionManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/ClusterDistributionManagerTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+
+import org.apache.geode.ForcedDisconnectException;
+import org.apache.geode.distributed.internal.membership.api.MemberDisconnectedException;
+
+public class ClusterDistributionManagerTest {
+
+  @Test
+  public void membershipFailureProcessingCreatesForcedDisconnectException() {
+    ClusterDistributionManager manager = mock(ClusterDistributionManager.class);
+    ClusterDistributionManager.DMListener listener =
+        new ClusterDistributionManager.DMListener(manager);
+    listener.membershipFailure("Testing", new MemberDisconnectedException("testing"));
+    // the root cause of membership failure should only be set once
+    verify(manager, times(1)).setRootCause(isA(Throwable.class));
+    // the root cause should be a ForcedDisconnectException
+    verify(manager, times(1)).setRootCause(isA(ForcedDisconnectException.class));
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/greplogs/ExpectedStrings.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/greplogs/ExpectedStrings.java
@@ -79,6 +79,7 @@ public class ExpectedStrings {
     expected.add(Pattern.compile("SystemAlertManager: A simple Alert."));
 
     expected.add(Pattern.compile("org.apache.geode.management.DependenciesNotFoundException"));
+    expected.add(Pattern.compile("EntryNotFoundException"));
 
     // expected.add(Pattern.compile("Java version older than"));
     // expected.add(Pattern.compile("Minimum system requirements not met. Unexpected behavior may

--- a/geode-dunit/src/main/java/org/apache/geode/test/greplogs/ExpectedStrings.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/greplogs/ExpectedStrings.java
@@ -79,7 +79,6 @@ public class ExpectedStrings {
     expected.add(Pattern.compile("SystemAlertManager: A simple Alert."));
 
     expected.add(Pattern.compile("org.apache.geode.management.DependenciesNotFoundException"));
-    expected.add(Pattern.compile("EntryNotFoundException"));
 
     // expected.add(Pattern.compile("Java version older than"));
     // expected.add(Pattern.compile("Minimum system requirements not met. Unexpected behavior may


### PR DESCRIPTION
avoid setting MemberDisconnectedException as a rootCause in
ClusterDistributionManager, even temporarily, as it's an internal
exception that should not be exposed to applications.

@kamilla1201 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
