### PR TITLE
GEODE-8496: Bump jackson from 2.11.3 to 2.12.1

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -62,18 +62,6 @@
         <scope>compile</scope>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-joda</artifactId>
-        <version>2.9.8</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.11.3</version>
-        <scope>compile</scope>
-      </dependency>
-      <dependency>
         <groupId>com.github.davidmoten</groupId>
         <artifactId>geo</artifactId>
         <version>0.7.7</version>
@@ -304,7 +292,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.9.8</version>
+        <version>2.10.9</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
@@ -556,19 +544,31 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.11.3</version>
+        <version>2.12.1</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.11.3</version>
+        <version>2.12.1</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.11.3</version>
+        <version>2.12.1</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-joda</artifactId>
+        <version>2.12.1</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jsr310</artifactId>
+        <version>2.12.1</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -87,8 +87,6 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'cglib', name: 'cglib', version: get('cglib.version'))
         api(group: 'com.arakelian', name: 'java-jq', version: '1.1.0')
         api(group: 'com.carrotsearch.randomizedtesting', name: 'randomizedtesting-runner', version: '2.7.8')
-        api(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.9.8')
-        api(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.3')
         api(group: 'com.github.davidmoten', name: 'geo', version: '0.7.7')
         api(group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0')
         api(group: 'com.github.stephenc.findbugs', name: 'findbugs-annotations', version: '1.3.9-1')
@@ -129,7 +127,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'javax.resource', name: 'javax.resource-api', version: '1.7.1')
         api(group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0')
         api(group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1')
-        api(group: 'joda-time', name: 'joda-time', version: '2.9.8')
+        api(group: 'joda-time', name: 'joda-time', version: '2.10.9')
         api(group: 'junit', name: 'junit', version: get('junit.version'))
         api(group: 'mx4j', name: 'mx4j-tools', version: '3.0.1')
         api(group: 'mysql', name: 'mysql-connector-java', version: '5.1.46')
@@ -174,10 +172,15 @@ class DependencyConstraints implements Plugin<Project> {
       }
     }
 
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.11.3') {
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.12.1') {
       entry('jackson-annotations')
       entry('jackson-core')
       entry('jackson-databind')
+    }
+
+    dependencySet(group: 'com.fasterxml.jackson.datatype', version: '2.12.1') {
+      entry('jackson-datatype-joda')
+      entry('jackson-datatype-jsr310')
     }
 
     dependencySet(group: 'com.jayway.jsonpath', version: '2.5.0') {

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1017,9 +1017,9 @@ lib/gfsh-dependencies.jar
 lib/httpclient-4.5.13.jar
 lib/httpcore-4.4.14.jar
 lib/istack-commons-runtime-4.0.0.jar
-lib/jackson-annotations-2.11.3.jar
-lib/jackson-core-2.11.3.jar
-lib/jackson-databind-2.11.3.jar
+lib/jackson-annotations-2.12.1.jar
+lib/jackson-core-2.12.1.jar
+lib/jackson-databind-2.12.1.jar
 lib/javax.activation-api-1.2.0.jar
 lib/javax.mail-api-1.6.2.jar
 lib/javax.resource-api-1.7.1.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -16,9 +16,9 @@ geode-redis-0.0.0.jar
 geode-serialization-0.0.0.jar
 geode-tcp-server-0.0.0.jar
 geode-wan-0.0.0.jar
-jackson-databind-2.11.3.jar
-jackson-annotations-2.11.3.jar
-jackson-core-2.11.3.jar
+jackson-databind-2.12.1.jar
+jackson-annotations-2.12.1.jar
+jackson-core-2.12.1.jar
 geode-membership-0.0.0.jar
 geode-http-service-0.0.0.jar
 geode-unsafe-0.0.0.jar

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/DistributedSystemMBeanIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/DistributedSystemMBeanIntegrationTest.java
@@ -40,6 +40,8 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 public class DistributedSystemMBeanIntegrationTest {
 
   public static final String SELECT_ALL = "select * from /testRegion r where r.id=1";
+  public static final String SELECT_ALL_BUT_LOCAL_DATE =
+      "select name, address, startDate, endDate, title from /testRegion r where r.id=1";
   public static final String SELECT_FIELDS = "select id, title from /testRegion r where r.id=1";
 
   @ClassRule
@@ -109,22 +111,28 @@ public class DistributedSystemMBeanIntegrationTest {
   }
 
   // this is simply to document the current behavior of gfsh
-  // gfsh doesn't attempt to format the date objects as of now, and it respect the json annotations
-  // when listing out the headers
   @Test
   public void queryAllUsingGfshDoesNotFormatDate() throws Exception {
     gfsh.connectAndVerify(server.getJmxPort(), GfshCommandRule.PortType.jmxManager);
     TabularResultModelAssert tabularAssert =
-        gfsh.executeAndAssertThat("query --query='" + SELECT_ALL + "'")
+        gfsh.executeAndAssertThat("query --query='" + SELECT_ALL_BUT_LOCAL_DATE + "'")
             .statusIsSuccess()
             .hasTableSection();
-    // note gfsh doesn't show id field and shows "title" field as "Job Title" when doing select *
     tabularAssert.hasColumns().asList().containsExactlyInAnyOrder("name", "address", "startDate",
-        "endDate", "birthday", "Job Title");
+        "endDate", "title");
     tabularAssert.hasColumn("startDate").containsExactly(date.getTime() + "");
     tabularAssert.hasColumn("endDate").containsExactly(sqlDate.getTime() + "");
-    tabularAssert.hasColumn("birthday")
-        .asList().asString().contains("\"year\":2020,\"month\":\"JANUARY\"");
+  }
+
+  // this is simply to document the current behavior of gfsh
+  // gfsh refused to format the date objects as of jackson 2.12's fix#2683
+  @Test
+  public void queryAllUsingGfshRefusesToFormatLocalDate() throws Exception {
+    gfsh.connectAndVerify(server.getJmxPort(), GfshCommandRule.PortType.jmxManager);
+    gfsh.executeAndAssertThat("query --query='" + SELECT_ALL + "'")
+        .statusIsError()
+        .containsOutput(
+            "Java 8 date/time type `java.time.LocalDate` not supported by default: add Module \"com.fasterxml.jackson.datatype:jackson-datatype-jsr310\"");
   }
 
   @Test


### PR DESCRIPTION
1 test fails after this bump.  it appears that the test was capturing a "bad" behavior that is now [prevented](https://github.com/FasterXML/jackson-databind/issues/2683) in Jackson 2.12

to reproduce: `./gradlew :geode-core:integrationTest --tests DistributedSystemMBeanIntegrationTest.queryAllUsingGfshDoesNotFormatDate`