### PR TITLE
GEODE-8898: run threads in HMGetDUnitTest

### DIFF
--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HMgetDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HMgetDUnitTest.java
@@ -96,9 +96,12 @@ public class HMgetDUnitTest {
     jedis1.hset(key, testMap);
 
     new ConcurrentLoopingThreads(HASH_SIZE,
-        (i) -> jedis1.hset(key, "field-" + i, "value-" + i),
+        (i) -> jedis1.hset(key, "field-" + i, "changedValue-" + i),
         (i) -> assertThat(jedis2.hmget(key, "field-" + i)).isNotNull(),
-        (i) -> assertThat(jedis3.hmget(key, "field-" + i)).isNotNull());
+        (i) -> assertThat(jedis3.hmget(key, "field-" + i)).isNotNull()).run();
+
+    Map<String, String> expectedResult = makeHashMap(HASH_SIZE, "field-", "changedValue-");
+    assertThat(jedis1.hgetAll(key)).containsExactlyInAnyOrderEntriesOf(expectedResult);
   }
 
   private Map<String, String> makeHashMap(int hashSize, String baseFieldName,


### PR DESCRIPTION
previously the threads were not being run. this runs them and adds an
assertion that the fields and values are correct at the end of the test.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
