### PR TITLE
GEODE-8772: Non-default server port in Tombstone tests

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.versions;
 
 import static org.apache.geode.cache.RegionShortcut.REPLICATE;
 import static org.apache.geode.cache.RegionShortcut.REPLICATE_PERSISTENT;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.internal.cache.InitialImageOperation.GIITestHookType.DuringApplyDelta;
 import static org.apache.geode.internal.cache.InitialImageOperation.resetAllGIITestHooks;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -38,6 +39,7 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
@@ -147,10 +149,14 @@ public class TombstoneDUnitTest implements Serializable {
     VM client = VM.getVM(0);
     VM server = VM.getVM(1);
 
+
     // Fire up the server and put in some data that is deletable
     server.invoke(() -> {
       createCacheAndRegion(REPLICATE);
-      cache.addCacheServer().start();
+      int serverPort = getRandomAvailableTCPPort();
+      CacheServer cacheServer = cache.addCacheServer();
+      cacheServer.setPort(serverPort);
+      cacheServer.start();
       for (int i = 0; i < 1000; i++) {
         region.put("K" + i, "V" + i);
       }
@@ -222,7 +228,10 @@ public class TombstoneDUnitTest implements Serializable {
     // Fire up the server and put in some data that is deletable
     server.invoke(() -> {
       createCacheAndRegion(REPLICATE);
-      cache.addCacheServer().start();
+      int serverPort = getRandomAvailableTCPPort();
+      CacheServer cacheServer = cache.addCacheServer();
+      cacheServer.setPort(serverPort);
+      cacheServer.start();
       for (int i = 0; i < 1000; i++) {
         region.put("K" + i, "V" + i);
       }


### PR DESCRIPTION
The "non-replicate" tombstone tests were starting cache servers on the
default port. When these tests run in parallel outside of docker, server
startup can fail if other tests have already bound the default port.

These tests now allocate the server port via AvailablePortHelper.

Authored-by: Dale Emery <demery@vmware.com>