### PR TITLE
GEODE-8496: Bump nebula-facets plugin. Fix deprecated gradle configuration use.

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -160,7 +160,7 @@
       <dependency>
         <groupId>com.tngtech.archunit</groupId>
         <artifactId>archunit-junit4</artifactId>
-        <version>0.14.1</version>
+        <version>0.15.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@
 
 plugins {
   id "wrapper"
-  id "nebula.facet" version "6.2.0" apply false
+  id "nebula.facet" version "7.0.9" apply false
   id "base"
   id "idea"
   id "eclipse"

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -104,7 +104,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'com.sun.istack', name: 'istack-commons-runtime', version: '4.0.0')
         api(group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2')
         api(group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.2')
-        api(group: 'com.tngtech.archunit', name:'archunit-junit4', version: '0.14.1')
+        api(group: 'com.tngtech.archunit', name:'archunit-junit4', version: '0.15.0')
         api(group: 'com.zaxxer', name: 'HikariCP', version: '3.4.5')
         api(group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4')
         api(group: 'commons-codec', name: 'commons-codec', version: '1.15')

--- a/extensions/geode-modules-tomcat7/build.gradle
+++ b/extensions/geode-modules-tomcat7/build.gradle
@@ -47,6 +47,8 @@ dependencies {
   integrationTestImplementation(project(':extensions:geode-modules-test'))
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation('org.httpunit:httpunit')
+  integrationTestImplementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat7.version'))
+  integrationTestImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat7.version'))
 }
 
 sonarqube {

--- a/extensions/geode-modules-tomcat8/build.gradle
+++ b/extensions/geode-modules-tomcat8/build.gradle
@@ -52,6 +52,7 @@ dependencies {
   distributedTestImplementation(project(':geode-dunit'))
   distributedTestImplementation(project(':geode-logging'))
   distributedTestImplementation('org.httpunit:httpunit')
+  distributedTestImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version'))
 }
 
 sonarqube {

--- a/extensions/geode-modules-tomcat8/build.gradle
+++ b/extensions/geode-modules-tomcat8/build.gradle
@@ -45,6 +45,7 @@ dependencies {
   // integrationTest
   integrationTestImplementation(project(':extensions:geode-modules-test'))
   integrationTestImplementation(project(':geode-dunit'))
+  integrationTestImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version'))
 
 
   // distributedTest

--- a/extensions/geode-modules-tomcat9/build.gradle
+++ b/extensions/geode-modules-tomcat9/build.gradle
@@ -45,6 +45,7 @@ dependencies {
   // integrationTest
   integrationTestImplementation(project(':extensions:geode-modules-test'))
   integrationTestImplementation(project(':geode-dunit'))
+  integrationTestImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat9.version'))
 }
 
 sonarqube {

--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 
   // distributedTest
   distributedTestImplementation(project(':geode-dunit'))
+  distributedTestImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
 }
 
 sonarqube {

--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -49,6 +49,7 @@ dependencies {
   integrationTestImplementation(project(':extensions:geode-modules-test'))
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation('pl.pragmatists:JUnitParams')
+  integrationTestImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
 
 
   // distributedTest

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -347,15 +347,9 @@ dependencies {
     testRuntime('com.pholser:junit-quickcheck-generators')
 
     integrationTestImplementation(project(':geode-gfsh'))
-    integrationTestImplementation(project(':geode-junit')) {
-        exclude module: 'geode-core'
-    }
-    integrationTestImplementation(project(':geode-dunit')) {
-        exclude module: 'geode-core'
-    }
-    integrationTestImplementation(project(':geode-log4j')) {
-        exclude module: 'geode-core'
-    }
+    integrationTestImplementation(project(':geode-junit'))
+    integrationTestImplementation(project(':geode-dunit'))
+    integrationTestImplementation(project(':geode-log4j'))
     integrationTestImplementation(project(':geode-concurrency-test'))
     integrationTestImplementation('org.apache.bcel:bcel')
     integrationTestImplementation('org.apache.logging.log4j:log4j-core')

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/api/CoreOnlyUsesMembershipAPIArchUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/membership/api/CoreOnlyUsesMembershipAPIArchUnitTest.java
@@ -140,8 +140,15 @@ public class CoreOnlyUsesMembershipAPIArchUnitTest {
   }
 
   private ClassFileImporter getClassFileImporter() {
+    ImportOption ignoreTestFacets = new ImportOption() {
+      @Override
+      public boolean includes(Location location) {
+        return !location.contains("/test/") && !location.contains("/integrationTest/");
+      }
+    };
     return new ClassFileImporter(
-        new ImportOptions().with(ImportOption.Predefined.DO_NOT_INCLUDE_ARCHIVES));
+        new ImportOptions()
+            .with(ignoreTestFacets));
   }
 
 

--- a/geode-membership/build.gradle
+++ b/geode-membership/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     integrationTestImplementation('com.tngtech.archunit:archunit-junit4')
     integrationTestImplementation('pl.pragmatists:JUnitParams')
 
-    integrationTestRuntime('org.apache.logging.log4j:log4j-core')
+    integrationTestRuntimeOnly('org.apache.logging.log4j:log4j-core')
 
 
     distributedTestImplementation(project(':geode-junit'))

--- a/geode-membership/src/test/resources/expected-pom.xml
+++ b/geode-membership/src/test/resources/expected-pom.xml
@@ -57,6 +57,16 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-tcp-server</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <scope>runtime</scope>
@@ -84,16 +94,6 @@
     <dependency>
       <groupId>commons-validator</groupId>
       <artifactId>commons-validator</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-serialization</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-tcp-server</artifactId>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/geode-redis/build.gradle
+++ b/geode-redis/build.gradle
@@ -75,13 +75,13 @@ dependencies {
   // This only exists for debugging PubSubNativeRedisAcceptanceTest
   acceptanceTestImplementation('org.buildobjects:jproc:2.3.0')
 
-  distributedTestCompile('org.apache.logging.log4j:log4j-core')
+  distributedTestImplementation('org.apache.logging.log4j:log4j-core')
   distributedTestImplementation(project(':geode-dunit'))
   distributedTestImplementation(sourceSets.commonTest.output)
   distributedTestImplementation('redis.clients:jedis')
   distributedTestImplementation('io.lettuce:lettuce-core')
 
-  distributedTestCompile('javax.servlet:javax.servlet-api')
+  distributedTestImplementation('javax.servlet:javax.servlet-api')
   distributedTestImplementation('org.springframework.boot:spring-boot-starter-jetty')
   distributedTestImplementation('org.springframework.boot:spring-boot-starter-web') {
     exclude module: 'spring-boot-starter-tomcat'

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -44,46 +44,23 @@ test {
 apply plugin: 'nebula.facet'
 facets {
   integrationTest {
-    testTaskName = 'integrationTest'
     includeInCheckLifecycle = false
   }
   distributedTest {
-    testTaskName = 'distributedTest'
     includeInCheckLifecycle = false
   }
   performanceTest {
-    testTaskName = 'performanceTest'
     includeInCheckLifecycle = false
   }
   acceptanceTest {
-    testTaskName = 'acceptanceTest'
     includeInCheckLifecycle = false
   }
   uiTest {
-    testTaskName = 'uiTest'
     includeInCheckLifecycle = false
   }
   upgradeTest {
-    testTaskName = 'upgradeTest'
     includeInCheckLifecycle = false
   }
-}
-
-configurations {
-  testAnnotationProcessor.extendsFrom annotationProcessor
-  integrationTestAnnotationProcessor.extendsFrom annotationProcessor
-  distributedTestAnnotationProcessor.extendsFrom annotationProcessor
-  performanceTestAnnotationProcessor.extendsFrom annotationProcessor
-  acceptanceTestAnnotationProcessor.extendsFrom annotationProcessor
-  uiTestAnnotationProcessor.extendsFrom annotationProcessor
-  upgradeTestAnnotationProcessor.extendsFrom annotationProcessor
-  // Facets does not extend the new runtimeOnly configurations
-  integrationTestRuntimeOnly.extendsFrom(runtimeOnly)
-  distributedTestRuntimeOnly.extendsFrom(runtimeOnly)
-  performanceTestRuntimeOnly.extendsFrom(runtimeOnly)
-  acceptanceTestRuntimeOnly.extendsFrom(runtimeOnly)
-  uiTestRuntimeOnly.extendsFrom(runtimeOnly)
-  upgradeTestRuntimeOnly.extendsFrom(runtimeOnly)
 }
 
 dependencies {


### PR DESCRIPTION
Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
