### PR TITLE
GEODE-8789: Prevent region name from being incorrectly logged twice

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -618,10 +618,10 @@ public abstract class BaseCommand implements Command {
     errorMsg.send(serverConnection);
   }
 
-  protected static void writeRegionDestroyedEx(Message msg, String regionName, String title,
+  protected static void writeRegionDestroyedEx(Message msg, String regionName, String reason,
       ServerConnection serverConnection) throws IOException {
-    String reason = serverConnection.getName() + ": Region named " + regionName + title;
-    RegionDestroyedException ex = new RegionDestroyedException(reason, regionName);
+    String exceptionMessage = serverConnection.getName() + ": Region named " + regionName + reason;
+    RegionDestroyedException ex = new RegionDestroyedException(exceptionMessage, regionName);
     if (serverConnection.getTransientFlag(REQUIRES_CHUNKED_RESPONSE)) {
       writeChunkedException(msg, ex, serverConnection);
     } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/CreateRegion.java
@@ -89,9 +89,7 @@ public class CreateRegion extends BaseCommand {
 
     Region parentRegion = serverConnection.getCache().getRegion(parentRegionName);
     if (parentRegion == null) {
-      String reason =
-          String.format("%s was not found during subregion creation request",
-              parentRegionName);
+      String reason = " was not found during subregion creation request";
       writeRegionDestroyedEx(clientMessage, parentRegionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy.java
@@ -119,8 +119,7 @@ public class Destroy extends BaseCommand {
 
     LocalRegion region = (LocalRegion) serverConnection.getCache().getRegion(regionName);
     if (region == null) {
-      String reason = String.format("%s was not found during destroy request",
-          regionName);
+      String reason = " was not found during destroy request";
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Destroy65.java
@@ -210,8 +210,7 @@ public class Destroy65 extends BaseCommand {
 
     final LocalRegion region = (LocalRegion) serverConnection.getCache().getRegion(regionName);
     if (region == null) {
-      String reason = String.format("%s was not found during destroy request",
-          regionName);
+      String reason = " was not found during destroy request";
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/DestroyRegion.java
@@ -110,7 +110,7 @@ public class DestroyRegion extends BaseCommand {
     LocalRegion region = (LocalRegion) serverConnection.getCache().getRegion(regionName);
     if (region == null) {
       String reason =
-          "Region was not found during destroy region request";
+          " was not found during destroy region request";
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Get70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Get70.java
@@ -125,7 +125,7 @@ public class Get70 extends BaseCommand {
 
     Region region = serverConnection.getCache().getRegion(regionName);
     if (region == null) {
-      String reason = String.format("%s was not found during get request", regionName);
+      String reason = " was not found during get request";
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Invalidate.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Invalidate.java
@@ -113,8 +113,7 @@ public class Invalidate extends BaseCommand {
     }
     LocalRegion region = (LocalRegion) serverConnection.getCache().getRegion(regionName);
     if (region == null) {
-      String reason = String.format("%s was not found during %s request",
-          regionName, "invalidate");
+      String reason = " was not found during invalidate request";
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/KeySet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/KeySet.java
@@ -86,8 +86,7 @@ public class KeySet extends BaseCommand {
 
     LocalRegion region = (LocalRegion) serverConnection.getCache().getRegion(regionName);
     if (region == null) {
-      String reason = String.format("%s was not found during key set request",
-          regionName);
+      String reason = " was not found during key set request";
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put.java
@@ -119,8 +119,7 @@ public class Put extends BaseCommand {
 
     LocalRegion region = (LocalRegion) serverConnection.getCache().getRegion(regionName);
     if (region == null) {
-      String reason =
-          ": Region was not found during put request";
+      String reason = " was not found during put request";
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Request.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Request.java
@@ -116,8 +116,7 @@ public class Request extends BaseCommand {
     } else {
       Region region = serverConnection.getCache().getRegion(regionName);
       if (region == null) {
-        String reason = String.format("%s was not found during get request",
-            regionName);
+        String reason = " was not found during get request";
         writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
         serverConnection.setAsTrue(RESPONDED);
       } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Size.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Size.java
@@ -80,8 +80,7 @@ public class Size extends BaseCommand {
 
     LocalRegion region = (LocalRegion) crHelper.getRegion(regionName);
     if (region == null) {
-      String reason = String.format("%s was not found during %s request",
-          regionName, "size");
+      String reason = " was not found during size request";
       writeRegionDestroyedEx(clientMessage, regionName, reason, serverConnection);
       serverConnection.setAsTrue(RESPONDED);
       return;


### PR DESCRIPTION
- Do not format the String containing the reason for the exception to
contain the region name

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
