### PR TITLE
GEODE-7861: Improve error reporting in GMSJoinLeave.join()

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -1001,7 +1001,8 @@ public class LocatorDUnitTest implements Serializable {
       // I guess it can throw this too...
 
     } catch (GemFireConfigException ex) {
-      assertThat(ex.getCause().getMessage().contains("Locator does not exist")).isTrue();
+      assertThat(ex.getCause().getMessage().contains("Could not contact any of the locators"))
+          .isTrue();
     }
   }
 

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -122,12 +122,12 @@ public class GMSJoinLeaveJUnitTest {
   }
 
   public void initMocks(boolean enableNetworkPartition, boolean useTestGMSJoinLeave,
-      String locators, String startLoactor)
+      String locators, String startLocator)
       throws Exception {
     mockConfig = mock(MembershipConfig.class);
     when(mockConfig.isNetworkPartitionDetectionEnabled()).thenReturn(enableNetworkPartition);
     when(mockConfig.getSecurityUDPDHAlgo()).thenReturn("");
-    when(mockConfig.getStartLocator()).thenReturn(startLoactor);
+    when(mockConfig.getStartLocator()).thenReturn(startLocator);
     when(mockConfig.getLocators()).thenReturn(locators);
     when(mockConfig.getMcastPort()).thenReturn(0);
     when(mockConfig.getMemberTimeout()).thenReturn(2000L);

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -565,12 +565,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
         this.isJoining = true; // added for bug #44373
 
         // connect
-        boolean ok = services.getJoinLeave().join();
-
-        if (!ok) {
-          throw new MembershipConfigurationException("Unable to join the distributed system.  "
-              + "Operation either timed out, was stopped or Locator does not exist.");
-        }
+        services.getJoinLeave().join();
 
         MembershipView<ID> initialView = createGeodeView(services.getJoinLeave().getView());
         latestView = new MembershipView<>(initialView, initialView.getViewId());

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/JoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/JoinLeave.java
@@ -29,7 +29,7 @@ public interface JoinLeave<ID extends MemberIdentifier> extends Service<ID> {
    * joins the distributed system and returns true if successful, false if not. Throws
    * MemberStartupException and MemberConfigurationException
    */
-  boolean join() throws MemberStartupException;
+  void join() throws MemberStartupException;
 
   /**
    * leaves the distributed system. Should be invoked before stop()

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/JoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/JoinLeave.java
@@ -16,6 +16,7 @@ package org.apache.geode.distributed.internal.membership.gms.interfaces;
 
 import org.apache.geode.distributed.internal.membership.api.MemberIdentifier;
 import org.apache.geode.distributed.internal.membership.api.MemberStartupException;
+import org.apache.geode.distributed.internal.membership.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 
 /**
@@ -26,8 +27,13 @@ import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
 public interface JoinLeave<ID extends MemberIdentifier> extends Service<ID> {
 
   /**
-   * joins the distributed system and returns true if successful, false if not. Throws
-   * MemberStartupException and MemberConfigurationException
+   * joins the distributed system.
+   *
+   * @throws MemberStartupException if there was a problem joining the cluster after membership
+   *         configuration has
+   *         completed.
+   * @throws MembershipConfigurationException if operation either timed out, was stopped or locator
+   *         does not exist.
    */
   void join() throws MemberStartupException;
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -315,14 +315,14 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
    * @return true if successful, false if not
    */
   @Override
-  public boolean join() throws MemberStartupException {
+  public void join() throws MemberStartupException {
 
     try {
       if (Boolean.getBoolean(BYPASS_DISCOVERY_PROPERTY)) {
         synchronized (viewInstallationLock) {
           becomeCoordinator();
         }
-        return true;
+        return;
       }
 
       SearchState<ID> state = searchState;
@@ -355,11 +355,11 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
               synchronized (viewInstallationLock) {
                 becomeCoordinator();
               }
-              return true;
+              return;
             }
           } else {
             if (attemptToJoin()) {
-              return true;
+              return;
             }
             if (this.isStopping) {
               break;
@@ -383,40 +383,44 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
             break;
           }
         }
-        try {
-          if (found && !state.hasContactedAJoinedLocator) {
-            // if locators are restarting they may be handing out IDs from a stale view that
-            // we should go through quickly. Otherwise we should sleep a bit to let failure
-            // detection select a new coordinator
-            if (state.possibleCoordinator.getVmViewId() < 0) {
-              logger.debug("sleeping for {} before making another attempt to find the coordinator",
-                  retrySleep);
-              Thread.sleep(retrySleep);
-            } else {
+        if (found && !state.hasContactedAJoinedLocator) {
+          try {
+            if (hasCoordinatorJoinedCluster(state.possibleCoordinator.getVmViewId(), retrySleep)) {
               // since we were given a coordinator that couldn't be used we should keep trying
               tries = 0;
               giveupTime = System.currentTimeMillis() + timeout;
             }
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new MembershipConfigurationException(
+                "Retry sleep interrupted. Giving up on joining the distributed system.");
           }
-        } catch (InterruptedException e) {
-          logger.debug("retry sleep interrupted - giving up on joining the distributed system");
-          return false;
         }
       } // for
 
       if (!this.isJoined) {
         logger.debug("giving up attempting to join the distributed system after "
             + (System.currentTimeMillis() - startTime) + "ms");
-      }
 
-      // to preserve old behavior we need to throw a MemberStartupException if
-      // unable to contact any of the locators
-      if (!this.isJoined && state.hasContactedAJoinedLocator) {
-        throw new MemberStartupException("Unable to join the distributed system in "
-            + (System.currentTimeMillis() - startTime) + "ms");
-      }
+        // to preserve old behavior we need to throw a MemberStartupException if
+        // unable to contact any of the locators
+        if (state.hasContactedAJoinedLocator) {
+          throw new MemberStartupException("Unable to join the distributed system in "
+              + (System.currentTimeMillis() - startTime) + "ms");
+        }
 
-      return this.isJoined;
+        if (state.locatorsContacted == 0) {
+          throw new MembershipConfigurationException(
+              "Unable to join the distributed system. Could not contact any of the locators: "
+                  + locators);
+        }
+
+        if (System.currentTimeMillis() > giveupTime) {
+          throw new MembershipConfigurationException(
+              "Unable to join the distributed system. Operation timed out");
+        }
+      }
+      return;
     } finally {
       // notify anyone waiting on the address to be completed
       if (this.isJoined) {
@@ -426,6 +430,24 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
       }
       searchState.cleanup();
     }
+  }
+
+  boolean hasCoordinatorJoinedCluster(int viewId, long retrySleep)
+      throws InterruptedException {
+    // if locators are restarting they may be handing out IDs from a stale view that
+    // we should go through quickly. Otherwise we should sleep a bit to let failure
+    // detection select a new coordinator
+    if (viewId < 0) {
+      // the process hasn't finished joining the cluster.
+      logger.debug("sleeping for {} before making another attempt to find the coordinator",
+          retrySleep);
+      Thread.sleep(retrySleep);
+    } else {
+      // the member has joined the cluster.
+      return true;
+    }
+
+    return false;
   }
 
   /**


### PR DESCRIPTION
When a member is unable to contact a join the system due to a failure to contact a locator, we could be a lot more specific, which would help users debug issues in their environment. We currently print out

> Unable to join the distributed system.  Operation either timed out, was stopped or Locator does not exist.

This change makes the exception message more specific. Instead of printing out the same message for 3 different problems, this change separates it out into 3 different messages. In case of a failure to contact a locator, the exception will include the underlying exception from the last locator we tried to contact as a cause. Also, the exception message will include the list of locators we tried to contact.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
