### PR TITLE
GEODE-8730: DualServerSNIAcceptanceTest fails to start server because port is in use

### DIFF
--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/docker-compose.yml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/docker-compose.yml
@@ -22,7 +22,8 @@ services:
     hostname: geode
     expose:
       - '10334'
-      - '40404'
+      - '8501'
+      - '8502'
     entrypoint: 'sh'
     command: '-c /geode/scripts/forever'
     networks:

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/haproxy.cfg
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/haproxy.cfg
@@ -37,8 +37,8 @@ backend locators-maeve
 
 backend servers-dolores
   mode tcp
-  server server1 geode:40404
+  server server1 geode:8501
 
 backend servers-clementine
   mode tcp
-  server server1 geode:40405
+  server server1 geode:8502

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/scripts/geode-starter-2.gfsh
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/scripts/geode-starter-2.gfsh
@@ -16,8 +16,8 @@
 #
 
 start locator --name=locator-maeve --connect=false --redirect-output --hostname-for-clients=locator-maeve --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/locator-maeve-keystore.jks
-start server --name=server-dolores --group=group-dolores --hostname-for-clients=server-dolores --locators=geode[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-dolores-keystore.jks
-start server --name=server-clementine --group=group-clementine --hostname-for-clients=server-clementine --server-port=40405 --locators=geode[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-clementine-keystore.jks
+start server --name=server-dolores --group=group-dolores --hostname-for-clients=server-dolores --server-port=8501 --locators=geode[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-dolores-keystore.jks
+start server --name=server-clementine --group=group-clementine --hostname-for-clients=server-clementine --server-port=8502 --locators=geode[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-clementine-keystore.jks
 connect --locator=geode[10334] --use-ssl=true --security-properties-file=/geode/config/gfsecurity.properties
 create region --name=region-dolores --group=group-dolores --type=REPLICATE
 create region --name=region-clementine --group=group-clementine --type=REPLICATE

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/scripts/geode-starter.gfsh
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/client/sni/scripts/geode-starter.gfsh
@@ -16,7 +16,7 @@
 #
 
 start locator --name=locator-maeve --connect=false --hostname-for-clients=locator-maeve --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/locator-maeve-keystore.jks
-start server --name=server-dolores --max-heap=256m --hostname-for-clients=server-dolores --locators=geode[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-dolores-keystore.jks
+start server --name=server-dolores --max-heap=256m --hostname-for-clients=server-dolores --server-port=8501 --locators=geode[10334] --properties-file=/geode/config/gemfire.properties --security-properties-file=/geode/config/gfsecurity.properties --J=-Dgemfire.ssl-keystore=/geode/config/server-dolores-keystore.jks
 connect --locator=geode[10334] --use-ssl=true --security-properties-file=/geode/config/gfsecurity.properties
 create region --name=jellyfish --type=REPLICATE
 


### PR DESCRIPTION
2 Dockerized cache servers (in test) were binding to ephemeral ports 40404, 40405. These can conflict with some ephemeral port that is bound in the container before the Geode cluster is started. They also can conflict with the RMI port bound by each cache server.

Changed the test to bind to ports 8501, 8502.

- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?