### PR TITLE
GEODE-8334: Fix an issue with testcontainers because of a change in Docker's API

### DIFF
--- a/ci/images/google-geode-builder/scripts/setup.sh
+++ b/ci/images/google-geode-builder/scripts/setup.sh
@@ -40,7 +40,9 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
     cgroupfs-mount \
     docker-compose \
-    docker-ce \
+    containerd.io \
+    docker-ce="5:19.03.14~3-0~ubuntu-focal" \
+    docker-ce-cli="5:19.03.14~3-0~ubuntu-focal" \
     git \
     google-chrome-stable \
     htop \

--- a/ci/pipelines/images/deploy_images_pipeline.sh
+++ b/ci/pipelines/images/deploy_images_pipeline.sh
@@ -72,7 +72,7 @@ pipeline-prefix: "${PIPELINE_PREFIX}"
 public-pipelines: ${PUBLIC_PIPELINES}
 gcp-project: ${GCP_PROJECT}
 windows-base-family: windows-2016
-linux-base-family: ubuntu-minimal-1804-lts
+linux-base-family: ubuntu-minimal-2004-lts
 YML
 
 


### PR DESCRIPTION
* Update Ubuntu to 20.04
* Use docker 19.03.14 because of breaking API changes.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
