### PR TITLE
GEODE-8901: Surviving side server forcefully disconnected after network drop

### DIFF
--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -672,7 +672,8 @@ public class GMSHealthMonitorJUnitTest {
   }
 
   @Test
-  public void testMemberIsNotAvailableWhenNotAssumingMembersInFinalCheckAreAvailable() throws Exception {
+  public void testMemberIsNotAvailableWhenNotAssumingMembersInFinalCheckAreAvailable()
+      throws Exception {
     useGMSHealthMonitorTestClass = true;
     simulateHeartbeatInGMSHealthMonitorTestClass = false;
 

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -657,6 +657,50 @@ public class GMSHealthMonitorJUnitTest {
   }
 
   @Test
+  public void testMemberIsAvailableWhenInFinalCheck() throws Exception {
+    useGMSHealthMonitorTestClass = true;
+    simulateHeartbeatInGMSHealthMonitorTestClass = false;
+
+    GMSMembershipView v = installAView();
+    setFailureDetectionPorts(v);
+
+    MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
+    testMonitor.addMemberInFinalCheck(memberToCheck);
+    assertThat(testMonitor.checkIfAvailable(memberToCheck,
+        "Member failed to acknowledge a membership view", false)).isTrue();
+  }
+
+  @Test
+  public void testMemberIsNotAvailableWhenCheckIfMemberInFinalCheckIsFalse() throws Exception {
+    useGMSHealthMonitorTestClass = true;
+    simulateHeartbeatInGMSHealthMonitorTestClass = false;
+
+    GMSMembershipView v = installAView();
+    setFailureDetectionPorts(v);
+
+    MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    when(joinLeave.isMemberLeaving(memberToCheck)).thenReturn(true);
+    GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
+    testMonitor.addMemberInFinalCheck(memberToCheck);
+    assertThat(testMonitor.checkIfAvailable(memberToCheck,
+        "Member failed to acknowledge a membership view", false, false)).isFalse();
+  }
+
+  @Test
+  public void testMemberIsNotAvailableWhenNotInFinalCheck() throws Exception {
+    useGMSHealthMonitorTestClass = true;
+    simulateHeartbeatInGMSHealthMonitorTestClass = false;
+
+    GMSMembershipView v = installAView();
+
+    MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
+    assertThat(testMonitor.checkIfAvailable(memberToCheck,
+        "Member failed to acknowledge a membership view", false, true)).isFalse();
+  }
+
+  @Test
   public void testFailedSelfCheckRemovesMemberAsSuspect() throws Exception {
     useGMSHealthMonitorTestClass = true;
     simulateHeartbeatInGMSHealthMonitorTestClass = false;

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitorJUnitTest.java
@@ -661,27 +661,27 @@ public class GMSHealthMonitorJUnitTest {
     useGMSHealthMonitorTestClass = true;
     simulateHeartbeatInGMSHealthMonitorTestClass = false;
 
-    GMSMembershipView v = installAView();
+    final GMSMembershipView v = installAView();
     setFailureDetectionPorts(v);
 
-    MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
-    GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
+    final MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    final GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
     testMonitor.addMemberInFinalCheck(memberToCheck);
     assertThat(testMonitor.checkIfAvailable(memberToCheck,
         "Member failed to acknowledge a membership view", false)).isTrue();
   }
 
   @Test
-  public void testMemberIsNotAvailableWhenCheckIfMemberInFinalCheckIsFalse() throws Exception {
+  public void testMemberIsNotAvailableWhenNotAssumingMembersInFinalCheckAreAvailable() throws Exception {
     useGMSHealthMonitorTestClass = true;
     simulateHeartbeatInGMSHealthMonitorTestClass = false;
 
-    GMSMembershipView v = installAView();
+    final GMSMembershipView v = installAView();
     setFailureDetectionPorts(v);
 
-    MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    final MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
     when(joinLeave.isMemberLeaving(memberToCheck)).thenReturn(true);
-    GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
+    final GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
     testMonitor.addMemberInFinalCheck(memberToCheck);
     assertThat(testMonitor.checkIfAvailable(memberToCheck,
         "Member failed to acknowledge a membership view", false, false)).isFalse();
@@ -691,11 +691,10 @@ public class GMSHealthMonitorJUnitTest {
   public void testMemberIsNotAvailableWhenNotInFinalCheck() throws Exception {
     useGMSHealthMonitorTestClass = true;
     simulateHeartbeatInGMSHealthMonitorTestClass = false;
+    installAView();
 
-    GMSMembershipView v = installAView();
-
-    MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
-    GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
+    final MemberIdentifier memberToCheck = gmsHealthMonitor.getNextNeighbor();
+    final GMSHealthMonitorTest testMonitor = (GMSHealthMonitorTest) gmsHealthMonitor;
     assertThat(testMonitor.checkIfAvailable(memberToCheck,
         "Member failed to acknowledge a membership view", false, true)).isFalse();
   }

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -893,25 +893,9 @@ public class GMSJoinLeaveJUnitTest {
   }
 
   @Test
-  public void testNetworkPartitionMessageFromNonMemberWithSameViewIdReceived() throws Exception {
+  public void testNetworkPartitionMessageFromNonMemberIgnored() throws Exception {
     initMocks();
     becomeCoordinatorForTest(gmsJoinLeave);
-    gmsJoinLeave.getView().setViewId(1);
-
-    mockMembers[0].setVmViewId(1);
-    NetworkPartitionMessage message = new NetworkPartitionMessage();
-    message.setSender(mockMembers[0]);
-    gmsJoinLeave.processMessage(message);
-    verify(manager).forceDisconnect(contains(mockMembers[0].toString()));
-  }
-
-  @Test
-  public void testNetworkPartitionMessageFromNonMemberWithOlderViewIdIgnored() throws Exception {
-    initMocks();
-    becomeCoordinatorForTest(gmsJoinLeave);
-    gmsJoinLeave.getView().setViewId(1);
-
-    mockMembers[0].setVmViewId(0);
     NetworkPartitionMessage message = new NetworkPartitionMessage();
     message.setSender(mockMembers[0]);
     gmsJoinLeave.processMessage(message);

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -552,7 +552,8 @@ public class GMSJoinLeaveJUnitTest {
   public void testDuplicateJoinRequestDoesNotCauseNewView() throws Exception {
     initMocks();
     when(healthMonitor.checkIfAvailable(isA(MemberIdentifier.class), isA(String.class),
-        isA(Boolean.class))).thenReturn(true);
+        isA(Boolean.class), isA(Boolean.class))).thenReturn(true);
+
     gmsJoinLeave.unitTesting.add("noRandomViewChange");
     prepareAndInstallView(gmsJoinLeaveMemberId,
         createMemberList(gmsJoinLeaveMemberId, mockMembers[0]));
@@ -581,7 +582,7 @@ public class GMSJoinLeaveJUnitTest {
     assertTrue("expected member to only be in the view once: " + mockMembers[2] + "; view: " + view,
         occurrences == 1);
     verify(healthMonitor, times(5)).checkIfAvailable(isA(MemberIdentifier.class),
-        isA(String.class), isA(Boolean.class));
+        isA(String.class), isA(Boolean.class), isA(Boolean.class));
   }
 
 
@@ -951,7 +952,7 @@ public class GMSJoinLeaveJUnitTest {
   public void testNoViewAckCausesRemovalMessage() throws Exception {
     initMocks(true);
     when(healthMonitor.checkIfAvailable(isA(MemberIdentifier.class), isA(String.class),
-        isA(Boolean.class))).thenReturn(false);
+        isA(Boolean.class), isA(Boolean.class))).thenReturn(false);
     prepareAndInstallView(mockMembers[0], createMemberList(mockMembers[0], gmsJoinLeaveMemberId));
     GMSMembershipView oldView = gmsJoinLeave.getView();
     GMSMembershipView newView = new GMSMembershipView(oldView, oldView.getViewId() + 1);
@@ -973,7 +974,7 @@ public class GMSJoinLeaveJUnitTest {
 
     verify(healthMonitor, timeout(10000).atLeast(1)).checkIfAvailable(
         isA(MemberIdentifier.class),
-        isA(String.class), isA(Boolean.class));
+        isA(String.class), isA(Boolean.class), isA(Boolean.class));
     // verify(messenger, atLeast(1)).send(isA(RemoveMemberMessage.class));
   }
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -675,8 +675,8 @@ public class GMSHealthMonitor<ID extends MemberIdentifier> implements HealthMoni
 
   @Override
   public boolean checkIfAvailable(ID mbr, String reason,
-      boolean initiateRemoval, boolean checkIfMemberInFinalCheck) {
-    if (checkIfMemberInFinalCheck && membersInFinalCheck.contains(mbr)) {
+      boolean initiateRemoval, boolean assumeMembersInFinalCheckAreAvailable) {
+    if (assumeMembersInFinalCheckAreAvailable && membersInFinalCheck.contains(mbr)) {
       return true; // status unknown for now but someone is checking
     }
     return inlineCheckIfAvailable(localAddress, currentView, initiateRemoval,

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/fd/GMSHealthMonitor.java
@@ -670,7 +670,13 @@ public class GMSHealthMonitor<ID extends MemberIdentifier> implements HealthMoni
   @Override
   public boolean checkIfAvailable(ID mbr, String reason,
       boolean initiateRemoval) {
-    if (membersInFinalCheck.contains(mbr)) {
+    return checkIfAvailable(mbr, reason, initiateRemoval, true);
+  }
+
+  @Override
+  public boolean checkIfAvailable(ID mbr, String reason,
+      boolean initiateRemoval, boolean checkIfMemberInFinalCheck) {
+    if (checkIfMemberInFinalCheck && membersInFinalCheck.contains(mbr)) {
       return true; // status unknown for now but someone is checking
     }
     return inlineCheckIfAvailable(localAddress, currentView, initiateRemoval,

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
@@ -45,6 +45,17 @@ public interface HealthMonitor<ID extends MemberIdentifier> extends Service<ID> 
   boolean checkIfAvailable(ID mbr, String reason, boolean initiateRemoval);
 
   /**
+   * Check on the health of the given member, initiating suspicion if it fails. Return true if the
+   * member is found to be available, false if it isn't.
+   *
+   * @param reason the reason this check is being performed
+   * @param initiateRemoval if the member should be removed if it is not available
+   * @param checkIfMemberInFinalCheck if true, check if the member is undergoing a final check
+   */
+  boolean checkIfAvailable(ID mbr, String reason, boolean initiateRemoval,
+      boolean checkIfMemberInFinalCheck);
+
+  /**
    * Invoked by the Manager, this notifies the HealthMonitor that a ShutdownMessage has been
    * received from the given member
    */

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
@@ -50,10 +50,10 @@ public interface HealthMonitor<ID extends MemberIdentifier> extends Service<ID> 
    *
    * @param reason the reason this check is being performed
    * @param initiateRemoval if the member should be removed if it is not available
-   * @param checkIfMemberInFinalCheck if true, check if the member is undergoing a final check
+   * @param assumeMembersInFinalCheckAreAvailable if true, assume that the members in final check are available
    */
   boolean checkIfAvailable(ID mbr, String reason, boolean initiateRemoval,
-      boolean checkIfMemberInFinalCheck);
+      boolean assumeMembersInFinalCheckAreAvailable);
 
   /**
    * Invoked by the Manager, this notifies the HealthMonitor that a ShutdownMessage has been

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/interfaces/HealthMonitor.java
@@ -50,7 +50,8 @@ public interface HealthMonitor<ID extends MemberIdentifier> extends Service<ID> 
    *
    * @param reason the reason this check is being performed
    * @param initiateRemoval if the member should be removed if it is not available
-   * @param assumeMembersInFinalCheckAreAvailable if true, assume that the members in final check are available
+   * @param assumeMembersInFinalCheckAreAvailable if true, assume that the members in final check
+   *        are available
    */
   boolean checkIfAvailable(ID mbr, String reason, boolean initiateRemoval,
       boolean assumeMembersInFinalCheckAreAvailable);

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1454,10 +1454,14 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
     if (isStopping) {
       return;
     }
-
-    String str = "Membership coordinator " + msg.getSender()
-        + " has declared that a network partition has occurred";
-    forceDisconnect(str);
+    ID sender = msg.getSender();
+    if (getView().getMembers().contains(sender) || getView().getViewId() == sender.getVmViewId()) {
+      String str = "Membership coordinator " + msg.getSender()
+          + " has declared that a network partition has occurred";
+      forceDisconnect(str);
+    } else {
+      logger.warn("Ignoring the network partition message from a non-member: " + msg.getSender());
+    }
   }
 
   @Override

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1455,7 +1455,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
       return;
     }
     ID sender = msg.getSender();
-    if (getView().getMembers().contains(sender) || getView().getViewId() == sender.getVmViewId()) {
+    if (getView().getMembers().contains(sender)) {
       String str = "Membership coordinator " + msg.getSender()
           + " has declared that a network partition has occurred";
       forceDisconnect(str);

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1792,7 +1792,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
     // return the member id if it fails health checks
     logger.info("checking state of member " + fmbr);
     if (services.getHealthMonitor().checkIfAvailable(fmbr,
-        "Member failed to acknowledge a membership view", false)) {
+        "Member failed to acknowledge a membership view", false, false)) {
       logger.info("member " + fmbr + " passed availability check");
       return true;
     }


### PR DESCRIPTION
We saw multiple failures during network partition when a server on the winning side gets forcefully disconnected. It happens because GMSHealthMonitor.checkIfAvailable() gives the suspect a pass if it's already being checked by another thread. As a result, the losing side locator sends a Network Partition message to the server on the winning side, and the server gets forcefully disconnected.

This change adds a boolean flag to GMSHealthMonitor.checkIfAvailable() that can disable checking if a suspect is already being checked by another thread.
It also changes the behavior of GMSHealthMonitor.processMessage() so that the method ignores network partition messages from non-members.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
