### PR TITLE
GEODE-8772: Mgmt request test assigns JMX port

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDistributedTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDistributedTest.java
@@ -19,9 +19,10 @@ package org.apache.geode.management.internal.rest;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
-import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,6 +60,7 @@ public class ManagementRequestLoggingDistributedTest implements Serializable {
   private File locatorDir;
   private File serverDir;
   private int httpPort;
+  private int jmxManagerPort;
   private int locatorPort;
 
   private transient ClusterManagementService service;
@@ -78,7 +80,9 @@ public class ManagementRequestLoggingDistributedTest implements Serializable {
     serverName = "server1";
     locatorDir = temporaryFolder.newFolder(locatorName);
     serverDir = temporaryFolder.newFolder(serverName);
-    httpPort = getRandomAvailableTCPPort();
+    int[] ports = getRandomAvailableTCPPorts(2);
+    httpPort = ports[0];
+    jmxManagerPort = ports[1];
 
     locatorPort = locatorVM.invoke(this::startLocator);
     serverVM.invoke(this::startServer);
@@ -141,6 +145,7 @@ public class ManagementRequestLoggingDistributedTest implements Serializable {
     builder.setWorkingDirectory(locatorDir.getAbsolutePath());
     builder.setPort(0);
     builder.set(HTTP_SERVICE_PORT, String.valueOf(httpPort));
+    builder.set(JMX_MANAGER_PORT, String.valueOf(jmxManagerPort));
     builder.set(LOG_LEVEL, "debug");
 
     locatorLauncher = builder.build();


### PR DESCRIPTION
ManagementRequestLoggingDistributedTest was using the default JMX port.
When run in parallel outside of docker, the test can fail to bind the
JMX manager if another test has already bound to that port.

ManagementRequestLoggingDistributedTest now assigns an available JMX
port.

Authored-by: Dale Emery <demery@vmware.com>