### PR TITLE
GEODE-8794: Support redis 6 HELLO command

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandSupportLevel.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandSupportLevel.java
@@ -19,5 +19,6 @@ package org.apache.geode.redis.internal;
 public enum RedisCommandSupportLevel {
   SUPPORTED,
   UNSUPPORTED,
-  UNIMPLEMENTED
+  UNIMPLEMENTED,
+  UNKNOWN
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -177,6 +177,17 @@ public enum RedisCommandType {
   UNKNOWN(new UnknownExecutor(), SUPPORTED),
 
   /***************************************
+   *** Unknown Commands ***
+   ***************************************/
+  /**
+   * This handles the special case when using the lettuce (and perhaps other) clients. This
+   * client sends a HELLO command to try and infer which protocol to use. If it receives back
+   * 'UNKNOWN command', it uses the older, RESP2, protocol. This also needs to work when
+   * authentication is enabled.
+   */
+  HELLO(new UnknownExecutor(), RedisCommandSupportLevel.UNKNOWN),
+
+  /***************************************
    *** Unsupported Commands ***
    ***************************************/
 
@@ -414,6 +425,10 @@ public enum RedisCommandType {
 
   public boolean isUnimplemented() {
     return supportLevel == UNIMPLEMENTED;
+  }
+
+  public boolean isUnknown() {
+    return supportLevel == RedisCommandSupportLevel.UNKNOWN;
   }
 
   public boolean isAllowedWhileSubscribed() {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -174,19 +174,6 @@ public enum RedisCommandType {
   PUNSUBSCRIBE(new PunsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(1)),
   UNSUBSCRIBE(new UnsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(1)),
 
-  UNKNOWN(new UnknownExecutor(), SUPPORTED),
-
-  /***************************************
-   *** Unknown Commands ***
-   ***************************************/
-  /**
-   * This handles the special case when using the lettuce (and perhaps other) clients. This
-   * client sends a HELLO command to try and infer which protocol to use. If it receives back
-   * 'UNKNOWN command', it uses the older, RESP2, protocol. This also needs to work when
-   * authentication is enabled.
-   */
-  HELLO(new UnknownExecutor(), RedisCommandSupportLevel.UNKNOWN),
-
   /***************************************
    *** Unsupported Commands ***
    ***************************************/
@@ -390,7 +377,12 @@ public enum RedisCommandType {
   ZREVRANK(null, UNIMPLEMENTED),
   ZSCORE(null, UNIMPLEMENTED),
   ZUNIONSCORE(null, UNIMPLEMENTED),
-  ZSCAN(null, UNIMPLEMENTED);
+  ZSCAN(null, UNIMPLEMENTED),
+
+  /***************************************
+   *** Unknown Commands ***
+   ***************************************/
+  UNKNOWN(new UnknownExecutor(), RedisCommandSupportLevel.UNKNOWN);
 
   private final Executor executor;
   private final ParameterRequirements parameterRequirements;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
@@ -80,6 +80,10 @@ public class Command {
     return commandType.isUnimplemented();
   }
 
+  public boolean isUnknown() {
+    return commandType.isUnknown();
+  }
+
   /**
    * Used to get the command element list
    *

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -281,6 +281,11 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
             channel.remoteAddress().toString());
       }
 
+      if (command.isUnknown()) {
+        writeToChannel(command.execute(this));
+        return;
+      }
+
       if (!isAuthenticated()) {
         writeToChannel(handleUnAuthenticatedCommand(command));
         return;

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -231,6 +231,10 @@ public class SupportedCommandsJUnitTest {
       "ZSCAN"
   };
 
+  private final String[] unknownCommands = new String[] {
+      "HELLO"
+  };
+
   @Test
   public void crossCheckAllUnsupportedCommands_areMarkedUnsupported() {
     for (String commandName : unSupportedCommands) {
@@ -278,8 +282,9 @@ public class SupportedCommandsJUnitTest {
     List<String> allCommands = new ArrayList<>(asList(supportedCommands));
     allCommands.addAll(asList(unSupportedCommands));
 
-    List<String> implementedCommands =
-        getAllImplementedCommands().stream().map(Enum::name).collect(Collectors.toList());
+    List<String> implementedCommands = getAllImplementedCommands().stream()
+        .filter(c -> !c.isUnknown())
+        .map(Enum::name).collect(Collectors.toList());
 
     assertThat(implementedCommands).containsExactlyInAnyOrderElementsOf(allCommands);
   }
@@ -289,6 +294,7 @@ public class SupportedCommandsJUnitTest {
     List<String> allCommands = new ArrayList<>(asList(supportedCommands));
     allCommands.addAll(asList(unSupportedCommands));
     allCommands.addAll(asList(unImplementedCommands));
+    allCommands.addAll(asList(unknownCommands));
 
     List<String> definedCommands =
         Arrays.stream(RedisCommandType.values()).map(Enum::name).collect(Collectors.toList());

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -58,7 +58,6 @@ public class SupportedCommandsJUnitTest {
       "SUBSCRIBE",
       "TTL",
       "TYPE",
-      "UNKNOWN",
       "UNSUBSCRIBE",
   };
 
@@ -232,7 +231,7 @@ public class SupportedCommandsJUnitTest {
   };
 
   private final String[] unknownCommands = new String[] {
-      "HELLO"
+      "UNKNOWN"
   };
 
   @Test


### PR DESCRIPTION
- This deals with some specfics related to how the lettuce v6 client
  determines what protocol to use when authentication is also enabled.

Authored-by: Jens Deppe <jdeppe@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
