### PR TITLE
GEODE-8736: maintain geode version for native and docs

### DIFF
--- a/dev-tools/release/create_support_branches.sh
+++ b/dev-tools/release/create_support_branches.sh
@@ -188,12 +188,12 @@ sed -e "s#return Collections.unmodifiableMap(allCommands#allCommands.put(Version
   -i.bak $COM
 
 #  directory: docs/guide/113
-#  product_version: '1.13'
+#  product_version: '1.13.2'
 #  product_version_nodot: '113'
 #  product_version_geode: '1.13'
 sed -E \
     -e "s#docs/guide/[0-9]+#docs/guide/${NEWVERSION_MM_NODOT}#" \
-    -e "s#product_version: '[0-9.]+'#product_version: '${NEWVERSION_MM}'#" \
+    -e "s#product_version: '[0-9.]+'#product_version: '${NEWVERSION}'#" \
     -e "s#version_nodot: '[0-9]+'#version_nodot: '${NEWVERSION_MM_NODOT}'#" \
     -e "s#product_version_geode: '[0-9.]+'#product_version_geode: '${NEWVERSION_MM}'#" \
     -i.bak geode-book/config.yml

--- a/dev-tools/release/deploy_rc_pipeline.sh
+++ b/dev-tools/release/deploy_rc_pipeline.sh
@@ -255,12 +255,18 @@ jobs:
               apt install -qq -y --no-install-recommends unzip git
               FULL_VERSION=$(cd geode-examples && git describe --tags | sed -e 's#^rel/v##' -e 's#-.*##')
               VERSION=$(echo $FULL_VERSION|sed -e 's/\.RC.*//')
-              STAGING_MAVEN=$(cat geode-examples/gradle.properties | grep geodeRepositoryUrl | awk '{print $3}')
-              curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
+              if [ "${FULL_VERSION}" = "${VERSION}" ] ; then
+                GRADLE_ARGS=""
+                curl -L -s https://downloads.apache.org/geode/${VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
+              else
+                STAGING_MAVEN=$(cat geode-examples/gradle.properties | grep geodeRepositoryUrl | awk '{print $3}')
+                GRADLE_ARGS="-PgeodeReleaseUrl=https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION} -PgeodeRepositoryUrl=${STAGING_MAVEN}""
+                curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
+              fi
               tar xzf src.tgz
               cd apache-geode-examples-${VERSION}-src
               java -version
-              ./gradlew -PgeodeReleaseUrl=https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION} -PgeodeRepositoryUrl=${STAGING_MAVEN} build runAll
+              ./gradlew ${GRADLE_ARGS} build runAll
   - name: build-geode-native-from-tag
     serial: true
     public: true

--- a/dev-tools/release/deploy_rc_pipeline.sh
+++ b/dev-tools/release/deploy_rc_pipeline.sh
@@ -260,7 +260,7 @@ jobs:
                 curl -L -s https://downloads.apache.org/geode/${VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
               else
                 STAGING_MAVEN=$(cat geode-examples/gradle.properties | grep geodeRepositoryUrl | awk '{print $3}')
-                GRADLE_ARGS="-PgeodeReleaseUrl=https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION} -PgeodeRepositoryUrl=${STAGING_MAVEN}""
+                GRADLE_ARGS="-PgeodeReleaseUrl=https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION} -PgeodeRepositoryUrl=${STAGING_MAVEN}"
                 curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
               fi
               tar xzf src.tgz

--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -144,6 +144,7 @@ git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/g
 git clone --single-branch --branch develop git@github.com:apache/geode.git geode-develop
 git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/geode-examples.git
 git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/geode-native.git
+git clone --single-branch --branch develop git@github.com:apache/geode-native.git geode-native-develop
 git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/geode-benchmarks.git
 git clone --single-branch --branch master git@github.com:Homebrew/homebrew-core.git
 

--- a/dev-tools/release/set_versions.sh
+++ b/dev-tools/release/set_versions.sh
@@ -126,7 +126,13 @@ sed -E \
     -e "s#product_version: '[0-9.]+'#product_version: '${VERSION}'#" \
     -i.bak geode-book/config.yml
 
-rm -f gradle.properties.bak geode-book/config.yml.bak
+#git clone -b branch --depth 1 https://github.com/apache/geode.git geode
+sed -e "s#clone -b [ds][evlopurt/0-9.]*#clone -b support/${VERSION_MM}#" \
+    -i.bak \
+    ci/docker/cache_dependencies.sh \
+    ci/images/google-geode-builder/scripts/cache_dependencies.sh
+
+rm -f gradle.properties.bak geode-book/config.yml.bak ci/docker/cache_dependencies.sh.bak ci/images/google-geode-builder/scripts/cache_dependencies.sh.bak
 set -x
 git add gradle.properties geode-book/config.yml
 if [ $(git diff --staged | wc -l) -gt 0 ] ; then

--- a/dev-tools/release/set_versions.sh
+++ b/dev-tools/release/set_versions.sh
@@ -112,7 +112,7 @@ trap 'failMsg2 $LINENO' ERR
 
 echo ""
 echo "============================================================"
-echo "Setting Geode versions and updating expected pom"
+echo "Setting Geode versions"
 echo "============================================================"
 set -x
 cd ${GEODE}
@@ -121,9 +121,14 @@ set +x
 #version = 1.13.0-build.0
 sed -e "s/^version =.*/version = ${VERSION}${BUILDSUFFIX}/" -i.bak gradle.properties
 
-rm gradle.properties.bak
+#  product_version: '1.13.2'
+sed -E \
+    -e "s#product_version: '[0-9.]+'#product_version: '${VERSION}'#" \
+    -i.bak geode-book/config.yml
+
+rm -f gradle.properties.bak geode-book/config.yml.bak
 set -x
-git add gradle.properties
+git add gradle.properties geode-book/config.yml
 if [ $(git diff --staged | wc -l) -gt 0 ] ; then
   git diff --staged --color | cat
   git commit -m "Bumping version to ${VERSION}${BUILDSUFFIX}"


### PR DESCRIPTION
travis, lgtm, and Dockerfile in native (support branch and develop) are now updated when a new version of Geode is released

product_version for Geode docs are now updated when a new version of Geode is released