### PR TITLE
GEODE-8906: capture gradle artifacts too

### DIFF
--- a/ci/scripts/rsync_code_down.sh
+++ b/ci/scripts/rsync_code_down.sh
@@ -44,12 +44,12 @@ OUTPUT_DIR=${BASE_DIR}/geode-results
 case $ARTIFACT_SLUG in
   windows*)
     JAVA_BUILD_PATH=C:/java8
-    EXEC_COMMAND="bash -c 'export JAVA_HOME=${JAVA_BUILD_PATH}; cd geode; ./gradlew --no-daemon combineReports'"
+    EXEC_COMMAND="bash -c 'export JAVA_HOME=${JAVA_BUILD_PATH}; cd geode; ./gradlew --no-daemon combineReports; mv ../.gradle .gradle_logs'"
     ;;
   *)
     # JAVA_BUILD_PATH=/usr/lib/jvm/java-${JAVA_BUILD_VERSION}-openjdk-amd64
     JAVA_BUILD_PATH=/usr/lib/jvm/bellsoft-java${JAVA_BUILD_VERSION}-amd64
-    EXEC_COMMAND="bash -c 'export JAVA_HOME=${JAVA_BUILD_PATH} && cd geode && ./gradlew --no-daemon combineReports'"
+    EXEC_COMMAND="bash -c 'export JAVA_HOME=${JAVA_BUILD_PATH} && cd geode && ./gradlew --no-daemon combineReports && mv ../.gradle .gradle_logs'"
     ;;
 esac
 

--- a/ci/scripts/shared_utilities.sh
+++ b/ci/scripts/shared_utilities.sh
@@ -25,7 +25,6 @@ find-here-test-reports() {
   find . -name "*-progress*txt" >> ${output_directories_file}
   find . -name "*.hprof" -o -name "hs_err*.log" -o -name "replay*.log" >> ${output_directories_file}
   find . -type d -name "callstacks" >> ${output_directories_file}
-  mv ${HOME}/.gradle .gradle_logs
   find .gradle_logs -name '*.log' >> ${output_directories_file}
   echo "Collecting the following artifacts..."
   cat ${output_directories_file}


### PR DESCRIPTION
* fix previous PR #5992 to pull in the gradle logs _before_ the rsync