### PR TITLE
GEODE-8906: capture additional crash artifacts

### DIFF
--- a/ci/scripts/shared_utilities.sh
+++ b/ci/scripts/shared_utilities.sh
@@ -23,7 +23,7 @@ find-here-test-reports() {
   find .  -type d -name "test-results" >> ${output_directories_file}
   (find . -type d -name "*Test" | grep "build/[^/]*Test$") >> ${output_directories_file}
   find . -name "*-progress*txt" >> ${output_directories_file}
-  find . -name "*.hprof" >> ${output_directories_file}
+  find . -name "*.hprof" -o -name "hs_err*.log" -o -name "hreplay*.log" >> ${output_directories_file}
   find . -type d -name "callstacks" >> ${output_directories_file}
   echo "Collecting the following artifacts..."
   cat ${output_directories_file}


### PR DESCRIPTION
see https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-support-1-13-main/jobs/DistributedTestOpenJDK11/builds/77#L5fc8ddb7:378 ... the only logs produced were not included in the artifacts captured