### PR TITLE
GEODE-8707: fix release scripts for 1.13.1

### DIFF
--- a/dev-tools/dependencies/README.md
+++ b/dev-tools/dependencies/README.md
@@ -4,12 +4,14 @@ of cutting the next release, to allow time for any subtle issues to surface.
 The Release Manager will call for a volunteer to update dependencies.  Here are some 
 scripts that may be helpful.
 
-Step 1: list all dependencies for which maven is aware of a newer version:
+Step 0: Create a JIRA ticket for this work.
+
+Step 1: List bump commands for all dependencies for which maven offers a newer version:
 
 cd geode
-dev-tools/dependencies/bump.sh -l
+dev-tools/dependencies/bump.sh -l <jira you will be committing this work under>
 
-Step 2: filter out certain dependencies that we cannot change, such as:
+Step 2: Filter out certain dependencies that we cannot change, such as:
 - jgroups
 - classgraph
 - gradle-tooling-api
@@ -21,26 +23,26 @@ Step 2: filter out certain dependencies that we cannot change, such as:
 - tomcat 6
 - archunit (13.0 and later get OOM on JDK8)
 
-Step 3: in some cases, maven suggests new majors, beta releases, or just wrong releases.
+Step 3: In some cases, maven suggests new majors, beta releases, or just wrong releases.
 Manually search for those dependencies on mavencentral to see if there is a better choice.
 Examples include:
 - commons-collections (versioning back in 2004 predated semver)
 - springfox-swagger (stay on 2.9, as 2.10 and later is completely re-architected)
 - selenium-api (these tests are very old, so stay on version pi)
 
-Step 4: create a PR and start bumping dependencies.  Push to the PR every few to run PR
+Step 4: Create a PR and start bumping dependencies.  Push to the PR every few to run PR
 checks.  Later, review the PR checks and try to narrow down which bump introduced problems
 and revert it.  At the end, create separate PRs for each one that was problematic and ask
 for help from someone in the community who knows that area better.
 
 To bump a dependency, in most cases there are 2-4 files that will be touched, but
-sometimes more.  The bump commands provided in step 1 just attempt to do a search-and-
+sometimes more.  Each bump command provided in step 1 just attempts to do a search-and-
 replace on the old version number, then a git add -p.  Very carefully answer 'y' to
 changes where the matched string was the version number of the library you are bumping.
 Answer 'n' to anything else.  The bump script will then create a commit and run a gradlew
-devBuild to smoke-test the new version.  Minor changes may be needed, e.g. replacing a
+devBuild to smoke-test the new version.  Minor touchups may be needed, e.g. replacing a
 call to a deprecated method.  Use commit --amend to add any such fixups.
 
-The first arg to bump.sh (the dependency name) is just used in the commit message.  It
+Note: the dependency-name argument to bump.sh is just used in the commit message.  It
 does not affect the grep.  If you have several dependencies with the same version, one 
 bump command will bump them all, so shorten, e.g. just "jetty" instead of "jetty-server".

--- a/dev-tools/release/commit_rc.sh
+++ b/dev-tools/release/commit_rc.sh
@@ -124,6 +124,7 @@ echo "============================================================"
 for DIR in ${GEODE} ${GEODE_EXAMPLES} ${GEODE_NATIVE} ${GEODE_BENCHMARKS} ; do
     set -x
     cd ${DIR}
+    git pull -r
     git push -u origin
     git push origin rel/v${FULL_VERSION}
     set +x

--- a/dev-tools/release/deploy_rc_pipeline.sh
+++ b/dev-tools/release/deploy_rc_pipeline.sh
@@ -58,6 +58,11 @@ resources:
     branch: support/<VERSION_MM>
     tag_filter: rel/v<VERSION_MM>.*.RC*
     uri: https://github.com/apache/geode.git
+- name: geode-develop
+  type: git
+  source:
+    branch: develop
+    uri: https://github.com/apache/geode.git
 - name: geode-examples
   type: git
   source:
@@ -116,7 +121,7 @@ jobs:
               ./gradlew test installDist
               gfsh=geode-assembly/build/install/apache-geode/bin/gfsh
               $gfsh version --full | grep "^Source-Revision: ${SHA}$"
-              $gfsh version --full | grep "^Product-Version: ${VERSION}$"
+              $gfsh version --full | grep "^Product-Version: ${VERSION}-build"
               ! $gfsh version --full | grep Oracle
   - name: build-geode-from-src-tgz
     serial: true
@@ -154,7 +159,7 @@ jobs:
               ./gradlew test installDist
               gfsh=geode-assembly/build/install/apache-geode/bin/gfsh
               $gfsh version --full | grep "^Source-Revision: ${SHA}$"
-              $gfsh version --full | grep "^Product-Version: ${VERSION}$"
+              $gfsh version --full | grep "^Product-Version: ${VERSION}-build"
               ! $gfsh version --full | grep Oracle
   - name: run-gfsh-from-tgz
     serial: true
@@ -579,6 +584,8 @@ jobs:
       - aggregate:
           - get: geode
             trigger: true
+      - aggregate:
+          - get: geode-develop
       - task: validate
         timeout: 1h
         config:
@@ -589,6 +596,7 @@ jobs:
               tag: 8
           inputs:
             - name: geode
+            - name: geode-develop
           platform: linux
           run:
             path: /bin/bash
@@ -599,7 +607,7 @@ jobs:
               apt update -q
               apt install -qq -y --no-install-recommends unzip git
               FULL_VERSION=$(cd geode && git describe --tags | sed -e 's#^rel/v##')
-              ./geode/dev-tools/release/license_review.sh -v $FULL_VERSION
+              ./geode-develop/dev-tools/release/license_review.sh -v $FULL_VERSION
 EOF
 fly -t concourse.apachegeode-ci.info-main login --team-name main --concourse-url https://concourse.apachegeode-ci.info/
 fly -t concourse.apachegeode-ci.info-main set-pipeline -p apache-support-${VERSION_MM//./-}-rc -c $PIPEYML

--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -140,6 +140,7 @@ echo "Cloning repositories..."
 echo "============================================================"
 set -x
 git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/geode.git
+#(cd geode; git reset --hard $desired_sha) #uncomment if latest commit is not the one desired
 git clone --single-branch --branch develop git@github.com:apache/geode.git geode-develop
 git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/geode-examples.git
 git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/geode-native.git

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -440,10 +440,12 @@ echo "7. Confirm that your homebrew PR passed its PR checks and was merged to ma
 echo "8. Check that ${VERSION} documentation has been published to https://geode.apache.org/docs/"
 [ -z "$DID_REMOVE" ] || DID_REMOVE=" and ${DID_REMOVE} info has been removed"
 echo "9. Check that ${VERSION} download info has been published to https://geode.apache.org/releases/${DID_REMOVE}"
+MAJOR="${VERSION_MM%.*}"
+MINOR="${VERSION_MM#*.}"
 PATCH="${VERSION##*.}"
 [ "${PATCH}" -ne 0 ] || echo "10. Ask on the dev list for a volunteer to begin the chore of updating 3rd-party dependency versions on develop (see dev-tools/dependencies/README.md)"
 M=$(date --date '+9 months' '+%a, %B %d %Y' 2>/dev/null || date -v +9m "+%a, %B %d %Y" 2>/dev/null || echo "9 months from now")
-[ "${PATCH}" -ne 0 ] || echo "11. Mark your calendar for $M to run ${0%/*}/end_of_support.sh -v ${VERSION_MM}"
+[ "${PATCH}" -ne 0 ] || echo "11. Mark your calendar for $M (assuming we release Geode ${MAJOR}.$((MINOR + 3)) on that day) to run ${0%/*}/end_of_support.sh -v ${VERSION_MM}"
 [ "${PATCH}" -ne 0 ] || echo "12. Log in to https://hub.docker.com/repository/docker/apachegeode/geode and update the latest Dockerfile linktext and url to ${VERSION_MM}"
 echo "Bump support pipeline to ${VERSION_MM}.$(( PATCH + 1 )) by plussing BumpPatch in https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-support-${VERSION_MM//./-}-main?group=Semver%20Management"
 echo "Run ${0%/*}/set_versions.sh -v ${VERSION_MM}.$(( PATCH + 1 )) -s"

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -50,7 +50,7 @@ if [[ ${FULL_VERSION} == "" ]] || [[ ${SIGNING_KEY} == "" ]] || [[ ${GITHUB_USER
     usage
 fi
 
-SIGNING_KEY=$(gpg --list-keys "${SIGNING_KEY}" | grep "${SIGNING_KEY}" | tr -d ' ')
+SIGNING_KEY=$(gpg --fingerprint "${SIGNING_KEY}"  | tr -d ' ' | grep "${SIGNING_KEY}" | tail -1)
 
 SIGNING_KEY=$(echo $SIGNING_KEY|sed 's/[^0-9A-Fa-f]//g')
 if [[ $SIGNING_KEY =~ ^[0-9A-Fa-f]{40}$ ]]; then

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -434,6 +434,7 @@ echo "2. Go to https://github.com/${GITHUB_USER}/homebrew-core/pull/new/apache-g
 echo "3. Go to https://github.com/${GITHUB_USER}/geode/pull/new/add-${VERSION}-to-old-versions and create the pull request"
 echo "4. Validate docker image: docker run -it apachegeode/geode"
 echo "5. Bulk-transition JIRA issues fixed in this release to Closed"
+echo "5b.Publish to GitHub (see https://cwiki.apache.org/confluence/display/GEODE/Releasing+Apache+Geode#ReleasingApacheGeode-PublishtoGitHub)"
 echo "6. Wait overnight for apache mirror sites to sync"
 echo "7. Confirm that your homebrew PR passed its PR checks and was merged to master"
 echo "8. Check that ${VERSION} documentation has been published to https://geode.apache.org/docs/"

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -91,7 +91,7 @@ fi
 function failMsg {
   errln=$1
   echo "ERROR: script did NOT complete successfully"
-  echo "Comment out any steps that already succeeded (approximately lines 99-$(( errln - 1 ))) and try again"
+  echo "Comment out any steps that already succeeded (approximately lines 116-$(( errln - 1 ))) and try again"
 }
 trap 'failMsg $LINENO' ERR
 


### PR DESCRIPTION
* use license review script from develop
* don't expect prod version in builds from source
* placeholders for releasing from not-the-latest SHA
