### PR TITLE
GEODE-8755: Write content list files to integration test dir

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/AssemblyContentsIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/AssemblyContentsIntegrationTest.java
@@ -58,7 +58,7 @@ public class AssemblyContentsIntegrationTest {
   @Test
   public void verifyAssemblyContents() throws IOException {
     Collection<String> currentAssemblyContent = getAssemblyContent();
-    Files.write(Paths.get("assembly_content.txt"), currentAssemblyContent);
+    Files.write(Paths.get("..", "assembly_content.txt"), currentAssemblyContent);
 
     assertThat(currentAssemblyContent)
         .as("The assembly contents have changed. Verify dependencies and "

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/BundledJarsJUnitTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/BundledJarsJUnitTest.java
@@ -67,7 +67,7 @@ public class BundledJarsJUnitTest {
         sortedJars.entrySet().stream().map(entry -> removeVersion(entry.getKey()));
     Set<String> bundledJarNames = new TreeSet<>(lines.collect(Collectors.toSet()));
 
-    Files.write(Paths.get("bundled_jars.txt"), bundledJarNames);
+    Files.write(Paths.get("..", "bundled_jars.txt"), bundledJarNames);
 
     Set<String> newJars = new TreeSet<>(bundledJarNames);
     newJars.removeAll(expectedJars);

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/GeodeDependencyJarIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/GeodeDependencyJarIntegrationTest.java
@@ -58,7 +58,7 @@ public class GeodeDependencyJarIntegrationTest {
   @Test
   public void verifyManifestClassPath() throws IOException {
     List<String> currentClasspathElements = getManifestClassPath();
-    Files.write(Paths.get("dependency_classpath.txt"), currentClasspathElements);
+    Files.write(Paths.get("..", "dependency_classpath.txt"), currentClasspathElements);
 
     assertThat(getManifestClassPath())
         .describedAs("The geode-dependency jar's manifest classpath has changed. Verify "


### PR DESCRIPTION
BundledJarsJUnitTest, AssemblyContentsIntegrationTest, and GeodeDependencyJarIntegrationTest once again write their output to the file paths indicated in their failure messages.

Authored-by: Dale Emery <demery@vmware.com>

Please review @yozaner1324 