### PR TITLE
GEODE-8882: Enable JetBrains NotNull Annotation

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -878,6 +878,12 @@
         <scope>compile</scope>
       </dependency>
       <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>20.1.0</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
         <groupId>org.apache.geode</groupId>
         <artifactId>geode-common</artifactId>
         <version>${version}</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -272,5 +272,10 @@ class DependencyConstraints implements Plugin<Project> {
     dependencySet(group: 'org.springframework.session', version: '2.4.1') {
       entry('spring-session-data-redis')
     }
+
+    dependencySet(group: 'org.jetbrains', version: '20.1.0') {
+      entry('annotations')
+    }
+
   }
 }

--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -26,8 +26,6 @@ dependencies {
   implementation(platform(project(':boms:geode-all-bom')))
   implementation('com.fasterxml.jackson.core:jackson-databind')
 
-  api('org.jetbrains:annotations')
-
   // test
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')

--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -26,6 +26,7 @@ dependencies {
   implementation(platform(project(':boms:geode-all-bom')))
   implementation('com.fasterxml.jackson.core:jackson-databind')
 
+  api('org.jetbrains:annotations')
 
   // test
   testImplementation('junit:junit')

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -202,6 +202,8 @@ dependencies {
     // find bugs leaks in from spring, needed to remove warnings.
     compileOnly('com.google.code.findbugs:jsr305')
 
+    compileOnly('org.jetbrains:annotations')
+
     //Jgroups is a core component of our membership system.
     implementation('org.jgroups:jgroups')
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/SocketMessageWriter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/SocketMessageWriter.java
@@ -22,6 +22,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jetbrains.annotations.NotNull;
+
 import org.apache.geode.DataSerializer;
 import org.apache.geode.Instantiator;
 import org.apache.geode.internal.InternalDataSerializer;
@@ -34,7 +36,8 @@ public class SocketMessageWriter {
       Integer.getInteger(GeodeGlossary.GEMFIRE_PREFIX + "serverToClientPingPeriod", 60000);
 
   public void writeHandshakeMessage(DataOutputStream dos, byte type, String p_msg,
-      KnownVersion clientVersion, byte endpointType, int queueSize) throws IOException {
+      @NotNull final KnownVersion clientVersion, byte endpointType, int queueSize)
+      throws IOException {
     String msg = p_msg;
 
     // write the message type

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/SocketMessageWriterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/SocketMessageWriterTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class SocketMessageWriterTest {
+
+  @Test
+  public void writeHandshakeMessageWithClientVersionNull() throws IOException {
+    final SocketMessageWriter writer = new SocketMessageWriter();
+    // can't mock DataOutputStream
+    final DataOutputStream outputStream = new DataOutputStream(new ByteArrayOutputStream());
+    writer.writeHandshakeMessage(outputStream, (byte) 1, "", null, (byte) 0, 0);
+  }
+}


### PR DESCRIPTION
[GEODE-8882](https://issues.apache.org/jira/browse/GEODE-8882)

This new annotation support is documented in the Geode Wiki: https://cwiki.apache.org/confluence/display/GEODE/@NotNull+Annotation

Oh and woopsie! We've already found our first bug via the `@NotNull` annotation:

![image](https://user-images.githubusercontent.com/4002/106076271-1f4e1700-60c4-11eb-9732-39242c3f8d5f.png)

Under "more actions" I pick:

![image](https://user-images.githubusercontent.com/4002/106076328-38ef5e80-60c4-11eb-9f1a-e8ba1c1398de.png)

Where I find this little gem passing a `null` for `clientVersion`:

![image](https://user-images.githubusercontent.com/4002/106076376-4a386b00-60c4-11eb-97ac-a9cfa798b32d.png)

Which will blow up with the recently-merged-to-`develop` changes from PR #5947 (which removed the null-check in the method of interest.)

Incidentally that call location is `ClientRegistrationMetadata.getAndValidateClientVersion()` where we were unable to ascertain the client's version! In that case our latest code on `develop` will generate an NPE on the server.

- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
