### PR TITLE
GEODE-7245: Remove most uses of latestViewReadLock in GMSMembership

### DIFF
--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipView.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipView.java
@@ -75,27 +75,18 @@ public class MembershipView<ID extends MemberIdentifier> {
     return members;
   }
 
-  /**
-   * return members that are i this view but not the given old view
-   */
-  public List<ID> getNewMembers(MembershipView<ID> olderView) {
-    List<ID> result = new ArrayList<>(members);
-    result.removeAll(olderView.getMembers());
-    return result;
-  }
-
   public Object get(int i) {
     return this.members.get(i);
   }
 
-  public MembershipView<ID> newViewWithMember(ID member) {
+  public MembershipView<ID> createNewViewWithMember(ID member) {
     return new MembershipView<>(creator, viewId,
         Stream.concat(members.stream(), Stream.of(member)).collect(toList()), shutdownMembers,
         crashedMembers);
   }
 
-  public MembershipView<ID> newViewWithoutMember(final ID member) {
-    return new MembershipView<ID>(creator, viewId,
+  public MembershipView<ID> createNewViewWithoutMember(final ID member) {
+    return new MembershipView<>(creator, viewId,
         members.stream().filter(m -> !m.equals(member)).collect(toList()), shutdownMembers,
         crashedMembers);
   }
@@ -144,10 +135,6 @@ public class MembershipView<ID extends MemberIdentifier> {
       return members.get(0);
     }
     return null;
-  }
-
-  public Set<ID> getShutdownMembers() {
-    return this.shutdownMembers;
   }
 
   public Set<ID> getCrashedMembers() {

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipView.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipView.java
@@ -14,75 +14,53 @@
  */
 package org.apache.geode.distributed.internal.membership.api;
 
+import static java.util.stream.Collectors.toList;
+
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
- * The MembershipView class represents a membership view. MembershipViews are typically
- * unmodifiable though you an create and manipulate one for local usel A MembershipView
- * defines who is in the cluster and knows which node created the view. It also knows which
- * members left or were removed when the view was created. MemberIdentifiers in the view
- * are marked with the viewId of the MembershipView in which they joined the cluster.
+ * The MembershipView class represents a membership view. A MembershipView defines who is in the
+ * cluster and knows which node created the view. It also knows which members left or were removed
+ * when the view was created. MemberIdentifiers in the view are marked with the viewId of the
+ * MembershipView in which they joined the cluster.
  */
 public class MembershipView<ID extends MemberIdentifier> {
 
-  private int viewId;
-  private List<ID> members;
-  private Set<ID> shutdownMembers;
-  private Set<ID> crashedMembers;
-  private ID creator;
-  private Set<ID> hashedMembers;
-  private volatile boolean unmodifiable;
-
+  private final int viewId;
+  private final List<ID> members;
+  private final Set<ID> shutdownMembers;
+  private final Set<ID> crashedMembers;
+  private final ID creator;
+  private final Set<ID> hashedMembers;
 
   public MembershipView() {
-    viewId = -1;
-    members = new ArrayList<>(0);
-    this.hashedMembers = new HashSet<>(members);
-    shutdownMembers = Collections.emptySet();
-    crashedMembers = new HashSet<>();
-    creator = null;
+    this(null, -1, Collections.emptyList());
   }
 
-  public MembershipView(ID creator, int viewId,
-      List<ID> members) {
-    this.viewId = viewId;
-    this.members = new ArrayList<>(members);
-    hashedMembers = new HashSet<>(this.members);
-    shutdownMembers = new HashSet<>();
-    crashedMembers = Collections.emptySet();
-    this.creator = creator;
+  public MembershipView(final ID creator, final int viewId, final List<ID> members) {
+    this(creator, viewId, members, Collections.emptySet(), Collections.emptySet());
   }
 
-  /**
-   * Create a new view with the contents of the given view and the specified view ID
-   */
-  public MembershipView(MembershipView<ID> other, int viewId) {
-    this.creator = other.creator;
-    this.viewId = viewId;
-    this.members = new ArrayList<>(other.members);
-    this.hashedMembers = new HashSet<>(other.members);
-    this.shutdownMembers = new HashSet<>(other.shutdownMembers);
-    this.crashedMembers = new HashSet<>(other.crashedMembers);
-  }
-
-  public MembershipView(ID creator, int viewId,
-      List<ID> mbrs, Set<ID> shutdowns,
-      Set<ID> crashes) {
+  public MembershipView(final ID creator, final int viewId, final List<ID> members,
+      final Set<ID> shutdowns, final Set<ID> crashes) {
     this.creator = creator;
     this.viewId = viewId;
-    this.members = mbrs;
-    this.hashedMembers = new HashSet<>(mbrs);
-    this.shutdownMembers = shutdowns;
-    this.crashedMembers = crashes;
-  }
 
-  public void makeUnmodifiable() {
-    unmodifiable = true;
+    /*
+     * Copy each collection, then store the ref to the unmodifiable
+     * wrapper so we can expose it.
+     */
+    this.members = Collections.unmodifiableList(new ArrayList<>(members));
+    this.shutdownMembers = Collections.unmodifiableSet(new HashSet<>(shutdowns));
+    this.crashedMembers = Collections.unmodifiableSet(new HashSet<>(crashes));
+
+    // make this unmodifiable for good measure (even though we don't expose it)
+    this.hashedMembers = Collections.unmodifiableSet(new HashSet<>(members));
   }
 
   public int getViewId() {
@@ -93,18 +71,8 @@ public class MembershipView<ID extends MemberIdentifier> {
     return this.creator;
   }
 
-  public void setCreator(ID creator) {
-    this.creator = creator;
-  }
-
-  public void setViewId(int viewId) {
-    this.viewId = viewId;
-  }
-
-
-
   public List<ID> getMembers() {
-    return Collections.unmodifiableList(this.members);
+    return members;
   }
 
   /**
@@ -120,28 +88,16 @@ public class MembershipView<ID extends MemberIdentifier> {
     return this.members.get(i);
   }
 
-  public void add(ID mbr) {
-    if (unmodifiable) {
-      throw new IllegalStateException("this membership view is not modifiable");
-    }
-    this.hashedMembers.add(mbr);
-    this.members.add(mbr);
+  public MembershipView<ID> newViewWithMember(ID member) {
+    return new MembershipView<>(creator, viewId,
+        Stream.concat(members.stream(), Stream.of(member)).collect(toList()), shutdownMembers,
+        crashedMembers);
   }
 
-  public boolean remove(ID mbr) {
-    if (unmodifiable) {
-      throw new IllegalStateException("this membership view is not modifiable");
-    }
-    this.hashedMembers.remove(mbr);
-    return this.members.remove(mbr);
-  }
-
-  public void removeAll(Collection<ID> ids) {
-    if (unmodifiable) {
-      throw new IllegalStateException("this membership view is not modifiable");
-    }
-    this.hashedMembers.removeAll(ids);
-    ids.forEach(this::remove);
+  public MembershipView<ID> newViewWithoutMember(final ID member) {
+    return new MembershipView<ID>(creator, viewId,
+        members.stream().filter(m -> !m.equals(member)).collect(toList()), shutdownMembers,
+        crashedMembers);
   }
 
   public boolean contains(MemberIdentifier mbr) {
@@ -166,7 +122,7 @@ public class MembershipView<ID extends MemberIdentifier> {
    * Returns the ID from this view that is equal to the argument. If no such ID exists the argument
    * is returned.
    */
-  public synchronized ID getCanonicalID(ID id) {
+  public ID getCanonicalID(ID id) {
     if (hashedMembers.contains(id)) {
       for (ID m : this.members) {
         if (id.equals(m)) {
@@ -176,7 +132,6 @@ public class MembershipView<ID extends MemberIdentifier> {
     }
     return id;
   }
-
 
 
   public ID getCoordinator() {
@@ -206,8 +161,9 @@ public class MembershipView<ID extends MemberIdentifier> {
     sb.append("View[").append(creator).append('|').append(viewId).append("] members: [");
     boolean first = true;
     for (ID mbr : this.members) {
-      if (!first)
+      if (!first) {
         sb.append(", ");
+      }
       sb.append(mbr);
       if (mbr == lead) {
         sb.append("{lead}");
@@ -218,8 +174,9 @@ public class MembershipView<ID extends MemberIdentifier> {
       sb.append("]  shutdown: [");
       first = true;
       for (ID mbr : this.shutdownMembers) {
-        if (!first)
+        if (!first) {
           sb.append(", ");
+        }
         sb.append(mbr);
         first = false;
       }
@@ -228,8 +185,9 @@ public class MembershipView<ID extends MemberIdentifier> {
       sb.append("]  crashed: [");
       first = true;
       for (ID mbr : this.crashedMembers) {
-        if (!first)
+        if (!first) {
           sb.append(", ");
+        }
         sb.append(mbr);
         first = false;
       }
@@ -239,7 +197,7 @@ public class MembershipView<ID extends MemberIdentifier> {
   }
 
   @Override
-  public synchronized boolean equals(Object other) {
+  public boolean equals(Object other) {
     if (other == this) {
       return true;
     }
@@ -250,7 +208,7 @@ public class MembershipView<ID extends MemberIdentifier> {
   }
 
   @Override
-  public synchronized int hashCode() {
+  public int hashCode() {
     return this.members.hashCode();
   }
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -275,7 +275,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
    * otherwise becomes pretty aggressive when a member is shutting down.
    */
   private final Set<ID> shutdownMembers =
-      Collections.synchronizedSet(new BoundedLinkedHashMap<ID, Object>().keySet());
+      Collections.synchronizedSet(Collections.newSetFromMap(new BoundedLinkedHashMap<>()));
 
   /**
    * per bug 39552, keep a list of members that have been shunned and for which a message is
@@ -1198,6 +1198,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
       logger.debug("Membership: recording shutdown status of {}", id);
     }
     this.shutdownMembers.add(id);
+    services.getHealthMonitor().memberShutdown(id, reason);
     services.getJoinLeave().memberShutdown(id, reason);
   }
 

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -1488,7 +1488,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
    * <p>
    * Like isShunned, this method holds the view lock while executing
    *
-   * Concurrency: protected by {@link #latestViewReadLock} ReentrantReadLock
+   * Concurrency: protected by {@link #latestViewReadLock}
    *
    * @param m the member in question
    * @return true if the given member is a surprise member

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -223,7 +223,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
   /**
    * This is the latest view (ordered list of IDs) that has been installed
    *
-   * All accesses to this object are protected via {@link #latestViewLock}
+   * Writing to this object is protected via {@link #latestViewLock}
    */
   private volatile MembershipView<ID> latestView = new MembershipView<>();
 
@@ -263,7 +263,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
    *
    * Members are removed after {@link #SHUNNED_SUNSET} seconds have passed.
    *
-   * Accesses to this list needs to be under the read or write lock of {@link #latestViewLock}
+   * Writing to this list needs to be under the write lock of {@link #latestViewLock}
    *
    * @see System#currentTimeMillis()
    */
@@ -273,6 +273,9 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
   /**
    * Members that have sent a shutdown message. This is used to suppress suspect processing that
    * otherwise becomes pretty aggressive when a member is shutting down.
+   *
+   * Accesses to this map should be synchronized on the map to avoid concurrent
+   * modification exceptions
    */
   private final Map<ID, Object> shutdownMembers = new BoundedLinkedHashMap<>();
 
@@ -281,7 +284,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
    * printed. Contents of this list are cleared at the same time they are removed from
    * {@link #shunnedMembers}.
    *
-   * Accesses to this list needs to be under the read or write lock of {@link #latestViewLock}
+   * Writing to this list needs to be under the write lock of {@link #latestViewLock}
    */
   private final HashSet<ID> shunnedAndWarnedMembers = new HashSet<>();
   /**
@@ -295,7 +298,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
    * {@link #surpriseMemberTimeout} milliseconds have passed, a view containing the member has not
    * arrived, the member is removed from membership and member-left notification is performed.
    * <p>
-   * > Accesses to this list needs to be under the read or write lock of {@link #latestViewLock}
+   * > Writing to this list needs to be under the write lock of {@link #latestViewLock}
    *
    * @see System#currentTimeMillis()
    */

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -491,7 +491,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
               "not seen in membership view in " + this.surpriseMemberTimeout + "ms");
         } else {
           if (!newlatestView.contains(entry.getKey())) {
-            newlatestView = newlatestView.newViewWithMember(entry.getKey());
+            newlatestView = newlatestView.createNewViewWithMember(entry.getKey());
           }
         }
       }
@@ -769,7 +769,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
         // should ensure it is not chosen as an elder.
         // This will get corrected when the member finally shows up in the
         // view.
-        latestView = latestView.newViewWithMember(member);
+        latestView = latestView.createNewViewWithMember(member);
       }
     } finally {
       latestViewWriteLock.unlock();
@@ -1432,7 +1432,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
     latestViewWriteLock.lock();
     try {
       if (latestView.contains(member)) {
-        latestView = latestView.newViewWithoutMember(member);
+        latestView = latestView.createNewViewWithoutMember(member);
       }
     } finally {
       latestViewWriteLock.unlock();

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/GMSMembership.java
@@ -1488,7 +1488,7 @@ public class GMSMembership<ID extends MemberIdentifier> implements Membership<ID
    * <p>
    * Like isShunned, this method holds the view lock while executing
    *
-   * Concurrency: protected by {@link #latestViewReadLock} ReentrantReadWriteLock
+   * Concurrency: protected by {@link #latestViewReadLock} ReentrantReadLock
    *
    * @param m the member in question
    * @return true if the given member is a surprise member


### PR DESCRIPTION
This change replaces most uses of `latestViewReadLock` with a volatile read of the latestView.
It also makes access to `shutdownMembers` synchronized. Currently, modification of `shutdownMembers` is done under a sync but access isn't synchronized.

GEODE-7245 is an improvement ticket, so it shouldn't require writing new tests.


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
