### PR TITLE
GEODE-8685: change export to not deserialize region values (#5735)

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntrySnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntrySnapshot.java
@@ -123,6 +123,20 @@ public class EntrySnapshot implements Region.Entry, DataSerializable {
     return v;
   }
 
+  /**
+   * If the value is available as a CachedDeserializable instance then return it.
+   * Otherwise behave as if getValue() was called.
+   */
+  public Object getValuePreferringCachedDeserializable() {
+    checkEntryDestroyed();
+    Object value = regionEntry.getValue(null);
+    if (value instanceof CachedDeserializable) {
+      return value;
+    } else {
+      return getRawValue();
+    }
+  }
+
   @Override
   public Object getValue() {
     checkEntryDestroyed();
@@ -281,5 +295,4 @@ public class EntrySnapshot implements Region.Entry, DataSerializable {
     }
     this.regionEntry.fromData(in);
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotPacket.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/snapshot/SnapshotPacket.java
@@ -25,6 +25,7 @@ import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.CachedDeserializable;
+import org.apache.geode.internal.cache.EntrySnapshot;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.NonTXEntry;
 import org.apache.geode.internal.cache.Token;
@@ -75,6 +76,10 @@ public class SnapshotPacket implements DataSerializableFixedID {
         } finally {
           OffHeapHelper.release(v);
         }
+      } else if (entry instanceof EntrySnapshot) {
+        EntrySnapshot entrySnapshot = (EntrySnapshot) entry;
+        Object entryValue = entrySnapshot.getValuePreferringCachedDeserializable();
+        value = convertToBytes(entryValue);
       } else {
         value = convertToBytes(entry.getValue());
       }

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ExportDataIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/ExportDataIntegrationTest.java
@@ -19,6 +19,9 @@ package org.apache.geode.management.internal.cli.commands;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.IntStream;
@@ -29,6 +32,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import org.apache.geode.DataSerializable;
+import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
@@ -52,9 +57,28 @@ public class ExportDataIntegrationTest {
   @Rule
   public TemporaryFolder tempDir = new TemporaryFolder();
 
-  private Region<String, String> region;
+  private Region<String, Object> region;
   private Path snapshotFile;
   private Path snapshotDir;
+
+  public static class StringWrapper implements DataSerializable {
+
+    private String value;
+
+    public StringWrapper(String string) {
+      value = string;
+    }
+
+    @Override
+    public void toData(DataOutput out) throws IOException {
+      DataSerializer.writeString(value, out);
+    }
+
+    @Override
+    public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+      throw new ClassNotFoundException("Should never be deserialized");
+    }
+  }
 
   @Before
   public void setup() throws Exception {
@@ -68,6 +92,7 @@ public class ExportDataIntegrationTest {
 
   @Test
   public void testExport() throws Exception {
+    loadRegion(new StringWrapper("value"));
     String exportCommand = buildBaseExportCommand()
         .addOption(CliStrings.EXPORT_DATA__FILE, snapshotFile.toString()).getCommandString();
     gfsh.executeAndAssertThat(exportCommand).statusIsSuccess();
@@ -152,7 +177,7 @@ public class ExportDataIntegrationTest {
     assertFalse(Files.exists(snapshotDir));
   }
 
-  private void loadRegion(String value) {
+  private void loadRegion(Object value) {
     IntStream.range(0, DATA_POINTS).forEach(i -> region.put("key" + i, value));
   }
 


### PR DESCRIPTION
Modified test to fail if it attempts to deserialize values during export.
Fixed product export code to no longer deserialize and test now passes.

Co-authored-by: Darrel Schneider <dschneider@vmware.com>
(cherry picked from commit 078ceb0187b718d86d6f6e6ec058d2c743e2655a)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
