### PR TITLE
GEODE-8767: NullPointerException in TCPConduit.getBufferPool due to conTable being null

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/ConnectionTable.java
@@ -207,7 +207,7 @@ public class ConnectionTable {
     threadConnectionMap = new ConcurrentHashMap();
     p2pReaderThreadPool = createThreadPoolForIO(conduit.getDM().getSystem().isShareSockets());
     socketCloser = new SocketCloser();
-    bufferPool = new BufferPool(owner.getStats());
+    bufferPool = conduit.getBufferPool();
   }
 
   private Executor createThreadPoolForIO(boolean conserveSockets) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -112,6 +112,8 @@ public class TCPConduit implements Runnable {
    */
   private final boolean useSSL;
 
+  private final BufferPool bufferPool;
+
   /**
    * The socket producer used by the cluster
    */
@@ -217,8 +219,8 @@ public class TCPConduit implements Runnable {
    * </pre>
    */
   public TCPConduit(Membership mgr, int port, InetAddress address, boolean isBindAddress,
-      DirectChannel receiver, Properties props) throws ConnectionException {
-    this(mgr, port, address, isBindAddress, receiver, props, ConnectionTable::create,
+      DirectChannel receiver, BufferPool bufferPool, Properties props) throws ConnectionException {
+    this(mgr, port, address, isBindAddress, receiver, bufferPool, props, ConnectionTable::create,
         SocketCreatorFactory.getSocketCreatorForComponent(SecurableCommunicationChannel.CLUSTER),
         () -> {
           try {
@@ -232,7 +234,7 @@ public class TCPConduit implements Runnable {
 
   @VisibleForTesting
   TCPConduit(Membership mgr, int port, InetAddress address, boolean isBindAddress,
-      DirectChannel receiver, Properties props,
+      DirectChannel receiver, BufferPool bufferPool, Properties props,
       Function<TCPConduit, ConnectionTable> connectionTableFactory, SocketCreator socketCreator,
       Runnable localHostValidation, boolean startAcceptor) throws ConnectionException {
     parseProperties(props);
@@ -241,6 +243,7 @@ public class TCPConduit implements Runnable {
     this.isBindAddress = isBindAddress;
     this.port = port;
     directChannel = receiver;
+    this.bufferPool = bufferPool;
     stats = null;
     config = null;
     membership = mgr;
@@ -946,7 +949,7 @@ public class TCPConduit implements Runnable {
   }
 
   public BufferPool getBufferPool() {
-    return conTable.getBufferPool();
+    return bufferPool;
   }
 
   public CancelCriterion getCancelCriterion() {

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
@@ -46,6 +46,7 @@ import org.apache.geode.distributed.internal.direct.DirectChannel;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.api.Membership;
 import org.apache.geode.internal.inet.LocalHostUtil;
+import org.apache.geode.internal.net.BufferPool;
 import org.apache.geode.internal.net.SSLConfig;
 import org.apache.geode.internal.net.SocketCreator;
 
@@ -73,10 +74,23 @@ public class TCPConduitTest {
   }
 
   @Test
+  public void closedConduitDoesNotThrowNPEWhenAskedForBufferPool() {
+    directChannel.getDM(); // Mockito demands that this mock be used in this test
+    TCPConduit tcpConduit =
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+            new Properties(),
+            TCPConduit -> connectionTable, socketCreator, doNothing(), false);
+    InternalDistributedMember member = mock(InternalDistributedMember.class);
+    tcpConduit.stop(null);
+    assertThat(tcpConduit.getBufferPool()).isNotNull();
+  }
+
+  @Test
   public void getConnectionThrowsAlertingIOException_ifCaughtIOException_whileAlerting()
       throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+            new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
@@ -99,7 +113,8 @@ public class TCPConduitTest {
   @Test
   public void getConnectionRethrows_ifCaughtIOException_whileNotAlerting() throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+            new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     Connection connection = mock(Connection.class);
@@ -123,7 +138,8 @@ public class TCPConduitTest {
   @Test
   public void getConnectionRethrows_ifCaughtIOException_whenMemberDoesNotExist() throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+            new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
@@ -143,7 +159,8 @@ public class TCPConduitTest {
   @Test
   public void getConnectionRethrows_ifCaughtIOException_whenMemberIsShunned() throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+            new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
@@ -166,7 +183,8 @@ public class TCPConduitTest {
   public void getConnectionThrowsDistributedSystemDisconnectedException_ifCaughtIOException_whenShutdownIsInProgress()
       throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+            new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))
@@ -191,7 +209,8 @@ public class TCPConduitTest {
   public void getConnectionThrowsDistributedSystemDisconnectedException_ifCaughtIOException_whenShutdownIsInProgress_andCancelIsInProgress()
       throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, new Properties(),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+            new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
     doThrow(new IOException("Cannot form connection to alert listener"))


### PR DESCRIPTION
A NPE was being thrown in TCPConduit.getBufferPool() because the conTable instance
variable is nulled out when the TCPConduit is stopped.  This commit
moves the buffer pool from TCPConduit's conTable object up to the enclosing
DirectChannel object.  This removes the need for DirectChannel to ask
TCPConduit for the buffer pool.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
