### PR TITLE
GEODE-5922: concurrency problems in SerialGatewaySenderQueue

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 
 import org.apache.logging.log4j.Logger;
@@ -168,13 +167,6 @@ public class SerialGatewaySenderQueue implements RegionQueue {
   private boolean isDiskSynchronous;
 
   /**
-   * The writeLock of this concurrent lock is used to protect access to the queue. It is implemented
-   * as a fair lock to ensure FIFO ordering of queueing attempts. Otherwise threads can be unfairly
-   * delayed.
-   */
-  private ReentrantReadWriteLock lock = new ReentrantReadWriteLock(true);
-
-  /**
    * The <code>Map</code> mapping the regionName->key to the queue key. This index allows fast
    * updating of entries in the queue for conflation.
    */
@@ -255,23 +247,18 @@ public class SerialGatewaySenderQueue implements RegionQueue {
   }
 
   @Override
-  public boolean put(Object event) throws CacheException {
-    lock.writeLock().lock();
-    try {
-      GatewaySenderEventImpl eventImpl = (GatewaySenderEventImpl) event;
-      final Region r = eventImpl.getRegion();
-      final boolean isPDXRegion =
-          (r instanceof DistributedRegion && r.getName().equals(PeerTypeRegistration.REGION_NAME));
-      final boolean isWbcl =
-          this.regionName.startsWith(AsyncEventQueueImpl.ASYNC_EVENT_QUEUE_PREFIX);
-      if (!(isPDXRegion && isWbcl)) {
-        putAndGetKey(event);
-        return true;
-      }
-      return false;
-    } finally {
-      lock.writeLock().unlock();
+  public synchronized boolean put(Object event) throws CacheException {
+    GatewaySenderEventImpl eventImpl = (GatewaySenderEventImpl) event;
+    final Region r = eventImpl.getRegion();
+    final boolean isPDXRegion =
+        (r instanceof DistributedRegion && r.getName().equals(PeerTypeRegistration.REGION_NAME));
+    final boolean isWbcl =
+        this.regionName.startsWith(AsyncEventQueueImpl.ASYNC_EVENT_QUEUE_PREFIX);
+    if (!(isPDXRegion && isWbcl)) {
+      putAndGetKey(event);
+      return true;
     }
+    return false;
   }
 
   private long putAndGetKey(Object object) throws CacheException {
@@ -295,6 +282,7 @@ public class SerialGatewaySenderQueue implements RegionQueue {
     return key.longValue();
   }
 
+
   @Override
   public AsyncEvent take() throws CacheException {
     // Unsupported since we have no callers.
@@ -316,71 +304,66 @@ public class SerialGatewaySenderQueue implements RegionQueue {
    * have peeked. If the entry was not peeked, this method will silently return.
    */
   @Override
-  public void remove() throws CacheException {
-    lock.writeLock().lock();
+  public synchronized void remove() throws CacheException {
+    if (peekedIds.isEmpty()) {
+      return;
+    }
+    Long key = peekedIds.remove();
+    boolean isExtraPeeked = extraPeekedIds.remove(key);
     try {
-      if (peekedIds.isEmpty()) {
-        return;
-      }
-      Long key = peekedIds.remove();
-      boolean isExtraPeeked = extraPeekedIds.remove(key);
-      try {
-        // Increment the head key
-        if (!isExtraPeeked) {
-          updateHeadKey(key.longValue());
-        }
-        removeIndex(key);
-        // Remove the entry at that key with a callback arg signifying it is
-        // a WAN queue so that AbstractRegionEntry.destroy can get the value
-        // even if it has been evicted to disk. In the normal case, the
-        // AbstractRegionEntry.destroy only gets the value in the VM.
-        this.region.localDestroy(key, WAN_QUEUE_TOKEN);
-        this.stats.decQueueSize();
-
-      } catch (EntryNotFoundException ok) {
-        // this is acceptable because the conflation can remove entries
-        // out from underneath us.
-        if (logger.isDebugEnabled()) {
-          logger.debug(
-              "{}: Did not destroy entry at {} it was not there. It should have been removed by conflation.",
-              this, key);
-        }
-      }
-
-      boolean wasEmpty = this.lastDispatchedKey == this.lastDestroyedKey;
+      // Increment the head key
       if (!isExtraPeeked) {
-        this.lastDispatchedKey = key;
-        // Remove also the extraPeekedIds right after this one so that
-        // they do not stay in the secondary's queue forever
-        long tmpKey = key;
-        while (extraPeekedIdsSentNotRemoved.contains(tmpKey = inc(tmpKey))) {
-          extraPeekedIdsSentNotRemoved.remove(tmpKey);
-          this.lastDispatchedKey = tmpKey;
-          updateHeadKey(tmpKey);
-        }
-      } else {
-        extraPeekedIdsSentNotRemoved.add(key);
-        // Remove if previous key was already dispatched so that it does
-        // not stay in the secondary's queue forever
-        long tmpKey = dec(key);
-        if (this.lastDispatchedKey == tmpKey) {
-          this.lastDispatchedKey = key;
-          updateHeadKey(key);
-        }
+        updateHeadKey(key.longValue());
       }
-      if (wasEmpty) {
-        synchronized (this) {
-          notifyAll();
-        }
-      }
+      removeIndex(key);
+      // Remove the entry at that key with a callback arg signifying it is
+      // a WAN queue so that AbstractRegionEntry.destroy can get the value
+      // even if it has been evicted to disk. In the normal case, the
+      // AbstractRegionEntry.destroy only gets the value in the VM.
+      this.region.localDestroy(key, WAN_QUEUE_TOKEN);
+      this.stats.decQueueSize();
 
+    } catch (EntryNotFoundException ok) {
+      // this is acceptable because the conflation can remove entries
+      // out from underneath us.
       if (logger.isDebugEnabled()) {
         logger.debug(
-            "{}: Destroyed entry at key {} setting the lastDispatched Key to {}. The last destroyed entry was {}",
-            this, key, this.lastDispatchedKey, this.lastDestroyedKey);
+            "{}: Did not destroy entry at {} it was not there. It should have been removed by conflation.",
+            this, key);
       }
-    } finally {
-      lock.writeLock().unlock();
+    }
+
+    boolean wasEmpty = this.lastDispatchedKey == this.lastDestroyedKey;
+    if (!isExtraPeeked) {
+      this.lastDispatchedKey = key;
+      // Remove also the extraPeekedIds right after this one so that
+      // they do not stay in the secondary's queue forever
+      long tmpKey = key;
+      while (extraPeekedIdsSentNotRemoved.contains(tmpKey = inc(tmpKey))) {
+        extraPeekedIdsSentNotRemoved.remove(tmpKey);
+        this.lastDispatchedKey = tmpKey;
+        updateHeadKey(tmpKey);
+      }
+    } else {
+      extraPeekedIdsSentNotRemoved.add(key);
+      // Remove if previous key was already dispatched so that it does
+      // not stay in the secondary's queue forever
+      long tmpKey = dec(key);
+      if (this.lastDispatchedKey == tmpKey) {
+        this.lastDispatchedKey = key;
+        updateHeadKey(key);
+      }
+    }
+    if (wasEmpty) {
+      synchronized (this) {
+        notifyAll();
+      }
+    }
+
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "{}: Destroyed entry at key {} setting the lastDispatched Key to {}. The last destroyed entry was {}",
+          this, key, this.lastDispatchedKey, this.lastDestroyedKey);
     }
   }
 
@@ -589,8 +572,7 @@ public class SerialGatewaySenderQueue implements RegionQueue {
       Object key = object.getKeyToConflate();
       Long previousIndex;
 
-      lock.writeLock().lock();
-      try {
+      synchronized (this) {
         Map<Object, Long> latestIndexesForRegion = this.indexes.get(rName);
         if (latestIndexesForRegion == null) {
           latestIndexesForRegion = new HashMap<>();
@@ -598,8 +580,6 @@ public class SerialGatewaySenderQueue implements RegionQueue {
         }
 
         previousIndex = latestIndexesForRegion.put(key, tailKey);
-      } finally {
-        lock.writeLock().unlock();
       }
 
       if (isDebugEnabled) {
@@ -680,7 +660,7 @@ public class SerialGatewaySenderQueue implements RegionQueue {
   }
 
   /*
-   * this must be invoked with lock.writeLock() held
+   * this must be invoked under synchronization
    */
   private void removeIndex(Long qkey) {
     // Determine whether conflation is enabled for this queue and object
@@ -946,8 +926,7 @@ public class SerialGatewaySenderQueue implements RegionQueue {
     if (tailKey.get() != -1) {
       return;
     }
-    lock.writeLock().lock();
-    try {
+    synchronized (this) {
       long largestKey = -1;
       long largestKeyLessThanHalfMax = -1;
       long smallestKey = -1;
@@ -995,8 +974,6 @@ public class SerialGatewaySenderQueue implements RegionQueue {
         logger.debug("{}: Initialized tail key to: {}, head key to: {}", this, this.tailKey,
             this.headKey);
       }
-    } finally {
-      lock.writeLock().unlock();
     }
   }
 
@@ -1241,8 +1218,7 @@ public class SerialGatewaySenderQueue implements RegionQueue {
             }
 
             long temp;
-            lock.writeLock().lock();
-            try {
+            synchronized (SerialGatewaySenderQueue.this) {
               temp = lastDispatchedKey;
               boolean wasEmpty = temp == lastDestroyedKey;
               while (lastDispatchedKey == lastDestroyedKey) {
@@ -1251,8 +1227,6 @@ public class SerialGatewaySenderQueue implements RegionQueue {
               }
               if (wasEmpty)
                 continue;
-            } finally {
-              lock.writeLock().unlock();
             }
             // release not needed since disallowOffHeapValues called
             EntryEventImpl event = EntryEventImpl.create((LocalRegion) region, Operation.DESTROY,


### PR DESCRIPTION
reverting 3ed37a754d789bb52cf190db23088e819955fd58, which caused enqueuing time for async queues to triple.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
