### PR TITLE
GEODE-8744: fix multiple versions of json-smart

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -344,6 +344,12 @@
         <scope>compile</scope>
       </dependency>
       <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>2.3</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
         <groupId>net.openhft</groupId>
         <artifactId>compiler</artifactId>
         <version>2.3.5</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -135,6 +135,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'mysql', name: 'mysql-connector-java', version: '5.1.46')
         api(group: 'net.java.dev.jna', name: 'jna', version: '5.5.0')
         api(group: 'net.java.dev.jna', name: 'jna-platform', version: '5.5.0')
+        api(group: 'net.minidev', name: 'json-smart', version: '2.3')
         api(group: 'net.openhft', name: 'compiler', version: '2.3.5')
         api(group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '5.0.4')
         api(group: 'net.sourceforge.pmd', name: 'pmd-java', version: '6.22.0')


### PR DESCRIPTION
develop and 1.12 release binaries contain only json-smart 2.3, but 1.13.1 contained both 1.3.1 and 2.3 due to the particular version of spring-security-oauth2-client in this release.  this change makes sure 2.3 is used in all places.

try `./gradlew :geode-pulse:dependencies | grep json-smart` with and without this fix to see the issue.