### PR TITLE
GEODE-8745: Closing the queue region when senders are stopped.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/asyncqueue/internal/SerialAsyncEventQueueImpl.java
@@ -193,6 +193,7 @@ public class SerialAsyncEventQueueImpl extends AbstractGatewaySender {
     InternalDistributedSystem system =
         (InternalDistributedSystem) this.cache.getDistributedSystem();
     system.handleResourceEvent(ResourceEvent.GATEWAYSENDER_STOP, this);
+    this.eventProcessor = null;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySenderEventProcessor.java
@@ -432,6 +432,7 @@ public abstract class AbstractGatewaySenderEventProcessor extends LoggingThread
 
     for (;;) {
       if (stopped()) {
+        this.resetLastPeekedEvents = true;
         break;
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderEventProcessor.java
@@ -111,10 +111,9 @@ public class SerialGatewaySenderEventProcessor extends AbstractGatewaySenderEven
       ThreadsMonitoring tMonitoring, boolean cleanQueues) {
     super("Event Processor for GatewaySender_" + id, sender, tMonitoring);
 
+    initializeMessageQueue(id, cleanQueues);
     this.unprocessedEvents = new LinkedHashMap<EventID, EventWrapper>();
     this.unprocessedTokens = new LinkedHashMap<EventID, Long>();
-
-    initializeMessageQueue(id, cleanQueues);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -49,6 +49,7 @@ import org.apache.geode.cache.EvictionAttributes;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionAttributes;
+import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.TimeoutException;
@@ -1163,7 +1164,14 @@ public class SerialGatewaySenderQueue implements RegionQueue {
 
   @Override
   public void close() {
-    removeCacheListener();
+    Region r = getRegion();
+    if (r != null && !r.isDestroyed()) {
+      try {
+        r.close();
+      } catch (RegionDestroyedException e) {
+      }
+    }
+
   }
 
   private class BatchRemovalThread extends Thread {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderOperationsDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderOperationsDistributedTest.java
@@ -304,8 +304,8 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
     vm4.invoke(() -> validateSenderStoppedState("ln"));
     vm5.invoke(() -> validateSenderStoppedState("ln"));
 
-    vm4.invoke(() -> validateQueueSizeStat("ln", 20));
-    vm5.invoke(() -> validateQueueSizeStat("ln", 20));
+    vm4.invoke(() -> validateQueueSizeStat("ln", 0));
+    vm5.invoke(() -> validateQueueSizeStat("ln", 0));
     /*
      * Should have no effect on GatewaySenderState
      */
@@ -389,6 +389,7 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
 
     vm4.invoke(() -> validateQueueSizeStat("ln", 0));
     vm5.invoke(() -> validateQueueSizeStat("ln", 0));
+
 
     // do a lot of puts while senders are restarting
     AsyncInvocation doPutsInVm7 = vm7.invokeAsync(() -> doPuts(className + "_RR", 5000));
@@ -619,12 +620,12 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
 
     vm5.invoke(() -> doPuts(className + "_RR", 10, 110));
 
-    vm5.invoke(() -> validateQueueContents("ln", 110));
+    vm5.invoke(() -> validateQueueContents("ln", 100));
     vm5.invoke(() -> stopSender("ln"));
     vm5.invoke(() -> validateSenderStoppedState("ln"));
 
     vm4.invoke(() -> startSender("ln"));
-    vm4.invoke(() -> validateQueueContents("ln", 110));
+    vm4.invoke(() -> validateQueueContents("ln", 10));
     vm4.invoke(() -> stopSender("ln"));
 
     vm5.invoke(() -> startSender("ln"));
@@ -632,7 +633,7 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
     vm2.invoke(() -> createReplicatedRegion(className + "_RR", null));
     vm2.invoke(() -> createReceiver());
 
-    vm2.invoke(() -> validateRegionSize(className + "_RR", 110));
+    vm2.invoke(() -> validateRegionSize(className + "_RR", 100));
     vm5.invoke(() -> stopSender("ln"));
 
     vm4.invoke(() -> startSender("ln"));

--- a/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderImpl.java
@@ -186,7 +186,7 @@ public class SerialGatewaySenderImpl extends AbstractRemoteGatewaySender {
         (InternalDistributedSystem) this.cache.getDistributedSystem();
     system.handleResourceEvent(ResourceEvent.GATEWAYSENDER_STOP, this);
 
-    // this.eventProcessor = null;
+    this.eventProcessor = null;
   }
 
   @Override


### PR DESCRIPTION
	* cleanQueues are applicable only while using persistence
	* when we are closing the region, the disk files are not deleted.
	* hence the values will still be maintained on restart.
	* Advantage will be that we are creating the queue region and its cache listener together
	* previously the region was not closed and cache listener was attached using mutators.
	* this caused secondary events to be missed before the cache listener is activated

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
