### PR TITLE
GEODE-8814: StressNewTestHelper is not specifying multiple tests correctly

### DIFF
--- a/geode-junit/src/main/java/org/apache/geode/test/util/StressNewTestHelper.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/util/StressNewTestHelper.java
@@ -93,8 +93,7 @@ public class StressNewTestHelper {
       }
 
       command.append(sourceToGradleMapping.get(sourceSet));
-      command.append(" --tests ");
-      command.append(String.join(",", entry.getValue()));
+      entry.getValue().forEach(x -> command.append(" --tests ").append(x));
       command.append(" ");
       testCount += entry.getValue().size();
     }

--- a/geode-junit/src/test/java/org/apache/geode/test/util/WhatExtendsJUnitTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/util/WhatExtendsJUnitTest.java
@@ -49,7 +49,7 @@ public class WhatExtendsJUnitTest {
   public void classAisExtendedByBandC() {
     scanner.add(getClassLocation(A.class));
     assertThat(scanner.buildGradleCommand()).isEqualTo(
-        "repeatUnitTest --tests WhatExtendsJUnitTest$B,WhatExtendsJUnitTest$C -PtestCount=2");
+        "repeatUnitTest --tests WhatExtendsJUnitTest$B --tests WhatExtendsJUnitTest$C -PtestCount=2");
   }
 
   @Test
@@ -58,7 +58,7 @@ public class WhatExtendsJUnitTest {
     scanner.add(getClassLocation(A.class));
     assertThat(scanner.buildGradleCommand())
         .isEqualTo(
-            "repeatUnitTest --tests WhatExtendsJUnitTest$B,WhatExtendsJUnitTest$C -PtestCount=2");
+            "repeatUnitTest --tests WhatExtendsJUnitTest$B --tests WhatExtendsJUnitTest$C -PtestCount=2");
   }
 
   @Test
@@ -66,7 +66,7 @@ public class WhatExtendsJUnitTest {
     scanner.add(getClassLocation(A.class, "foo/src/test/java/"));
     assertThat(scanner.buildGradleCommand())
         .isEqualTo(
-            "repeatUnitTest --tests WhatExtendsJUnitTest$B,WhatExtendsJUnitTest$C -PtestCount=2");
+            "repeatUnitTest --tests WhatExtendsJUnitTest$B --tests WhatExtendsJUnitTest$C -PtestCount=2");
   }
 
   @Test
@@ -75,7 +75,7 @@ public class WhatExtendsJUnitTest {
     scanner.add(getClassLocation(this.getClass(), "foo/src/integrationTest/java/"));
     assertThat(scanner.buildGradleCommand())
         .isEqualTo(
-            "repeatUnitTest --tests WhatExtendsJUnitTest$B,WhatExtendsJUnitTest$C repeatIntegrationTest --tests WhatExtendsJUnitTest -PtestCount=3");
+            "repeatUnitTest --tests WhatExtendsJUnitTest$B --tests WhatExtendsJUnitTest$C repeatIntegrationTest --tests WhatExtendsJUnitTest -PtestCount=3");
   }
 
   @Test


### PR DESCRIPTION
- Multiple tests should each declare a separate `--tests` option instead
  of being comma separated.

Authored-by: Jens Deppe <jdeppe@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
