### PR TITLE
GEODE-8577: Increase time to get Redis native connection

### DIFF
--- a/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -16,11 +16,9 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import org.junit.ClassRule;
-import org.junit.Ignore;
 
 import org.apache.geode.NativeRedisTestRule;
 
-@Ignore("GEODE-8577")
 public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTest {
   @ClassRule
   public static NativeRedisTestRule redis = new NativeRedisTestRule();

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
@@ -715,7 +715,7 @@ public abstract class AbstractPubSubIntegrationTest implements RedisPortSupplier
   private Jedis getConnection() {
     Exception lastException = null;
 
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 20; i++) {
       Jedis client = null;
       try {
         client = new Jedis("localhost", getPort(), JEDIS_TIMEOUT);
@@ -731,7 +731,7 @@ public abstract class AbstractPubSubIntegrationTest implements RedisPortSupplier
         }
       }
       try {
-        Thread.sleep(1000);
+        Thread.sleep(5000);
       } catch (InterruptedException e) {
         e.printStackTrace();
       }


### PR DESCRIPTION
- It's possible that the test is exhausting the number of available
  sockets. Closed connections sit in TIME_WAIT for 60 seconds on Linux.
  This change increases the time to get a connection beyond that to
  allow for connections to be fully closed and ports to be released.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
