### PR TITLE
GEODE-8704: many CI failures in Jetty9CachingClientServerTest

### DIFF
--- a/extensions/geode-modules-session-internal/src/main/java/org/apache/geode/modules/session/internal/filter/attributes/AbstractSessionAttributes.java
+++ b/extensions/geode-modules-session-internal/src/main/java/org/apache/geode/modules/session/internal/filter/attributes/AbstractSessionAttributes.java
@@ -68,6 +68,10 @@ public abstract class AbstractSessionAttributes implements SessionAttributes {
 
   private long creationTime;
 
+  public AbstractSessionAttributes() {
+    lastAccessedTime = System.currentTimeMillis();
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ServerContainer.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ServerContainer.java
@@ -202,6 +202,7 @@ public abstract class ServerContainer {
           " --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED" +
           " --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" +
           " --add-opens java.base/jdk.internal.ref=ALL-UNNAMED" +
+          " --add-opens java.base/jdk.internal.platform.cgroupv1=ALL-UNNAMED" +
           " --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED";
     }
     config.setProperty(GeneralPropertySet.START_JVMARGS, jvmArgs);

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Jetty9CachingClientServerTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/session/tests/Jetty9CachingClientServerTest.java
@@ -23,14 +23,12 @@ import java.util.function.IntSupplier;
 
 import javax.servlet.http.HttpSession;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 
-@Ignore("GEODE-8704")
 public class Jetty9CachingClientServerTest extends GenericAppServerClientServerTest {
 
   @Override


### PR DESCRIPTION
When the openjdk version used in the pipeline was updated from `11.0.8` to `11.0.9.1`, `Jetty9CachingClientServerTest.java` tests were failing.  Last accessed time was not getting set upon initialization of `AbstractSessionAttributes`.  Added a no arg constructor to initialize `lastAccessedTime` and the additional JVM arg: `--add-opens java.base/jdk.internal.platform.cgroupv1=ALL-UNNAMED`