### PR TITLE
GEODE-8799: Increase defaults for OperationExecutors.MAX_THREADS and ClusterOperationExecutors.MAX_PR_THREADS

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterOperationExecutors.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterOperationExecutors.java
@@ -68,8 +68,7 @@ public class ClusterOperationExecutors implements OperationExecutors {
       Integer.getInteger("DistributionManager.MAX_PR_META_DATA_CLEANUP_THREADS", 1);
 
   private static final int MAX_PR_THREADS = Integer.getInteger("DistributionManager.MAX_PR_THREADS",
-      Math.max(Runtime.getRuntime().availableProcessors() * 4, 16));
-
+      Math.max(Runtime.getRuntime().availableProcessors() * 32, 200));
 
   private static final int INCOMING_QUEUE_LIMIT =
       Integer.getInteger("DistributionManager.INCOMING_QUEUE_LIMIT", 80000);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/OperationExecutors.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/OperationExecutors.java
@@ -26,7 +26,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
  */
 public interface OperationExecutors {
   int MAX_THREADS =
-      Integer.getInteger("DistributionManager.MAX_THREADS", 300);
+      Integer.getInteger("DistributionManager.MAX_THREADS", 1000);
 
   int MAX_FE_THREADS = Integer.getInteger("DistributionManager.MAX_FE_THREADS",
       Math.max(Runtime.getRuntime().availableProcessors() * 16, 100));

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/OperationExecutors.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/OperationExecutors.java
@@ -26,7 +26,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
  */
 public interface OperationExecutors {
   int MAX_THREADS =
-      Integer.getInteger("DistributionManager.MAX_THREADS", 100);
+      Integer.getInteger("DistributionManager.MAX_THREADS", 300);
 
   int MAX_FE_THREADS = Integer.getInteger("DistributionManager.MAX_FE_THREADS",
       Math.max(Runtime.getRuntime().availableProcessors() * 16, 100));

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/properties.html
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/properties.html
@@ -371,7 +371,7 @@ TBA
 <dd>
 <em>Public:</em> false
 <p>
-<em>Integer:</em> (default is 100)
+<em>Integer:</em> (default is 100 or 16 * number of processors, whichever is larger)
 <p>
 Maximum function execution threads.
 <p>
@@ -383,7 +383,7 @@ See <code>org.apache.geode.distributed.internal.DistributionManager#MAX_FE_THREA
 <dd>
 <em>Public:</em> false
 <p>
-<em>Integer</em> (default is 200)
+<em>Integer</em> (default is 200 or 32 * number of processors, whichever is larger)
 <p>
 See <code>org.apache.geode.distributed.internal.DistributionManager#MAX_PR_THREADS</code>.
 <p>

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/properties.html
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/properties.html
@@ -411,7 +411,7 @@ TBA
 <dd>
 <em>Public:</em> false
 <p>
-<em>Integer</em> (default is 300)
+<em>Integer</em> (default is 1000)
 <p>
 See <code>org.apache.geode.distributed.internal.DistributionManager#MAX_THREADS</code>.
 <p>

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/properties.html
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/properties.html
@@ -383,7 +383,7 @@ See <code>org.apache.geode.distributed.internal.DistributionManager#MAX_FE_THREA
 <dd>
 <em>Public:</em> false
 <p>
-<em>Integer</em> (default is 1)
+<em>Integer</em> (default is 200)
 <p>
 See <code>org.apache.geode.distributed.internal.DistributionManager#MAX_PR_THREADS</code>.
 <p>
@@ -411,7 +411,7 @@ TBA
 <dd>
 <em>Public:</em> false
 <p>
-<em>Integer</em> (default is 100)
+<em>Integer</em> (default is 300)
 <p>
 See <code>org.apache.geode.distributed.internal.DistributionManager#MAX_THREADS</code>.
 <p>


### PR DESCRIPTION
- OperationExecutors.MAX_THREADS new default is 300
- ClusterOperationExecutors.MAX_PR_THREADS new default is
Math.max(Runtime.getRuntime().availableProcessors() * 32, 200))
- Removed unit test case for setting system property, since it cannot be
cleared afterwards without unloading the class

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
