### PR TITLE
GEODE-8838: Provide some ability to launch ChildVM with specific port for RemoteDUnitVM stub

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/DUnitEnv.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/DUnitEnv.java
@@ -15,10 +15,8 @@
 package org.apache.geode.test.dunit;
 
 import java.io.File;
-import java.rmi.RemoteException;
 import java.util.Properties;
 
-import org.apache.geode.test.dunit.internal.BounceResult;
 
 /**
  * This class provides an abstraction over the environment that is used to run dunit. This will
@@ -60,9 +58,6 @@ public abstract class DUnitEnv {
   public abstract Properties getDistributedSystemProperties();
 
   public abstract int getId();
-
-  public abstract BounceResult bounce(String version, int pid, boolean force)
-      throws RemoteException;
 
   public abstract File getWorkingDirectory(int pid);
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
@@ -33,7 +33,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.internal.AvailablePort;
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.process.ProcessUtils;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.test.dunit.internal.ChildVMLauncher;
@@ -591,7 +591,7 @@ public class VM implements Serializable {
       // this case, ephemeral ports that are allocated early may end up conflicting with these
       // fixed ports. So when we bounce a VM, use an RMI port outside the usual range of ephemeral
       // ports for MacOS (49152–65535) and Linux (32768-60999).
-      int remoteStubPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
+      int remoteStubPort = AvailablePortHelper.getRandomAvailableTCPPort();
       processHolder = childVMLauncher.launchVM(targetVersion, id, true, remoteStubPort);
       version = targetVersion;
       client = childVMLauncher.getStub(id);

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/VM.java
@@ -33,6 +33,7 @@ import java.util.concurrent.Callable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.internal.AvailablePort;
 import org.apache.geode.internal.process.ProcessUtils;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.test.dunit.internal.ChildVMLauncher;
@@ -584,7 +585,14 @@ public class VM implements Serializable {
         executeMethodOnObject(runnable, "run", new Object[0]);
       }
       processHolder.waitFor();
-      processHolder = childVMLauncher.launchVM(targetVersion, id, true);
+
+      // We typically try and use ephemeral ports everywhere. However, sometimes an ephemeral port
+      // created during a prior start needs to be used as a fixed port on subsequent bounces. In
+      // this case, ephemeral ports that are allocated early may end up conflicting with these
+      // fixed ports. So when we bounce a VM, use an RMI port outside the usual range of ephemeral
+      // ports for MacOS (49152–65535) and Linux (32768-60999).
+      int remoteStubPort = AvailablePort.getRandomAvailablePort(AvailablePort.SOCKET);
+      processHolder = childVMLauncher.launchVM(targetVersion, id, true, remoteStubPort);
       version = targetVersion;
       client = childVMLauncher.getStub(id);
       available = true;

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ChildVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ChildVM.java
@@ -41,6 +41,7 @@ public class ChildVM {
     try {
       int namingPort = Integer.getInteger(DUnitLauncher.RMI_PORT_PARAM);
       int vmNum = Integer.getInteger(DUnitLauncher.VM_NUM_PARAM);
+      int remoteStubPort = Integer.getInteger(DUnitLauncher.REMOTE_STUB_PORT_PARAM, 0);
       String geodeVersion = System.getProperty(DUnitLauncher.VM_VERSION_PARAM);
       int pid = OSProcess.getId();
       logger.info("VM" + vmNum + " is launching" + (pid > 0 ? " with PID " + pid : ""));
@@ -52,7 +53,7 @@ public class ChildVM {
           .lookup("//localhost:" + namingPort + "/" + DUnitLauncher.MASTER_PARAM);
       DUnitLauncher.init(holder);
       DUnitLauncher.locatorPort = holder.getLocatorPort();
-      final RemoteDUnitVM dunitVM = new RemoteDUnitVM();
+      final RemoteDUnitVM dunitVM = new RemoteDUnitVM(remoteStubPort);
       final String name = "//localhost:" + namingPort + "/vm" + vmNum;
       Naming.rebind(name, dunitVM);
       JUnit4DistributedTestCase.initializeBlackboard();

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ChildVMLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ChildVMLauncher.java
@@ -20,7 +20,7 @@ import java.rmi.RemoteException;
 
 public interface ChildVMLauncher {
 
-  ProcessHolder launchVM(String version, int vmNum, boolean bouncedVM)
+  ProcessHolder launchVM(String version, int vmNum, boolean bouncedVM, int remoteStubPort)
       throws IOException;
 
   RemoteDUnitVMIF getStub(int i) throws RemoteException, NotBoundException, InterruptedException;

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitHost.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitHost.java
@@ -32,7 +32,7 @@ class DUnitHost extends Host {
   DUnitHost(String hostName, ProcessManager processManager, VMEventNotifier vmEventNotifier)
       throws RemoteException {
     super(hostName, vmEventNotifier);
-    this.debuggingVM = new VM(this, VersionManager.CURRENT_VERSION, -1, new RemoteDUnitVM(), null,
+    this.debuggingVM = new VM(this, VersionManager.CURRENT_VERSION, -1, new RemoteDUnitVM(0), null,
         null);
     this.processManager = processManager;
     this.vmEventNotifier = vmEventNotifier;
@@ -104,7 +104,7 @@ class DUnitHost extends Host {
         }
 
         // now create the one we really want
-        processManager.launchVM(version, n, false);
+        processManager.launchVM(version, n, false, 0);
         processManager.waitForVMs(DUnitLauncher.STARTUP_TIMEOUT);
         addVM(n, version, processManager.getStub(n), processManager.getProcessHolder(n),
             processManager);

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
@@ -118,6 +118,7 @@ public class DUnitLauncher {
 
   static final String MASTER_PARAM = "DUNIT_MASTER";
 
+  public static final String REMOTE_STUB_PORT_PARAM = "DUnitLauncher.REMOTE_STUB_PORT";
   public static final String RMI_PORT_PARAM = GEMFIRE_PREFIX + "DUnitLauncher.RMI_PORT";
   public static final String RMI_HOST_PARAM = GEMFIRE_PREFIX + "DUnitLauncher.RMI_HOST";
   public static final String VM_NUM_PARAM = GEMFIRE_PREFIX + "DUnitLauncher.VM_NUM";

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/Master.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/Master.java
@@ -14,13 +14,10 @@
  */
 package org.apache.geode.test.dunit.internal;
 
-import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
 import java.rmi.registry.Registry;
 import java.rmi.server.UnicastRemoteObject;
 
-import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.version.VersionManager;
 
 public class Master extends UnicastRemoteObject implements MasterRemote {
   private static final long serialVersionUID = 1178600200232603119L;
@@ -49,26 +46,4 @@ public class Master extends UnicastRemoteObject implements MasterRemote {
     // do nothing
   }
 
-  @Override
-  public BounceResult bounce(int pid) {
-    return bounce(VersionManager.CURRENT_VERSION, pid, false);
-  }
-
-  @Override
-  public BounceResult bounce(String version, int pid, boolean force) {
-    processManager.bounce(version, pid, force);
-
-    try {
-      if (!processManager.waitForVMs(DUnitLauncher.STARTUP_TIMEOUT)) {
-        throw new RuntimeException(DUnitLauncher.STARTUP_TIMEOUT_MESSAGE);
-      }
-      RemoteDUnitVMIF remote =
-          (RemoteDUnitVMIF) registry.lookup(VM.getVMName(VersionManager.CURRENT_VERSION, pid));
-      return new BounceResult(pid, remote);
-    } catch (RemoteException | NotBoundException e) {
-      throw new RuntimeException("could not lookup name", e);
-    } catch (InterruptedException e) {
-      throw new RuntimeException("Failed waiting for VM", e);
-    }
-  }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/MasterRemote.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/MasterRemote.java
@@ -25,7 +25,4 @@ public interface MasterRemote extends Remote {
 
   void ping() throws RemoteException;
 
-  BounceResult bounce(int pid) throws RemoteException;
-
-  BounceResult bounce(String version, int pid, boolean force) throws RemoteException;
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/RemoteDUnitVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/RemoteDUnitVM.java
@@ -26,8 +26,8 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
 class RemoteDUnitVM extends UnicastRemoteObject implements RemoteDUnitVMIF {
   private static final Logger logger = LogService.getLogger();
 
-  RemoteDUnitVM() throws RemoteException {
-    // super
+  RemoteDUnitVM(int port) throws RemoteException {
+    super(port);
   }
 
   /**

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/StandAloneDUnitEnv.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/StandAloneDUnitEnv.java
@@ -15,7 +15,6 @@
 package org.apache.geode.test.dunit.internal;
 
 import java.io.File;
-import java.rmi.RemoteException;
 import java.util.Properties;
 
 import org.apache.geode.test.dunit.DUnitEnv;
@@ -52,11 +51,6 @@ public class StandAloneDUnitEnv extends DUnitEnv {
   @Override
   public int getId() {
     return Integer.getInteger(DUnitLauncher.VM_NUM_PARAM, -1);
-  }
-
-  @Override
-  public BounceResult bounce(String version, int pid, boolean force) throws RemoteException {
-    return master.bounce(version, pid, force);
   }
 
   @Override


### PR DESCRIPTION
- This change is intended to address an issue with port bind conflicts
  specifically when VMs are restarted. Thus this change only specifies a
  specific port when bouncing a VM. In this case we use a RMI port
  outside the usual range of ephemeral ports for MacOS (49152–65535) and
  Linux (32768-60999).
- We typically try and use ephemeral ports everywhere. However,
  sometimes an ephemeral port created during a prior start needs to be
  used as a fixed port on subsequent bounces. In this case, ephemeral
  ports that are allocated early may end up conflicting with these fixed
  ports.
- Remove various unused methods related to bounce()ing VMs.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
