### PR TITLE
GEODE-8873: Do not log stack trace for Exception in MessageDispatcher

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
@@ -19,6 +19,7 @@ import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import java.io.IOException;
 import java.net.Socket;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -467,18 +468,18 @@ public class MessageDispatcher extends LoggingThread {
 
     // Processing gets here if isStopped=true. What is this code below doing?
     if (!exceptionOccurred) {
-      List<ClientMessage> list = null;
+      List<ClientMessage> list = new ArrayList<>();
       try {
         // Clear the interrupt status if any,
         Thread.interrupted();
         int size = _messageQueue.size();
-        list = uncheckedCast(_messageQueue.peek(size));
+        list.addAll(uncheckedCast(_messageQueue.peek(size)));
         if (logger.isDebugEnabled()) {
           logger.debug(
               "{}: After flagging the dispatcher to stop , the residual List of messages to be dispatched={} size={}",
-              this, list, (list == null) ? 0 : list.size());
+              this, list, list.size());
         }
-        if (list != null && list.size() > 0) {
+        if (list.size() > 0) {
           long start = getStatistics().startTime();
           Iterator<ClientMessage> itr = list.iterator();
           while (itr.hasNext()) {
@@ -505,11 +506,11 @@ public class MessageDispatcher extends LoggingThread {
         }
         logger.info(String.format(
             "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
-            (!isStopped()) ? toString() + ": " : "", (list == null) ? 0 : list.size()));
+            (!isStopped()) ? toString() + ": " : "", list.size()));
         logger.info(extraMsg);
       }
 
-      if (list != null && !list.isEmpty() && logger.isTraceEnabled()) {
+      if (!list.isEmpty() && logger.isTraceEnabled()) {
         logger.trace("Messages remaining in the list are: {}", list);
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -475,16 +476,15 @@ public class MessageDispatcher extends LoggingThread {
         if (logger.isDebugEnabled()) {
           logger.debug(
               "{}: After flagging the dispatcher to stop , the residual List of messages to be dispatched={} size={}",
-              this, list, list.size());
+              this, list, (list == null) ? 0 : list.size());
         }
-        if (list.size() > 0) {
+        if (list != null && list.size() > 0) {
           long start = getStatistics().startTime();
-          for (final ClientMessage o : list) {
-            dispatchMessage(o);
+          Iterator<ClientMessage> itr = list.iterator();
+          while (itr.hasNext()) {
+            dispatchMessage(itr.next());
             getStatistics().endMessage(start);
-            // @todo asif: shouldn't we call itr.remove() since the current msg
-            // has been sent? That way list will be more accurate
-            // if we have an exception.
+            itr.remove();
           }
           _messageQueue.remove();
         }
@@ -493,7 +493,6 @@ public class MessageDispatcher extends LoggingThread {
           logger.debug("CacheClientNotifier stopped due to cancellation");
         }
       } catch (Exception e) {
-        // if (logger.isInfoEnabled()) {
         String extraMsg = null;
 
         if ("Broken pipe".equals(e.getMessage())) {
@@ -501,29 +500,18 @@ public class MessageDispatcher extends LoggingThread {
         } else if (e instanceof RegionDestroyedException) {
           extraMsg = "Problem caused by message queue being closed.";
         }
-        final Object[] msgArgs = new Object[] {((!isStopped()) ? toString() + ": " : ""),
-            ((list == null) ? 0 : list.size())};
-        if (extraMsg != null) {
-          // Dont print exception details, but add on extraMsg
-          logger.info(
-              String.format(
-                  "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
-                  msgArgs));
-          logger.info(extraMsg);
-        } else {
-          // Print full stacktrace
-          logger.info(String.format(
-              "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
-              msgArgs),
-              e);
+        if (extraMsg == null) {
+          extraMsg = "Problem caused by: " + e.getMessage();
         }
+        logger.info(String.format(
+            "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
+            (!isStopped()) ? toString() + ": " : "", (list == null) ? 0 : list.size()));
+        logger.info(extraMsg);
       }
 
-      if (list != null && logger.isTraceEnabled()) {
+      if (list != null && !list.isEmpty() && logger.isTraceEnabled()) {
         logger.trace("Messages remaining in the list are: {}", list);
       }
-
-      // }
     }
     if (logger.isTraceEnabled()) {
       logger.trace("{}: Dispatcher thread is ending", this);


### PR DESCRIPTION
- For benign exceptions encountered after stopping the MessageDispatcher, do not log the entire Exception stack trace at info level

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [N/A] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
