### PR TITLE
GEODE-8858: unit/integration tests for HSETNX

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
@@ -387,6 +387,18 @@ public abstract class AbstractHashesIntegrationTest implements RedisPortSupplier
     jedis.del(set_key);
   }
 
+  @Test
+  public void hsetnx_shouldThrowError_givenWrongNumberOfArguments() {
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSETNX))
+        .hasMessageContaining("wrong number of arguments");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSETNX, "1"))
+        .hasMessageContaining("wrong number of arguments");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSETNX, "1", "2"))
+        .hasMessageContaining("wrong number of arguments");
+    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSETNX, "1", "2", "3", "4"))
+        .hasMessageContaining("wrong number of arguments");
+  }
+
   /**
    * Test the HVALS command
    */

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
@@ -376,11 +376,12 @@ public abstract class AbstractHashesIntegrationTest implements RedisPortSupplier
     jedis.sadd(set_key, field);
 
     assertThatThrownBy(
-        () -> jedis.hsetnx(string_key, field, "something else")).isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("WRONGTYPE");
+        () -> jedis.hsetnx(string_key, field, "something else"))
+            .isInstanceOf(JedisDataException.class)
+            .hasMessageContaining("WRONGTYPE");
     assertThatThrownBy(
         () -> jedis.hsetnx(set_key, field, "something else")).isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("WRONGTYPE");
+            .hasMessageContaining("WRONGTYPE");
 
     jedis.del(string_key);
     jedis.del(set_key);

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
@@ -365,6 +365,27 @@ public abstract class AbstractHashesIntegrationTest implements RedisPortSupplier
 
   }
 
+  @Test
+  public void hsetNX_shouldThrowErrorIfKeyIsWrongType() {
+    String string_key = "String_Key";
+    String set_key = "Set_Key";
+    String field = "field";
+    String value = "value";
+
+    jedis.set(string_key, value);
+    jedis.sadd(set_key, field);
+
+    assertThatThrownBy(
+        () -> jedis.hsetnx(string_key, field, "something else")).isInstanceOf(JedisDataException.class)
+        .hasMessageContaining("WRONGTYPE");
+    assertThatThrownBy(
+        () -> jedis.hsetnx(set_key, field, "something else")).isInstanceOf(JedisDataException.class)
+        .hasMessageContaining("WRONGTYPE");
+
+    jedis.del(string_key);
+    jedis.del(set_key);
+  }
+
   /**
    * Test the HVALS command
    */


### PR DESCRIPTION
Add missing unit/integration tests for HSETNX. Confirm "WRONGTYPE" error when operating on non-hash keys.