### PR TITLE
GEODE-8772: Make tests assign ports

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDistributedTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/ManagementRequestLoggingDistributedTest.java
@@ -19,9 +19,10 @@ package org.apache.geode.management.internal.rest;
 import static java.nio.charset.Charset.defaultCharset;
 import static org.apache.commons.io.FileUtils.readFileToString;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
-import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -59,6 +60,7 @@ public class ManagementRequestLoggingDistributedTest implements Serializable {
   private File locatorDir;
   private File serverDir;
   private int httpPort;
+  private int jmxManagerPort;
   private int locatorPort;
 
   private transient ClusterManagementService service;
@@ -78,7 +80,9 @@ public class ManagementRequestLoggingDistributedTest implements Serializable {
     serverName = "server1";
     locatorDir = temporaryFolder.newFolder(locatorName);
     serverDir = temporaryFolder.newFolder(serverName);
-    httpPort = getRandomAvailableTCPPort();
+    int[] ports = getRandomAvailableTCPPorts(2);
+    httpPort = ports[0];
+    jmxManagerPort = ports[1];
 
     locatorPort = locatorVM.invoke(this::startLocator);
     serverVM.invoke(this::startServer);
@@ -141,6 +145,7 @@ public class ManagementRequestLoggingDistributedTest implements Serializable {
     builder.setWorkingDirectory(locatorDir.getAbsolutePath());
     builder.setPort(0);
     builder.set(HTTP_SERVICE_PORT, String.valueOf(httpPort));
+    builder.set(JMX_MANAGER_PORT, String.valueOf(jmxManagerPort));
     builder.set(LOG_LEVEL, "debug");
 
     locatorLauncher = builder.build();

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
@@ -23,6 +23,8 @@ import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_S
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.START_DEV_REST_API;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
@@ -63,7 +65,6 @@ import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.server.CacheServer;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.xmlcache.RegionAttributesCreation;
 import org.apache.geode.pdx.PdxInstance;
@@ -168,15 +169,18 @@ public class RestAPIsAndInterOpsDUnitTest
   }
 
   private int startManager(final String locators, final String[] regions) throws IOException {
+    int[] ports = getRandomAvailableTCPPorts(2);
+    int jmxManagerPort = ports[0];
+    int httpPort = ports[1];
+
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, String.valueOf(0));
     props.setProperty(LOCATORS, locators);
 
     props.setProperty(JMX_MANAGER, "true");
     props.setProperty(JMX_MANAGER_START, "true");
-    props.setProperty(JMX_MANAGER_PORT, "0");
+    props.setProperty(JMX_MANAGER_PORT, String.valueOf(jmxManagerPort));
 
-    final int httpPort = AvailablePortHelper.getRandomAvailableTCPPort();
     // Set REST service related configuration
     props.setProperty(START_DEV_REST_API, "true");
     props.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
@@ -190,7 +194,7 @@ public class RestAPIsAndInterOpsDUnitTest
 
   private String startBridgeServerWithRestService(final String hostName, final String locators,
       final String[] regions) throws IOException {
-    final int serverPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    final int serverPort = getRandomAvailableTCPPort();
     // create Cache of given VM and start HTTP service with REST APIs service
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, String.valueOf(0));

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
@@ -24,7 +24,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.START_DEV_REST_API;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
-import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
@@ -169,9 +168,7 @@ public class RestAPIsAndInterOpsDUnitTest
   }
 
   private int startManager(final String locators, final String[] regions) throws IOException {
-    int[] ports = getRandomAvailableTCPPorts(2);
-    int jmxManagerPort = ports[0];
-    int httpPort = ports[1];
+    int httpPort = getRandomAvailableTCPPort();
 
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, String.valueOf(0));

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsAndInterOpsDUnitTest.java
@@ -179,7 +179,7 @@ public class RestAPIsAndInterOpsDUnitTest
 
     props.setProperty(JMX_MANAGER, "true");
     props.setProperty(JMX_MANAGER_START, "true");
-    props.setProperty(JMX_MANAGER_PORT, String.valueOf(jmxManagerPort));
+    props.setProperty(JMX_MANAGER_PORT, "0");
 
     // Set REST service related configuration
     props.setProperty(START_DEV_REST_API, "true");

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.versions;
 
 import static org.apache.geode.cache.RegionShortcut.REPLICATE;
 import static org.apache.geode.cache.RegionShortcut.REPLICATE_PERSISTENT;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.internal.cache.InitialImageOperation.GIITestHookType.DuringApplyDelta;
 import static org.apache.geode.internal.cache.InitialImageOperation.resetAllGIITestHooks;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -38,6 +39,7 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.DistributionMessageObserver;
@@ -147,10 +149,14 @@ public class TombstoneDUnitTest implements Serializable {
     VM client = VM.getVM(0);
     VM server = VM.getVM(1);
 
+
     // Fire up the server and put in some data that is deletable
     server.invoke(() -> {
       createCacheAndRegion(REPLICATE);
-      cache.addCacheServer().start();
+      int serverPort = getRandomAvailableTCPPort();
+      CacheServer cacheServer = cache.addCacheServer();
+      cacheServer.setPort(serverPort);
+      cacheServer.start();
       for (int i = 0; i < 1000; i++) {
         region.put("K" + i, "V" + i);
       }
@@ -222,7 +228,10 @@ public class TombstoneDUnitTest implements Serializable {
     // Fire up the server and put in some data that is deletable
     server.invoke(() -> {
       createCacheAndRegion(REPLICATE);
-      cache.addCacheServer().start();
+      int serverPort = getRandomAvailableTCPPort();
+      CacheServer cacheServer = cache.addCacheServer();
+      cacheServer.setPort(serverPort);
+      cacheServer.start();
       for (int i = 0; i < 1000; i++) {
         region.put("K" + i, "V" + i);
       }

--- a/geode-dunit/src/main/java/org/apache/geode/cache/client/internal/LocatorTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache/client/internal/LocatorTestBase.java
@@ -17,10 +17,12 @@ package org.apache.geode.cache.client.internal;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.START_LOCATOR;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 
 import java.io.File;
 import java.io.IOException;
@@ -47,7 +49,6 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.server.ServerLoadProbe;
 import org.apache.geode.distributed.DistributedSystem;
 import org.apache.geode.distributed.Locator;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.Invoke;
@@ -118,13 +119,16 @@ public abstract class LocatorTestBase extends JUnit4DistributedTestCase {
 
   protected int startLocator(final String hostName, final String otherLocators) throws Exception {
     disconnectFromDS();
-    final int httpPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    int[] ports = getRandomAvailableTCPPorts(2);
+    int httpPort = ports[0];
+    int jmxManagerPort = ports[1];
     Properties props = new Properties();
     props.put(MCAST_PORT, String.valueOf(0));
     props.put(LOCATORS, otherLocators);
     props.put(LOG_LEVEL, LogWriterUtils.getDUnitLogLevel());
     props.put(ENABLE_CLUSTER_CONFIGURATION, "false");
     props.put(HTTP_SERVICE_PORT, String.valueOf(httpPort));
+    props.put(JMX_MANAGER_PORT, String.valueOf(jmxManagerPort));
     File logFile = new File("");
     InetAddress bindAddr = null;
     try {


### PR DESCRIPTION
Some tests in ManagementRequestLoggingDistributedTest and
RestAPIsAndInterOpsDUnitTest were using the default JMX port (1099).
Some tests in TombstoneDUnitTest were using the default cache server
port (40404). When these tests run in parallel outside of docker, they
can fail to bind these ports if another test has already bound them.

These tests now assign ports via AvailablePortHelper.

Authored-by: Dale Emery <demery@vmware.com>