### PR TITLE
GEODE-8947: Use waiting thread pool only in limited senario.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteOperationMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tx/RemoteOperationMessage.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache.tx;
 
-import static org.apache.geode.distributed.ConfigurationProperties.CONSERVE_SOCKETS;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -180,9 +179,8 @@ public abstract class RemoteOperationMessage extends DistributionMessage
       return;
     }
 
-    String conserveSockets = getConserveSocketsSetting(dm);
-    if (conserveSockets != null && conserveSockets.equals("false")) {
-      // reply inline for CONSERVE_SOCKETS == false case.
+    if (dm.getSystem().threadOwnsResources()) {
+      // reply inline if thread owns socket.
       doRemoteOperation(dm, cache);
       return;
     }
@@ -193,10 +191,6 @@ public abstract class RemoteOperationMessage extends DistributionMessage
       // reply inline for non-transactional case.
       doRemoteOperation(dm, cache);
     }
-  }
-
-  String getConserveSocketsSetting(ClusterDistributionManager dm) {
-    return dm.getSystem().getProperties().getProperty(CONSERVE_SOCKETS);
   }
 
   boolean isTransactional() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tx/RemoteOperationMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tx/RemoteOperationMessageTest.java
@@ -305,8 +305,8 @@ public class RemoteOperationMessageTest {
 
 
   @Test
-  public void processInvokesDoRemoteOperationIfConserveSocketsIsFalse() {
-    doReturn("false").when(msg).getConserveSocketsSetting(dm);
+  public void processInvokesDoRemoteOperationIfThreadOwnsResources() {
+    when(system.threadOwnsResources()).thenReturn(true);
     doNothing().when(msg).doRemoteOperation(dm, cache);
 
     msg.process(dm);
@@ -316,8 +316,8 @@ public class RemoteOperationMessageTest {
   }
 
   @Test
-  public void processInvokesDoRemoteOperationIfConserveSocketsIsTrueAndNotTransactional() {
-    doReturn("true").when(msg).getConserveSocketsSetting(dm);
+  public void processInvokesDoRemoteOperationIfThreadDoesNotOwnResourcesAndNotTransactional() {
+    when(system.threadOwnsResources()).thenReturn(false);
     doReturn(false).when(msg).isTransactional();
     doNothing().when(msg).doRemoteOperation(dm, cache);
 
@@ -334,7 +334,7 @@ public class RemoteOperationMessageTest {
   }
 
   @Test
-  public void isTransactionalReturnsTrueIfCannotParticipateInTransaction() {
+  public void isTransactionalReturnsFalseIfCannotParticipateInTransaction() {
     doReturn(1).when(msg).getTXUniqId();
     doReturn(false).when(msg).canParticipateInTransaction();
 
@@ -342,7 +342,7 @@ public class RemoteOperationMessageTest {
   }
 
   @Test
-  public void isTransactionalReturnsFalseIfHasTXUniqueIdAndCanParticipateInTransaction() {
+  public void isTransactionalReturnsTrueIfHasTXUniqueIdAndCanParticipateInTransaction() {
     doReturn(1).when(msg).getTXUniqId();
 
     assertThat(msg.canParticipateInTransaction()).isTrue();


### PR DESCRIPTION
  * Only when processing transactional message and when conserve-sockets set to true case, a
    separate thread in waiting pool will be used to process the message.
  * This is to addresses performance issue if there won't be deadlock.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
