### PR TITLE
GEODE-8862: Uses another thread to process DistributedCacheOperation

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedCacheOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DistributedCacheOperation.java
@@ -1106,15 +1106,8 @@ public abstract class DistributedCacheOperation {
         }
 
         final LocalRegion lclRgn = getLocalRegionForProcessing(dm);
-        if (lclRgn == null) {
-          this.closed = true;
-          if (logger.isDebugEnabled()) {
-            logger.debug("{} region not found, nothing to do", this);
-          }
-          return;
-        }
         sendReply = false;
-        if (lclRgn.getScope().isDistributedNoAck()) {
+        if (lclRgn != null && lclRgn.getScope().isDistributedNoAck()) {
           dm.getExecutors().getWaitingThreadPool().execute(() -> basicProcess(dm, lclRgn));
           return;
         }
@@ -1164,10 +1157,17 @@ public abstract class DistributedCacheOperation {
       }
 
       InitializationLevel oldLevel = ANY_INIT;
-      if (lclRgn.getScope().isDistributedNoAck()) {
+      if (lclRgn != null && lclRgn.getScope().isDistributedNoAck()) {
         oldLevel = LocalRegion.setThreadInitLevelRequirement(BEFORE_INITIAL_IMAGE);
       }
       try {
+        if (lclRgn == null) {
+          this.closed = true;
+          if (logger.isDebugEnabled()) {
+            logger.debug("{} region not found, nothing to do", this);
+          }
+          return;
+        }
         // Could this cause a deadlock, because this can block a P2P reader
         // thread which might be needed to read the create region reply??
         // DAN - I don't think this does anything because process called
@@ -1257,7 +1257,7 @@ public abstract class DistributedCacheOperation {
         SystemFailure.checkFailure();
         thr = t;
       } finally {
-        if (lclRgn.getScope().isDistributedNoAck()) {
+        if (lclRgn != null && lclRgn.getScope().isDistributedNoAck()) {
           LocalRegion.setThreadInitLevelRequirement(oldLevel);
         }
         checkVersionIsRecorded(this.versionTag, lclRgn);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedCacheOperationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedCacheOperationTest.java
@@ -128,11 +128,7 @@ public class DistributedCacheOperationTest {
     message.process(dm);
 
     verify(message, never()).basicProcess(dm, region);
-    verify(message).sendReply(
-        eq(sender),
-        eq(processorId),
-        eq(null),
-        eq(dm));
+    verify(message).sendReply(sender, processorId, null, dm);
   }
 
   @Test
@@ -153,11 +149,7 @@ public class DistributedCacheOperationTest {
 
     assertThat(message.closed).isTrue();
     verify(message, never()).basicProcess(dm, region);
-    verify(message).sendReply(
-        eq(sender),
-        eq(processorId),
-        eq(null),
-        eq(dm));
+    verify(message).sendReply(sender, processorId, null, dm);
   }
 
   @Test
@@ -202,18 +194,14 @@ public class DistributedCacheOperationTest {
 
     message.process(dm);
 
-    verify(message, never()).sendReply(
-        eq(sender),
-        eq(processorId),
-        eq(null),
-        eq(dm));
+    verify(message, never()).sendReply(sender, processorId, null, dm);
   }
 
   static class TestOperation extends DistributedCacheOperation {
     boolean endOperationInvoked;
     DistributedRegion region;
 
-    TestOperation(CacheEvent event) {
+    TestOperation(CacheEvent<?, ?> event) {
       super(event);
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedCacheOperationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedCacheOperationTest.java
@@ -39,23 +39,22 @@ import org.apache.geode.cache.CacheEvent;
 import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.OperationExecutors;
 import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.DistributedCacheOperation.CacheOperationMessage;
 import org.apache.geode.internal.cache.persistence.PersistentMemberID;
 import org.apache.geode.internal.cache.versions.VersionTag;
-import org.apache.geode.test.fake.Fakes;
 
 public class DistributedCacheOperationTest {
   private TestCacheOperationMessage message;
   private InternalDistributedMember sender;
-  private ClusterDistributionManager dm;
   private LocalRegion region;
   private VersionTag<?> versionTag;
   private Scope scope;
   private OperationExecutors executors;
+
+  private final ClusterDistributionManager dm = mock(ClusterDistributionManager.class);
   private final int processorId = 1;
 
   @Before
@@ -64,9 +63,6 @@ public class DistributedCacheOperationTest {
     sender = mock(InternalDistributedMember.class);
     versionTag = mock(VersionTag.class);
 
-    GemFireCacheImpl cache = Fakes.cache();
-    InternalDistributedSystem system = cache.getSystem();
-    dm = (ClusterDistributionManager) system.getDistributionManager();
     region = mock(LocalRegion.class);
     executors = mock(OperationExecutors.class);
     scope = mock(Scope.class);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedCacheOperationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedCacheOperationTest.java
@@ -136,18 +136,12 @@ public class DistributedCacheOperationTest {
   }
 
   @Test
-  public void processSendsReplyIfLocalRegionIsNull() {
+  public void processInvokesBasicProcessIfLocalRegionIsNull() {
     doReturn(null).when(message).getLocalRegionForProcessing(dm);
 
     message.process(dm);
 
-    assertThat(message.closed).isTrue();
-    verify(message, never()).basicProcess(dm, region);
-    verify(message).sendReply(
-        eq(sender),
-        eq(processorId),
-        eq(null),
-        eq(dm));
+    verify(message).basicProcess(dm, null);
   }
 
   @Test

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
@@ -6250,9 +6250,8 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
 
       vm1.invoke("check afterCreate and tombstone count", () -> {
         checkCCRegionTombstoneCount("after create in other vm", 0);
-        assertThat(afterCreates).describedAs("expected " + numEntries + " afterCreates")
-            .isEqualTo(
-                numEntries);
+        await().untilAsserted(() -> assertThat(afterCreates)
+            .describedAs("expected " + numEntries + " afterCreates").isEqualTo(numEntries));
         assertThat(CCRegion.size()).isEqualTo(numEntries);
         try {
           await()


### PR DESCRIPTION
  * Do not process DistributedCacheOperation in-line if scope is DISTRIBUTED_NO_ACK.
  * This is to solve a potential deadlock. The p2p reader thread could be blocked
    on synchronized lock of an entry, and could not handle the DLock GRANT message
    which is needed by another thread holding the synchronized lock.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
