### PR TITLE
GEODE-8920: Modify debug logging to make it easier to trace a message

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
@@ -211,7 +211,7 @@ public class DirectChannel {
       InternalDistributedMember[] p_destinations,
       final DistributionMessage msg, long ackWaitThreshold, long ackSAThreshold)
       throws ConnectExceptions, NotSerializableException {
-    InternalDistributedMember destinations[] = p_destinations;
+    InternalDistributedMember[] destinations = p_destinations;
 
     // Collects connect exceptions that happened during previous attempts to send.
     // These represent members we are not able to distribute to.
@@ -276,7 +276,7 @@ public class DirectChannel {
           retryInfo = null;
           retry = true;
         }
-        final List cons = new ArrayList(destinations.length);
+        final List<Connection> cons = new ArrayList<>(destinations.length);
         ConnectExceptions ce = getConnections(mgr, msg, destinations, orderedMsg, retry, ackTimeout,
             ackSDTimeout, cons);
 
@@ -299,9 +299,9 @@ public class DirectChannel {
           return bytesWritten;
         }
 
-        if (retry && logger.isDebugEnabled()) {
-          logger.debug("Retrying send ({}{}) to {} peers ({}) via tcp/ip",
-              msg, cons.size(), cons);
+        if (logger.isDebugEnabled()) {
+          logger.debug("{} on these {} connections: {}",
+              (retry ? "Retrying send" : "Sending"), cons.size(), cons);
         }
         DMStats stats = getDMStats();
         List<?> sentCons; // used for cons we sent to this time

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -3224,7 +3224,7 @@ public class Connection implements Runnable {
   private void setThreadName(int dominoNumber) {
     Thread.currentThread().setName(THREAD_KIND_IDENTIFIER + " for " + remoteAddr + " "
         + (sharedResource ? "" : "un") + "shared" + " " + (preserveOrder ? "" : "un")
-        + "ordered" + " uid=" + uniqueId + (dominoNumber > 0 ? " dom #" + dominoNumber : "")
+        + "ordered sender uid=" + uniqueId + (dominoNumber > 0 ? " dom #" + dominoNumber : "")
         + " local port=" + socket.getLocalPort() + " remote port=" + socket.getPort());
   }
 


### PR DESCRIPTION
This PR changes the debug log messages to include the uniqueId of each outgoing Connection.

Before connections are formed, DirectChannel.sendToMany prints out a message and the destinations:

`[debug 2021/02/18 17:00:07.408 CST peergemfire_2_3_host1_69611 <vm_7_thr_17_peer_2_3_host1_69611> tid=0x139] Sending (CloseCacheMessage@65a3824f processorId=11477 sender=192.168.1.74(peergemfire_2_3_host1_69611:69611)<ec><v1>:41005 (processorId=11477)) to 2 peers ([192.168.1.74(peergemfire_2_2_host1_69609:69609)<ec><v2>:41007, 192.168.1.74(peergemfire_2_1_host1_69607:69607)<ec><v1>:41003]) via tcp/ip
`

After connections are formed, it prints them out, including the uids:
`[debug 2021/02/18 17:00:07.408 CST peergemfire_2_3_host1_69611 <vm_7_thr_17_peer_2_3_host1_69611> tid=0x139] Sending on these 2 connections: [192.168.1.74(peergemfire_2_2_host1_69609:69609)<ec><v2>:41007(uid=153), 192.168.1.74(peergemfire_2_1_host1_69607:69607)<ec><v1>:41003(uid=154)]
`


Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
