### PR TITLE
GEODE-8696: Fix deadlock in FederatingManager

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/FederatingManager.java
@@ -112,7 +112,7 @@ public class FederatingManager extends Manager implements ManagerMembership {
    * Management exception has to be handled by the caller.
    */
   @Override
-  public synchronized void startManager() {
+  public void startManager() {
     try {
       lifecycleLock.lock();
       try {
@@ -162,7 +162,7 @@ public class FederatingManager extends Manager implements ManagerMembership {
   }
 
   @Override
-  public synchronized void stopManager() {
+  public void stopManager() {
     lifecycleLock.lock();
     try {
       // remove hidden management regions and federatedMBeans
@@ -352,7 +352,7 @@ public class FederatingManager extends Manager implements ManagerMembership {
     }
   }
 
-  private synchronized void executeTask(Runnable task) {
+  private void executeTask(Runnable task) {
     try {
       executorService.get().execute(task);
     } catch (RejectedExecutionException ignored) {


### PR DESCRIPTION
FederatingManager now uses a ReentrantLock instead of synchronization. Remove
the redundant synchronization keywords that result in the deadlock.

This PR fixes the following deadlock:
```
Found one Java-level deadlock:
=============================
"Pooled High Priority Message Processor 5":
  waiting to lock monitor 0x00007f3ac400d558 (object 0x00000000fd486c20, a java.util.HashMap),
  which is held by "vm_0_thr_0_locator_managing1_host1_13259"
"vm_0_thr_0_locator_managing1_host1_13259":
  waiting for ownable synchronizer 0x00000000fd2f3fb0, (a java.util.concurrent.locks.ReentrantLock$NonfairSync),
  which is held by "DM-MemberEventInvoker"
"DM-MemberEventInvoker":
  waiting to lock monitor 0x00007f3af8002d28 (object 0x00000000fd3d12a8, a org.apache.geode.management.internal.FederatingManager),
  which is held by "vm_0_thr_0_locator_managing1_host1_13259"
{noformat}{noformat}
Java stack information for the threads listed above:
===================================================
```
```
"Pooled High Priority Message Processor 5":
  at org.apache.geode.management.internal.BaseManagementService.getExistingManagementService(BaseManagementService.java:106)
  - waiting to lock <0x00000000fd486c20> (a java.util.HashMap)
  at org.apache.geode.management.ManagementService.getExistingManagementService(ManagementService.java:52)
  at org.apache.geode.management.internal.JmxManagerAdvisee.fillInProfile(JmxManagerAdvisee.java:99)
  at org.apache.geode.distributed.internal.DistributionAdvisor.createProfile(DistributionAdvisor.java:1033)
  at org.apache.geode.management.internal.JmxManagerAdvisee.getProfile(JmxManagerAdvisee.java:65)
  at org.apache.geode.distributed.internal.DistributionAdvisor$Profile.handleDistributionAdvisee(DistributionAdvisor.java:1541)
  at org.apache.geode.management.internal.JmxManagerAdvisor$JmxManagerProfile.processIncoming(JmxManagerAdvisor.java:332)
  at org.apache.geode.internal.cache.UpdateAttributesProcessor$UpdateAttributesMessage.process(UpdateAttributesProcessor.java:291)
  at org.apache.geode.distributed.internal.DistributionMessage.scheduleAction(DistributionMessage.java:376)
  at org.apache.geode.distributed.internal.DistributionMessage$1.run(DistributionMessage.java:441)
  at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
  at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
  at org.apache.geode.distributed.internal.ClusterOperationExecutors.runUntilShutdown(ClusterOperationExecutors.java:446)
  at org.apache.geode.distributed.internal.ClusterOperationExecutors.doHighPriorityThread(ClusterOperationExecutors.java:404)
  at org.apache.geode.distributed.internal.ClusterOperationExecutors$$Lambda$136/1646252585.invoke(Unknown Source)
  at org.apache.geode.logging.internal.executors.LoggingThreadFactory.lambda$newThread$0(LoggingThreadFactory.java:120)
  at org.apache.geode.logging.internal.executors.LoggingThreadFactory$$Lambda$134/1613570844.run(Unknown Source)
  at java.lang.Thread.run(Thread.java:748)
```
```
"vm_0_thr_0_locator_managing1_host1_13259":
  at sun.misc.Unsafe.park(Native Method)
  - parking to wait for  <0x00000000fd2f3fb0> (a java.util.concurrent.locks.ReentrantLock$NonfairSync)
  at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:870)
  at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1199)
  at java.util.concurrent.locks.ReentrantLock$NonfairSync.lock(ReentrantLock.java:209)
  at java.util.concurrent.locks.ReentrantLock.lock(ReentrantLock.java:285)
  at org.apache.geode.management.internal.FederatingManager.startManager(FederatingManager.java:134)
  - locked <0x00000000fd3d12a8> (a org.apache.geode.management.internal.FederatingManager)
  at org.apache.geode.management.internal.SystemManagementService.startManager(SystemManagementService.java:373)
  - locked <0x00000000fd486c20> (a java.util.HashMap)
  at org.apache.geode.management.internal.beans.ManagementAdapter.handleCacheCreation(ManagementAdapter.java:199)
  at org.apache.geode.management.internal.beans.ManagementListener.handleEvent(ManagementListener.java:127)
  at org.apache.geode.distributed.internal.InternalDistributedSystem.notifyResourceEventListeners(InternalDistributedSystem.java:2086)
  at org.apache.geode.distributed.internal.InternalDistributedSystem.handleResourceEvent(InternalDistributedSystem.java:643)
  at org.apache.geode.internal.cache.GemFireCacheImpl.initialize(GemFireCacheImpl.java:1437)
  at org.apache.geode.internal.cache.InternalCacheBuilder.create(InternalCacheBuilder.java:191)
  - locked <0x00000000f0a15060> (a java.lang.Class for org.apache.geode.internal.cache.GemFireCacheImpl)
  - locked <0x00000000f0a29790> (a java.lang.Class for org.apache.geode.internal.cache.InternalCacheBuilder)
  at org.apache.geode.internal.cache.InternalCacheBuilder.create(InternalCacheBuilder.java:158)
  - locked <0x00000000f0a29790> (a java.lang.Class for org.apache.geode.internal.cache.InternalCacheBuilder)
  at org.apache.geode.cache.CacheFactory.create(CacheFactory.java:142)
  at hydra.CacheVersionHelper.configureAndCreateCache(CacheVersionHelper.java:51)
  at hydra.CacheHelper.createCacheWithHttpService(CacheHelper.java:127)
  - locked <0x00000000fd1f1070> (a java.lang.Class for hydra.CacheHelper)
  at hydra.CacheHelper.createCache(CacheHelper.java:87)
  at management.test.federation.FederationTest.createCache(FederationTest.java:234)
  at management.test.federation.FederationTest.initialize(FederationTest.java:225)
  at management.test.federation.FederationTest.HydraInitTask_initialize(FederationTest.java:130)
  - locked <0x00000000fd1f1308> (a java.lang.Class for management.test.federation.FederationTest)
  at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
  at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
  at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
  at java.lang.reflect.Method.invoke(Method.java:498)
  at hydra.MethExecutor.execute(MethExecutor.java:173)
  at hydra.MethExecutor.execute(MethExecutor.java:141)
  at hydra.TestTask.execute(TestTask.java:197)
  at hydra.RemoteTestModule$1.run(RemoteTestModule.java:213)
```
```
"DM-MemberEventInvoker":
  at org.apache.geode.management.internal.FederatingManager.executeTask(FederatingManager.java:357)
  - waiting to lock <0x00000000fd3d12a8> (a org.apache.geode.management.internal.FederatingManager)
  at org.apache.geode.management.internal.FederatingManager.addMember(FederatingManager.java:199)
  at org.apache.geode.management.internal.ManagementMembershipListener.memberJoined(ManagementMembershipListener.java:73)
  at org.apache.geode.distributed.internal.ClusterDistributionManager$MemberJoinedEvent.handleEvent(ClusterDistributionManager.java:2478)
  at org.apache.geode.distributed.internal.ClusterDistributionManager$MemberEvent.handleEvent(ClusterDistributionManager.java:2431)
  at org.apache.geode.distributed.internal.ClusterDistributionManager$MemberEvent.handleEvent(ClusterDistributionManager.java:2420)
  at org.apache.geode.distributed.internal.ClusterDistributionManager.handleMemberEvent(ClusterDistributionManager.java:1404)
  at org.apache.geode.distributed.internal.ClusterDistributionManager.access$200(ClusterDistributionManager.java:108)
  at org.apache.geode.distributed.internal.ClusterDistributionManager$MemberEventInvoker.run(ClusterDistributionManager.java:1436)
  at java.lang.Thread.run(Thread.java:748)
```