### PR TITLE
GEODE-8746: unit tests fail in 1.13 on latest bionic jdk8 build 275

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -430,7 +430,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.64</version>
+        <version>1.67</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -430,7 +430,7 @@
       <dependency>
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.67</version>
+        <version>1.64</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -478,7 +478,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>3.3.3</version>
+        <version>3.6.28</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -149,7 +149,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.apache.shiro', name: 'shiro-core', version: get('shiro.version'))
         api(group: 'org.assertj', name: 'assertj-core', version: '3.15.0')
         api(group: 'org.awaitility', name: 'awaitility', version: '4.0.2')
-        api(group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.64')
+        api(group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.67')
         api(group: 'org.codehaus.cargo', name: 'cargo-core-uberjar', version: '1.7.11')
         api(group: 'org.eclipse.jetty', name: 'jetty-server', version: get('jetty.version'))
         api(group: 'org.eclipse.jetty', name: 'jetty-webapp', version: get('jetty.version'))

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -149,7 +149,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.apache.shiro', name: 'shiro-core', version: get('shiro.version'))
         api(group: 'org.assertj', name: 'assertj-core', version: '3.15.0')
         api(group: 'org.awaitility', name: 'awaitility', version: '4.0.2')
-        api(group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.67')
+        api(group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.64')
         api(group: 'org.codehaus.cargo', name: 'cargo-core-uberjar', version: '1.7.11')
         api(group: 'org.eclipse.jetty', name: 'jetty-server', version: get('jetty.version'))
         api(group: 'org.eclipse.jetty', name: 'jetty-webapp', version: get('jetty.version'))

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -157,7 +157,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.httpunit', name: 'httpunit', version: '1.7.3')
         api(group: 'org.iq80.snappy', name: 'snappy', version: '0.4')
         api(group: 'org.jgroups', name: 'jgroups', version: get('jgroups.version'))
-        api(group: 'org.mockito', name: 'mockito-core', version: '3.3.3')
+        api(group: 'org.mockito', name: 'mockito-core', version: '3.6.28')
         api(group: 'org.mortbay.jetty', name: 'servlet-api', version: '3.0.20100224')
         api(group: 'org.openjdk.jmh', name: 'jmh-core', version: '1.23')
         api(group: 'org.postgresql', name: 'postgresql', version: '42.2.8')

--- a/geode-core/src/test/java/org/apache/geode/pdx/internal/PeerTypeRegistrationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/pdx/internal/PeerTypeRegistrationTest.java
@@ -30,10 +30,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.internal.util.reflection.FieldSetter;
 
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.Statistics;
@@ -122,14 +122,16 @@ public class PeerTypeRegistrationTest {
   }
 
   @Test
-  public void pdxPersistenceIsSetWithUserDefinedDiskStore() throws NoSuchFieldException {
+  public void pdxPersistenceIsSetWithUserDefinedDiskStore()
+      throws NoSuchFieldException, IllegalAccessException {
     PeerTypeRegistration peerTypeRegistration = spy(new PeerTypeRegistration(internalCache));
     doReturn(factory).when(internalCache).createRegionFactory();
     when(internalCache.getPdxPersistent()).thenReturn(true);
     CacheConfig config = mock(CacheConfig.class);
     when(internalCache.getCacheConfig()).thenReturn(config);
 
-    FieldSetter.setField(config, config.getClass().getField("pdxDiskStoreUserSet"), true);
+    Field field = config.getClass().getField("pdxDiskStoreUserSet");
+    field.setBoolean(config, Boolean.TRUE);
     final String diskStoreName = "userDiskStore";
     when(internalCache.getPdxDiskStore()).thenReturn(diskStoreName);
 

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/functions/GetRegionsFunctionTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/functions/GetRegionsFunctionTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.util.Collections;
 
@@ -28,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.DataPolicy;
@@ -59,7 +59,7 @@ public class GetRegionsFunctionTest {
 
   @Before
   public void setUp() {
-    initMocks(this);
+    MockitoAnnotations.openMocks(this);
 
     when(functionContext.<RegionInformation[]>getResultSender()).thenReturn(resultSender);
   }

--- a/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorTest.java
+++ b/geode-web/src/test/java/org/apache/geode/management/internal/web/controllers/support/LoginHandlerInterceptorTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -42,6 +41,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.springframework.web.servlet.HandlerInterceptor;
 
 import org.apache.geode.internal.security.SecurityService;
@@ -61,7 +61,7 @@ public class LoginHandlerInterceptorTest {
   @Before
   public void setUp() {
     LoginHandlerInterceptor.getEnvironment().clear();
-    initMocks(this);
+    MockitoAnnotations.openMocks(this);
     interceptor = new LoginHandlerInterceptor(securityService);
   }
 


### PR DESCRIPTION
WIP do not review

I am using this PR to attempt to isolate whether a single dependency bump explains why these JDK8 unit tests pass on develop but not 1.13 with latest ubuntu containing jdk1.8.0_275