### PR TITLE
GEODE-8765: Fix NullPointerException when group-transaction-events an…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -1260,7 +1260,6 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     addPeekedEvents(batch, batchSize == BATCH_BASED_ON_TIME_ONLY ? DEFAULT_BATCH_SIZE : batchSize);
 
     int bId;
-    Map<TransactionId, Integer> incompleteTransactionsInBatch = new HashMap<>();
     while (batchSize == BATCH_BASED_ON_TIME_ONLY || batch.size() < batchSize) {
       if (areLocalBucketQueueRegionsPresent() && ((bId = getRandomPrimaryBucket(prQ)) != -1)) {
         GatewaySenderEventImpl object = (GatewaySenderEventImpl) peekAhead(prQ, bId);
@@ -1280,13 +1279,6 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
             logger.debug("The gatewayEventImpl in peek is {}", object);
           }
           batch.add(object);
-          if (object.getTransactionId() != null) {
-            if (object.isLastEventInTransaction()) {
-              incompleteTransactionsInBatch.remove(object.getTransactionId());
-            } else {
-              incompleteTransactionsInBatch.put(object.getTransactionId(), bId);
-            }
-          }
           peekedEvents.add(object);
 
         } else {
@@ -1316,7 +1308,7 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     }
 
     if (batch.size() > 0) {
-      peekEventsFromIncompleteTransactions(batch, incompleteTransactionsInBatch, prQ);
+      peekEventsFromIncompleteTransactions(batch, prQ);
     }
 
     if (isDebugEnabled) {
@@ -1351,11 +1343,13 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
   }
 
   private void peekEventsFromIncompleteTransactions(List<GatewaySenderEventImpl> batch,
-      Map<TransactionId, Integer> incompleteTransactionIdsInBatch, PartitionedRegion prQ) {
+      PartitionedRegion prQ) {
     if (!mustGroupTransactionEvents()) {
       return;
     }
 
+    Map<TransactionId, Integer> incompleteTransactionIdsInBatch =
+        getIncompleteTransactionsInBatch(batch);
     if (areAllTransactionsCompleteInBatch(incompleteTransactionIdsInBatch)) {
       return;
     }
@@ -1387,6 +1381,21 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
             transactionId, retries);
       }
     }
+  }
+
+  private Map<TransactionId, Integer> getIncompleteTransactionsInBatch(List batch) {
+    Map<TransactionId, Integer> incompleteTransactionsInBatch = new HashMap<>();
+    for (Object object : batch) {
+      GatewaySenderEventImpl event = (GatewaySenderEventImpl) object;
+      if (event.getTransactionId() != null) {
+        if (event.isLastEventInTransaction()) {
+          incompleteTransactionsInBatch.remove(event.getTransactionId());
+        } else {
+          incompleteTransactionsInBatch.put(event.getTransactionId(), event.getBucketId());
+        }
+      }
+    }
+    return incompleteTransactionsInBatch;
   }
 
   private boolean areAllTransactionsCompleteInBatch(Map incompleteTransactions) {
@@ -1472,19 +1481,18 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     for (int i = 0; i < batchSize || incompleteTransactionsInBatch.size() != 0; i++) {
       GatewaySenderEventImpl event = this.peekedEventsProcessing.remove();
       batch.add(event);
-      if (event.getTransactionId() != null) {
-        if (event.isLastEventInTransaction()) {
-          incompleteTransactionsInBatch.remove(event.getTransactionId());
-        } else {
-          incompleteTransactionsInBatch.add(event.getTransactionId());
+      if (mustGroupTransactionEvents()) {
+        if (event.getTransactionId() != null) {
+          if (event.isLastEventInTransaction()) {
+            incompleteTransactionsInBatch.remove(event.getTransactionId());
+          } else {
+            incompleteTransactionsInBatch.add(event.getTransactionId());
+          }
         }
       }
       if (this.peekedEventsProcessing.isEmpty()) {
         this.resetLastPeeked = false;
         this.peekedEventsProcessingInProgress = false;
-        if (incompleteTransactionsInBatch.size() != 0) {
-          logger.error("A batch with incomplete transactions has been sent.");
-        }
         break;
       }
     }
@@ -1547,9 +1555,9 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
 
     try {
       Predicate<GatewaySenderEventImpl> hasTransactionIdPredicate =
-          x -> x.getTransactionId().equals(transactionId);
+          getHasTransactionIdPredicate(transactionId);
       Predicate<GatewaySenderEventImpl> isLastEventInTransactionPredicate =
-          x -> x.isLastEventInTransaction();
+          getIsLastEventInTransactionPredicate();
       objects =
           brq.getElementsMatching(hasTransactionIdPredicate, isLastEventInTransactionPredicate);
     } catch (BucketRegionQueueUnavailableException e) {
@@ -1561,6 +1569,16 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     // finished with peeked objects.
   }
 
+  @VisibleForTesting
+  public static Predicate<GatewaySenderEventImpl> getIsLastEventInTransactionPredicate() {
+    return x -> x.isLastEventInTransaction();
+  }
+
+  @VisibleForTesting
+  public static Predicate<GatewaySenderEventImpl> getHasTransactionIdPredicate(
+      TransactionId transactionId) {
+    return x -> transactionId.equals(x.getTransactionId());
+  }
 
   protected BucketRegionQueue getBucketRegionQueueByBucketId(final PartitionedRegion prQ,
       final int bucketId) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -1350,7 +1350,7 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
 
     Map<TransactionId, Integer> incompleteTransactionIdsInBatch =
         getIncompleteTransactionsInBatch(batch);
-    if (areAllTransactionsCompleteInBatch(incompleteTransactionIdsInBatch)) {
+    if (incompleteTransactionIdsInBatch.size() == 0) {
       return;
     }
 
@@ -1383,10 +1383,10 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
     }
   }
 
-  private Map<TransactionId, Integer> getIncompleteTransactionsInBatch(List batch) {
+  private Map<TransactionId, Integer> getIncompleteTransactionsInBatch(
+      List<GatewaySenderEventImpl> batch) {
     Map<TransactionId, Integer> incompleteTransactionsInBatch = new HashMap<>();
-    for (Object object : batch) {
-      GatewaySenderEventImpl event = (GatewaySenderEventImpl) object;
+    for (GatewaySenderEventImpl event : batch) {
       if (event.getTransactionId() != null) {
         if (event.isLastEventInTransaction()) {
           incompleteTransactionsInBatch.remove(event.getTransactionId());
@@ -1396,10 +1396,6 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
       }
     }
     return incompleteTransactionsInBatch;
-  }
-
-  private boolean areAllTransactionsCompleteInBatch(Map incompleteTransactions) {
-    return (incompleteTransactions.size() == 0);
   }
 
   @VisibleForTesting

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionQueueJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionQueueJUnitTest.java
@@ -37,7 +37,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.GatewaySenderEventImpl;
 import org.apache.geode.internal.cache.wan.GatewaySenderStats;
-import org.apache.geode.internal.cache.wan.parallel.ParallelGatewaySenderEventProcessor;
 import org.apache.geode.internal.cache.wan.parallel.ParallelGatewaySenderHelper;
 import org.apache.geode.internal.cache.wan.parallel.ParallelGatewaySenderQueue;
 import org.apache.geode.internal.statistics.DummyStatisticsFactory;
@@ -141,33 +140,32 @@ public class BucketRegionQueueJUnitTest {
   @Test
   public void testGetElementsMatchingWithParallelGatewaySenderQueuePredicatesAndSomeEventsNotInTransactions()
       throws ForceReattemptException {
-    ParallelGatewaySenderEventProcessor processor =
-        ParallelGatewaySenderHelper.createParallelGatewaySenderEventProcessor(this.sender);
+    ParallelGatewaySenderHelper.createParallelGatewaySenderEventProcessor(this.sender);
 
     TransactionId tx1 = new TXId(null, 1);
     TransactionId tx2 = new TXId(null, 2);
     TransactionId tx3 = new TXId(null, 3);
 
     GatewaySenderEventImpl event1 = createMockGatewaySenderEvent(1, tx1, false);
-    GatewaySenderEventImpl eventNotInTransaction1 = createMockGatewaySenderEvent(8, null, false);
-    GatewaySenderEventImpl event2 = createMockGatewaySenderEvent(2, tx2, false);
-    GatewaySenderEventImpl event3 = createMockGatewaySenderEvent(3, tx1, true);
-    GatewaySenderEventImpl event4 = createMockGatewaySenderEvent(4, tx2, true);
-    GatewaySenderEventImpl event5 = createMockGatewaySenderEvent(5, tx3, false);
-    GatewaySenderEventImpl event6 = createMockGatewaySenderEvent(6, tx3, false);
-    GatewaySenderEventImpl event7 = createMockGatewaySenderEvent(7, tx1, true);
+    GatewaySenderEventImpl eventNotInTransaction1 = createMockGatewaySenderEvent(2, null, false);
+    GatewaySenderEventImpl event2 = createMockGatewaySenderEvent(3, tx2, false);
+    GatewaySenderEventImpl event3 = createMockGatewaySenderEvent(4, tx1, true);
+    GatewaySenderEventImpl event4 = createMockGatewaySenderEvent(5, tx2, true);
+    GatewaySenderEventImpl event5 = createMockGatewaySenderEvent(6, tx3, false);
+    GatewaySenderEventImpl event6 = createMockGatewaySenderEvent(7, tx3, false);
+    GatewaySenderEventImpl event7 = createMockGatewaySenderEvent(8, tx1, true);
 
     this.bucketRegionQueue
         .cleanUpDestroyedTokensAndMarkGIIComplete(InitialImageOperation.GIIStatus.NO_GII);
 
-    this.bucketRegionQueue.addToQueue(Long.valueOf(1), event1);
-    this.bucketRegionQueue.addToQueue(Long.valueOf(2), eventNotInTransaction1);
-    this.bucketRegionQueue.addToQueue(Long.valueOf(3), event2);
-    this.bucketRegionQueue.addToQueue(Long.valueOf(4), event3);
-    this.bucketRegionQueue.addToQueue(Long.valueOf(5), event4);
-    this.bucketRegionQueue.addToQueue(Long.valueOf(6), event5);
-    this.bucketRegionQueue.addToQueue(Long.valueOf(7), event6);
-    this.bucketRegionQueue.addToQueue(Long.valueOf(8), event7);
+    this.bucketRegionQueue.addToQueue(1L, event1);
+    this.bucketRegionQueue.addToQueue(2L, eventNotInTransaction1);
+    this.bucketRegionQueue.addToQueue(3L, event2);
+    this.bucketRegionQueue.addToQueue(4L, event3);
+    this.bucketRegionQueue.addToQueue(5L, event4);
+    this.bucketRegionQueue.addToQueue(6L, event5);
+    this.bucketRegionQueue.addToQueue(7L, event6);
+    this.bucketRegionQueue.addToQueue(8L, event7);
 
     Predicate<GatewaySenderEventImpl> hasTransactionIdPredicate =
         ParallelGatewaySenderQueue.getHasTransactionIdPredicate(tx1);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -1739,22 +1739,14 @@ public class WANTestBase extends DistributedTestCase {
 
   public static void createSender(String dsName, int remoteDsId, boolean isParallel,
       Integer maxMemory, Integer batchSize, boolean isConflation, boolean isPersistent,
-      GatewayEventFilter filter, boolean isManualStart, boolean groupTransactionEvents) {
-    createSender(dsName, remoteDsId, isParallel, maxMemory, batchSize, isConflation, isPersistent,
-        filter, isManualStart, groupTransactionEvents, 0);
-  }
-
-  public static void createSender(String dsName, int remoteDsId, boolean isParallel,
-      Integer maxMemory, Integer batchSize, boolean isConflation, boolean isPersistent,
       GatewayEventFilter filter, boolean isManualStart) {
     createSender(dsName, remoteDsId, isParallel, maxMemory, batchSize, isConflation, isPersistent,
-        filter, isManualStart, false, 0);
+        filter, isManualStart, false);
   }
 
   public static void createSender(String dsName, int remoteDsId, boolean isParallel,
       Integer maxMemory, Integer batchSize, boolean isConflation, boolean isPersistent,
-      GatewayEventFilter filter, boolean isManualStart, boolean groupTransactionEvents,
-      int dispatcherThreads) {
+      GatewayEventFilter filter, boolean isManualStart, boolean groupTransactionEvents) {
     final IgnoredException exln = IgnoredException.addIgnoredException("Could not connect");
     try {
       File persistentDirectory =
@@ -1762,12 +1754,9 @@ public class WANTestBase extends DistributedTestCase {
       persistentDirectory.mkdir();
       DiskStoreFactory dsf = cache.createDiskStoreFactory();
       File[] dirs1 = new File[] {persistentDirectory};
-      if (dispatcherThreads == 0) {
-        dispatcherThreads = numDispatcherThreadsForTheRun;
-      }
       GatewaySenderFactory gateway = configureGateway(dsf, dirs1, dsName, isParallel, maxMemory,
           batchSize, isConflation, isPersistent, filter, isManualStart,
-          dispatcherThreads, GatewaySender.DEFAULT_ORDER_POLICY,
+          numDispatcherThreadsForTheRun, GatewaySender.DEFAULT_ORDER_POLICY,
           GatewaySender.DEFAULT_SOCKET_BUFFER_SIZE);
       gateway.setGroupTransactionEvents(groupTransactionEvents);
       gateway.create(dsName, remoteDsId);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -1739,14 +1739,22 @@ public class WANTestBase extends DistributedTestCase {
 
   public static void createSender(String dsName, int remoteDsId, boolean isParallel,
       Integer maxMemory, Integer batchSize, boolean isConflation, boolean isPersistent,
-      GatewayEventFilter filter, boolean isManualStart) {
+      GatewayEventFilter filter, boolean isManualStart, boolean groupTransactionEvents) {
     createSender(dsName, remoteDsId, isParallel, maxMemory, batchSize, isConflation, isPersistent,
-        filter, isManualStart, false);
+        filter, isManualStart, groupTransactionEvents, 0);
   }
 
   public static void createSender(String dsName, int remoteDsId, boolean isParallel,
       Integer maxMemory, Integer batchSize, boolean isConflation, boolean isPersistent,
-      GatewayEventFilter filter, boolean isManualStart, boolean groupTransactionEvents) {
+      GatewayEventFilter filter, boolean isManualStart) {
+    createSender(dsName, remoteDsId, isParallel, maxMemory, batchSize, isConflation, isPersistent,
+        filter, isManualStart, false, 0);
+  }
+
+  public static void createSender(String dsName, int remoteDsId, boolean isParallel,
+      Integer maxMemory, Integer batchSize, boolean isConflation, boolean isPersistent,
+      GatewayEventFilter filter, boolean isManualStart, boolean groupTransactionEvents,
+      int dispatcherThreads) {
     final IgnoredException exln = IgnoredException.addIgnoredException("Could not connect");
     try {
       File persistentDirectory =
@@ -1754,9 +1762,12 @@ public class WANTestBase extends DistributedTestCase {
       persistentDirectory.mkdir();
       DiskStoreFactory dsf = cache.createDiskStoreFactory();
       File[] dirs1 = new File[] {persistentDirectory};
+      if (dispatcherThreads == 0) {
+        dispatcherThreads = numDispatcherThreadsForTheRun;
+      }
       GatewaySenderFactory gateway = configureGateway(dsf, dirs1, dsName, isParallel, maxMemory,
           batchSize, isConflation, isPersistent, filter, isManualStart,
-          numDispatcherThreadsForTheRun, GatewaySender.DEFAULT_ORDER_POLICY,
+          dispatcherThreads, GatewaySender.DEFAULT_ORDER_POLICY,
           GatewaySender.DEFAULT_SOCKET_BUFFER_SIZE);
       gateway.setGroupTransactionEvents(groupTransactionEvents);
       gateway.create(dsName, remoteDsId);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
@@ -62,7 +62,7 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
   @Test
   public void test_ParallelGatewaySenderMetaRegionNotExposedToUser_Bug44216() {
     Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
     createCache(lnPort);
     createSender("ln", 2, true, 100, 300, false, false, null, true);
@@ -84,10 +84,10 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
     }
 
     GemFireCacheImpl gemCache = (GemFireCacheImpl) cache;
-    Set regionSet = gemCache.rootRegions();
+    Set<?> regionSet = gemCache.rootRegions();
 
     for (Object r : regionSet) {
-      if (((Region) r).getName()
+      if (((Region<?, ?>) r).getName()
           .equals(((AbstractGatewaySender) sender).getQueues().toArray(new RegionQueue[1])[0]
               .getRegion().getName())) {
         fail("The shadowPR is exposed to the user");
@@ -690,18 +690,18 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
     vm2.invoke(createReceiverPartitionedRegionRedundancy1());
     vm3.invoke(createReceiverPartitionedRegionRedundancy1());
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm7.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 5000));
     Wait.pause(500);
-    AsyncInvocation inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
-    AsyncInvocation inv3 =
+    AsyncInvocation<Void> inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
+    AsyncInvocation<Void> inv3 =
         vm6.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 10000));
     Wait.pause(1500);
-    AsyncInvocation inv4 = vm5.invokeAsync(() -> WANTestBase.killSender());
-    inv1.join();
-    inv2.join();
-    inv3.join();
-    inv4.join();
+    AsyncInvocation<Void> inv4 = vm5.invokeAsync(() -> WANTestBase.killSender());
+    inv1.await();
+    inv2.await();
+    inv3.await();
+    inv4.await();
 
     vm6.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 10000));
     vm7.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 10000));
@@ -1054,7 +1054,7 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
     vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "PARENT_PR", null, 0,
         100, isOffHeap(), shortcut));
     String parentRegionFullPath =
-        (String) vm3.invoke(() -> WANTestBase.getRegionFullPath(getTestMethodName() + "PARENT_PR"));
+        vm3.invoke(() -> WANTestBase.getRegionFullPath(getTestMethodName() + "PARENT_PR"));
 
     // create colocated (child) PR on site1
     vm3.invoke(() -> WANTestBase.createColocatedPartitionedRegion(getTestMethodName() + "CHILD_PR",
@@ -1252,14 +1252,19 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
     createReceiverInVMs(vm2, vm3);
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
 
+    vm4.invoke(() -> setNumDispatcherThreadsForTheRun(2));
+    vm5.invoke(() -> setNumDispatcherThreadsForTheRun(2));
+    vm6.invoke(() -> setNumDispatcherThreadsForTheRun(2));
+    vm7.invoke(() -> setNumDispatcherThreadsForTheRun(2));
+
     vm4.invoke(
-        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true, 2));
+        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true));
     vm5.invoke(
-        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true, 2));
+        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true));
     vm6.invoke(
-        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true, 2));
+        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true));
     vm7.invoke(
-        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true, 2));
+        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true));
 
     vm4.invoke(
         () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
@@ -1282,7 +1287,7 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
     int customers = 4;
 
     int transactionsPerCustomer = 1000;
-    final Map keyValuesInTransactions = new HashMap();
+    final Map<Object, Object> keyValuesInTransactions = new HashMap<>();
     for (int custId = 0; custId < customers; custId++) {
       for (int i = 0; i < transactionsPerCustomer; i++) {
         CustId custIdObject = new CustId(custId);
@@ -1299,7 +1304,7 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
 
     int ordersPerCustomerNotInTransactions = 1000;
 
-    final Map keyValuesNotInTransactions = new HashMap();
+    final Map<Object, Object> keyValuesNotInTransactions = new HashMap<>();
     for (int custId = 0; custId < customers; custId++) {
       for (int i = 0; i < ordersPerCustomerNotInTransactions; i++) {
         CustId custIdObject = new CustId(custId);
@@ -1310,12 +1315,12 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
 
     // eventsPerTransaction is 1 (orders) + 3 (shipments)
     int eventsPerTransaction = 4;
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm7.invokeAsync(
             () -> WANTestBase.doOrderAndShipmentPutsInsideTransactions(keyValuesInTransactions,
                 eventsPerTransaction));
 
-    AsyncInvocation inv2 =
+    AsyncInvocation<Void> inv2 =
         vm6.invokeAsync(
             () -> WANTestBase.putGivenKeyValue(orderRegionName, keyValuesNotInTransactions));
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
@@ -17,6 +17,8 @@ package org.apache.geode.internal.cache.wan.parallel;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import junitparams.JUnitParamsRunner;
@@ -33,6 +35,11 @@ import org.apache.geode.cache.client.ServerOperationException;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.RegionQueue;
+import org.apache.geode.internal.cache.execute.data.CustId;
+import org.apache.geode.internal.cache.execute.data.Order;
+import org.apache.geode.internal.cache.execute.data.OrderId;
+import org.apache.geode.internal.cache.execute.data.Shipment;
+import org.apache.geode.internal.cache.execute.data.ShipmentId;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.BatchException70;
 import org.apache.geode.internal.cache.wan.WANTestBase;
@@ -1235,6 +1242,107 @@ public class ParallelWANPropagationDUnitTest extends WANTestBase {
     vm5.invoke(() -> WANTestBase.validateEmptyBucketToTempQueueMap("ln"));
   }
 
+  @Test
+  public void testPartitionedParallelPropagationWithGroupTransactionEventsAndMixOfEventsInAndNotInTransactions()
+      throws Exception {
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+
+    createCacheInVMs(nyPort, vm2, vm3);
+    createReceiverInVMs(vm2, vm3);
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+
+    vm4.invoke(
+        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true, 2));
+    vm5.invoke(
+        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true, 2));
+    vm6.invoke(
+        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true, 2));
+    vm7.invoke(
+        () -> WANTestBase.createSender("ln", 2, true, 100, 10, false, false, null, true, true, 2));
+
+    vm4.invoke(
+        () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
+            isOffHeap()));
+    vm5.invoke(
+        () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
+            isOffHeap()));
+    vm6.invoke(
+        () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
+            isOffHeap()));
+    vm7.invoke(
+        () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
+            isOffHeap()));
+
+    startSenderInVMs("ln", vm4, vm5, vm6, vm7);
+
+    vm2.invoke(() -> createCustomerOrderShipmentPartitionedRegion(null, 1, 8, isOffHeap()));
+    vm3.invoke(() -> createCustomerOrderShipmentPartitionedRegion(null, 1, 8, isOffHeap()));
+
+    int customers = 4;
+
+    int transactionsPerCustomer = 1000;
+    final Map keyValuesInTransactions = new HashMap();
+    for (int custId = 0; custId < customers; custId++) {
+      for (int i = 0; i < transactionsPerCustomer; i++) {
+        CustId custIdObject = new CustId(custId);
+        OrderId orderId = new OrderId(i, custIdObject);
+        ShipmentId shipmentId1 = new ShipmentId(i, orderId);
+        ShipmentId shipmentId2 = new ShipmentId(i + 1, orderId);
+        ShipmentId shipmentId3 = new ShipmentId(i + 2, orderId);
+        keyValuesInTransactions.put(orderId, new Order());
+        keyValuesInTransactions.put(shipmentId1, new Shipment());
+        keyValuesInTransactions.put(shipmentId2, new Shipment());
+        keyValuesInTransactions.put(shipmentId3, new Shipment());
+      }
+    }
+
+    int ordersPerCustomerNotInTransactions = 1000;
+
+    final Map keyValuesNotInTransactions = new HashMap();
+    for (int custId = 0; custId < customers; custId++) {
+      for (int i = 0; i < ordersPerCustomerNotInTransactions; i++) {
+        CustId custIdObject = new CustId(custId);
+        OrderId orderId = new OrderId(i + transactionsPerCustomer * customers, custIdObject);
+        keyValuesNotInTransactions.put(orderId, new Order());
+      }
+    }
+
+    // eventsPerTransaction is 1 (orders) + 3 (shipments)
+    int eventsPerTransaction = 4;
+    AsyncInvocation inv1 =
+        vm7.invokeAsync(
+            () -> WANTestBase.doOrderAndShipmentPutsInsideTransactions(keyValuesInTransactions,
+                eventsPerTransaction));
+
+    AsyncInvocation inv2 =
+        vm6.invokeAsync(
+            () -> WANTestBase.putGivenKeyValue(orderRegionName, keyValuesNotInTransactions));
+
+    inv1.await();
+    inv2.await();
+
+    int entries =
+        ordersPerCustomerNotInTransactions * customers + transactionsPerCustomer * customers;
+
+    vm4.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+    vm5.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+    vm6.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+    vm7.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+
+    vm2.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+    vm3.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+
+    vm4.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+    vm5.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+    vm6.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+    vm7.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+
+    vm7.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
+    vm6.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
+    vm5.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
+    vm4.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
+  }
 
   private static RegionShortcut[] getRegionShortcuts() {
     return new RegionShortcut[] {RegionShortcut.PARTITION, RegionShortcut.PARTITION_PERSISTENT};

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagation_PartitionedRegionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagation_PartitionedRegionDUnitTest.java
@@ -14,12 +14,20 @@
  */
 package org.apache.geode.internal.cache.wan.serial;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.internal.cache.ForceReattemptException;
+import org.apache.geode.internal.cache.execute.data.CustId;
+import org.apache.geode.internal.cache.execute.data.Order;
+import org.apache.geode.internal.cache.execute.data.OrderId;
+import org.apache.geode.internal.cache.execute.data.Shipment;
+import org.apache.geode.internal.cache.execute.data.ShipmentId;
 import org.apache.geode.internal.cache.wan.WANTestBase;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
@@ -370,5 +378,108 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
 
     vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
     vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
+  }
+
+  @Test
+  public void testPartitionedSerialPropagationWithGroupTransactionEventsAndMixOfEventsInAndNotInTransactions()
+      throws Exception {
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+
+    createCacheInVMs(nyPort, vm2, vm3);
+    createReceiverInVMs(vm2, vm3);
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+
+    vm4.invoke(
+        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true, 1));
+    vm5.invoke(
+        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true, 1));
+    vm6.invoke(
+        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true, 1));
+    vm7.invoke(
+        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true, 1));
+
+
+    vm4.invoke(
+        () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
+            isOffHeap()));
+    vm5.invoke(
+        () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
+            isOffHeap()));
+    vm6.invoke(
+        () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
+            isOffHeap()));
+    vm7.invoke(
+        () -> WANTestBase.createCustomerOrderShipmentPartitionedRegion("ln", 2, 10,
+            isOffHeap()));
+
+    startSenderInVMs("ln", vm4, vm5, vm6, vm7);
+
+    vm2.invoke(() -> createCustomerOrderShipmentPartitionedRegion(null, 1, 8, isOffHeap()));
+    vm3.invoke(() -> createCustomerOrderShipmentPartitionedRegion(null, 1, 8, isOffHeap()));
+
+    int customers = 4;
+
+    int transactionsPerCustomer = 1000;
+    final Map keyValuesInTransactions = new HashMap();
+    for (int custId = 0; custId < customers; custId++) {
+      for (int i = 0; i < transactionsPerCustomer; i++) {
+        CustId custIdObject = new CustId(custId);
+        OrderId orderId = new OrderId(i, custIdObject);
+        ShipmentId shipmentId1 = new ShipmentId(i, orderId);
+        ShipmentId shipmentId2 = new ShipmentId(i + 1, orderId);
+        ShipmentId shipmentId3 = new ShipmentId(i + 2, orderId);
+        keyValuesInTransactions.put(orderId, new Order());
+        keyValuesInTransactions.put(shipmentId1, new Shipment());
+        keyValuesInTransactions.put(shipmentId2, new Shipment());
+        keyValuesInTransactions.put(shipmentId3, new Shipment());
+      }
+    }
+
+    int ordersPerCustomerNotInTransactions = 1000;
+
+    final Map keyValuesNotInTransactions = new HashMap();
+    for (int custId = 0; custId < customers; custId++) {
+      for (int i = 0; i < ordersPerCustomerNotInTransactions; i++) {
+        CustId custIdObject = new CustId(custId);
+        OrderId orderId = new OrderId(i + transactionsPerCustomer * customers, custIdObject);
+        keyValuesNotInTransactions.put(orderId, new Order());
+      }
+    }
+
+    // eventsPerTransaction is 1 (orders) + 3 (shipments)
+    int eventsPerTransaction = 4;
+    AsyncInvocation inv1 =
+        vm7.invokeAsync(
+            () -> WANTestBase.doOrderAndShipmentPutsInsideTransactions(keyValuesInTransactions,
+                eventsPerTransaction));
+
+    AsyncInvocation inv2 =
+        vm6.invokeAsync(
+            () -> WANTestBase.putGivenKeyValue(orderRegionName, keyValuesNotInTransactions));
+
+    inv1.await();
+    inv2.await();
+
+    int entries =
+        ordersPerCustomerNotInTransactions * customers + transactionsPerCustomer * customers;
+
+    vm4.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+    vm5.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+    vm6.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+    vm7.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+
+    vm2.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+    vm3.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, entries));
+
+    vm4.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+    vm5.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+    vm6.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+    vm7.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
+
+    vm7.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
+    vm6.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
+    vm5.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
+    vm4.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
   }
 }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagation_PartitionedRegionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagation_PartitionedRegionDUnitTest.java
@@ -43,10 +43,10 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
   }
 
   @Test
-  public void testPartitionedSerialPropagation() throws Exception {
+  public void testPartitionedSerialPropagation() {
 
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2, vm3);
     createReceiverInVMs(vm2, vm3);
@@ -79,10 +79,10 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
   }
 
   @Test
-  public void testBothReplicatedAndPartitionedSerialPropagation() throws Exception {
+  public void testBothReplicatedAndPartitionedSerialPropagation() {
 
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2, vm3);
     createReceiverInVMs(vm2, vm3);
@@ -130,10 +130,10 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
   }
 
   @Test
-  public void testSerialReplicatedAndPartitionedPropagation() throws Exception {
+  public void testSerialReplicatedAndPartitionedPropagation() {
 
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2, vm3);
     createReceiverInVMs(vm2, vm3);
@@ -184,10 +184,10 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
   }
 
   @Test
-  public void testSerialReplicatedAndSerialPartitionedPropagation() throws Exception {
+  public void testSerialReplicatedAndSerialPartitionedPropagation() {
 
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2, vm3);
     createReceiverInVMs(vm2, vm3);
@@ -244,11 +244,11 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
   }
 
   @Test
-  public void testPartitionedSerialPropagationToTwoWanSites() throws Exception {
+  public void testPartitionedSerialPropagationToTwoWanSites() {
 
     Integer lnPort = createFirstLocatorWithDSId(1);
-    Integer nyPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-    Integer tkPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(3, lnPort));
+    Integer nyPort = vm0.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer tkPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(3, lnPort));
 
     createCacheInVMs(nyPort, vm2);
     vm2.invoke(() -> WANTestBase.createReceiver());
@@ -296,8 +296,8 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
     IgnoredException.addIgnoredException("Connection reset");
     IgnoredException.addIgnoredException("Unexpected IOException");
 
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2, vm3);
     createReceiverInVMs(vm2, vm3);
@@ -330,12 +330,12 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
     IgnoredException.addIgnoredException(CacheClosedException.class.getName());
     IgnoredException.addIgnoredException(ForceReattemptException.class.getName());
     // start async puts
-    AsyncInvocation inv =
+    AsyncInvocation<Void> inv =
         vm5.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
     // close the cache on vm4 in between the puts
     vm4.invoke(() -> WANTestBase.killSender());
 
-    inv.join();
+    inv.await();
     vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
     vm3.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
     vm4.invoke(() -> WANTestBase.checkConflatedStats("ln", 0));
@@ -343,10 +343,10 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
   }
 
   @Test
-  public void testPartitionedSerialPropagationWithParallelThreads() throws Exception {
+  public void testPartitionedSerialPropagationWithParallelThreads() {
 
-    Integer lnPort = (Integer) vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = (Integer) vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
     createCacheInVMs(nyPort, vm2, vm3);
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
@@ -390,14 +390,19 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
     createReceiverInVMs(vm2, vm3);
     createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
 
+    vm4.invoke(() -> setNumDispatcherThreadsForTheRun(1));
+    vm5.invoke(() -> setNumDispatcherThreadsForTheRun(1));
+    vm6.invoke(() -> setNumDispatcherThreadsForTheRun(1));
+    vm7.invoke(() -> setNumDispatcherThreadsForTheRun(1));
+
     vm4.invoke(
-        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true, 1));
+        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true));
     vm5.invoke(
-        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true, 1));
+        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true));
     vm6.invoke(
-        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true, 1));
+        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true));
     vm7.invoke(
-        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true, 1));
+        () -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true, true));
 
 
     vm4.invoke(
@@ -421,7 +426,7 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
     int customers = 4;
 
     int transactionsPerCustomer = 1000;
-    final Map keyValuesInTransactions = new HashMap();
+    final Map<Object, Object> keyValuesInTransactions = new HashMap<>();
     for (int custId = 0; custId < customers; custId++) {
       for (int i = 0; i < transactionsPerCustomer; i++) {
         CustId custIdObject = new CustId(custId);
@@ -438,7 +443,7 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
 
     int ordersPerCustomerNotInTransactions = 1000;
 
-    final Map keyValuesNotInTransactions = new HashMap();
+    final Map<Object, Object> keyValuesNotInTransactions = new HashMap<>();
     for (int custId = 0; custId < customers; custId++) {
       for (int i = 0; i < ordersPerCustomerNotInTransactions; i++) {
         CustId custIdObject = new CustId(custId);
@@ -449,12 +454,12 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
 
     // eventsPerTransaction is 1 (orders) + 3 (shipments)
     int eventsPerTransaction = 4;
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm7.invokeAsync(
             () -> WANTestBase.doOrderAndShipmentPutsInsideTransactions(keyValuesInTransactions,
                 eventsPerTransaction));
 
-    AsyncInvocation inv2 =
+    AsyncInvocation<Void> inv2 =
         vm6.invokeAsync(
             () -> WANTestBase.putGivenKeyValue(orderRegionName, keyValuesNotInTransactions));
 


### PR DESCRIPTION
…d events in and not in transactions are sent.

A NullPointerException (caught later in the code) can
happen when events without a transactionId in
gateway sender queues are retrieved to complete
transactions.
The problem is that equals is invoked on a
possibly null object (the transactionId).
The call has been rewritten to avoid the
NullPointer exception.

The NullPointerException had different undesired effects
in the Parallel and in the Serial Gateway senders.

In Parallel Gateway Senders it can provoke that events
are left in the queue without ever being drained
although all events are replicated.
In Serial Gateway Senders, the effect is much
more severe as once the NullPointerException is
reached, no events from the queue are replicated.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
