### PR TITLE
GEODE-8879: add error messages for internal commands

### DIFF
--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
@@ -66,4 +66,24 @@ public abstract class AbstractUnknownIntegrationTest implements RedisPortSupplie
     assertThatThrownBy(() -> jedis.sendCommand("HELLO"::getBytes))
         .hasMessage("ERR unknown command `HELLO`, with args beginning with: ");
   }
+
+  @Test
+  public void givenInternalSMembersCommand_returnsUnknownCommandErrorWithArgumentsListed() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand("INTERNALSMEMBERS"::getBytes, "something", "somethingElse"))
+            .hasMessage(
+                "ERR unknown command `INTERNALSMEMBERS`, with args beginning with: `something`, `somethingElse`, ");
+  }
+
+  @Test
+  public void givenInternalPTTLCommand_returnsUnknownCommandErrorWithArgumentsListed() {
+    assertThatThrownBy(() -> jedis.sendCommand("INTERNALPTTL"::getBytes, "something"))
+        .hasMessage("ERR unknown command `INTERNALPTTL`, with args beginning with: `something`, ");
+  }
+
+  @Test
+  public void givenInternalTypeCommand_returnsUnknownCommandErrorWithArgumentsListed() {
+    assertThatThrownBy(() -> jedis.sendCommand("INTERNALTYPE"::getBytes, "something"))
+        .hasMessage("ERR unknown command `INTERNALTYPE`, with args beginning with: `something`, ");
+  }
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -179,9 +179,9 @@ public enum RedisCommandType {
    ********* Internal Commands ***********
    ***************************************/
   // do not call these directly, only to be used in other commands
-  INTERNALPTTL(null, INTERNAL, new ExactParameterRequirements(2)),
-  INTERNALTYPE(null, INTERNAL, new ExactParameterRequirements(2)),
-  INTERNALSMEMBERS(null, INTERNAL, new ExactParameterRequirements(3)),
+  INTERNALPTTL(new UnknownExecutor(), INTERNAL, new ExactParameterRequirements(2)),
+  INTERNALTYPE(new UnknownExecutor(), INTERNAL, new ExactParameterRequirements(2)),
+  INTERNALSMEMBERS(new UnknownExecutor(), INTERNAL, new ExactParameterRequirements(3)),
 
   /***************************************
    *** Unsupported Commands ***


### PR DESCRIPTION
when internal commands are called directly, they should return a helpful
error message

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
