### PR TITLE
GEODE-8942: Fix docker.gradle working dir

### DIFF
--- a/gradle/docker.gradle
+++ b/gradle/docker.gradle
@@ -114,16 +114,10 @@ project.ext.dockerConfig = {
         cmdList[0] = ("${project.testJVM}/bin/java" as String)
       }
 
-      def matcher = (cmdList[cmdList.length - 1] =~ /.*Executor (\d*).*/)
-
-      def workdir = new File(cmd.getWorkingDir() + matcher[0][1])
-      workdir.mkdirs()
-      cmd.withWorkingDir(workdir.toString())
-
       // copy the classpath file to the working dir
       def classPathFileIndex = cmdList.findIndexOf { it =~ /^@.*gradle-worker-classpath.*txt$/ }
       if (classPathFileIndex > 0) {
-        def dst = new File(workdir, "gradle-worker-classpath.txt")
+        def dst = new File(cmd.getWorkingDir(), "gradle-worker-classpath.txt")
         if (!dst.exists()) {
           def src = new File(cmdList[classPathFileIndex].substring(1))
           dst.write(src.text)


### PR DESCRIPTION
Change docker.gradle to stop appending the Gradle worker ID onto the
test worker JVM's working directory name. As of GEODE-8637, the working
directory is already unique by the time docker.gradle operates on it,
and appending the worker ID makes the test run in the wrong directory.
