### PR TITLE
GEODE-8833: Set possible duplicate flag for persistent region

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put65.java
@@ -229,16 +229,8 @@ public class Put65 extends BaseCommand {
 
     // msg.isRetry might be set by v7.0 and later clients
     if (clientMessage.isRetry()) {
-      // if (logger.isDebugEnabled()) {
-      // logger.debug("DEBUG: encountered isRetry in Put65");
-      // }
-      clientEvent.setPossibleDuplicate(true);
-      if (region.getAttributes().getConcurrencyChecksEnabled()) {
-        // recover the version tag from other servers
-        clientEvent.setRegion(region);
-        if (!recoverVersionTagForRetriedOperation(clientEvent)) {
-          clientEvent.setPossibleDuplicate(false); // no-one has seen this event
-        }
+      if (shouldSetPossibleDuplicate(region, clientEvent)) {
+        clientEvent.setPossibleDuplicate(true);
       }
     }
 
@@ -496,6 +488,22 @@ public class Put65 extends BaseCommand {
     stats.incWritePutResponseTime(DistributionStats.getStatTime() - start);
 
 
+  }
+
+  boolean shouldSetPossibleDuplicate(LocalRegion region, EventIDHolder clientEvent) {
+    boolean shouldSetPossibleDuplicate = true;
+    if (region.getAttributes().getConcurrencyChecksEnabled()) {
+      // recover the version tag from other servers
+      clientEvent.setRegion(region);
+      boolean withPersistence = region.getAttributes().getDataPolicy().withPersistence();
+      if (!recoverVersionTagForRetriedOperation(clientEvent) && !withPersistence) {
+        // For persistent region, it is possible that all persistent copies went offline.
+        // Do not reset possible duplicate in this case, as persistent data
+        // can be recovered during the retry after recover of version tag failed.
+        shouldSetPossibleDuplicate = false; // no-one has seen this event
+      }
+    }
+    return shouldSetPossibleDuplicate;
   }
 
   protected void writeReply(Message origMsg, ServerConnection servConn, boolean sendOldValue,


### PR DESCRIPTION
  For persistent region, even though a version tag is not recovered, the possibleDuplicate
  flag is still needed to be set for the cleint retry message.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
