### PR TITLE
GEODE-8590: Cleanup dependencies in the session state modules and GEODE-8732: Update Tomcat9 module to publish to Maven

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -1065,6 +1065,24 @@
       </dependency>
       <dependency>
         <groupId>org.apache.geode</groupId>
+        <artifactId>geode-modules</artifactId>
+        <version>${version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.geode</groupId>
+        <artifactId>geode-modules-tomcat8</artifactId>
+        <version>${version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.geode</groupId>
+        <artifactId>geode-modules-tomcat9</artifactId>
+        <version>${version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.geode</groupId>
         <artifactId>geode-lucene-test</artifactId>
         <version>${version}</version>
         <scope>compile</scope>

--- a/extensions/geode-modules-session-internal/build.gradle
+++ b/extensions/geode-modules-session-internal/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.geode.gradle.plugins.DependencyConstraints
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -19,21 +17,11 @@ import org.apache.geode.gradle.plugins.DependencyConstraints
 
 apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
-
-
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':extensions:geode-modules'))
-  compile(project(':geode-core'))
-  implementation(project(':geode-logging'))
+  // main
+  implementation(platform(project(':boms:geode-all-bom')))
+  implementation(project(':extensions:geode-modules'))
 
-  implementation('javax.servlet:javax.servlet-api')
-  implementation('mx4j:mx4j')
-  implementation('org.apache.tomcat:servlet-api:' + DependencyConstraints.get('tomcat6.version'))
-  implementation('org.slf4j:slf4j-api')
+  compileOnly(platform(project(':boms:geode-all-bom')))
+  compileOnly('javax.servlet:javax.servlet-api')
 }
-
-jar {
-  baseName = 'geode-modules-session-internal'
-}
-

--- a/extensions/geode-modules-test/build.gradle
+++ b/extensions/geode-modules-test/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.geode.gradle.plugins.DependencyConstraints
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,38 +15,20 @@ import org.apache.geode.gradle.plugins.DependencyConstraints
  * limitations under the License.
  */
 
+import org.apache.geode.gradle.plugins.DependencyConstraints
+
 apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
-
-
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':extensions:geode-modules')) {
-    // Remove everything related to Tomcat 6.x
-    exclude group: 'org.apache.tomcat'
-  }
-  compile(project(':geode-core'))
-  implementation(project(':geode-logging'))
-
-  compile(project(':geode-junit')) {
-    exclude module: 'geode-core'
-  }
-
-  implementation('org.assertj:assertj-core')
+  // main
+  implementation(platform(project(':boms:geode-all-bom')))
+  implementation(project(':geode-dunit'))
   implementation('org.springframework:spring-core')
-  implementation('org.mockito:mockito-core')
-  implementation('commons-io:commons-io')
-  implementation('javax.servlet:javax.servlet-api')
-  implementation('junit:junit')
-  implementation('org.httpunit:httpunit') {
-    // this version of httpunit contains very outdated xercesImpl
-    exclude group: 'xerces'
-  }
+  implementation('org.httpunit:httpunit')
+  implementation('pl.pragmatists:JUnitParams')
 
-  compileOnly('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version')) {
-    exclude module: 'annotations-api'
-    exclude module: 'coyote'
-    exclude module: 'tribes'
-  }
+  api(project(':extensions:geode-modules'))
+
+  compileOnly(platform(project(':boms:geode-all-bom')))
+  compileOnly('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
 }
-

--- a/extensions/geode-modules-test/build.gradle
+++ b/extensions/geode-modules-test/build.gradle
@@ -31,4 +31,8 @@ dependencies {
 
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
+
+  compile(project(':geode-junit')) {
+    exclude module: 'geode-core'
+  }
 }

--- a/extensions/geode-modules-tomcat7/build.gradle
+++ b/extensions/geode-modules-tomcat7/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.geode.gradle.plugins.DependencyConstraints
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,57 +15,36 @@ import org.apache.geode.gradle.plugins.DependencyConstraints
  * limitations under the License.
  */
 
+import org.apache.geode.gradle.plugins.DependencyConstraints
+
 apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
 evaluationDependsOn(":geode-core")
 
-
-
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':geode-core'))
-  implementation('mx4j:mx4j')
-  implementation('javax.servlet:javax.servlet-api')
-  integrationTestImplementation('org.httpunit:httpunit')
-  integrationTestImplementation('junit:junit')
-  compile(project(':extensions:geode-modules')) {
-    // Remove everything related to Tomcat 6.x
-    exclude group: 'org.apache.tomcat'
-  }
-  testImplementation(project(':extensions:geode-modules')) {
-    // Remove everything related to Tomcat 6.x
-    exclude group: 'org.apache.tomcat'
-  }
+  //main
+  implementation(platform(project(':boms:geode-all-bom')))
 
-  implementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat7.version')) {
-    exclude module: 'tomcat-annotations-api'
-    exclude module: 'tomcat-servlet-api'
-  }
-  implementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat7.version')) {
-    exclude module: 'tomcat-servlet-api'
-  }
-  implementation('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat7.version'))
+  api(project(':geode-core'))
+  api(project(':extensions:geode-modules'))
 
-  testImplementation('org.httpunit:httpunit')
+  compileOnly(platform(project(':boms:geode-all-bom')))
+  compileOnly('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat7.version'))
+  compileOnly('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat7.version'))
+
+
+  // test
+  testImplementation(project(':extensions:geode-modules-test'))
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
-  testImplementation(project(':extensions:geode-modules-test'))
-  integrationTestImplementation(project(':geode-dunit')) {
-    exclude module: 'geode-core'
-  }
+  testImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat7.version'))
+  testImplementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat7.version'))
+
+
+  // integrationTest
   integrationTestImplementation(project(':extensions:geode-modules-test'))
-
-  integrationTestRuntimeOnly('javax.annotation:jsr250-api')
-  integrationTestRuntimeOnly('javax.ejb:ejb-api')
-  integrationTestRuntimeOnly('javax.servlet:javax.servlet-api')
-  integrationTestRuntimeOnly('org.eclipse.persistence:javax.persistence')
-  integrationTestRuntimeOnly('xerces:xercesImpl')
-}
-
-eclipse.classpath.file {
-  whenMerged { classpath ->
-    classpath.entries.removeAll { entry -> entry.path.contains('geode-modules/build')}
-  }
+  integrationTestImplementation(project(':geode-dunit'))
+  integrationTestImplementation('org.httpunit:httpunit')
 }
 

--- a/extensions/geode-modules-tomcat8/build.gradle
+++ b/extensions/geode-modules-tomcat8/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.geode.gradle.plugins.DependencyConstraints
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,72 +15,45 @@ import org.apache.geode.gradle.plugins.DependencyConstraints
  * limitations under the License.
  */
 
+import org.apache.geode.gradle.plugins.DependencyConstraints
+
 apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
+apply from: "${rootDir}/${scriptDir}/warnings.gradle"
+apply from: "${rootDir}/${scriptDir}/publish-java.gradle"
 
 evaluationDependsOn(":geode-core")
 
-
-
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-  distributedTestImplementation('junit:junit')
-  implementation('mx4j:mx4j')
-  distributedTestImplementation(project(':geode-logging'))
-  testImplementation('org.httpunit:httpunit')
-  testImplementation('org.apache.tomcat:tomcat-jaspic-api:' + DependencyConstraints.get('tomcat8.version'))
-  testImplementation('org.httpunit:httpunit')
+  // main
+  implementation(platform(project(':boms:geode-all-bom')))
+
+  api(project(':geode-core'))
+  api(project(':extensions:geode-modules'))
+
+  compileOnly(platform(project(':boms:geode-all-bom')))
+  compileOnly('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version'))
+
+
+  // test
+  testImplementation(project(':extensions:geode-modules-test'))
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
-  testImplementation(project(':extensions:geode-modules-test'))
-  distributedTestImplementation('org.httpunit:httpunit')
-  distributedTestImplementation('org.apache.tomcat:tomcat-jaspic-api:' + DependencyConstraints.get('tomcat8.version'))
-  distributedTestImplementation('org.springframework:spring-core')
-  compile(project(':geode-core'))
-  compile(project(':extensions:geode-modules')) {
-    exclude group: 'org.apache.tomcat'
-  }
-  testImplementation(project(':extensions:geode-modules')) {
-    exclude group: 'org.apache.tomcat'
-  }
+  testImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version'))
 
 
-  implementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version')) {
-    exclude module: 'tomcat-annotations-api'
-    exclude module: 'tomcat-servlet-api'
-  }
-  implementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat8.version')) {
-    exclude module: 'tomcat-servlet-api'
-  }
-  implementation('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat8.version'))
-  implementation('javax.servlet:javax.servlet-api')
-
-  integrationTestImplementation(project(':geode-dunit')) {
-    exclude module: 'geode-core'
-  }
-  integrationTestImplementation(project(':geode-junit')) {
-    exclude module: 'geode-core'
-  }
+  // integrationTest
   integrationTestImplementation(project(':extensions:geode-modules-test'))
-  integrationTestRuntimeOnly('xerces:xercesImpl')
-  integrationTestRuntimeOnly('javax.annotation:javax.annotation-api')
+  integrationTestImplementation(project(':geode-dunit'))
 
-  distributedTestImplementation(project(':geode-dunit')) {
-    exclude module: 'geode-core'
-  }
 
-  distributedTestImplementation(project(':geode-junit')) {
-    exclude module: 'geode-core'
-  }
+  // distributedTest
   distributedTestImplementation(project(':extensions:geode-modules-test'))
-
-  distributedTestRuntimeOnly('xerces:xercesImpl')
-  distributedTestRuntimeOnly('javax.annotation:javax.annotation-api')
+  distributedTestImplementation(project(':geode-dunit'))
+  distributedTestImplementation(project(':geode-logging'))
+  distributedTestImplementation('org.httpunit:httpunit')
 }
 
-eclipse.classpath.file {
-  whenMerged { classpath ->
-    classpath.entries.removeAll { entry -> entry.path.contains('geode-modules/build')}
-  }
+sonarqube {
+  skipProject = true
 }
-

--- a/extensions/geode-modules-tomcat8/src/test/resources/expected-pom.xml
+++ b/extensions/geode-modules-tomcat8/src/test/resources/expected-pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.geode</groupId>
+  <artifactId>geode-modules-tomcat8</artifactId>
+  <version>${version}</version>
+  <name>Apache Geode</name>
+  <description>Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing</description>
+  <url>http://geode.apache.org</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:https://github.com:apache/geode.git</connection>
+    <developerConnection>scm:git:https://github.com:apache/geode.git</developerConnection>
+    <url>https://github.com/apache/geode</url>
+  </scm>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.geode</groupId>
+        <artifactId>geode-all-bom</artifactId>
+        <version>${version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-modules</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/extensions/geode-modules-tomcat9/build.gradle
+++ b/extensions/geode-modules-tomcat9/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.geode.gradle.plugins.DependencyConstraints
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,46 +15,38 @@ import org.apache.geode.gradle.plugins.DependencyConstraints
  * limitations under the License.
  */
 
+import org.apache.geode.gradle.plugins.DependencyConstraints
+
 apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
+apply from: "${rootDir}/${scriptDir}/warnings.gradle"
+apply from: "${rootDir}/${scriptDir}/publish-java.gradle"
 
 evaluationDependsOn(":geode-core")
 
-
-
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-  api(project(':extensions:geode-modules')) {
-    exclude group: 'org.apache.tomcat'
-  }
-//  testImplementation(project(':extensions:geode-modules')) {
-//    exclude group: 'org.apache.tomcat'
-//  }
+  // main
+  implementation(platform(project(':boms:geode-all-bom')))
 
-  implementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat9.version')) {
-    exclude module: 'tomcat-annotations-api'
-    exclude module: 'tomcat-servlet-api'
-  }
-  implementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat9.version')) {
-    exclude module: 'tomcat-servlet-api'
-  }
-  implementation('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat9.version'))
-  implementation('javax.servlet:javax.servlet-api:' + '3.1.0')
+  api(project(':geode-core'))
+  api(project(':extensions:geode-modules'))
 
-  testImplementation('org.httpunit:httpunit')
+  compileOnly(platform(project(':boms:geode-all-bom')))
+  compileOnly('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat9.version'))
+
+
+  // test
+  testImplementation(project(':extensions:geode-modules-test'))
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
-  testImplementation(project(':extensions:geode-modules-test'))
+  testImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat9.version'))
 
-  distributedTestImplementation(project(':extensions:geode-modules-test'))
 
-  distributedTestRuntimeOnly('xerces:xercesImpl')
-  distributedTestRuntimeOnly('javax.annotation:javax.annotation-api')
+  // integrationTest
+  integrationTestImplementation(project(':extensions:geode-modules-test'))
+  integrationTestImplementation(project(':geode-dunit'))
 }
 
-eclipse.classpath.file {
-  whenMerged { classpath ->
-    classpath.entries.removeAll { entry -> entry.path.contains('geode-modules/build')}
-  }
+sonarqube {
+  skipProject = true
 }
-

--- a/extensions/geode-modules-tomcat9/src/test/resources/expected-pom.xml
+++ b/extensions/geode-modules-tomcat9/src/test/resources/expected-pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.geode</groupId>
+  <artifactId>geode-modules-tomcat9</artifactId>
+  <version>${version}</version>
+  <name>Apache Geode</name>
+  <description>Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing</description>
+  <url>http://geode.apache.org</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:https://github.com:apache/geode.git</connection>
+    <developerConnection>scm:git:https://github.com:apache/geode.git</developerConnection>
+    <url>https://github.com/apache/geode</url>
+  </scm>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.geode</groupId>
+        <artifactId>geode-all-bom</artifactId>
+        <version>${version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-modules</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.geode.gradle.plugins.DependencyConstraints
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -17,57 +15,43 @@ import org.apache.geode.gradle.plugins.DependencyConstraints
  * limitations under the License.
  */
 
+import org.apache.geode.gradle.plugins.DependencyConstraints
+
 apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
+apply from: "${rootDir}/${scriptDir}/publish-java.gradle"
 
 evaluationDependsOn(":geode-core")
 
-
-
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  // main
+  implementation(platform(project(':boms:geode-all-bom')))
   implementation(project(':geode-logging'))
   implementation(project(':geode-membership'))
   implementation(project(':geode-serialization'))
-  compile(project(':geode-core'))
-  integrationTestImplementation(project(':extensions:geode-modules-test')) {
-    exclude module: 'geode-modules'
-  }
-  integrationTestImplementation(project(':geode-dunit')) {
-    exclude module: 'geode-core'
-  }
-  integrationTestImplementation(project(':geode-junit')) {
-    exclude module: 'geode-core'
-  }
-
-  implementation('javax.servlet:javax.servlet-api')
-  implementation('mx4j:mx4j')
-  implementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version')) {
-    exclude module: 'annotations-api'
-    exclude module: 'coyote'
-    exclude module: 'tribes'
-  }
-  implementation('org.apache.tomcat:catalina:' + DependencyConstraints.get('tomcat6.version'))
-  implementation('org.apache.tomcat:juli:' + DependencyConstraints.get('tomcat6.version'))
-  implementation('org.apache.tomcat:servlet-api:' + DependencyConstraints.get('tomcat6.version'))
   implementation('org.slf4j:slf4j-api')
 
+  api(project(':geode-core'))
+
+  compileOnly(platform(project(':boms:geode-all-bom')))
+  compileOnly('javax.servlet:javax.servlet-api')
+  compileOnly('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
+
+
+  // test
   testImplementation('org.apache.bcel:bcel')
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
+  testImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
 
 
-  integrationTestImplementation('junit:junit')
+  // integrationTest
+  integrationTestImplementation(project(':extensions:geode-modules-test'))
+  integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation('pl.pragmatists:JUnitParams')
 
-  integrationTestRuntimeOnly('org.apache.tomcat:coyote:' + DependencyConstraints.get('tomcat6.version'))
-  integrationTestRuntimeOnly('xerces:xercesImpl')
 
-  distributedTestImplementation(project(':geode-junit')) {
-    exclude module: 'geode-core'
-  }
-  distributedTestImplementation(project(':geode-dunit')) {
-    exclude module: 'geode-core'
-  }
+  // distributedTest
+  distributedTestImplementation(project(':geode-dunit'))
 }
 

--- a/extensions/geode-modules/src/test/resources/expected-pom.xml
+++ b/extensions/geode-modules/src/test/resources/expected-pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.apache.geode</groupId>
+  <artifactId>geode-modules</artifactId>
+  <version>${version}</version>
+  <name>Apache Geode</name>
+  <description>Apache Geode provides a database-like consistency model, reliable transaction processing and a shared-nothing architecture to maintain very low latency performance with high concurrency processing</description>
+  <url>http://geode.apache.org</url>
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+  <scm>
+    <connection>scm:git:https://github.com:apache/geode.git</connection>
+    <developerConnection>scm:git:https://github.com:apache/geode.git</developerConnection>
+    <url>https://github.com/apache/geode</url>
+  </scm>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.geode</groupId>
+        <artifactId>geode-all-bom</artifactId>
+        <version>${version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-logging</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-membership</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/gradle/publish-java.gradle
+++ b/gradle/publish-java.gradle
@@ -28,3 +28,50 @@ publishing {
     }
   }
 }
+
+gradle.taskGraph.whenReady({ graph ->
+  tasks.withType(Jar).each { jar ->
+    jar.doFirst {
+      def projectDependencies = []
+      def runtimeList = []
+
+      // Iterate over runtime classpath dependencies and separate project dependencies from library
+      // dependencies.
+      configurations.runtimeClasspath
+              .collect { it.name - ".jar" }
+              .each { dependency ->
+                if (dependency.startsWith("geode-")) {
+                  projectDependencies.add(dependency)
+                } else {
+                  runtimeList.add(dependency+".jar")
+                }
+              }
+
+      // Iterate over project (parent) dependencies and remove its runtime library dependencies from
+      // the current project's runtime library dependencies.
+      // Also removes all parent project's runtime project dependencies from the current project.
+      // This returns a unique set of parent project and library dependencies that are not found
+      // within it's parent's project dependencies.
+      projectDependencies.clone().each { projectDependency ->
+        def geodeProject = projectDependency - "-${version}.jar"
+        if (projectDependencies.contains(geodeProject)) {
+          try {
+            def parentProject = project(":$geodeProject" - "-$version")
+            def collect = parentProject.configurations.runtimeClasspath.collect { it.name }
+            runtimeList.removeAll(collect)
+            projectDependencies.removeAll(collect.collect {it-".jar"})
+          } catch (UnknownProjectException ignore) {
+          }
+        }
+      }
+
+      manifest {
+        attributes.put("Class-Path", runtimeList.join(' '))
+        attributes.put("Dependent-Modules", projectDependencies.join(' '))
+        attributes.put("Module-Name", project.name)
+      }
+    }
+  }
+})
+
+


### PR DESCRIPTION
* Fixes Geode session state dependencies.
* Fixes module manifest project detection.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
