### PR TITLE
Change the ownership of README files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -308,5 +308,5 @@ BUILDING.md                                                       @rhoughton-piv
 CODE_OF_CONDUCT.md                                                @upthewaterspout @pivotal-amurmann @nonbinaryprogrammer
 LICENSE                                                           @onichols-pivotal @dickcav @metatype
 NOTICE                                                            @onichols-pivotal @dickcav @metatype
-README.md                                                         @upthewaterspout @pivotal-amurmann
+/README.md                                                         @upthewaterspout @pivotal-amurmann
 #TESTING.md


### PR DESCRIPTION
Change CODEOWNERS such that the top level README is be owned by Alexander and 
I, but individual module READMEs are owned by the module owners.
