### PR TITLE
Removing myself from a few code-owner directories

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -41,7 +41,7 @@ geode-core/**/org/apache/geode/distributed/internal/membership/** @bschuchardt @
 geode-core/**/org/apache/geode/internal/tcp/**                    @bschuchardt @Bill
 geode-core/**/org/apache/geode/distributed/internal/direct/**     @bschuchardt @Bill
 geode-core/**/org/apache/geode/internal/net/**                    @bschuchardt @Bill
-geode-core/**/org/apache/geode/net/**                             @bschuchardt @Bill
+geode-core/**/org/apache/geode/net/**                             @Bill @mivanac
 geode-core/**/org/apache/geode/distributed/*                      @bschuchardt @Bill @kirklund
 geode-core/**/org/apache/geode/distributed/internal/*             @bschuchardt @Bill @kirklund
 
@@ -86,9 +86,9 @@ geode-core/**/org/apache/geode/internal/cache/*                   @nabarunnag @D
 #-----------------------------------------------------------------
 # Region entry management
 #-----------------------------------------------------------------
-geode-core/**/org/apache/geode/internal/cache/entries/**          @dschneider-pivotal @sabbey37 @bschuchardt @upthewaterspout @kirklund @mhansonp
-geode-core/**/org/apache/geode/internal/cache/region/entry/**     @dschneider-pivotal @sabbey37 @bschuchardt @upthewaterspout @kirklund @mhansonp
-geode-core/**/org/apache/geode/internal/cache/map/**              @dschneider-pivotal @sabbey37 @bschuchardt @upthewaterspout @kirklund @mhansonp
+geode-core/**/org/apache/geode/internal/cache/entries/**          @dschneider-pivotal @sabbey37 @upthewaterspout @kirklund @mhansonp
+geode-core/**/org/apache/geode/internal/cache/region/entry/**     @dschneider-pivotal @sabbey37 @upthewaterspout @kirklund @mhansonp
+geode-core/**/org/apache/geode/internal/cache/map/**              @dschneider-pivotal @sabbey37 @upthewaterspout @kirklund @mhansonp
 geode-core/**/org/apache/geode/compression/**                     @dschneider-pivotal @sabbey37 @kirklund
 geode-core/**/org/apache/geode/internal/cache/compression/**      @dschneider-pivotal @sabbey37 @kirklund
 
@@ -185,7 +185,7 @@ geode-core/**/org/apache/geode/internal/cache/backup/**           @dschneider-pi
 # Region Version Vectors - used for sychronization on
 # member failures and persistent recovery
 #-----------------------------------------------------------------
-geode-core/**/org/apache/geode/internal/cache/versions/**         @dschneider-pivotal @gesterzhou @bschuchardt
+geode-core/**/org/apache/geode/internal/cache/versions/**         @dschneider-pivotal @gesterzhou
 
 #-----------------------------------------------------------------
 # WAN messaging and queues


### PR DESCRIPTION
There are some cache directories that had me as a code owner, but I haven't worked on that code in many years.  A couple of recent PRs made it clear to me that I shouldn't be a required reviewer for those directories.

I've also replaced myself with @mivanac in the directory with the SSL extension parameter.  He wrote that code and should be a reviewer for any changes made to it.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
