### PR TITLE
GEODE-8851: FunctionRemoteContext should support version ordinals GEODE_1_12_1 and GEODE_1_13_1

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1297,8 +1297,8 @@ fromData,22
 toData,19
 
 org/apache/geode/internal/cache/execute/FunctionRemoteContext,2
-fromData,145
-toData,123
+fromData,187
+toData,165
 
 org/apache/geode/internal/cache/ha/HARegionQueue$DispatchedAndCurrentEvents,2
 fromData,37

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionRemoteContext.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionRemoteContext.java
@@ -86,7 +86,12 @@ public class FunctionRemoteContext implements DataSerializable {
     }
     this.isReExecute = DataSerializer.readBoolean(in);
 
-    if (StaticSerialization.getVersionForDataStream(in).isNotOlderThan(KnownVersion.GEODE_1_14_0)) {
+    KnownVersion dataStreamVersion = StaticSerialization.getVersionForDataStream(in);
+    if (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_14_0)
+        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_12_1)
+            && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_13_0))
+        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_1)
+            && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_14_0))) {
       this.principal = DataSerializer.readObject(in);
     }
   }
@@ -109,8 +114,12 @@ public class FunctionRemoteContext implements DataSerializable {
     }
     DataSerializer.writeBoolean(this.isReExecute, out);
 
-    if (StaticSerialization.getVersionForDataStream(out)
-        .isNotOlderThan(KnownVersion.GEODE_1_14_0)) {
+    KnownVersion dataStreamVersion = StaticSerialization.getVersionForDataStream(out);
+    if (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_14_0)
+        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_12_1)
+            && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_13_0))
+        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_1)
+            && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_14_0))) {
       DataSerializer.writeObject(this.principal, out);
     }
   }

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/Version.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/Version.java
@@ -65,6 +65,17 @@ public interface Version extends Comparable<Version> {
   boolean isNotOlderThan(Version version);
 
   /**
+   * Test if this version is newer than or equal to the given version. Synonym for
+   * {@link #isNotOlderThan(Version)}.
+   *
+   * @param version to compare to this version
+   * @return true if this is the same version or newer, otherwise false.
+   */
+  default boolean isNewerThanOrEqualTo(Version version) {
+    return isNotOlderThan(version);
+  }
+
+  /**
    * Test if this version is newer than given version.
    *
    * @param version to compare to this version


### PR DESCRIPTION
- Also adds KnownVersion.isNewerThanOrEqualTo as synonym to
  KnownVersion.isNotOlderThan.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
