### PR TITLE
GEODE-8769: help ensure stats are settled before testing

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/RedisStatsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/RedisStatsIntegrationTest.java
@@ -77,7 +77,7 @@ public class RedisStatsIntegrationTest {
 
     preTestKeySpaceHits = redisStats.getKeyspaceHits();
     preTestKeySpaceMisses = redisStats.getKeyspaceMisses();
-    preTestConnectionsReceived = redisStats.getConnectionsReceived();
+    preTestConnectionsReceived = redisStats.getTotalConnectionsReceived();
     preTestConnectedClients = redisStats.getConnectedClients();
   }
 
@@ -496,16 +496,16 @@ public class RedisStatsIntegrationTest {
   }
 
   @Test
-  public void connectionsReceivedStat_shouldIncrement_WhenNewConnectionOccurs() {
+  public void totalConnectionsReceivedStat_shouldIncrement_WhenNewConnectionOccurs() {
 
     Jedis jedis2 = new Jedis("localhost", server.getPort(), TIMEOUT);
     jedis2.ping();
 
-    assertThat(redisStats.getConnectionsReceived()).isEqualTo(preTestConnectionsReceived + 1);
+    assertThat(redisStats.getTotalConnectionsReceived()).isEqualTo(preTestConnectionsReceived + 1);
 
     jedis2.close();
 
-    assertThat(redisStats.getConnectionsReceived()).isEqualTo(preTestConnectionsReceived + 1);
+    assertThat(redisStats.getTotalConnectionsReceived()).isEqualTo(preTestConnectionsReceived + 1);
   }
 
   // ######################## Server Section ################

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/RedisStatsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/RedisStatsIntegrationTest.java
@@ -49,6 +49,10 @@ public class RedisStatsIntegrationTest {
   private static long START_TIME;
   private static StatisticsClock statisticsClock;
 
+  private Long preTestKeySpaceHits = 0l;
+  private Long preTestKeySpaceMisses = 0l;
+  private Long preTestConnectionsReceived = 0l;
+  private Long preTestConnectedClients = 0l;
 
 
   @ClassRule
@@ -70,13 +74,20 @@ public class RedisStatsIntegrationTest {
     jedis.sadd(EXISTING_SET_KEY_2, "m4", "m5", "m6");
 
     redisStats = server.getServer().getStats();
-    redisStats.clearAllStats();
+
+    preTestKeySpaceHits = redisStats.getKeyspaceHits();
+    preTestKeySpaceMisses = redisStats.getKeyspaceMisses();
+    preTestConnectionsReceived = redisStats.getConnectionsReceived();
+    preTestConnectedClients = redisStats.getConnectedClients();
   }
 
   @After
   public void after() {
     jedis.flushAll();
     jedis.close();
+    GeodeAwaitility.await().atMost(Duration.ofSeconds(2))
+        .untilAsserted(() -> assertThat(redisStats.getConnectedClients())
+            .isEqualTo(0));
   }
 
   // #############Stats Section###################################
@@ -86,10 +97,10 @@ public class RedisStatsIntegrationTest {
     jedis.get(EXISTING_STRING_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
 
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -98,9 +109,9 @@ public class RedisStatsIntegrationTest {
     jedis.get("Nonexistent_Key");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   // TODO: Set doesn't work like native Redis!
@@ -109,9 +120,9 @@ public class RedisStatsIntegrationTest {
     jedis.set(EXISTING_STRING_KEY, "New_Value");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   // TODO: Set doesn't work like native Redis!
@@ -120,9 +131,9 @@ public class RedisStatsIntegrationTest {
     jedis.set("Another_Key", "Another_Value");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -130,9 +141,9 @@ public class RedisStatsIntegrationTest {
     jedis.getbit(EXISTING_STRING_KEY, 0);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -140,9 +151,9 @@ public class RedisStatsIntegrationTest {
     jedis.getbit("Nonexistent_Key", 0);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -150,9 +161,9 @@ public class RedisStatsIntegrationTest {
     jedis.getrange(EXISTING_STRING_KEY, 0, 1);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -160,9 +171,9 @@ public class RedisStatsIntegrationTest {
     jedis.getrange("Nonexistent_Key", 0, 1);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -170,9 +181,9 @@ public class RedisStatsIntegrationTest {
     jedis.getSet(EXISTING_STRING_KEY, "New_Value");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -180,9 +191,9 @@ public class RedisStatsIntegrationTest {
     jedis.getSet("Nonexistent_Key", "FakeValue");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -190,9 +201,9 @@ public class RedisStatsIntegrationTest {
     jedis.strlen(EXISTING_STRING_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -200,9 +211,9 @@ public class RedisStatsIntegrationTest {
     jedis.strlen(NONEXISTENT_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -210,9 +221,9 @@ public class RedisStatsIntegrationTest {
     jedis.mget(EXISTING_STRING_KEY, "Nonexistent_Key");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -220,9 +231,9 @@ public class RedisStatsIntegrationTest {
     jedis.bitop(BitOP.AND, EXISTING_STRING_KEY, EXISTING_STRING_KEY, "Nonexistent_Key");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0 + 2);
+        .isEqualTo(preTestKeySpaceHits + 2);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -230,9 +241,9 @@ public class RedisStatsIntegrationTest {
     jedis.bitcount(EXISTING_STRING_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -240,9 +251,9 @@ public class RedisStatsIntegrationTest {
     jedis.bitcount("Nonexistent_Key");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -250,9 +261,9 @@ public class RedisStatsIntegrationTest {
     jedis.bitpos(EXISTING_STRING_KEY, true);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -260,9 +271,9 @@ public class RedisStatsIntegrationTest {
     jedis.bitpos("Nonexistent_Key", true);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -270,9 +281,9 @@ public class RedisStatsIntegrationTest {
     jedis.hget(EXISTING_HASH_KEY, "Field1");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -280,9 +291,9 @@ public class RedisStatsIntegrationTest {
     jedis.hget("Nonexistent_Hash", "Field1");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -290,9 +301,9 @@ public class RedisStatsIntegrationTest {
     jedis.smembers(EXISTING_SET_KEY_1);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -300,9 +311,9 @@ public class RedisStatsIntegrationTest {
     jedis.smembers("Nonexistent_Set");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -314,9 +325,9 @@ public class RedisStatsIntegrationTest {
         "Nonexistent_Set");
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0 + 2);
+        .isEqualTo(preTestKeySpaceHits + 2);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -324,9 +335,9 @@ public class RedisStatsIntegrationTest {
     jedis.exists(EXISTING_STRING_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -334,9 +345,9 @@ public class RedisStatsIntegrationTest {
     jedis.exists(NONEXISTENT_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -344,9 +355,9 @@ public class RedisStatsIntegrationTest {
     jedis.type(EXISTING_STRING_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -354,9 +365,9 @@ public class RedisStatsIntegrationTest {
     jedis.type(NONEXISTENT_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -364,9 +375,9 @@ public class RedisStatsIntegrationTest {
     jedis.ttl(EXISTING_STRING_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceHits + 1);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceMisses);
   }
 
   @Test
@@ -374,9 +385,9 @@ public class RedisStatsIntegrationTest {
     jedis.ttl(NONEXISTENT_KEY);
 
     assertThat(redisStats.getKeyspaceHits())
-        .isEqualTo(0);
+        .isEqualTo(preTestKeySpaceHits);
     assertThat(redisStats.getKeyspaceMisses())
-        .isEqualTo(1);
+        .isEqualTo(preTestKeySpaceMisses + 1);
   }
 
   @Test
@@ -468,33 +479,33 @@ public class RedisStatsIntegrationTest {
 
   }
 
-
   // ######################### Clients Section #################################
 
   @Test
   public void clientsStat_withConnectAndClose_isCorrect() {
 
-    jedis = new Jedis("localhost", server.getPort(), TIMEOUT);
-    jedis.ping();
+    Jedis jedis2 = new Jedis("localhost", server.getPort(), TIMEOUT);
+    jedis2.ping();
 
-    assertThat(redisStats.getConnectedClients()).isEqualTo(1);
+    assertThat(redisStats.getConnectedClients()).isEqualTo(preTestConnectedClients + 1);
 
-    jedis.close();
+    jedis2.close();
     GeodeAwaitility.await().atMost(Duration.ofSeconds(2))
-        .untilAsserted(() -> assertThat(redisStats.getConnectedClients()).isEqualTo(0));
+        .untilAsserted(
+            () -> assertThat(redisStats.getConnectedClients()).isEqualTo(preTestConnectedClients));
   }
 
   @Test
   public void connectionsReceivedStat_shouldIncrement_WhenNewConnectionOccurs() {
 
-    jedis = new Jedis("localhost", server.getPort(), TIMEOUT);
-    jedis.ping();
+    Jedis jedis2 = new Jedis("localhost", server.getPort(), TIMEOUT);
+    jedis2.ping();
 
-    assertThat(redisStats.getConnectionsReceived()).isEqualTo(1);
+    assertThat(redisStats.getConnectionsReceived()).isEqualTo(preTestConnectionsReceived + 1);
 
-    jedis.close();
+    jedis2.close();
 
-    assertThat(redisStats.getConnectionsReceived()).isEqualTo(1);
+    assertThat(redisStats.getConnectionsReceived()).isEqualTo(preTestConnectionsReceived + 1);
   }
 
   // ######################## Server Section ################
@@ -524,7 +535,6 @@ public class RedisStatsIntegrationTest {
     assertThat(redisStats.getUptimeInDays())
         .isEqualTo(expectedDays);
   }
-
 
   public long getStartTime() {
     return START_TIME;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisStats.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisStats.java
@@ -114,22 +114,6 @@ public class RedisStats {
     perSecondExecutor = startPerSecondUpdater();
   }
 
-  public void clearAllStats() {
-    commandsProcessed.set(0);
-    opsPerSecond.set(0);
-    totalNetworkBytesRead.set(0);
-    connectionsReceived.set(0);
-    expirations.set(0);
-    keyspaceHits.set(0);
-    keyspaceMisses.set(0);
-    stats.setLong(clientId, 0);
-    stats.setLong(passiveExpirationChecksId, 0);
-    stats.setLong(passiveExpirationCheckTimeId, 0);
-    stats.setLong(passiveExpirationsId, 0);
-    stats.setLong(expirationsId, 0);
-    stats.setLong(expirationTimeId, 0);
-  }
-
   private static void fillListWithCompletedCommandDescriptors(StatisticsTypeFactory f,
       ArrayList<StatisticDescriptor> descriptorList) {
     for (RedisCommandType command : RedisCommandType.values()) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisStats.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisStats.java
@@ -54,7 +54,7 @@ public class RedisStats {
   private final AtomicLong commandsProcessed = new AtomicLong();
   private final AtomicLong opsPerSecond = new AtomicLong();
   private final AtomicLong totalNetworkBytesRead = new AtomicLong();
-  private final AtomicLong connectionsReceived = new AtomicLong();
+  private final AtomicLong totalConnectionsReceived = new AtomicLong();
   private final AtomicLong expirations = new AtomicLong();
   private final AtomicLong keyspaceHits = new AtomicLong();
   private final AtomicLong keyspaceMisses = new AtomicLong();
@@ -195,7 +195,7 @@ public class RedisStats {
   }
 
   public void addClient() {
-    connectionsReceived.incrementAndGet();
+    totalConnectionsReceived.incrementAndGet();
     stats.incLong(clientId, 1);
   }
 
@@ -203,8 +203,8 @@ public class RedisStats {
     stats.incLong(clientId, -1);
   }
 
-  public long getConnectionsReceived() {
-    return connectionsReceived.get();
+  public long getTotalConnectionsReceived() {
+    return totalConnectionsReceived.get();
   }
 
   public long getConnectedClients() {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/server/InfoExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/server/InfoExecutor.java
@@ -101,7 +101,7 @@ public class InfoExecutor extends AbstractExecutor {
             "instantaneous_ops_per_sec:" + redisStats.getOpsPerformedOverLastSecond() + "\r\n" +
             "total_net_input_bytes:" + redisStats.getTotalNetworkBytesRead() + "\r\n" +
             "instantaneous_input_kbps:" + instantaneous_input_kbps + "\r\n" +
-            "total_connections_received:" + redisStats.getConnectionsReceived() + "\r\n" +
+            "total_connections_received:" + redisStats.getTotalConnectionsReceived() + "\r\n" +
             "keyspace_hits:" + redisStats.getKeyspaceHits() + "\r\n" +
             "keyspace_misses:" + redisStats.getKeyspaceMisses() + "\r\n" +
             "evicted_keys:0\r\n" +


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ X] Is your initial contribution a single, squashed commit?

- [ X] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.

This helps to mitigate the issue but does not completely solve it. The problem happens when multiple threads are opening multiple Redis connections, and the statistics are reset. Depending on the timing of the connection opening and closing, the operations can interleave and result in an inconsistent state for the statistics. The stats will be "eventually correct" unless their values are explicitly reset at an unlucky time.