### PR TITLE
GEODE-8894 allow individual deltas to trigger bucket size recalculation

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaFaultInDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaFaultInDUnitTest.java
@@ -32,10 +32,6 @@ import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 
-/**
- * Test that the bucket size does not go negative when we fault out and in a delta object.
- *
- */
 
 public class DeltaFaultInDUnitTest extends JUnit4CacheTestCase {
 
@@ -45,7 +41,7 @@ public class DeltaFaultInDUnitTest extends JUnit4CacheTestCase {
   }
 
   @Test
-  public void test() throws Exception {
+  public void bucketSizeShould_notGoNegative_onFaultInDeltaObject() throws Exception {
     final Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
@@ -166,7 +166,7 @@ public class DeltaForceSizingFlagDUnitTest {
     return vm0.invoke("getSizeFromPRStats", () -> {
       Cache cache = ClusterStartupRule.getCache();
       assertThat(cache).isNotNull();
-      LocalRegion region = (LocalRegion) cache.getRegion(TEST_REGION_NAME);
+      InternalRegion region = (InternalRegion) cache.getRegion(TEST_REGION_NAME);
       if (region instanceof PartitionedRegion) {
         long total = 0;
         PartitionedRegion pr = (PartitionedRegion) region;
@@ -186,7 +186,7 @@ public class DeltaForceSizingFlagDUnitTest {
 
       Cache cache = ClusterStartupRule.getCache();
       assertThat(cache).isNotNull();
-      LocalRegion region = (LocalRegion) cache.getRegion(TEST_REGION_NAME);
+      InternalRegion region = (InternalRegion) cache.getRegion(TEST_REGION_NAME);
       return region.getEvictionCounter();
     });
   }
@@ -195,7 +195,7 @@ public class DeltaForceSizingFlagDUnitTest {
     return vm0.invoke("getObjectSizerInvocations", () -> {
       Cache cache = ClusterStartupRule.getCache();
       assertThat(cache).isNotNull();
-      LocalRegion region = (LocalRegion) cache.getRegion(TEST_REGION_NAME);
+      InternalRegion region = (InternalRegion) cache.getRegion(TEST_REGION_NAME);
       return getObjectSizerInvocations(region);
     });
   }
@@ -204,12 +204,12 @@ public class DeltaForceSizingFlagDUnitTest {
     vm0.invoke("Put data", () -> {
       Cache cache = ClusterStartupRule.getCache();
       assertThat(cache).isNotNull();
-      LocalRegion region = (LocalRegion) cache.getRegion(TEST_REGION_NAME);
+      InternalRegion region = (InternalRegion) cache.getRegion(TEST_REGION_NAME);
       region.put(DeltaForceSizingFlagDUnitTest.DELTA_KEY, value);
     });
   }
 
-  protected static int getObjectSizerInvocations(LocalRegion region) {
+  protected static int getObjectSizerInvocations(InternalRegion region) {
     TestObjectSizer sizer = (TestObjectSizer) region.getEvictionAttributes().getObjectSizer();
     int result = sizer.invocations.get();
     logger.info("objectSizerInvocations=" + result);
@@ -240,7 +240,7 @@ public class DeltaForceSizingFlagDUnitTest {
     vm.invoke("assertValueType", () -> {
       Cache cache = ClusterStartupRule.getCache();
       assertThat(cache).isNotNull();
-      LocalRegion region = (LocalRegion) cache.getRegion(TEST_REGION_NAME);
+      InternalRegion region = (InternalRegion) cache.getRegion(TEST_REGION_NAME);
       Object value = region.getValueInVM(DeltaForceSizingFlagDUnitTest.DELTA_KEY);
       switch (expectedType) {
         case RAW_VALUE:

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
@@ -1,0 +1,1070 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Test;
+
+import org.apache.geode.DataSerializable;
+import org.apache.geode.DataSerializer;
+import org.apache.geode.cache.AttributesFactory;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.EvictionAction;
+import org.apache.geode.cache.EvictionAttributes;
+import org.apache.geode.cache.InterestPolicy;
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.SubscriptionAttributes;
+import org.apache.geode.cache.control.ResourceManager;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.cache.util.CacheListenerAdapter;
+import org.apache.geode.cache.util.ObjectSizer;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.test.dunit.Assert;
+import org.apache.geode.test.dunit.Host;
+import org.apache.geode.test.dunit.SerializableCallable;
+import org.apache.geode.test.dunit.SerializableRunnable;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
+
+/**
+ * A test of the when we will use the object sizer to determine the actual size of objects wrapped
+ * in CacheDeserializables.
+ * <p>
+ * <p>
+ * <p>
+ * TODO - I was intending to add tests that have an index and object sizer, but it appears we don't
+ * support indexes on regions with overflow to disk.
+ */
+
+public class DeltaForceSizingFlagDUnitTest extends JUnit4CacheTestCase {
+
+  public DeltaForceSizingFlagDUnitTest() {
+    super();
+  }
+
+  @Test
+  public void testRRMemLRU() {
+    doRRMemLRUTest();
+  }
+
+  @Test
+  public void testRRMemLRUDeltaAndFlag() {
+    doRRMemLRUDeltaTest(true);
+  }
+
+  @Test
+  public void testRRMemLRUDelta() {
+    doRRMemLRUDeltaTest(false);
+  }
+
+  @Test
+  public void testRRListener() {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createRR(vm0);
+    createRR(vm1);
+
+    addListener(vm0);
+    addListener(vm1);
+
+    doListenerTestRR(vm0, vm1);
+  }
+
+  @Test
+  public void testPRMemLRU() {
+    doPRMemLRUTest();
+  }
+
+  @Test
+  public void testPRMemLRUAndFlagDeltaPutOnPrimary() {
+    doPRDeltaTestLRU(false, false, true, false);
+  }
+
+  @Test
+  public void testPRMemLRUDeltaPutOnPrimary() {
+    doPRDeltaTestLRU(false, false, true, false);
+  }
+
+  @Test
+  public void testPRMemLRUAndFlagDeltaPutOnSecondary() {
+    doPRDeltaTestLRU(false, false, false, true);
+  }
+
+  @Test
+  public void testPRMemLRUDeltaPutOnSecondary() {
+    doPRDeltaTestLRU(false, false, false, true);
+  }
+
+  @Test
+  public void testPRNoLRUDelta() {
+    doPRNoLRUDeltaTest(false);
+  }
+
+  @Test
+  public void testPRNoLRUAndFlagDelta() {
+    doPRNoLRUDeltaTest(true);
+  }
+
+  @Test
+  public void testPRListener() {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createPR(vm0, true);
+    createPR(vm1, true);
+
+    addListener(vm0);
+    addListener(vm1);
+
+    doListenerTestPR(vm0, vm1);
+  }
+
+  @Test
+  public void testPRHeapLRU() {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createPRHeapLRU(vm0);
+    createPRHeapLRU(vm1);
+
+    put(vm0, new TestKey("a"), new TestObject(100, 1000));
+
+    assertValueType(vm0, new TestKey("a"), ValueType.CD_SERIALIZED);
+    assertValueType(vm1, new TestKey("a"), ValueType.CD_SERIALIZED);
+
+    assertEquals(1, getObjectSizerInvocations(vm0));
+    long origSize0 = getSizeFromPRStats(vm0);
+    assertTrue("Size was " + origSize0, 1000 > origSize0);
+    assertEquals(1, getObjectSizerInvocations(vm1));
+    long origSize1 = getSizeFromPRStats(vm1);
+    assertTrue("Size was " + origSize1, 1000 > origSize1);
+
+    get(vm0, new TestKey("a"), new TestObject(100, 1000));
+
+    assertValueType(vm0, new TestKey("a"), ValueType.CD_DESERIALIZED);
+    assertValueType(vm1, new TestKey("a"), ValueType.CD_SERIALIZED);
+    // assertTrue(1000 < getSizeFromPRStats(vm0));
+    assertEquals(3, getObjectSizerInvocations(vm0));
+    // assertTrue(1000 > getSizeFromPRStats(vm1));
+    assertEquals(1, getObjectSizerInvocations(vm1));
+
+    // Test what happens when we reach the heap threshold??
+  }
+
+  @Test
+  public void testRRHeapLRU() {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createRRHeapLRU(vm0);
+    createRRHeapLRU(vm1);
+
+    put(vm0, "a", new TestObject(100, 1000));
+
+    assertValueType(vm0, "a", ValueType.RAW_VALUE);
+    assertValueType(vm1, "a", ValueType.CD_SERIALIZED);
+
+    assertEquals(1, getObjectSizerInvocations(vm0));
+    assertEquals(0, getObjectSizerInvocations(vm1));
+
+    get(vm1, "a", new TestObject(100, 1000));
+
+    assertValueType(vm0, "a", ValueType.RAW_VALUE);
+    assertValueType(vm1, "a", ValueType.CD_DESERIALIZED);
+    assertEquals(1, getObjectSizerInvocations(vm0));
+    assertEquals(1, getObjectSizerInvocations(vm1));
+
+    // Test what happens when we reach the heap threshold??
+  }
+
+  @Test
+  public void testPRHeapLRUDeltaWithFlagPutOnPrimary() {
+    doPRDeltaTestLRU(false, true, true, false);
+  }
+
+  @Test
+  public void testPRHeapLRUDeltaPutOnPrimary() {
+    doPRDeltaTestLRU(false, true, true, false);
+  }
+
+  @Test
+  public void testPRHeapLRUDeltaWithFlagPutOnSecondary() {
+    doPRDeltaTestLRU(false, true, false, true);
+  }
+
+  @Test
+  public void testPRHeapLRUDeltaPutOnSecondary() {
+    doPRDeltaTestLRU(false, true, false, true);
+  }
+
+  // test to cover bug41916
+  @Test
+  public void testLargeDelta() {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createPR(vm0, false);
+    createPR(vm1, false);
+    // make a string bigger than socket-buffer-size which defaults to 32k
+    int BIG_DELTA_SIZE = 32 * 1024 * 2;
+    StringBuilder sb = new StringBuilder(BIG_DELTA_SIZE);
+    for (int i = 0; i < BIG_DELTA_SIZE; i++) {
+      sb.append('7');
+    }
+    TestDelta delta1 = new TestDelta(true, sb.toString());
+
+    assignPRBuckets(vm0);
+    boolean vm0isPrimary = prHostsBucketForKey(vm0, 0);
+    if (!vm0isPrimary) {
+      assertEquals(true, prHostsBucketForKey(vm1, 0));
+    }
+    VM primaryVm;
+    VM secondaryVm;
+    if (vm0isPrimary) {
+      primaryVm = vm0;
+      secondaryVm = vm1;
+    } else {
+      primaryVm = vm1;
+      secondaryVm = vm0;
+    }
+
+    put(secondaryVm, 0, delta1);
+  }
+
+  void doPRDeltaTestLRU(boolean shouldSizeChange, boolean heapLRU, boolean putOnPrimary,
+      boolean wasDelta) {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    if (heapLRU) {
+      createPRHeapLRU(vm0);
+      createPRHeapLRU(vm1);
+    } else {// memLRU
+      createPR(vm0, true);
+      createPR(vm1, true);
+    }
+    assignPRBuckets(vm0);
+    boolean vm0isPrimary = prHostsBucketForKey(vm0, 0);
+    if (!vm0isPrimary) {
+      assertEquals(true, prHostsBucketForKey(vm1, 0));
+    }
+    VM primaryVm;
+    VM secondaryVm;
+    if (vm0isPrimary) {
+      primaryVm = vm0;
+      secondaryVm = vm1;
+    } else {
+      primaryVm = vm1;
+      secondaryVm = vm0;
+    }
+
+    TestDelta delta1 = new TestDelta(false, "12345", shouldSizeChange);
+    if (putOnPrimary) {
+      put(primaryVm, 0, delta1);
+    } else {
+      put(secondaryVm, 0, delta1);
+    }
+    // if the put is done on the primary then it will be CD_DESERIALIZED on the primary
+    // otherwise it will be CD_SERIALIZED on the primary.
+    if (putOnPrimary) {
+      assertValueType(primaryVm, 0, ValueType.CD_DESERIALIZED);
+      assertEquals(1, getObjectSizerInvocations(primaryVm));
+    } else {
+      assertValueType(primaryVm, 0, ValueType.CD_SERIALIZED);
+      assertEquals(0, getObjectSizerInvocations(primaryVm));
+    }
+    // It will always be CD_SERIALIZED on the secondary.
+    assertValueType(secondaryVm, 0, ValueType.CD_SERIALIZED);
+    assertEquals(0, getObjectSizerInvocations(secondaryVm));
+
+    long origEvictionSize0 = getSizeFromEvictionStats(primaryVm);
+    long origEvictionSize1 = getSizeFromEvictionStats(secondaryVm);
+    long origPRSize0 = getSizeFromPRStats(primaryVm);
+    long origPRSize1 = getSizeFromPRStats(secondaryVm);
+    delta1.info = "1234567890";
+    delta1.hasDelta = true;
+    // Update the delta
+    if (putOnPrimary) {
+      put(primaryVm, 0, delta1);
+    } else {
+      put(secondaryVm, 0, delta1);
+    }
+
+    assertValueType(primaryVm, 0, ValueType.CD_DESERIALIZED);
+    assertValueType(secondaryVm, 0, ValueType.CD_DESERIALIZED);
+
+    if (shouldSizeChange) {
+      assertEquals(2, getObjectSizerInvocations(primaryVm));
+      // once when we deserialize the value in the cache
+      // and once when we size the new value from applying the delta
+      assertEquals(2, getObjectSizerInvocations(secondaryVm));
+    } else if (wasDelta) {
+      assertEquals(0, getObjectSizerInvocations(primaryVm));
+      // 1 sizer invoke since the first value needs to be deserialized
+      assertEquals(0, getObjectSizerInvocations(secondaryVm));
+    } else {
+      assertEquals(1, getObjectSizerInvocations(primaryVm));
+      // 1 sizer invoke since the first value needs to be deserialized
+      assertEquals(0, getObjectSizerInvocations(secondaryVm));
+    }
+
+    long finalEvictionSize0 = getSizeFromEvictionStats(primaryVm);
+    long finalEvictionSize1 = getSizeFromEvictionStats(secondaryVm);
+    long finalPRSize0 = getSizeFromPRStats(primaryVm);
+    long finalPRSize1 = getSizeFromPRStats(secondaryVm);
+    if (shouldSizeChange) {
+      // I'm not sure what the change in size should be, because we went
+      // from serialized to deserialized
+      assertTrue(finalEvictionSize0 - origEvictionSize0 != 0);
+      assertTrue(finalPRSize0 - origPRSize0 != 0);
+      assertTrue(finalEvictionSize1 - origEvictionSize1 != 0);
+      assertTrue(finalPRSize1 - origPRSize1 != 0);
+    } else {
+      assertEquals(0, finalEvictionSize1 - origEvictionSize1);
+      assertEquals(0, finalPRSize0 - origPRSize0);
+      assertEquals(0, finalPRSize1 - origPRSize1);
+    }
+  }
+
+  private void addListener(VM vm) {
+    vm.invoke(new SerializableRunnable("Add listener") {
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        Region region = cache.getRegion("region");
+        try {
+          region.getAttributesMutator().addCacheListener(new TestCacheListener());
+        } catch (Exception e) {
+          Assert.fail("couldn't create index", e);
+        }
+      }
+    });
+  }
+
+
+  private void doListenerTestRR(VM vm0, VM vm1) {
+    assertEquals(0, getObjectSizerInvocations(vm0));
+    assertEquals(0, getObjectSizerInvocations(vm1));
+    put(vm0, "a", new TestObject(100, 100000));
+    assertEquals(1, getObjectSizerInvocations(vm0));
+    assertEquals(1, getObjectSizerInvocations(vm1));
+
+    long origEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long origEvictionSize1 = getSizeFromEvictionStats(vm1);
+
+    assertValueType(vm0, "a", ValueType.RAW_VALUE);
+    assertValueType(vm1, "a", ValueType.CD_DESERIALIZED);
+    assertTrue(origEvictionSize0 >= 100000);
+    assertTrue(origEvictionSize1 >= 100000);
+
+    put(vm0, "a", new TestObject(200, 200000));
+    assertEquals(2, getObjectSizerInvocations(vm0));
+    assertEquals(2, getObjectSizerInvocations(vm1));
+
+    long finalEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long finalEvictionSize1 = getSizeFromEvictionStats(vm1);
+
+    assertValueType(vm0, "a", ValueType.RAW_VALUE);
+    assertValueType(vm1, "a", ValueType.CD_DESERIALIZED);
+    assertEquals(100000, finalEvictionSize0 - origEvictionSize0);
+    assertEquals(100000, finalEvictionSize1 - origEvictionSize1);
+  }
+
+  private void doListenerTestPR(VM vm0, VM vm1) {
+    assertEquals(0, getObjectSizerInvocations(vm0));
+    assertEquals(0, getObjectSizerInvocations(vm1));
+    put(vm0, "a", new TestObject(100, 100000));
+    assertEquals(1, getObjectSizerInvocations(vm0));
+    assertEquals(1, getObjectSizerInvocations(vm1));
+
+    long origEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long origEvictionSize1 = getSizeFromEvictionStats(vm1);
+    long origPRSize0 = getSizeFromPRStats(vm1);
+    long origPRSize1 = getSizeFromPRStats(vm1);
+
+    assertValueType(vm0, "a", ValueType.CD_DESERIALIZED);
+    assertValueType(vm1, "a", ValueType.CD_DESERIALIZED);
+    assertTrue(origEvictionSize1 >= 100000);
+    assertTrue(origEvictionSize0 >= 100000);
+    assertTrue(origPRSize0 <= 500);
+    assertTrue(origPRSize1 <= 500);
+
+    put(vm0, "a", new TestObject(200, 200000));
+    assertEquals(2, getObjectSizerInvocations(vm0));
+    assertEquals(2, getObjectSizerInvocations(vm1));
+
+    long finalEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long finalEvictionSize1 = getSizeFromEvictionStats(vm1);
+    long finalPRSize0 = getSizeFromPRStats(vm0);
+    long finalPRSize1 = getSizeFromPRStats(vm1);
+
+    assertValueType(vm0, "a", ValueType.CD_DESERIALIZED);
+    assertValueType(vm1, "a", ValueType.CD_DESERIALIZED);
+    assertEquals(100000, finalEvictionSize0 - origEvictionSize0);
+    assertEquals(100000, finalEvictionSize1 - origEvictionSize1);
+    assertEquals(100, finalPRSize0 - origPRSize0);
+    assertEquals(100, finalPRSize1 - origPRSize1);
+  }
+
+
+  private void doRRMemLRUTest() {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createRR(vm0);
+    createRR(vm1);
+    put(vm0, "a", new TestObject(100, 100000));
+    long origEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long origEvictionSize1 = getSizeFromEvictionStats(vm1);
+    put(vm0, "a", new TestObject(200, 200000));
+
+    assertValueType(vm0, "a", ValueType.RAW_VALUE);
+    assertValueType(vm1, "a", ValueType.CD_SERIALIZED);
+    assertEquals(2, getObjectSizerInvocations(vm0));
+
+    long finalEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long finalEvictionSize1 = getSizeFromEvictionStats(vm1);
+    assertEquals(100000, finalEvictionSize0 - origEvictionSize0);
+    assertEquals(100, finalEvictionSize1 - origEvictionSize1);
+
+    assertEquals(0, getObjectSizerInvocations(vm1));
+
+    // Do a get to make sure we deserialize the object and calculate
+    // the size adjustment
+    Object v = new TestObject(200, 200000);
+    get(vm1, "a", v);
+    int vSize = CachedDeserializableFactory.calcSerializedMemSize(v);
+
+    assertValueType(vm1, "a", ValueType.CD_DESERIALIZED);
+    long evictionSizeAfterGet = getSizeFromEvictionStats(vm1);
+    assertEquals(1, getObjectSizerInvocations(vm1));
+    assertEquals(200000 + CachedDeserializableFactory.overhead() - vSize,
+        evictionSizeAfterGet - finalEvictionSize1);
+
+    // Do a put that will trigger an eviction if it is deserialized
+    put(vm0, "b", new TestObject(100, 1000000));
+
+    assertEquals(1, getEvictions(vm0));
+    assertEquals(0, getEvictions(vm1));
+
+    // Do a get to make sure we deserialize the object and calculate
+    // the size adjustment
+    get(vm1, "b", new TestObject(100, 1000000));
+    assertEquals(1, getEvictions(vm1));
+  }
+
+  private void doPRMemLRUTest() {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createPR(vm0, true);
+    createPR(vm1, true);
+    put(vm0, 0, new TestObject(100, 100000));
+    assertValueType(vm0, 0, ValueType.CD_SERIALIZED);
+    assertValueType(vm1, 0, ValueType.CD_SERIALIZED);
+    long origEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long origEvictionSize1 = getSizeFromEvictionStats(vm1);
+    long origPRSize0 = getSizeFromPRStats(vm0);
+    long origPRSize1 = getSizeFromPRStats(vm1);
+    put(vm0, 0, new TestObject(200, 200000));
+
+    assertEquals(0, getObjectSizerInvocations(vm0));
+
+    long finalEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long finalPRSize0 = getSizeFromPRStats(vm0);
+    long finalEvictionSize1 = getSizeFromEvictionStats(vm1);
+    long finalPRSize1 = getSizeFromPRStats(vm1);
+    assertEquals(100, finalEvictionSize0 - origEvictionSize0);
+    assertEquals(100, finalEvictionSize1 - origEvictionSize1);
+    assertEquals(100, finalPRSize0 - origPRSize0);
+    assertEquals(100, finalPRSize1 - origPRSize1);
+
+    assertEquals(0, getObjectSizerInvocations(vm1));
+
+    // Do a get to see if we deserialize the object and calculate
+    // the size adjustment
+    Object v = new TestObject(200, 200000);
+    get(vm0, 0, v);
+    int vSize = CachedDeserializableFactory.calcSerializedMemSize(v);
+    assertValueType(vm0, 0, ValueType.CD_DESERIALIZED);
+    assertValueType(vm1, 0, ValueType.CD_SERIALIZED);
+    long evictionSizeAfterGet = getSizeFromEvictionStats(vm0);
+    long prSizeAfterGet = getSizeFromPRStats(vm0);
+    assertEquals(1, getObjectSizerInvocations(vm0));
+    assertEquals(0, getObjectSizerInvocations(vm1));
+    assertEquals(200000 + CachedDeserializableFactory.overhead() - vSize,
+        evictionSizeAfterGet - finalEvictionSize0);
+    assertEquals(0, prSizeAfterGet - finalPRSize0);
+
+    // Do a put that will trigger an eviction if it is deserialized
+    // It should not be deserialized.
+    put(vm0, 113, new TestObject(100, 1024 * 1024));
+    assertValueType(vm0, 113, ValueType.CD_SERIALIZED);
+    assertValueType(vm1, 113, ValueType.CD_SERIALIZED);
+    long evictionSizeAfterPutVm1 = getSizeFromEvictionStats(vm1);
+
+    assertEquals(0, getEvictions(vm0));
+    assertEquals(0, getEvictions(vm1));
+
+    // Do a get to make sure we deserialize the object and calculate
+    // the size adjustment which should force an eviction
+    get(vm1, 113, new TestObject(100, 1024 * 1024));
+    long evictionSizeAfterGetVm1 = getSizeFromEvictionStats(vm1);
+    assertValueType(vm0, 113, ValueType.CD_SERIALIZED);
+    assertValueType(vm1, 113, ValueType.EVICTED);
+    assertEquals(1, getObjectSizerInvocations(vm0)); // from the get of key 0 on vm0
+    assertEquals(0, getEvictions(vm0));
+    assertEquals(1, getObjectSizerInvocations(vm1));
+    assertEquals(2, getEvictions(vm1));
+  }
+
+  private void doRRMemLRUDeltaTest(boolean shouldSizeChange) {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createRR(vm0);
+    createRR(vm1);
+    TestDelta delta1 = new TestDelta(false, "12345", shouldSizeChange);
+    put(vm0, "a", delta1);
+
+    assertValueType(vm0, "a", ValueType.RAW_VALUE);
+    assertValueType(vm1, "a", ValueType.CD_SERIALIZED);
+    assertEquals(1, getObjectSizerInvocations(vm0));
+    assertEquals(0, getObjectSizerInvocations(vm1));
+
+    long origEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long origEvictionSize1 = getSizeFromEvictionStats(vm1);
+    delta1.info = "1234567890";
+    delta1.hasDelta = true;
+    // Update the delta
+    put(vm0, "a", delta1);
+
+    assertValueType(vm0, "a", ValueType.RAW_VALUE);
+    assertValueType(vm1, "a", ValueType.CD_DESERIALIZED);
+
+    assertEquals(2, getObjectSizerInvocations(vm0));
+
+    long finalEvictionSize0 = getSizeFromEvictionStats(vm0);
+    long finalEvictionSize1 = getSizeFromEvictionStats(vm1);
+    assertEquals(5, finalEvictionSize0 - origEvictionSize0);
+    if (shouldSizeChange) {
+      assertEquals(1, getObjectSizerInvocations(vm1));
+      // I'm not sure what the change in size should be, because we went
+      // from serialized to deserialized
+      assertTrue(finalEvictionSize1 - origEvictionSize1 != 0);
+    } else {
+      // we invoke the sizer once when we deserialize the original to apply the delta to it
+      assertEquals(0, getObjectSizerInvocations(vm1));
+      assertEquals(0, finalEvictionSize1 - origEvictionSize1);
+    }
+  }
+
+  private void doPRNoLRUDeltaTest(boolean shouldSizeChange) {
+    Host host = Host.getHost(0);
+    VM vm0 = host.getVM(0);
+    VM vm1 = host.getVM(1);
+
+    createPR(vm0, false);
+    createPR(vm1, false);
+
+    TestDelta delta1 = new TestDelta(false, "12345", shouldSizeChange);
+    put(vm0, "a", delta1);
+    long origPRSize0 = getSizeFromPRStats(vm0);
+    long origPRSize1 = getSizeFromPRStats(vm1);
+
+    // Update the delta
+    delta1.info = "1234567890";
+    delta1.hasDelta = true;
+    put(vm0, "a", delta1);
+    long finalPRSize0 = getSizeFromPRStats(vm0);
+    long finalPRSize1 = getSizeFromPRStats(vm1);
+
+    if (shouldSizeChange) {
+      // I'm not sure what the change in size should be, because we went
+      // from serialized to deserialized
+      logger.info("finalPRSize0:" + finalPRSize0 + " origPRSize0: " + origPRSize0);
+      logger.info("finalPRSize1:" + finalPRSize1 + " origPRSize1: " + origPRSize1);
+      assertTrue(finalPRSize0 - origPRSize0 != 0);
+      assertTrue(finalPRSize1 - origPRSize1 != 0);
+    } else {
+      assertEquals(0, finalPRSize0 - origPRSize0);
+      assertEquals(0, finalPRSize1 - origPRSize1);
+    }
+  }
+
+  private long getSizeFromPRStats(VM vm0) {
+    return (Long) vm0.invoke(new SerializableCallable() {
+
+      @Override
+      public Object call() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        if (region instanceof PartitionedRegion) {
+          long total = 0;
+          PartitionedRegion pr = ((PartitionedRegion) region);
+          for (int i = 0; i < pr.getPartitionAttributes().getTotalNumBuckets(); i++) {
+            total += pr.getDataStore().getBucketSize(i);
+          }
+          return total;
+        } else {
+          return 0L;
+        }
+      }
+    });
+  }
+
+
+  private long getSizeFromEvictionStats(VM vm0) {
+    return (Long) vm0.invoke(new SerializableCallable() {
+
+      @Override
+      public Object call() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        return getSizeFromEvictionStats(region);
+      }
+    });
+  }
+
+  private long getEvictions(VM vm0) {
+    return (Long) vm0.invoke(new SerializableCallable() {
+
+      @Override
+      public Object call() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        return getEvictions(region);
+      }
+    });
+  }
+
+  private int getObjectSizerInvocations(VM vm0) {
+    return (Integer) vm0.invoke(new SerializableCallable() {
+
+      @Override
+      public Object call() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        return getObjectSizerInvocations(region);
+      }
+    });
+  }
+
+  private void assignPRBuckets(VM vm) {
+    vm.invoke(new SerializableRunnable("assignPRBuckets") {
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        PartitionRegionHelper.assignBucketsToPartitions(cache.getRegion("region"));
+      }
+    });
+  }
+
+  private boolean prHostsBucketForKey(VM vm, final Object key) {
+    Boolean result = (Boolean) vm.invoke(new SerializableCallable("prHostsBucketForKey") {
+      @Override
+      public Object call() {
+        Cache cache = getCache();
+        DistributedMember myId = cache.getDistributedSystem().getDistributedMember();
+        Region region = cache.getRegion("region");
+        DistributedMember hostMember = PartitionRegionHelper.getPrimaryMemberForKey(region, key);
+        if (hostMember == null) {
+          throw new IllegalStateException("bucket for key " + key + " is not hosted!");
+        }
+        boolean res = Boolean.valueOf(myId.equals(hostMember));
+        // cache.getLogger().info("DEBUG prHostsBucketForKey=" + res);
+        return res;
+      }
+    });
+    return result.booleanValue();
+  }
+
+  private void put(VM vm0, final Object key, final Object value) {
+    vm0.invoke(new SerializableRunnable("Put data") {
+
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        // cache.getLogger().info("DEBUG about to put(" + key + ", " + value + ")");
+        region.put(key, value);
+      }
+    });
+  }
+
+  private void get(VM vm0, final Object key, final Object value) {
+    vm0.invoke(new SerializableRunnable("Put data") {
+
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        assertEquals(value, region.get(key));
+      }
+    });
+  }
+
+  protected int getObjectSizerInvocations(LocalRegion region) {
+    TestObjectSizer sizer = (TestObjectSizer) region.getEvictionAttributes().getObjectSizer();
+    int result = sizer.invocations.get();
+    region.getCache().getLogger().info("objectSizerInvocations=" + result);
+    return result;
+  }
+
+  private long getSizeFromEvictionStats(LocalRegion region) {
+    long result = region.getEvictionCounter();
+    // region.getCache().getLogger().info("DEBUG evictionSize=" + result);
+    return result;
+  }
+
+  private long getEvictions(LocalRegion region) {
+    return region.getTotalEvictions();
+  }
+
+  private void createRR(VM vm) {
+    vm.invoke(new SerializableRunnable("Create rr") {
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        AttributesFactory<Integer, TestDelta> attr = new AttributesFactory<Integer, TestDelta>();
+        attr.setDiskSynchronous(true);
+        attr.setDataPolicy(DataPolicy.REPLICATE);
+        attr.setScope(Scope.DISTRIBUTED_ACK);
+        attr.setEvictionAttributes(EvictionAttributes.createLRUMemoryAttributes(1,
+            new TestObjectSizer(), EvictionAction.OVERFLOW_TO_DISK));
+        attr.setDiskDirs(getMyDiskDirs());
+        Region region = cache.createRegion("region", attr.create());
+      }
+    });
+
+  }
+
+  private void assertValueType(VM vm, final Object key, final ValueType expectedType) {
+    vm.invoke(new SerializableRunnable("Create rr") {
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        LocalRegion region = (LocalRegion) cache.getRegion("region");
+        Object value = region.getValueInVM(key);
+        switch (expectedType) {
+          case RAW_VALUE:
+            assertTrue("Value was " + value + " type " + value.getClass(),
+                !(value instanceof CachedDeserializable));
+            break;
+          case CD_SERIALIZED:
+            assertTrue("Value was " + value + " type " + value.getClass(),
+                value instanceof CachedDeserializable);
+            assertTrue("Value not serialized",
+                ((CachedDeserializable) value).getValue() instanceof byte[]);
+            break;
+          case CD_DESERIALIZED:
+            assertTrue("Value was " + value + " type " + value.getClass(),
+                value instanceof CachedDeserializable);
+            assertTrue("Value was serialized",
+                !(((CachedDeserializable) value).getValue() instanceof byte[]));
+            break;
+          case EVICTED:
+            assertEquals(null, value);
+            break;
+        }
+      }
+    });
+  }
+
+  private File[] getMyDiskDirs() {
+    long random = new Random().nextLong();
+    File file = new File(Long.toString(random));
+    file.mkdirs();
+    return new File[] {file};
+  }
+
+  private void createPR(VM vm, final boolean enableLRU) {
+    vm.invoke(new SerializableRunnable("Create pr") {
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        AttributesFactory<Integer, TestDelta> attr = new AttributesFactory<Integer, TestDelta>();
+        attr.setDiskSynchronous(true);
+        PartitionAttributesFactory<Integer, TestDelta> paf =
+            new PartitionAttributesFactory<Integer, TestDelta>();
+        paf.setRedundantCopies(1);
+        if (enableLRU) {
+          paf.setLocalMaxMemory(1); // memlru limit is 1 megabyte
+          attr.setEvictionAttributes(EvictionAttributes
+              .createLRUMemoryAttributes(new TestObjectSizer(), EvictionAction.OVERFLOW_TO_DISK));
+          attr.setDiskDirs(getMyDiskDirs());
+        }
+        PartitionAttributes<Integer, TestDelta> prAttr = paf.create();
+        attr.setPartitionAttributes(prAttr);
+        attr.setDataPolicy(DataPolicy.PARTITION);
+        attr.setSubscriptionAttributes(new SubscriptionAttributes(InterestPolicy.ALL));
+        Region<Integer, TestDelta> region = cache.createRegion("region", attr.create());
+      }
+    });
+
+  }
+
+  private void createRRHeapLRU(VM vm) {
+    vm.invoke(new SerializableRunnable("Create rr") {
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        ResourceManager manager = cache.getResourceManager();
+        manager.setCriticalHeapPercentage(95);
+        manager.setEvictionHeapPercentage(90);
+        AttributesFactory<Integer, TestDelta> attr = new AttributesFactory<Integer, TestDelta>();
+        attr.setEvictionAttributes(EvictionAttributes.createLRUHeapAttributes(new TestObjectSizer(),
+            EvictionAction.OVERFLOW_TO_DISK));
+        attr.setDiskDirs(getMyDiskDirs());
+        attr.setDataPolicy(DataPolicy.REPLICATE);
+        attr.setScope(Scope.DISTRIBUTED_ACK);
+        attr.setDiskDirs(getMyDiskDirs());
+        Region region = cache.createRegion("region", attr.create());
+      }
+    });
+
+  }
+
+  private void createPRHeapLRU(VM vm) {
+    vm.invoke(new SerializableRunnable("Create pr") {
+      @Override
+      public void run() {
+        Cache cache = getCache();
+        ResourceManager manager = cache.getResourceManager();
+        manager.setCriticalHeapPercentage(95);
+        manager.setEvictionHeapPercentage(90);
+
+        AttributesFactory<Integer, TestDelta> attr = new AttributesFactory<Integer, TestDelta>();
+        PartitionAttributesFactory<Integer, TestDelta> paf =
+            new PartitionAttributesFactory<Integer, TestDelta>();
+        paf.setRedundantCopies(1);
+        attr.setEvictionAttributes(EvictionAttributes.createLRUHeapAttributes(new TestObjectSizer(),
+            EvictionAction.LOCAL_DESTROY));
+        PartitionAttributes<Integer, TestDelta> prAttr = paf.create();
+        attr.setPartitionAttributes(prAttr);
+        attr.setDataPolicy(DataPolicy.PARTITION);
+        attr.setSubscriptionAttributes(new SubscriptionAttributes(InterestPolicy.ALL));
+        Region<Integer, TestDelta> region = cache.createRegion("region", attr.create());
+      }
+    });
+
+  }
+
+  private static class TestObjectSizer implements ObjectSizer {
+    private AtomicInteger invocations = new AtomicInteger();
+
+    @Override
+    public int sizeof(Object o) {
+      if (InternalDistributedSystem.getLogger().fineEnabled()) {
+        InternalDistributedSystem.getLogger()
+            .fine("TestObjectSizer invoked"/* , new Exception("stack trace") */);
+      }
+      if (o instanceof TestObject) {
+        // org.apache.geode.internal.cache.GemFireCache.getInstance().getLogger().info("DEBUG
+        // TestObjectSizer: sizeof o=" + o, new RuntimeException("STACK"));
+        invocations.incrementAndGet();
+        return ((TestObject) o).sizeForSizer;
+      }
+      if (o instanceof TestDelta) {
+        // org.apache.geode.internal.cache.GemFireCache.getInstance().getLogger().info("DEBUG
+        // TestObjectSizer: sizeof delta o=" + o, new RuntimeException("STACK"));
+        invocations.incrementAndGet();
+        return ((TestDelta) o).info.length();
+      }
+      // This is the key. Why don't we handle Integers internally?
+      if (o instanceof Integer) {
+        return 0;
+      }
+      if (o instanceof TestKey) {
+        // org.apache.geode.internal.cache.GemFireCache.getInstance().getLogger().info("DEBUG
+        // TestObjectSizer: sizeof TestKey o=" + o, new RuntimeException("STACK"));
+        invocations.incrementAndGet();
+        return ((TestKey) o).value.length();
+      }
+      throw new RuntimeException("Unpected type to be sized " + o.getClass() + ", object=" + o);
+    }
+  }
+
+  private static class TestKey implements DataSerializable {
+    String value;
+
+    public TestKey() {
+
+    }
+
+    public TestKey(String value) {
+      this.value = value;
+    }
+
+    @Override
+    public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+      value = DataSerializer.readString(in);
+    }
+
+    @Override
+    public void toData(DataOutput out) throws IOException {
+      DataSerializer.writeString(value, out);
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((value == null) ? 0 : value.hashCode());
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null) {
+        return false;
+      }
+      if (!(obj instanceof TestKey)) {
+        return false;
+      }
+      TestKey other = (TestKey) obj;
+      if (value == null) {
+        if (other.value != null) {
+          return false;
+        }
+      } else if (!value.equals(other.value)) {
+        return false;
+      }
+      return true;
+    }
+
+  }
+
+  private static class TestObject implements DataSerializable {
+    public int sizeForSizer;
+    public int sizeForSerialization;
+
+    public TestObject() {
+
+    }
+
+
+    public TestObject(int sizeForSerialization, int sizeForSizer) {
+      super();
+      this.sizeForSizer = sizeForSizer;
+      this.sizeForSerialization = sizeForSerialization;
+    }
+
+    @Override
+    public void fromData(DataInput in) throws IOException, ClassNotFoundException {
+      sizeForSizer = in.readInt();
+      sizeForSerialization = in.readInt();
+      // We don't actually need these things.
+      in.skipBytes(sizeForSerialization);
+    }
+
+    @Override
+    public void toData(DataOutput out) throws IOException {
+      out.writeInt(sizeForSizer);
+      out.writeInt(sizeForSerialization);
+      out.write(new byte[sizeForSerialization]);
+
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + sizeForSerialization;
+      result = prime * result + sizeForSizer;
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null) {
+        return false;
+      }
+      if (!(obj instanceof TestObject)) {
+        return false;
+      }
+      TestObject other = (TestObject) obj;
+      if (sizeForSerialization != other.sizeForSerialization) {
+        return false;
+      }
+      if (sizeForSizer != other.sizeForSizer) {
+        return false;
+      }
+      return true;
+    }
+
+    @Override
+    public String toString() {
+      return "TestObject [sizeForSerialization=" + sizeForSerialization + ", sizeForSizer="
+          + sizeForSizer + "]";
+    }
+  }
+
+  public static class TestCacheListener extends CacheListenerAdapter {
+
+    @Override
+    public void afterCreate(EntryEvent event) {
+      // Make sure we deserialize the new value
+      event.getRegion().getCache().getLogger().fine("invoked afterCreate with " + event);
+      event.getRegion().getCache().getLogger().info(String.format("%s",
+          "value is " + event.getNewValue()));
+    }
+
+    @Override
+    public void afterUpdate(EntryEvent event) {
+      // Make sure we deserialize the new value
+      event.getRegion().getCache().getLogger().fine("invoked afterUpdate with ");
+      event.getRegion().getCache().getLogger().info(String.format("%s",
+          "value is " + event.getNewValue()));
+    }
+
+  }
+
+  enum ValueType {
+    RAW_VALUE, CD_SERIALIZED, CD_DESERIALIZED, EVICTED
+  }
+
+}

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
@@ -51,19 +51,13 @@ import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.SerializableCallable;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
 
 /**
- * A test of the when we will use the object sizer to determine the actual size of objects wrapped
- * in CacheDeserializables.
- * <p>
- * <p>
- * <p>
- * TODO - I was intending to add tests that have an index and object sizer, but it appears we don't
- * support indexes on regions with overflow to disk.
+ * Tests the use of the per-delta "forceRecalculateSize" flag.
  */
 
-public class DeltaForceSizingFlagDUnitTest extends JUnit4CacheTestCase {
+public class DeltaForceSizingFlagDUnitTest extends CacheTestCase {
 
   public DeltaForceSizingFlagDUnitTest() {
     super();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
@@ -308,7 +308,7 @@ public class DeltaForceSizingFlagDUnitTest {
 
     @Override
     public int sizeof(Object o) {
-      logger.debug("TestObjectSizer invoked"/* , new Exception("stack trace") */);
+      logger.info("TestObjectSizer invoked");
       if (o instanceof TestObject) {
         invocations.incrementAndGet();
         return ((TestObject) o).sizeForSizer;
@@ -439,17 +439,15 @@ public class DeltaForceSizingFlagDUnitTest {
     @Override
     public void afterCreate(EntryEvent<K, V> event) {
       // Make sure we deserialize the new value
-      logger.debug("invoked afterCreate with " + event);
-      logger.info(String.format("%s",
-          "value is " + event.getNewValue()));
+      logger.info("invoked afterCreate with " + event);
+      logger.info("value is " + event.getNewValue());
     }
 
     @Override
     public void afterUpdate(EntryEvent<K, V> event) {
       // Make sure we deserialize the new value
-      logger.debug("invoked afterUpdate with ");
-      logger.info(String.format("%s",
-          "value is " + event.getNewValue()));
+      logger.info("invoked afterUpdate with ");
+      logger.info("value is " + event.getNewValue());
     }
 
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
@@ -20,10 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.DataInput;
-import java.io.DataOutput;
 import java.io.File;
-import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -32,8 +29,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import org.apache.geode.DataSerializable;
-import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.DiskStoreFactory;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
@@ -220,17 +220,18 @@ public class DeltaForceSizingFlagDUnitTest {
     memberVM.invoke("Create replicateRegion", () -> {
       Cache cache = ClusterStartupRule.getCache();
       assertThat(cache).isNotNull();
-      RegionFactory<Integer, TestDelta> regionFactory = cache.createRegionFactory();
-      regionFactory.setDiskSynchronous(true);
-      regionFactory.setDataPolicy(DataPolicy.REPLICATE);
-      regionFactory.setScope(Scope.DISTRIBUTED_ACK);
-      regionFactory.setEvictionAttributes(EvictionAttributes.createLRUMemoryAttributes(1,
-          new TestObjectSizer(), EvictionAction.OVERFLOW_TO_DISK));
 
       DiskStoreFactory diskStoreFactory = cache.createDiskStoreFactory();
       diskStoreFactory.setDiskDirs(getMyDiskDirs());
       diskStoreFactory.create(RR_DISK_STORE_NAME);
+
+      RegionFactory<Integer, TestDelta> regionFactory = cache.createRegionFactory();
+      regionFactory.setDataPolicy(DataPolicy.REPLICATE);
       regionFactory.setDiskStoreName(RR_DISK_STORE_NAME);
+      regionFactory.setDiskSynchronous(true);
+      regionFactory.setEvictionAttributes(EvictionAttributes.createLRUMemoryAttributes(1,
+          new TestObjectSizer(), EvictionAction.OVERFLOW_TO_DISK));
+      regionFactory.setScope(Scope.DISTRIBUTED_ACK);
 
       regionFactory.create(TEST_REGION_NAME);
     });
@@ -277,15 +278,15 @@ public class DeltaForceSizingFlagDUnitTest {
       Cache cache = ClusterStartupRule.getCache();
       assertThat(cache).isNotNull();
 
-      RegionFactory<Integer, TestDelta> regionFactory = cache.createRegionFactory();
-
-      regionFactory.setDiskSynchronous(true);
       PartitionAttributesFactory<Integer, TestDelta> paf =
           new PartitionAttributesFactory<>();
       paf.setRedundantCopies(1);
       PartitionAttributes<Integer, TestDelta> prAttr = paf.create();
-      regionFactory.setPartitionAttributes(prAttr);
+
+      RegionFactory<Integer, TestDelta> regionFactory = cache.createRegionFactory();
       regionFactory.setDataPolicy(DataPolicy.PARTITION);
+      regionFactory.setDiskSynchronous(true);
+      regionFactory.setPartitionAttributes(prAttr);
       regionFactory.setSubscriptionAttributes(new SubscriptionAttributes(InterestPolicy.ALL));
       regionFactory.create(TEST_REGION_NAME);
     });

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaForceSizingFlagDUnitTest.java
@@ -314,58 +314,8 @@ public class DeltaForceSizingFlagDUnitTest {
       if (o instanceof Integer) {
         return 0;
       }
-      if (o instanceof TestKey) {
-        invocations.incrementAndGet();
-        return ((TestKey) o).value.length();
-      }
       throw new RuntimeException("Unexpected type to be sized " + o.getClass() + ", object=" + o);
     }
-  }
-
-  private static class TestKey implements DataSerializable {
-    String value;
-
-    public TestKey(String value) {
-      this.value = value;
-    }
-
-    @Override
-    public void fromData(DataInput in) throws IOException, ClassNotFoundException {
-      value = DataSerializer.readString(in);
-    }
-
-    @Override
-    public void toData(DataOutput out) throws IOException {
-      DataSerializer.writeString(value, out);
-    }
-
-    @Override
-    public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + ((value == null) ? 0 : value.hashCode());
-      return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      }
-      if (obj == null) {
-        return false;
-      }
-      if (!(obj instanceof TestKey)) {
-        return false;
-      }
-      TestKey other = (TestKey) obj;
-      if (value == null) {
-        return other.value == null;
-      } else {
-        return value.equals(other.value);
-      }
-    }
-
   }
 
   enum ValueType {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/TestDelta.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/TestDelta.java
@@ -67,7 +67,6 @@ public class TestDelta implements Delta, DataSerializable, Cloneable {
 
   @Override
   public synchronized void fromDelta(DataInput in) throws IOException, InvalidDeltaException {
-    // new Exception("DAN - From Delta Called").printStackTrace();
     this.hasDelta = true;
     info = DataSerializer.readString(in);
     forceRecalculateSize = DataSerializer.readBoolean(in);
@@ -81,21 +80,17 @@ public class TestDelta implements Delta, DataSerializable, Cloneable {
 
   @Override
   public boolean getForceRecalculateSize() {
-    // new Exception("RINGLES - getForceRecalculateSize Called: " +
-    // forceRecalculateSize).printStackTrace();
     return forceRecalculateSize;
   }
 
   @Override
   public synchronized void toDelta(DataOutput out) throws IOException {
-    // new Exception("DAN - To Delta Called").printStackTrace();
     DataSerializer.writeString(info, out);
     DataSerializer.writeBoolean(forceRecalculateSize, out);
   }
 
   @Override
   public synchronized void fromData(DataInput in) throws IOException, ClassNotFoundException {
-    // new Exception("DAN - From Data Called").printStackTrace();
     info = DataSerializer.readString(in);
     serializations = in.readInt();
     deserializations = in.readInt();
@@ -106,7 +101,6 @@ public class TestDelta implements Delta, DataSerializable, Cloneable {
 
   @Override
   public synchronized void toData(DataOutput out) throws IOException {
-    // new Exception("DAN - To Data Called").printStackTrace();
     serializations++;
     DataSerializer.writeString(info, out);
     out.writeInt(serializations);
@@ -117,7 +111,6 @@ public class TestDelta implements Delta, DataSerializable, Cloneable {
 
   @Override
   public synchronized Object clone() throws CloneNotSupportedException {
-    // new Exception("DAN - Clone Called").printStackTrace();
     clones++;
     return super.clone();
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/TestDelta.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/TestDelta.java
@@ -33,12 +33,28 @@ public class TestDelta implements Delta, DataSerializable, Cloneable {
   public int deserializations;
   public int deltas;
   public int clones;
+  public boolean forceRecalculateSize;
 
   public TestDelta() {}
 
   public TestDelta(boolean hasDelta, String info) {
     this.hasDelta = hasDelta;
     this.info = info;
+    this.forceRecalculateSize = false;
+  }
+
+  public TestDelta(boolean hasDelta, String info, boolean forceRecalculateSize) {
+    this.hasDelta = hasDelta;
+    this.info = info;
+    this.forceRecalculateSize = forceRecalculateSize;
+  }
+
+  @Override
+  public String toString() {
+    return "TestDelta{" +
+        "info='" + info + '\'' +
+        "forceRecalculateSize='" + forceRecalculateSize + '\'' +
+        '}';
   }
 
   public synchronized void checkFields(final int serializations, final int deserializations,
@@ -54,6 +70,7 @@ public class TestDelta implements Delta, DataSerializable, Cloneable {
     // new Exception("DAN - From Delta Called").printStackTrace();
     this.hasDelta = true;
     info = DataSerializer.readString(in);
+    forceRecalculateSize = DataSerializer.readBoolean(in);
     deltas++;
   }
 
@@ -63,9 +80,17 @@ public class TestDelta implements Delta, DataSerializable, Cloneable {
   }
 
   @Override
+  public boolean getForceRecalculateSize() {
+    // new Exception("RINGLES - getForceRecalculateSize Called: " +
+    // forceRecalculateSize).printStackTrace();
+    return forceRecalculateSize;
+  }
+
+  @Override
   public synchronized void toDelta(DataOutput out) throws IOException {
     // new Exception("DAN - To Delta Called").printStackTrace();
     DataSerializer.writeString(info, out);
+    DataSerializer.writeBoolean(forceRecalculateSize, out);
   }
 
   @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/TestDelta.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/TestDelta.java
@@ -52,8 +52,8 @@ public class TestDelta implements Delta, DataSerializable, Cloneable {
   @Override
   public String toString() {
     return "TestDelta{" +
-        "info='" + info + '\'' +
-        "forceRecalculateSize='" + forceRecalculateSize + '\'' +
+        "info='" + info + "'" +
+        "forceRecalculateSize='" + forceRecalculateSize + "'" +
         '}';
   }
 

--- a/geode-core/src/main/java/org/apache/geode/Delta.java
+++ b/geode-core/src/main/java/org/apache/geode/Delta.java
@@ -55,18 +55,19 @@ public interface Delta {
   void fromDelta(DataInput in) throws IOException, InvalidDeltaException;
 
   /**
-   * By default, buckets do not recalculate their size when deltas are applied. This optimizes for
-   * the case where the sie of an entry does not change. However, if the size does increase or
+   * By default, entry sizes are not recalculated when deltas are applied. This optimizes for the
+   * case where the size of an entry does not change. However, if an entry size does increase or
    * decrease, this default behavior can result in the memory usage statistics becoming inaccurate.
+   * These are used to monitor the health of Geode instances, and for balancing memory usage across
+   * partitioned regions.
    *
-   * There is a global Geode property, DELTAS_RECALCULATE_SIZE, which can be used to cause all
-   * deltas to trigger bucket size recalculation when deltas are applied. By default, this is set
+   * There is a system property, gemfire.DELTAS_RECALCULATE_SIZE, which can be used to cause all
+   * deltas to trigger entry size recalculation when deltas are applied. By default, this is set
    * to 'false' because of potential performance impacts when every delta triggers a recalculation.
    *
-   * This method allows bucket size recalculation on a per-delta basis. For example, geode-redis
-   * uses deltas heavily, and many commands (e.g. APPEND) cause the size of the entry to change.
-   * By overriding this method to return 'true', Redis memory usage statistics can be kept accurate
-   * without impacting the performance of other Geode operations.
+   * To allow entry size recalculation on a per-delta basis, classes that extend the Delta interface
+   * should override this method to return 'true'. This may impact performance of specific delta
+   * types, but will not globally affect the performance of other Geode delta operations.
    *
    * @since 1.14
    */

--- a/geode-core/src/main/java/org/apache/geode/Delta.java
+++ b/geode-core/src/main/java/org/apache/geode/Delta.java
@@ -41,6 +41,7 @@ public interface Delta {
    * presence of a delta by calling {@link Delta#hasDelta()} on the object. The delta is written to
    * the {@link DataOutput} object provided by GemFire.
    *
+   * <p>
    * Any delta state should be reset in this method.
    */
   void toDelta(DataOutput out) throws IOException;
@@ -61,10 +62,12 @@ public interface Delta {
    * These are used to monitor the health of Geode instances, and for balancing memory usage across
    * partitioned regions.
    *
+   * <p>
    * There is a system property, gemfire.DELTAS_RECALCULATE_SIZE, which can be used to cause all
    * deltas to trigger entry size recalculation when deltas are applied. By default, this is set
    * to 'false' because of potential performance impacts when every delta triggers a recalculation.
    *
+   * <p>
    * To allow entry size recalculation on a per-delta basis, classes that extend the Delta interface
    * should override this method to return 'true'. This may impact performance of specific delta
    * types, but will not globally affect the performance of other Geode delta operations.

--- a/geode-core/src/main/java/org/apache/geode/Delta.java
+++ b/geode-core/src/main/java/org/apache/geode/Delta.java
@@ -40,7 +40,7 @@ public interface Delta {
    * This method is invoked on an application object at the delta sender, if GemFire determines the
    * presence of a delta by calling {@link Delta#hasDelta()} on the object. The delta is written to
    * the {@link DataOutput} object provided by GemFire.
-   * <p>
+   *
    * Any delta state should be reset in this method.
    */
   void toDelta(DataOutput out) throws IOException;

--- a/geode-core/src/main/java/org/apache/geode/Delta.java
+++ b/geode-core/src/main/java/org/apache/geode/Delta.java
@@ -67,6 +67,8 @@ public interface Delta {
    * uses deltas heavily, and many commands (e.g. APPEND) cause the size of the entry to change.
    * By overriding this method to return 'true', Redis memory usage statistics can be kept accurate
    * without impacting the performance of other Geode operations.
+   *
+   * @since 1.14
    */
   default boolean getForceRecalculateSize() {
     return false;

--- a/geode-core/src/main/java/org/apache/geode/Delta.java
+++ b/geode-core/src/main/java/org/apache/geode/Delta.java
@@ -55,7 +55,18 @@ public interface Delta {
   void fromDelta(DataInput in) throws IOException, InvalidDeltaException;
 
   /**
-   * Allows Delta implementations to ensure bucket sizes are recalculated after delta is applied
+   * By default, buckets do not recalculate their size when deltas are applied. This optimizes for
+   * the case where the sie of an entry does not change. However, if the size does increase or
+   * decrease, this default behavior can result in the memory usage statistics becoming inaccurate.
+   *
+   * There is a global Geode property, DELTAS_RECALCULATE_SIZE, which can be used to cause all
+   * deltas to trigger bucket size recalculation when deltas are applied. By default, this is set
+   * to 'false' because of potential performance impacts when every delta triggers a recalculation.
+   *
+   * This method allows bucket size recalculation on a per-delta basis. For example, geode-redis
+   * uses deltas heavily, and many commands (e.g. APPEND) cause the size of the entry to change.
+   * By overriding this method to return 'true', Redis memory usage statistics can be kept accurate
+   * without impacting the performance of other Geode operations.
    */
   default boolean getForceRecalculateSize() {
     return false;

--- a/geode-core/src/main/java/org/apache/geode/Delta.java
+++ b/geode-core/src/main/java/org/apache/geode/Delta.java
@@ -23,17 +23,16 @@ import java.io.IOException;
  * This interface defines a contract between the application and GemFire that allows GemFire to
  * determine whether an application object contains a delta, allows GemFire to extract the delta
  * from an application object, and generate a new application object by applying a delta to an
- * existing application object. The difference in object state is contained in the
- * {@link DataOutput} and {@link DataInput} parameters.
+ * existing application object. The difference in object state is contained in the {@link
+ * DataOutput} and {@link DataInput} parameters.
  *
  * @since GemFire 6.1
- *
  */
 public interface Delta {
 
   /**
-   * Returns true if this object has pending changes it can write out as a delta.
-   * Returns false if this object must be transmitted in its entirety.
+   * Returns true if this object has pending changes it can write out as a delta. Returns false if
+   * this object must be transmitted in its entirety.
    */
   boolean hasDelta();
 
@@ -41,9 +40,8 @@ public interface Delta {
    * This method is invoked on an application object at the delta sender, if GemFire determines the
    * presence of a delta by calling {@link Delta#hasDelta()} on the object. The delta is written to
    * the {@link DataOutput} object provided by GemFire.
-   *
+   * <p>
    * Any delta state should be reset in this method.
-   *
    */
   void toDelta(DataOutput out) throws IOException;
 
@@ -53,7 +51,13 @@ public interface Delta {
    * This method throws an {@link InvalidDeltaException} when the delta in the {@link DataInput}
    * cannot be applied to the object. GemFire automatically handles an {@link InvalidDeltaException}
    * by reattempting the update by sending the full application object.
-   *
    */
   void fromDelta(DataInput in) throws IOException, InvalidDeltaException;
+
+  /**
+   * Allows Delta implementations to ensure bucket sizes are recalculated after delta is applied
+   */
+  default boolean getForceRecalculateSize() {
+    return false;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1871,8 +1871,6 @@ public class BucketRegion extends DistributedRegion implements Bucket {
           long start = DistributionStats.getStatTime();
           ((org.apache.geode.Delta) instance).toDelta(hdos);
           event.setDeltaBytes(hdos.toByteArray());
-          event.setForceRecalculateSize(
-              ((org.apache.geode.Delta) instance).getForceRecalculateSize());
           partitionedRegion.getCachePerfStats().endDeltaPrepared(start);
         } catch (RuntimeException re) {
           throw re;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1864,6 +1864,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
         return;
       }
       Object instance = cd.getValue();
+
       if (instance instanceof org.apache.geode.Delta
           && ((org.apache.geode.Delta) instance).hasDelta()) {
         try (HeapDataOutputStream hdos = new HeapDataOutputStream(KnownVersion.CURRENT)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -1870,6 +1870,8 @@ public class BucketRegion extends DistributedRegion implements Bucket {
           long start = DistributionStats.getStatTime();
           ((org.apache.geode.Delta) instance).toDelta(hdos);
           event.setDeltaBytes(hdos.toByteArray());
+          event.setForceRecalculateSize(
+              ((org.apache.geode.Delta) instance).getForceRecalculateSize());
           partitionedRegion.getCachePerfStats().endDeltaPrepared(start);
         } catch (RuntimeException re) {
           throw re;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CopyHelper;
 import org.apache.geode.DataSerializer;
+import org.apache.geode.Delta;
 import org.apache.geode.DeltaSerializationException;
 import org.apache.geode.GemFireIOException;
 import org.apache.geode.InvalidDeltaException;
@@ -1520,7 +1521,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
     if (obj instanceof byte[] || obj == null || obj instanceof CachedDeserializable
         || obj == Token.NOT_AVAILABLE || Token.isInvalidOrRemoved(obj)
         // don't serialize delta object already serialized
-        || obj instanceof org.apache.geode.Delta) { // internal delta
+        || obj instanceof Delta) { // internal delta
       return obj;
     }
     final CachedDeserializable cd;
@@ -1712,11 +1713,11 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
     // This is a horrible hack, but we need to get the size of the object
     // When we store an entry. This code is only used when we do a put
     // in the primary.
-    if (v instanceof org.apache.geode.Delta && getRegion().isUsedForPartitionedRegionBucket()) {
+    if (v instanceof Delta && getRegion().isUsedForPartitionedRegionBucket()) {
       int vSize;
       Object ov = basicGetOldValue();
       if (ov instanceof CachedDeserializable && !(GemFireCacheImpl.DELTAS_RECALCULATE_SIZE
-          || ((org.apache.geode.Delta) v).getForceRecalculateSize())) {
+          || ((Delta) v).getForceRecalculateSize())) {
         vSize = ((CachedDeserializable) ov).getValueSizeInBytes();
       } else {
         vSize = CachedDeserializableFactory.calcMemSize(v, getRegion().getObjectSizer(), false);
@@ -1835,7 +1836,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
       boolean deltaBytesApplied = false;
       try (ByteArrayDataInput in = new ByteArrayDataInput(getDeltaBytes())) {
         long start = getRegion().getCachePerfStats().getTime();
-        ((org.apache.geode.Delta) value).fromDelta(in);
+        ((Delta) value).fromDelta(in);
         getRegion().getCachePerfStats().endDeltaUpdate(start);
         deltaBytesApplied = true;
       } catch (RuntimeException rte) {
@@ -1859,7 +1860,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
         CachedDeserializable old = (CachedDeserializable) oldValueInVM;
         int valueSize;
         if (GemFireCacheImpl.DELTAS_RECALCULATE_SIZE
-            || ((org.apache.geode.Delta) value).getForceRecalculateSize()) {
+            || ((Delta) value).getForceRecalculateSize()) {
           valueSize =
               CachedDeserializableFactory.calcMemSize(value, getRegion().getObjectSizer(), false);
         } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -165,6 +165,9 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
    */
   private byte[] deltaBytes = null;
 
+  /* Is this special about recalculating size? */
+  private boolean forceRecalculateSize = false;
+
   /** routing information for cache clients for this event */
   private FilterInfo filterInfo;
 
@@ -1716,7 +1719,8 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
     if (v instanceof org.apache.geode.Delta && getRegion().isUsedForPartitionedRegionBucket()) {
       int vSize;
       Object ov = basicGetOldValue();
-      if (ov instanceof CachedDeserializable && !GemFireCacheImpl.DELTAS_RECALCULATE_SIZE) {
+      if (ov instanceof CachedDeserializable && !GemFireCacheImpl.DELTAS_RECALCULATE_SIZE
+          && !this.forceRecalculateSize) {
         vSize = ((CachedDeserializable) ov).getValueSizeInBytes();
       } else {
         vSize = CachedDeserializableFactory.calcMemSize(v, getRegion().getObjectSizer(), false);
@@ -1858,7 +1862,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
       if (wasCD) {
         CachedDeserializable old = (CachedDeserializable) oldValueInVM;
         int valueSize;
-        if (GemFireCacheImpl.DELTAS_RECALCULATE_SIZE) {
+        if (GemFireCacheImpl.DELTAS_RECALCULATE_SIZE || this.forceRecalculateSize) {
           valueSize =
               CachedDeserializableFactory.calcMemSize(value, getRegion().getObjectSizer(), false);
         } else {
@@ -2569,6 +2573,10 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
    */
   public void setDeltaBytes(byte[] deltaBytes) {
     this.deltaBytes = deltaBytes;
+  }
+
+  public void setForceRecalculateSize(boolean forceRecalculateSize) {
+    this.forceRecalculateSize = forceRecalculateSize;
   }
 
   // TODO (ashetkar) Can this.op.isCreate() be used instead?

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -265,7 +265,6 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
   protected EntryEventImpl(final InternalRegion region, Operation op, Object key,
       @Retained(ENTRY_EVENT_NEW_VALUE) Object newVal, Object callbackArgument, boolean originRemote,
       DistributedMember distributedMember, boolean generateCallbacks, boolean initializeId) {
-
     this.region = region;
     InternalDistributedSystem ds =
         (InternalDistributedSystem) region.getCache().getDistributedSystem();
@@ -1719,8 +1718,8 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
     if (v instanceof org.apache.geode.Delta && getRegion().isUsedForPartitionedRegionBucket()) {
       int vSize;
       Object ov = basicGetOldValue();
-      if (ov instanceof CachedDeserializable && !GemFireCacheImpl.DELTAS_RECALCULATE_SIZE
-          && !this.forceRecalculateSize) {
+      if (ov instanceof CachedDeserializable && !(GemFireCacheImpl.DELTAS_RECALCULATE_SIZE
+          || this.forceRecalculateSize)) {
         vSize = ((CachedDeserializable) ov).getValueSizeInBytes();
       } else {
         vSize = CachedDeserializableFactory.calcMemSize(v, getRegion().getObjectSizer(), false);
@@ -1840,6 +1839,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
       try (ByteArrayDataInput in = new ByteArrayDataInput(getDeltaBytes())) {
         long start = getRegion().getCachePerfStats().getTime();
         ((org.apache.geode.Delta) value).fromDelta(in);
+        forceRecalculateSize = ((org.apache.geode.Delta) value).getForceRecalculateSize();
         getRegion().getCachePerfStats().endDeltaUpdate(start);
         deltaBytesApplied = true;
       } catch (RuntimeException rte) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventImpl.java
@@ -165,7 +165,7 @@ public class EntryEventImpl implements InternalEntryEvent, InternalCacheEvent,
    */
   private byte[] deltaBytes = null;
 
-  /* Is this special about recalculating size? */
+  /** If true, causes deltas to trigger recalculation of bucket size **/
   private boolean forceRecalculateSize = false;
 
   /** routing information for cache clients for this event */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -1728,7 +1728,6 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         }
         if (extractDelta && ((Delta) value).hasDelta()) {
           try (HeapDataOutputStream hdos = new HeapDataOutputStream(KnownVersion.CURRENT)) {
-            long start = DistributionStats.getStatTime();
             try {
               ((Delta) value).toDelta(hdos);
             } catch (RuntimeException re) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -1737,9 +1737,6 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
               throw new DeltaSerializationException("Caught exception while sending delta", e);
             }
             event.setDeltaBytes(hdos.toByteArray());
-            event.setForceRecalculateSize(
-                ((org.apache.geode.Delta) value).getForceRecalculateSize());
-            getCachePerfStats().endDeltaPrepared(start);
           }
         }
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -1737,6 +1737,8 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
               throw new DeltaSerializationException("Caught exception while sending delta", e);
             }
             event.setDeltaBytes(hdos.toByteArray());
+            event.setForceRecalculateSize(
+                ((org.apache.geode.Delta) value).getForceRecalculateSize());
             getCachePerfStats().endDeltaPrepared(start);
           }
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -151,7 +151,6 @@ import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.DistributionAdvisor;
 import org.apache.geode.distributed.internal.DistributionManager;
-import org.apache.geode.distributed.internal.DistributionStats;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ResourceEvent;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventImplTest.java
@@ -29,9 +29,11 @@ import static org.mockito.Mockito.when;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.Delta;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.SerializedCacheValue;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
@@ -911,6 +913,60 @@ public class EntryEventImplTest {
     EntryEventImpl event = createEntryEvent(region, null);
 
     assertThat(event.isTransactional()).isFalse();
+  }
+
+  @Test
+  public void shouldRecalculateSize_returnsTrue_ifGetForceRecalculateSizeIsTrue_andDELTAS_RECALCULATE_SIZEisTrue() {
+    GemFireCacheImpl.DELTAS_RECALCULATE_SIZE = true;
+    Delta deltaValue = mock(Delta.class);
+    when(deltaValue.getForceRecalculateSize())
+        .thenReturn(true);
+
+    boolean value = EntryEventImpl.shouldRecalculateSize(deltaValue);
+
+    assertThat(value).isTrue();
+  }
+
+  @Test
+  public void shouldRecalculateSize_returnsTrue_ifDELTAS_RECALCULATE_SIZEisTrue_andGetForceRecalculateSizeIsFalse() {
+    GemFireCacheImpl.DELTAS_RECALCULATE_SIZE = true;
+    Delta deltaValue = mock(Delta.class);
+    when(deltaValue.getForceRecalculateSize())
+        .thenReturn(false);
+
+    boolean value = EntryEventImpl.shouldRecalculateSize(deltaValue);
+
+    assertThat(value).isTrue();
+  }
+
+  @Test
+  public void shouldRecalculateSize_returnsTrue_ifGetForceRecalculateSizeIsTrue_andDELTAS_RECALCULATE_SIZEIsFalse() {
+    GemFireCacheImpl.DELTAS_RECALCULATE_SIZE = false;
+    Delta deltaValue = mock(Delta.class);
+    when(deltaValue.getForceRecalculateSize())
+        .thenReturn(true);
+
+    boolean value = EntryEventImpl.shouldRecalculateSize(deltaValue);
+
+    assertThat(value).isTrue();
+  }
+
+
+  @Test
+  public void shouldRecalculateSize_returnsFalse_ifBothDELTAS_RECALCULATE_SIZEIsFalse_andGetForceRecalculateSizeIsFalse() {
+    GemFireCacheImpl.DELTAS_RECALCULATE_SIZE = false;
+    Delta deltaValue = mock(Delta.class);
+    when(deltaValue.getForceRecalculateSize())
+        .thenReturn(false);
+
+    boolean value = EntryEventImpl.shouldRecalculateSize(deltaValue);
+
+    assertThat(value).isFalse();
+  }
+
+  @After
+  public void tearDown() {
+    GemFireCacheImpl.DELTAS_RECALCULATE_SIZE = false;
   }
 
   private static class EntryEventImplWithOldValuesDisabled extends EntryEventImpl {


### PR DESCRIPTION
The Redis subsystem uses Deltas heavily, but by default deltas do not trigger an update to the size of their buckets. This leads to incorrect memory usage accounting over the long term, especially with the use of Redis commands like "APPEND". (See GEODE-8859.)

It is possible to set the system property "DELTAS_RECALCULATE_SIZE", but this is a global value that would affect the processing of all deltas, including non-Redis operations.

Instead, this update adds a new default method to the Delta interface, that can be overridden by individual Delta implementations (such as Redis). This triggers the same behavior as DELTAS_RECALCULATE_SIZE, but on a per-delta basis. Thus, other Geode operations will not force bucket size recalculations unless the global property is set, but Redis statistics will be correct (once they are updated to override this new method).