### PR TITLE
GEODE-8875: Removing packages element from log4j2 configuration file

### DIFF
--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/launchers/LocatorLauncherWithCustomLogConfigAcceptanceTest.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/launchers/LocatorLauncherWithCustomLogConfigAcceptanceTest.xml
@@ -12,7 +12,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/launchers/LocatorLauncherWithPulseAndCustomLogConfigAcceptanceTestWithGeodePlugins.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/launchers/LocatorLauncherWithPulseAndCustomLogConfigAcceptanceTestWithGeodePlugins.xml
@@ -12,7 +12,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/launchers/ServerLauncherWithCustomLogConfigAcceptanceTest.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/launchers/ServerLauncherWithCustomLogConfigAcceptanceTest.xml
@@ -12,7 +12,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/LocatorWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/LocatorWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml
@@ -12,7 +12,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/ServerWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml
+++ b/geode-assembly/src/acceptanceTest/resources/org/apache/geode/logging/ServerWithCustomLogConfigAcceptanceTestWithGeodePlugins.xml
@@ -12,7 +12,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/RestartOfMemberDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/RestartOfMemberDistributedTest.java
@@ -27,6 +27,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.geode.ForcedDisconnectException;
+import org.apache.geode.alerting.internal.spi.AlertingIOException;
 import org.apache.geode.distributed.internal.membership.api.MemberDisconnectedException;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 
@@ -56,6 +57,7 @@ public class RestartOfMemberDistributedTest {
 
     addIgnoredException(ForcedDisconnectException.class.getName());
     addIgnoredException(MemberDisconnectedException.class.getName());
+    addIgnoredException(AlertingIOException.class);
     addIgnoredException("Possible loss of quorum due to the loss");
     addIgnoredException("Received invalid result from");
   }

--- a/geode-core/src/test/resources/org/apache/geode/test/golden/log4j2-test.xml
+++ b/geode-core/src/test/resources/org/apache/geode/test/golden/log4j2-test.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>

--- a/geode-docs/managing/logging/configuring_log4j2.html.md.erb
+++ b/geode-docs/managing/logging/configuring_log4j2.html.md.erb
@@ -67,13 +67,7 @@ Custom Log4j 2 configuration in <%=vars.product_name%> comes with some caveats a
 
 - Geode's custom Log4j 2 Appenders can be used in a custom log4j2.xml. This requires:
  
-  1. Specify "org.apache.geode" in the packages attribute of Configuration to enable Log4j 2 to find and use Geode classes:
-     
-    ```xml
-    <Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
-    ```
-
-  2. Specify GeodeConsole, GeodeLogWriter, and/or GeodeAlert in the Appenders section:
+  1. Specify GeodeConsole, GeodeLogWriter, and/or GeodeAlert in the Appenders section:
  
     ```xml
     <Properties>
@@ -93,4 +87,4 @@ Custom Log4j 2 configuration in <%=vars.product_name%> comes with some caveats a
  
     (Note that GeodeAlert does not use a PatternLayout)
 
-  3. See the default `log4j2.xml` in the Geode source directory `geode-log4j/src/main/resources/` as a reference for creating a custom configuration.
+  2. See the default `log4j2.xml` in the Geode source directory `geode-log4j/src/main/resources/` as a reference for creating a custom configuration.

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/alerting/log4j/internal/impl/AlertAppenderIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/alerting/log4j/internal/impl/AlertAppenderIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/BothLogWriterAppendersIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/BothLogWriterAppendersIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/CacheWithCustomLogConfigIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/CacheWithCustomLogConfigIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="custom-pattern">CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z} message=%message%nthrowable=%throwable%n
         </Property>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/ConfigurationWithLogLevelChangesIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/ConfigurationWithLogLevelChangesIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/DistributedSystemWithBothLogWriterAppendersIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/DistributedSystemWithBothLogWriterAppendersIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/DistributedSystemWithLogLevelChangesIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/DistributedSystemWithLogLevelChangesIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GemfireVerboseMarkerFilterAcceptIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GemfireVerboseMarkerFilterAcceptIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GemfireVerboseMarkerFilterDenyIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GemfireVerboseMarkerFilterDenyIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeConsoleAppenderIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeConsoleAppenderIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeConsoleAppenderWithCacheIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeConsoleAppenderWithCacheIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
         <Property name="geode-default">true</Property>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeConsoleAppenderWithSystemOutRuleIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeConsoleAppenderWithSystemOutRuleIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeVerboseMarkerFilterAcceptIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeVerboseMarkerFilterAcceptIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeVerboseMarkerFilterDenyIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/GeodeVerboseMarkerFilterDenyIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/LogServiceWithCustomLogConfigIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/LogServiceWithCustomLogConfigIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="custom-pattern">CUSTOM: level=%level time=%date{yyyy/MM/dd HH:mm:ss.SSS z} message=%message%nthrowable=%throwable%n
         </Property>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/LogWriterAppenderIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/LogWriterAppenderIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/LogWriterAppenderWithLimitsIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/LogWriterAppenderWithLimitsIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/LogWriterAppenderWithMemberNameInXmlIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/LogWriterAppenderWithMemberNameInXmlIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/SecurityLogWriterAppenderIntegrationTest_log4j2.xml
+++ b/geode-log4j/src/integrationTest/resources/org/apache/geode/logging/log4j/internal/impl/SecurityLogWriterAppenderIntegrationTest_log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="INFO" shutdownHook="disable">
     <Properties>
         <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     </Properties>

--- a/geode-log4j/src/main/resources/log4j2-cli.xml
+++ b/geode-log4j/src/main/resources/log4j2-cli.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
   </Properties>

--- a/geode-log4j/src/main/resources/log4j2.xml
+++ b/geode-log4j/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode">
+<Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} %memberName &lt;%thread&gt; tid=%hexTid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>

--- a/geode-membership/src/integrationTest/resources/log4j2.xml
+++ b/geode-membership/src/integrationTest/resources/log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="WARN" shutdownHook="disable" packages="org.apache.geode.distributed.internal.membership">
+<Configuration status="WARN" shutdownHook="disable">
   <Properties>
     <Property name="geode-pattern">[%level{lowerCase=true} %date{yyyy/MM/dd HH:mm:ss.SSS z} &lt;%thread&gt; tid=%tid] %message%n%throwable%n</Property>
     <Property name="geode-default">true</Property>

--- a/geode-pulse/src/main/resources/log4j2.xml
+++ b/geode-pulse/src/main/resources/log4j2.xml
@@ -13,7 +13,7 @@
   ~ or implied. See the License for the specific language governing permissions and limitations under
   ~ the License.
   -->
-<Configuration status="INFO" name="Pulse" packages="org.apache.geode">
+<Configuration status="INFO" name="Pulse">
     <Appenders>
         <File name="File" fileName="pulse.log">
             <PatternLayout>


### PR DESCRIPTION
This element causes log4j to scan all geode jars on startup. This slows down
the startup time of all geode processes, including gfsh.

It is not necessary because log4j has an annotation processor to generate a
config file that helps it find plugs that it needs.
