### PR TITLE
GEODE-8964: Entry created via TX putIfAbsent with null value can write incorrect data to cache

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -754,8 +754,13 @@ public class TXCommitMessage extends PooledDistributionMessage
           ee.getRegion().invokeTXCallbacks(EnumListenerEvent.AFTER_CREATE, ee, true,
               isLastTransactionEvent);
         } else {
-          ee.getRegion().invokeTXCallbacks(EnumListenerEvent.AFTER_UPDATE, ee, true,
-              isLastTransactionEvent);
+          if (ee.getNewValue() == null) { // GEODE-8964, fixes GII and TX create conflict that
+            ee.getRegion(). // produces an Update with null value
+                invokeTXCallbacks(EnumListenerEvent.AFTER_CREATE, ee, true, isLastTransactionEvent);
+          } else {
+            ee.getRegion().invokeTXCallbacks(EnumListenerEvent.AFTER_UPDATE, ee, true,
+                isLastTransactionEvent);
+          }
         }
       } finally {
         ee.release();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXCommitMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXCommitMessageTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
@@ -80,4 +81,26 @@ public class TXCommitMessageTest {
     verify(filterInfo2).setChangeAppliedToCache(true);
   }
 
+  @Test
+  public void firePendingCallbacksSendsAFTER_CREATECallbackIfUpdateEntryEventHasNullNewValue() {
+    TXCommitMessage message = spy(new TXCommitMessage());
+    LocalRegion region = mock(LocalRegion.class, RETURNS_DEEP_STUBS);
+    EntryEventImpl updateEvent = mock(EntryEventImpl.class, RETURNS_DEEP_STUBS);
+    EntryEventImpl lastTxEvent = mock(EntryEventImpl.class, RETURNS_DEEP_STUBS);
+
+    List<EntryEventImpl> callbacks = new ArrayList<>();
+    callbacks.add(updateEvent);
+    callbacks.add(lastTxEvent);
+
+    when(updateEvent.getLocalFilterInfo()).thenReturn(null);
+    when(updateEvent.getNewValue()).thenReturn(null);
+    when(updateEvent.getRegion()).thenReturn(region);
+
+    doReturn(lastTxEvent).when(message).getLastTransactionEvent(callbacks);
+
+    message.firePendingCallbacks(callbacks);
+
+    verify(region, only()).invokeTXCallbacks(EnumListenerEvent.AFTER_CREATE, updateEvent, true,
+        false);
+  }
 }


### PR DESCRIPTION
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
