### PR TITLE
GEODE-8979: CI Failure: SSLSocketHostNameVerificationIntegrationTest

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketHostNameVerificationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketHostNameVerificationIntegrationTest.java
@@ -55,6 +55,7 @@ import org.apache.geode.cache.ssl.CertificateMaterial;
 import org.apache.geode.distributed.internal.DMStats;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionConfigImpl;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.junit.categories.MembershipTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
@@ -83,7 +84,6 @@ public class SSLSocketHostNameVerificationIntegrationTest {
         new Boolean[] {Boolean.FALSE, Boolean.FALSE});
   }
 
-  private DistributionConfig distributionConfig;
   private SocketCreator socketCreator;
   private InetAddress localHost;
   private Thread serverThread;
@@ -105,7 +105,7 @@ public class SSLSocketHostNameVerificationIntegrationTest {
   public void setUp() throws Exception {
     IgnoredException.addIgnoredException("javax.net.ssl.SSLException: Read timed out");
 
-    this.localHost = InetAddress.getLoopbackAddress();
+    localHost = InetAddress.getLoopbackAddress();
 
     CertificateMaterial ca = new CertificateBuilder()
         .commonName("Test CA")
@@ -120,30 +120,30 @@ public class SSLSocketHostNameVerificationIntegrationTest {
         .issuedBy(ca);
 
     if (addCertificateSAN) {
-      certBuilder.sanDnsName(this.localHost.getHostName());
+      certBuilder.sanDnsName(localHost.getHostName());
     }
 
     CertificateMaterial locatorCert = certBuilder.generate();
     certStores.withCertificate("locator", locatorCert);
 
-    this.distributionConfig =
-        new DistributionConfigImpl(
-            certStores.propertiesWith("cluster", false, doEndPointIdentification));
+    DistributionConfig distributionConfig = new DistributionConfigImpl(
+        certStores.propertiesWith("cluster", false, doEndPointIdentification));
 
-    SocketCreatorFactory.setDistributionConfig(this.distributionConfig);
-    this.socketCreator = SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER);
+    SocketCreatorFactory.setDistributionConfig(distributionConfig);
+    socketCreator = SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER);
   }
 
   @After
   public void tearDown() throws Exception {
-    if (this.clientSocket != null) {
-      this.clientSocket.close();
+    if (serverThread != null && serverThread.isAlive()) {
+      serverThread.interrupt();
+      serverThread.join(GeodeAwaitility.getTimeout().toMillis());
     }
-    if (this.serverSocket != null) {
-      this.serverSocket.close();
+    if (clientSocket != null) {
+      clientSocket.close();
     }
-    if (this.serverThread != null && this.serverThread.isAlive()) {
-      this.serverThread.interrupt();
+    if (serverSocket != null) {
+      serverSocket.close();
     }
     SocketCreatorFactory.close();
   }
@@ -151,13 +151,13 @@ public class SSLSocketHostNameVerificationIntegrationTest {
   @Test
   public void nioHandshakeValidatesHostName() throws Exception {
     ServerSocketChannel serverChannel = ServerSocketChannel.open();
-    this.serverSocket = serverChannel.socket();
+    serverSocket = serverChannel.socket();
 
     InetSocketAddress addr = new InetSocketAddress(localHost, 0);
     serverSocket.bind(addr, 10);
-    int serverPort = this.serverSocket.getLocalPort();
+    int serverPort = serverSocket.getLocalPort();
 
-    this.serverThread = startServerNIO(serverSocket, 15000);
+    serverThread = startServerNIO(serverSocket, 15000);
 
     await().until(() -> serverThread.isAlive());
 
@@ -165,13 +165,13 @@ public class SSLSocketHostNameVerificationIntegrationTest {
     await().until(
         () -> clientChannel.connect(new InetSocketAddress(localHost, serverPort)));
 
-    this.clientSocket = clientChannel.socket();
+    clientSocket = clientChannel.socket();
 
     SSLEngine sslEngine =
-        this.socketCreator.createSSLEngine(this.localHost.getHostName(), 1234, true);
+        socketCreator.createSSLEngine(localHost.getHostName(), 1234, true);
 
     try {
-      this.socketCreator.handshakeSSLSocketChannel(clientSocket.getChannel(),
+      socketCreator.handshakeSSLSocketChannel(clientSocket.getChannel(),
           sslEngine, 0, true,
           ByteBuffer.allocate(sslEngine.getSession().getPacketBufferSize()),
           new BufferPool(mock(DMStats.class)));
@@ -184,23 +184,23 @@ public class SSLSocketHostNameVerificationIntegrationTest {
     } catch (SSLHandshakeException sslException) {
       if (doEndPointIdentification && !addCertificateSAN) {
         assertThat(sslException).hasRootCauseInstanceOf(CertificateException.class)
-            .hasStackTraceContaining("No name matching " + this.localHost.getHostName() + " found");
+            .hasStackTraceContaining("No name matching " + localHost.getHostName() + " found");
       } else {
         assertThat(sslException).doesNotHaveSameClassAs(new CertificateException(
-            "No name matching " + this.localHost.getHostName() + " found"));
+            "No name matching " + localHost.getHostName() + " found"));
         throw sslException;
       }
     }
   }
 
   private Thread startServerNIO(final ServerSocket serverSocket, int timeoutMillis) {
-    Thread serverThread = new Thread(new MyThreadGroup(this.testName.getMethodName()), () -> {
+    Thread serverThread = new Thread(new MyThreadGroup(testName.getMethodName()), () -> {
       NioSslEngine engine = null;
       Socket socket = null;
       try {
         socket = serverSocket.accept();
         SocketCreator sc = SocketCreatorFactory.getSocketCreatorForComponent(CLUSTER);
-        final SSLEngine sslEngine = sc.createSSLEngine(this.localHost.getHostName(), 1234, false);
+        final SSLEngine sslEngine = sc.createSSLEngine(localHost.getHostName(), 1234, false);
         engine =
             sc.handshakeSSLSocketChannel(socket.getChannel(),
                 sslEngine,
@@ -211,18 +211,17 @@ public class SSLSocketHostNameVerificationIntegrationTest {
       } catch (Throwable throwable) {
         serverException = throwable;
       } finally {
-        if (engine != null && socket != null) {
+        if (engine != null) {
           final NioSslEngine nioSslEngine = engine;
           engine.close(socket.getChannel());
           assertThatThrownBy(() -> {
             try (final ByteBufferSharing unused =
                 nioSslEngine.unwrap(ByteBuffer.wrap(new byte[0]))) {
             }
-          })
-              .isInstanceOf(IOException.class);
+          }).isInstanceOf(IOException.class);
         }
       }
-    }, this.testName.getMethodName() + "-server");
+    }, testName.getMethodName() + "-server");
 
     serverThread.start();
     return serverThread;


### PR DESCRIPTION
This test was closing a client socket before ensuring that a thread it
had created was finished.  If the socket is closed quickly enough it
could cause that thread to get an IOException and cause the test to
fail.

The fix is to ensure that the thread is finished before closing the
client socket in the tearDown method.  There are many other edits
to remove the use of "this.".

@kamilla1201 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
