### PR TITLE
GEODE-8958: When timestamps get corrupted.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -171,7 +171,7 @@ public class TombstoneDUnitTest implements Serializable {
 
   @Test
   public void testWhenAnOutOfRangeTimeStampIsSeenWeExpireItInNonReplicateTombstoneSweeper() {
-    VM server1 = VM.getVM(-1);
+    VM server1 = VM.getVM(0);
     VM server2 = VM.getVM(1);
     final int FAR_INTO_THE_FUTURE = 1000000; // 1 million millis into the future
     final int count = 2000;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -147,11 +147,10 @@ public class TombstoneDUnitTest implements Serializable {
 
   @Test
   public void testRewriteBadOldestTombstoneTimeReplicateForTimestamp() {
-    VM server1 = VM.getVM(-1);
+    VM server1 = VM.getVM(0);
     VM server2 = VM.getVM(1);
 
     final int count = 10;
-
     server1.invoke(() -> {
       createCacheAndRegion(RegionShortcut.REPLICATE_PERSISTENT);
       for (int i = 0; i < count; i++) {
@@ -166,18 +165,13 @@ public class TombstoneDUnitTest implements Serializable {
           ((InternalCache) cache).getTombstoneService().getSweeper((LocalRegion) region);
 
       RegionEntry regionEntry = ((LocalRegion) region).getRegionEntry("K0");
-      VersionTag<?> versionTag = regionEntry.getVersionStamp()
-          .asVersionTag();
-      versionTag.setVersionTimeStamp(System.currentTimeMillis() + 100000);
+      VersionTag<?> versionTag = regionEntry.getVersionStamp().asVersionTag();
+      versionTag.setVersionTimeStamp(System.currentTimeMillis() + 1000000);
+
       TombstoneService.Tombstone modifiedTombstone =
           new TombstoneService.Tombstone(regionEntry, (LocalRegion) region,
               versionTag);
       tombstoneSweeper.tombstones.add(modifiedTombstone);
-      if (tombstoneSweeper.getOldestTombstoneTime() > 0) {
-        System.out.println("We have a problem");
-      } else {
-        System.out.println("It works.");
-      }
       tombstoneSweeper.checkOldestUnexpired(System.currentTimeMillis());
       // Send tombstone gc message to vm1.
       assertThat(tombstoneSweeper.getOldestTombstoneTime()).isEqualTo(0);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -61,7 +61,7 @@ public class TombstoneDUnitTest implements Serializable {
   private static Cache cache;
   private static Region<String, String> region;
   final String REGION_NAME = "TestRegion";
-  final int EXPIRY_TIME=600000;
+  final int EXPIRY_TIME = 600000;
 
   @Rule
   public DistributedRule distributedRule = new DistributedRule();
@@ -126,7 +126,6 @@ public class TombstoneDUnitTest implements Serializable {
     VM server2 = VM.getVM(1);
     final int FAR_INTO_THE_FUTURE = 1000000; // 1 million millis into the future
 
-
     final int count = 10;
     server1.invoke(() -> {
       createCacheAndRegion(RegionShortcut.REPLICATE_PERSISTENT);
@@ -175,8 +174,9 @@ public class TombstoneDUnitTest implements Serializable {
       // Send tombstone gc message to vm1.
       for (int i = 0; i < count; i++) {
         region.destroy("K" + i);
-        assertThat(tombstoneSweeper.getOldestTombstoneTime() + EXPIRY_TIME - System.currentTimeMillis())
-            .isGreaterThan(0);
+        assertThat(
+            tombstoneSweeper.getOldestTombstoneTime() + EXPIRY_TIME - System.currentTimeMillis())
+                .isGreaterThan(0);
         performGC(1);
       }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -194,7 +194,7 @@ public class TombstoneDUnitTest implements Serializable {
 
       // Get one of the entries
 
-      PartitionedRegion partitionedRegion = (PartitionedRegion)region;
+      PartitionedRegion partitionedRegion = (PartitionedRegion) region;
       RegionEntry regionEntry = partitionedRegion.getBucketRegion("K0").getRegionEntry("K0");
 
       /*
@@ -218,8 +218,6 @@ public class TombstoneDUnitTest implements Serializable {
       assertThat(tombstoneSweeper.getOldestTombstoneTime()).isEqualTo(0);
     });
   }
-
-
 
 
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -169,15 +169,13 @@ public class TombstoneDUnitTest implements Serializable {
       VersionTag<?> versionTag = regionEntry.getVersionStamp()
           .asVersionTag();
       versionTag.setVersionTimeStamp(System.currentTimeMillis() + 100000);
-      TombstoneService.Tombstone
-          modifiedTombstone =
+      TombstoneService.Tombstone modifiedTombstone =
           new TombstoneService.Tombstone(regionEntry, (LocalRegion) region,
               versionTag);
       tombstoneSweeper.tombstones.add(modifiedTombstone);
       if (tombstoneSweeper.getOldestTombstoneTime() > 0) {
         System.out.println("We have a problem");
-      }
-      else {
+      } else {
         System.out.println("It works.");
       }
       tombstoneSweeper.checkOldestUnexpired(System.currentTimeMillis());

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/versions/TombstoneDUnitTest.java
@@ -61,7 +61,6 @@ public class TombstoneDUnitTest implements Serializable {
   private static Cache cache;
   private static Region<String, String> region;
   final String REGION_NAME = "TestRegion";
-  final int EXPIRY_TIME = 600000;
 
   @Rule
   public DistributedRule distributedRule = new DistributedRule();
@@ -175,8 +174,9 @@ public class TombstoneDUnitTest implements Serializable {
       for (int i = 0; i < count; i++) {
         region.destroy("K" + i);
         assertThat(
-            tombstoneSweeper.getOldestTombstoneTime() + EXPIRY_TIME - System.currentTimeMillis())
-                .isGreaterThan(0);
+            tombstoneSweeper.getOldestTombstoneTime()
+                + TombstoneService.REPLICATE_TOMBSTONE_TIMEOUT_DEFAULT - System.currentTimeMillis())
+                    .isGreaterThan(0);
         performGC(1);
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
@@ -426,11 +426,11 @@ public class TombstoneService {
 
     @Override
     protected boolean hasExpired(long msUntilTombstoneExpires) {
-    /*
-     * In case the tombstone expiration time would be too far out lets cap it. This is just
-     * making the system fault tolerant in the case that there are large clock jumps or
-     * unrealistically large timestamps.
-     */
+      /*
+       * In case the tombstone expiration time would be too far out lets cap it. This is just
+       * making the system fault tolerant in the case that there are large clock jumps or
+       * unrealistically large timestamps.
+       */
       return msUntilTombstoneExpires <= 0 || msUntilTombstoneExpires > EXPIRY_TIME;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
@@ -426,7 +426,12 @@ public class TombstoneService {
 
     @Override
     protected boolean hasExpired(long msUntilTombstoneExpires) {
-      return msUntilTombstoneExpires <= 0;
+    /*
+     * In case the tombstone expiration time would be too far out lets cap it. This is just
+     * making the system fault tolerant in the case that there are large clock jumps or
+     * unrealistically large timestamps.
+     */
+      return msUntilTombstoneExpires <= 0 || msUntilTombstoneExpires > EXPIRY_TIME;
     }
 
     @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
@@ -751,7 +751,11 @@ public class TombstoneService {
         testHook_forceExpirationCount--;
         return true;
       }
-      // In case
+      /*
+       * In case the tombstone expiration time would be too far out lets cap it. This is just
+       * making the system fault tolerant in the case that there are large clock jumps or
+       * unrealistically large timestamps.
+       */
       return msTillHeadTombstoneExpires <= 0 || msTillHeadTombstoneExpires > EXPIRY_TIME;
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
@@ -373,7 +373,8 @@ public class TombstoneService {
     return this.replicatedTombstoneSweeper.getBlockGCLock();
   }
 
-  protected static class Tombstone extends CompactVersionHolder {
+  @VisibleForTesting
+  public static class Tombstone extends CompactVersionHolder {
     // tombstone overhead size
     public static final int PER_TOMBSTONE_OVERHEAD =
         ReflectionSingleObjectSizer.REFERENCE_SIZE // queue's reference to the tombstone
@@ -384,8 +385,8 @@ public class TombstoneService {
 
     RegionEntry entry;
     LocalRegion region;
-
-    Tombstone(RegionEntry entry, LocalRegion region, VersionTag destroyedVersion) {
+    @VisibleForTesting
+    public Tombstone(RegionEntry entry, LocalRegion region, VersionTag destroyedVersion) {
       super(destroyedVersion);
       this.entry = entry;
       this.region = region;
@@ -749,7 +750,8 @@ public class TombstoneService {
         testHook_forceExpirationCount--;
         return true;
       }
-      return msTillHeadTombstoneExpires <= 0;
+      // In case
+      return msTillHeadTombstoneExpires <= 0 || msTillHeadTombstoneExpires > EXPIRY_TIME;
     }
 
     @Override
@@ -847,7 +849,8 @@ public class TombstoneService {
      * are left in this queue and the sweeper thread figures out that they are no longer valid
      * tombstones.
      */
-    protected final Queue<Tombstone> tombstones;
+    @VisibleForTesting
+    public final Queue<Tombstone> tombstones;
     /**
      * Estimate of the amount of memory used by this sweeper
      */
@@ -1063,7 +1066,8 @@ public class TombstoneService {
     /**
      * See if the oldest unexpired tombstone should be expired.
      */
-    private void checkOldestUnexpired(long now) {
+    @VisibleForTesting
+    public void checkOldestUnexpired(long now) {
       sleepTime = 0;
       lockQueueHead();
       Tombstone oldest = tombstones.peek();
@@ -1078,8 +1082,8 @@ public class TombstoneService {
           if (logger.isTraceEnabled(LogMarker.TOMBSTONE_VERBOSE)) {
             logger.trace(LogMarker.TOMBSTONE_VERBOSE, "oldest unexpired tombstone is {}", oldest);
           }
-          long msTillHeadTombstoneExpires = oldest.getVersionTimeStamp() + EXPIRY_TIME - now;
-          if (hasExpired(msTillHeadTombstoneExpires)) {
+          long msUntilHeadTombstoneExpires = oldest.getVersionTimeStamp() + EXPIRY_TIME - now;
+          if (hasExpired(msUntilHeadTombstoneExpires)) {
             try {
               tombstones.remove();
               expireTombstone(oldest);
@@ -1089,7 +1093,7 @@ public class TombstoneService {
               logger.warn("Unexpected exception while processing tombstones", e);
             }
           } else {
-            sleepTime = msTillHeadTombstoneExpires;
+            sleepTime = Math.min(msUntilHeadTombstoneExpires, EXPIRY_TIME);
           }
         }
       } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
@@ -425,8 +425,8 @@ public class TombstoneService {
     }
 
     @Override
-    protected boolean hasExpired(long msTillHeadTombstoneExpires) {
-      return msTillHeadTombstoneExpires <= 0;
+    protected boolean hasExpired(long msUntilTombstoneExpires) {
+      return msUntilTombstoneExpires <= 0;
     }
 
     @Override
@@ -746,7 +746,7 @@ public class TombstoneService {
     }
 
     @Override
-    protected boolean hasExpired(long msTillHeadTombstoneExpires) {
+    protected boolean hasExpired(long msUntilTombstoneExpires) {
       if (testHook_forceExpirationCount > 0) {
         testHook_forceExpirationCount--;
         return true;
@@ -756,7 +756,7 @@ public class TombstoneService {
        * making the system fault tolerant in the case that there are large clock jumps or
        * unrealistically large timestamps.
        */
-      return msTillHeadTombstoneExpires <= 0 || msTillHeadTombstoneExpires > EXPIRY_TIME;
+      return msUntilTombstoneExpires <= 0 || msUntilTombstoneExpires > EXPIRY_TIME;
     }
 
     @Override
@@ -1130,7 +1130,7 @@ public class TombstoneService {
 
     protected abstract void handleNoUnexpiredTombstones();
 
-    protected abstract boolean hasExpired(long msTillTombstoneExpires);
+    protected abstract boolean hasExpired(long msUntilTombstoneExpires);
 
     protected abstract void expireTombstone(Tombstone tombstone);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
@@ -385,6 +385,7 @@ public class TombstoneService {
 
     RegionEntry entry;
     LocalRegion region;
+
     @VisibleForTesting
     public Tombstone(RegionEntry entry, LocalRegion region, VersionTag destroyedVersion) {
       super(destroyedVersion);


### PR DESCRIPTION
The system would wait, now it does expires it and moves on.

