### PR TITLE
GEODE-8740: increase test job timeouts

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -504,7 +504,7 @@ jobs:
         - name: concourse-metadata-resource
         outputs:
         - name: results
-      timeout: 8h
+      timeout: {{ run_var.timeout }}
       ensure:
         do:
         - task: cleanup_benchmarks

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -24,14 +24,17 @@ benchmarks:
     flag: ''
     options: ''
     max_in_flight: 4
+    timeout: 24h
   - title: '_with_ssl'
     flag: '-PwithSsl -PtestJVM=/usr/lib/jvm/bellsoft-java11-amd64'
     options: '--tests=*GetBenchmark --tests=*PutBenchmark'
     max_in_flight: 1
+    timeout: 3h
   - title: '_with_security_manager'
     flag: '-PwithSecurityManager'
     options: '--tests=Partitioned*'
     max_in_flight: 2
+    timeout: 5h
 
 build_test:
   ARTIFACT_SLUG: build
@@ -130,10 +133,10 @@ tests:
   RAM: '90'
   name: Integration
 - ARTIFACT_SLUG: upgradetestfiles
-  CALL_STACK_TIMEOUT: '3000'
+  CALL_STACK_TIMEOUT: '4800'
   CPUS: '96'
   DUNIT_PARALLEL_FORKS: '48'
-  EXECUTE_TEST_TIMEOUT: 1h
+  EXECUTE_TEST_TIMEOUT: 90m
   GRADLE_TASK: upgradeTest
   MAX_IN_FLIGHT: 2
   PARALLEL_DUNIT: 'true'


### PR DESCRIPTION
Recently UpgradeTestOpenJDK8 has been taking ~59 minutes and its job timeout is 1h.  After adding 1.13.1 as old version, it tipped to taking slightly over an hour.  Timeout for this job is increased to 1h30m as there's no need to cut it so close.

Recent changes to Benchmarks have also caused longer runs (from 4h -> 7h in the best case, and much much longer in the worst case).  The current job timeout of 8h is being hit frequently, and after trying a temporary increase to 16h, we still saw successful runs taking 15h, and still some timing out, so timeout is increased to 24h for now.  Also added separate timeouts for the other Benchmarks jobs which are more predictable and much shorter.