### PR TITLE
GEODE-7739: Fix race in federating of MXBeans

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -399,7 +399,7 @@ public class FederatingManager extends Manager implements ManagerMembership {
           monitorFactory.setDataPolicy(DataPolicy.REPLICATE);
           monitorFactory.setConcurrencyChecksEnabled(false);
           ManagementCacheListener managementCacheListener =
-              new ManagementCacheListener(proxyFactory);
+              new ManagementCacheListener(proxyFactory, cache.getCancelCriterion());
           monitorFactory.addCacheListener(managementCacheListener);
           monitorFactory.setIsUsedForMetaRegion(true);
           monitorFactory.setCachePerfStatsHolder(monitoringRegionStats);
@@ -416,7 +416,8 @@ public class FederatingManager extends Manager implements ManagerMembership {
               .setEvictionAttributes(EvictionAttributes.createLRUEntryAttributes(
                   ManagementConstants.NOTIF_REGION_MAX_ENTRIES, EvictionAction.LOCAL_DESTROY));
 
-          NotificationCacheListener notifListener = new NotificationCacheListener(proxyFactory);
+          NotificationCacheListener notifListener =
+              new NotificationCacheListener(proxyFactory, cache.getCancelCriterion());
           notificationFactory.addCacheListener(notifListener);
           notificationFactory.setIsUsedForMetaRegion(true);
           notificationFactory.setCachePerfStatsHolder(monitoringRegionStats);

--- a/geode-core/src/main/java/org/apache/geode/management/internal/ManagementCacheListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/ManagementCacheListener.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal;
 
+import java.util.Objects;
+
 import javax.management.ObjectName;
 
 import org.apache.logging.log4j.Logger;
@@ -37,6 +39,8 @@ public class ManagementCacheListener extends CacheListenerAdapter<String, Object
   private final StoppableCountDownLatch readyLatch;
 
   ManagementCacheListener(MBeanProxyFactory mBeanProxyFactory, CancelCriterion cancelCriterion) {
+    Objects.requireNonNull(mBeanProxyFactory);
+    Objects.requireNonNull(cancelCriterion);
     this.mBeanProxyFactory = mBeanProxyFactory;
     readyLatch = new StoppableCountDownLatch(cancelCriterion, 1);
   }
@@ -69,7 +73,8 @@ public class ManagementCacheListener extends CacheListenerAdapter<String, Object
       mBeanProxyFactory.removeProxy(event.getDistributedMember(), objectName, oldObject);
     } catch (Exception e) {
       if (logger.isDebugEnabled()) {
-        logger.debug("Proxy Destroy failed for {} with exception {}", objectName, e.getMessage(), e);
+        logger.debug("Proxy Destroy failed for {} with exception {}", objectName, e.getMessage(),
+            e);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/NotificationCacheListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/NotificationCacheListener.java
@@ -14,101 +14,48 @@
  */
 package org.apache.geode.management.internal;
 
-
 import javax.management.Notification;
 
-import org.apache.geode.cache.CacheListener;
+import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.EntryEvent;
-import org.apache.geode.cache.RegionEvent;
+import org.apache.geode.cache.util.CacheListenerAdapter;
+import org.apache.geode.internal.util.concurrent.StoppableCountDownLatch;
 
 /**
- * This listener will be attached to each notification region corresponding to a member
- *
+ * This listener will be attached to each notification region corresponding to a member.
  */
-public class NotificationCacheListener implements CacheListener<NotificationKey, Notification> {
+public class NotificationCacheListener extends CacheListenerAdapter<NotificationKey, Notification> {
 
-  /**
-   * For the
-   */
-  private NotificationHubClient notifClient;
+  private final NotificationHubClient notificationHubClient;
+  private final StoppableCountDownLatch readyLatch;
 
-  private volatile boolean readyForEvents;
-
-  public NotificationCacheListener(MBeanProxyFactory proxyHelper) {
-
-    notifClient = new NotificationHubClient(proxyHelper);
-    this.readyForEvents = false;
-
+  NotificationCacheListener(MBeanProxyFactory proxyHelper, CancelCriterion cancelCriterion) {
+    notificationHubClient = new NotificationHubClient(proxyHelper);
+    readyLatch = new StoppableCountDownLatch(cancelCriterion, 1);
   }
 
   @Override
   public void afterCreate(EntryEvent<NotificationKey, Notification> event) {
-    if (!readyForEvents) {
-      return;
-    }
-    notifClient.sendNotification(event);
-
-  }
-
-  @Override
-  public void afterDestroy(EntryEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterInvalidate(EntryEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionClear(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionCreate(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionDestroy(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionInvalidate(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
-  }
-
-  @Override
-  public void afterRegionLive(RegionEvent<NotificationKey, Notification> event) {
-    // TODO Auto-generated method stub
-
+    waitUntilReady();
+    notificationHubClient.sendNotification(event);
   }
 
   @Override
   public void afterUpdate(EntryEvent<NotificationKey, Notification> event) {
-    if (!readyForEvents) {
-      return;
+    waitUntilReady();
+    notificationHubClient.sendNotification(event);
+  }
+
+  void markReady() {
+    readyLatch.countDown();
+  }
+
+  private void waitUntilReady() {
+    try {
+      readyLatch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
     }
-    notifClient.sendNotification(event);
-
   }
-
-  @Override
-  public void close() {
-    // TODO Auto-generated method stub
-
-  }
-
-  public void markReady() {
-    readyForEvents = true;
-  }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/NotificationCacheListener.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/NotificationCacheListener.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal;
 
+import java.util.Objects;
+
 import javax.management.Notification;
 
 import org.apache.geode.CancelCriterion;
@@ -30,6 +32,8 @@ public class NotificationCacheListener extends CacheListenerAdapter<Notification
   private final StoppableCountDownLatch readyLatch;
 
   NotificationCacheListener(MBeanProxyFactory proxyHelper, CancelCriterion cancelCriterion) {
+    Objects.requireNonNull(proxyHelper);
+    Objects.requireNonNull(cancelCriterion);
     notificationHubClient = new NotificationHubClient(proxyHelper);
     readyLatch = new StoppableCountDownLatch(cancelCriterion, 1);
   }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/FederatingManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/FederatingManagerTest.java
@@ -47,6 +47,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.ErrorCollector;
 import org.mockito.ArgumentCaptor;
 
+import org.apache.geode.CancelCriterion;
 import org.apache.geode.StatisticsFactory;
 import org.apache.geode.alerting.internal.spi.AlertLevel;
 import org.apache.geode.cache.CacheClosedException;
@@ -106,17 +107,19 @@ public class FederatingManagerTest {
 
     when(cache.getCacheForProcessingClientRequests())
         .thenReturn(cacheForClientAccess);
+    when(cacheForClientAccess.getCancelCriterion())
+        .thenReturn(mock(CancelCriterion.class));
     when(cacheForClientAccess.createInternalRegionFactory())
         .thenReturn(regionFactory1)
         .thenReturn(regionFactory2);
-    when(regionFactory1.create(any()))
-        .thenReturn(mock(Region.class));
-    when(regionFactory2.create(any()))
-        .thenReturn(mock(Region.class));
     when(distributedSystemMXBean.getAlertLevel())
         .thenReturn(AlertLevel.WARNING.name());
     when(jmxAdapter.getDistributedSystemMXBean())
         .thenReturn(distributedSystemMXBean);
+    when(regionFactory1.create(any()))
+        .thenReturn(mock(Region.class));
+    when(regionFactory2.create(any()))
+        .thenReturn(mock(Region.class));
     when(system.getDistributionManager())
         .thenReturn(mock(DistributionManager.class));
   }


### PR DESCRIPTION
Change boolean controlled early-outs to CountDownLatches listeners that
provide MXBean federation.

Co-authored-by: John Hutchison <hutchisonjo@vmware.com>

(Based on @jhutchison's #5778.)