### PR TITLE
GEODE-8996: Fixed rebalance gfsh and REST API in mixed version mode

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -297,8 +297,8 @@ dependencies {
 
   upgradeTestCompileOnly(platform(project(':boms:geode-all-bom')))
   upgradeTestCompileOnly('io.swagger:swagger-annotations')
-
   upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
+  distributedTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
   upgradeTestRuntimeOnly(project(':extensions:session-testing-war'))
   upgradeTestRuntimeOnly('org.codehaus.cargo:cargo-core-uberjar')
   upgradeTestRuntimeOnly('org.apache.httpcomponents:httpclient')

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -299,6 +299,7 @@ dependencies {
   upgradeTestCompileOnly('io.swagger:swagger-annotations')
   upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
   distributedTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
+  testImplementation('org.assertj:assertj-core')
   upgradeTestRuntimeOnly(project(':extensions:session-testing-war'))
   upgradeTestRuntimeOnly('org.codehaus.cargo:cargo-core-uberjar')
   upgradeTestRuntimeOnly('org.apache.httpcomponents:httpclient')

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPICompatibilityTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPICompatibilityTest.java
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.geode.rest.internal.web.controllers;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.management.configuration.DiskStore;
+import org.apache.geode.management.operation.RebalanceOperation;
+import org.apache.geode.management.operation.RestoreRedundancyRequest;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.BackwardCompatibilityTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.MemberStarterRule;
+import org.apache.geode.test.version.TestVersion;
+import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.util.internal.GeodeJsonMapper;
+
+@Category({BackwardCompatibilityTest.class})
+@RunWith(Parameterized.class)
+public class RestAPICompatibilityTest {
+  private final String oldVersion;
+  private static ObjectMapper mapper = GeodeJsonMapper.getMapper();
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<String> data() {
+    List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
+    result.removeIf(s -> TestVersion.compare(s, "1.11.0") < 0);
+    return result;
+  }
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  public RestAPICompatibilityTest(String oldVersion) throws JsonProcessingException {
+    this.oldVersion = oldVersion;
+    DiskStore diskStore = new DiskStore();
+    diskStore.setName("diskStore");
+    postRESTAPICalls = new HashMap<>();
+    // {REST endpoint,{Body, Successful Status Message, Introduced in version}}
+    postRESTAPICalls.put("/management/v1/operations/rebalances",
+        new String[] {mapper.writeValueAsString(new RebalanceOperation()), "Operation started",
+            "1.11.0"});
+    postRESTAPICalls.put("/management/v1/operations/restoreRedundancy",
+        new String[] {mapper.writeValueAsString(new RestoreRedundancyRequest()),
+            "Operation started", "1.13.1"});
+  }
+
+  private static Map<String, String[]> postRESTAPICalls;
+
+
+  private static final String[][] getRESTAPICalls = {
+      // REST endpoint , status
+      {"/geode-mgmt/v1/management/commands?cmd=rebalance", "OK"}
+  };
+
+  @Test
+  public void restCommandExecutedOnLatestLocatorShouldBeBackwardsCompatible() throws Exception {
+    // Initialize all cluster members with old versions
+    MemberVM locator1 =
+        cluster.startLocatorVM(0, 0, oldVersion, MemberStarterRule::withHttpService);
+    int locatorPort1 = locator1.getPort();
+    MemberVM locator2 =
+        cluster.startLocatorVM(1, 0, oldVersion,
+            x -> x.withConnectionToLocator(locatorPort1).withHttpService());
+    int locatorPort2 = locator2.getPort();
+    cluster
+        .startServerVM(2, oldVersion, s -> s.withRegion(RegionShortcut.PARTITION, "region")
+            .withConnectionToLocator(locatorPort1, locatorPort2));
+    cluster
+        .startServerVM(3, oldVersion, s -> s.withRegion(RegionShortcut.PARTITION, "region")
+            .withConnectionToLocator(locatorPort1, locatorPort2));
+
+    // Roll locators to the current version
+    cluster.stop(0);
+    // gradle sets a property telling us where the build is located
+    final String buildDir = System.getProperty("geode.build.dir", System.getProperty("user.dir"));
+    locator1 = cluster.startLocatorVM(0, l -> l.withHttpService().withPort(locatorPort1)
+        .withConnectionToLocator(locatorPort2)
+        .withSystemProperty("geode.build.dir", buildDir));
+    cluster.stop(1);
+
+    cluster.startLocatorVM(1,
+        x -> x.withConnectionToLocator(locatorPort1).withHttpService().withPort(locatorPort2)
+            .withConnectionToLocator(locatorPort1)
+            .withSystemProperty("geode.build.dir", buildDir));
+
+    gfsh.connectAndVerify(locator1);
+    gfsh.execute("list members");
+    // Execute REST api calls to from the new locators to the old servers to ensure that backwards
+    // compatibility is maintained
+
+    executeAndValidatePOSTRESTCalls(locator1.getHttpPort());
+    executeAndValidateGETRESTCalls(locator1.getHttpPort());
+
+  }
+
+  void executeAndValidatePOSTRESTCalls(int locator) throws Exception {
+
+    CloseableHttpClient httpClient = HttpClients.createDefault();
+    for (Map.Entry<String, String[]> entry : postRESTAPICalls.entrySet()) {
+      // Skip the test is the version is before the REST api was introduced.
+      if (TestVersion.compare(oldVersion, entry.getValue()[2]) < 0) {
+        continue;
+      }
+      HttpPost post =
+          new HttpPost("http://localhost:" + locator + entry.getKey());
+      post.addHeader("Content-Type", "application/json");
+      post.addHeader("Accept", "application/json");
+      StringEntity jsonStringEntity =
+          new StringEntity(entry.getValue()[0], ContentType.DEFAULT_TEXT);
+      post.setEntity(jsonStringEntity);
+      CloseableHttpResponse response = httpClient.execute(post);
+
+      HttpEntity entity = response.getEntity();
+      InputStream content = entity.getContent();
+
+      BufferedReader reader = new BufferedReader(new InputStreamReader(content));
+      String line;
+      StringBuilder sb = new StringBuilder();
+      while ((line = reader.readLine()) != null) {
+        sb.append(line);
+      }
+      JsonNode jsonObject = mapper.readTree(sb.toString());
+      String statusCode = jsonObject.findValue("statusCode").textValue();
+      assertTrue(statusCode.equals("ACCEPTED") || statusCode.contains("OK"));
+      String statusMessage = jsonObject.findValue("statusMessage").textValue();
+      assertTrue(statusMessage.contains(entry.getValue()[1]));
+    }
+  }
+
+  public static void executeAndValidateGETRESTCalls(int locator) throws Exception {
+
+    CloseableHttpClient httpclient = HttpClients.createDefault();
+    for (String[] commandExpectedResponsePair : getRESTAPICalls) {
+      HttpGet get =
+          new HttpGet("http://localhost:" + locator +
+              commandExpectedResponsePair[0]);
+      CloseableHttpResponse response = httpclient.execute(get);
+      HttpEntity entity = response.getEntity();
+      InputStream content = entity.getContent();
+      BufferedReader reader = new BufferedReader(new InputStreamReader(content));
+      String line;
+      StringBuilder sb = new StringBuilder();
+      while ((line = reader.readLine()) != null) {
+        sb.append(line);
+      }
+      System.out.println("Result : " + sb.toString());
+      JsonNode jsonObject = mapper.readTree(sb.toString());
+      String statusCode = jsonObject.findValue("status").textValue();
+      assertTrue(statusCode.contains(commandExpectedResponsePair[1]));
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CacheRealizationFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CacheRealizationFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geode.management.internal.cli.functions;
+
+public class CacheRealizationFunction extends
+    org.apache.geode.management.internal.functions.CacheRealizationFunction {
+  private static final long serialVersionUID = 6209080805559452304L;
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RebalanceFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RebalanceFunction.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.management.internal.cli.functions;
+
+public class RebalanceFunction extends
+    org.apache.geode.management.internal.functions.RebalanceFunction {
+  private static final long serialVersionUID = 1L;
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/functions/CacheRealizationFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/functions/CacheRealizationFunction.java
@@ -68,6 +68,7 @@ public class CacheRealizationFunction implements InternalFunction<List> {
   private static final Logger logger = LogService.getLogger();
   @Immutable
   private static final Map<Class, ConfigurationRealizer> realizers = new HashMap<>();
+  private static final long serialVersionUID = -2695517414081975343L;
 
   static {
     realizers.put(Region.class, new RegionConfigRealizer());

--- a/geode-core/src/main/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformer.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformer.java
@@ -451,7 +451,6 @@ public class RebalanceOperationPerformer
   @NotNull
   private Function getRebalanceFunction(InternalDistributedMember dsMember) {
     Function rebalanceFunction;
-    System.out.println("NABA " + dsMember.getVersion().toString());
     if (dsMember.getVersion()
         .isOlderThan(KnownVersion.GEODE_1_12_0)) {
       rebalanceFunction =

--- a/geode-core/src/main/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformer.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformer.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.jetbrains.annotations.NotNull;
 
 import org.apache.geode.annotations.Experimental;
 import org.apache.geode.annotations.VisibleForTesting;
@@ -37,7 +38,9 @@ import org.apache.geode.cache.control.RebalanceResults;
 import org.apache.geode.cache.control.ResourceManager;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
@@ -123,11 +126,11 @@ public class RebalanceOperationPerformer
       functionArgs[1] = setRegionName;
 
       functionArgs[2] = null;
-
+      Function function = getRebalanceFunction((InternalDistributedMember) member);
       List<String> resultList = null;
       try {
         resultList = (List<String>) ManagementUtils
-            .executeFunction(new RebalanceFunction(), functionArgs, Collections.singleton(member))
+            .executeFunction(function, functionArgs, Collections.singleton(member))
             .getResult();
       } catch (Exception ignored) {
 
@@ -136,7 +139,6 @@ public class RebalanceOperationPerformer
       RebalanceRegionResult result = new RebalanceRegionResultImpl();
       if (resultList != null && !resultList.isEmpty()) {
         List<String> rstList = Arrays.asList(resultList.get(0).split(","));
-
         result = toRebalanceRegionResult(rstList);
       }
 
@@ -375,7 +377,8 @@ public class RebalanceOperationPerformer
         if (memberPR.dsMemberList.size() > 1) {
           for (int i = 0; i < memberPR.dsMemberList.size(); i++) {
             DistributedMember dsMember = memberPR.dsMemberList.get(i);
-            RebalanceFunction rebalanceFunction = new RebalanceFunction();
+            Function rebalanceFunction = getRebalanceFunction(
+                (InternalDistributedMember) dsMember);
             Object[] functionArgs = new Object[3];
             functionArgs[0] = simulate;
             Set<String> regionSet = new HashSet<>();
@@ -445,6 +448,20 @@ public class RebalanceOperationPerformer
     return rebalanceResult;
   }
 
+  @NotNull
+  private Function getRebalanceFunction(InternalDistributedMember dsMember) {
+    Function rebalanceFunction;
+    System.out.println("NABA " + dsMember.getVersion().toString());
+    if (dsMember.getVersion()
+        .isOlderThan(KnownVersion.GEODE_1_12_0)) {
+      rebalanceFunction =
+          new org.apache.geode.management.internal.cli.functions.RebalanceFunction();
+    } else {
+      rebalanceFunction = new RebalanceFunction();
+    }
+    return rebalanceFunction;
+  }
+
   private static RebalanceRegionResult toRebalanceRegionResult(List<String> rstList) {
     RebalanceRegionResultImpl result = new RebalanceRegionResultImpl();
     result.setBucketCreateBytes(Long.parseLong(rstList.get(0)));
@@ -456,8 +473,14 @@ public class RebalanceOperationPerformer
     result.setPrimaryTransferTimeInMilliseconds(Long.parseLong(rstList.get(6)));
     result.setPrimaryTransfersCompleted(Integer.parseInt(rstList.get(7)));
     result.setTimeInMilliseconds(Long.parseLong(rstList.get(8)));
-    result.setNumOfMembers(Integer.parseInt(rstList.get(9)));
-    result.setRegionName(rstList.get(10).replace(SEPARATOR, ""));
+    if (rstList.size() < 11) {
+      result.setNumOfMembers(-1);
+      result.setRegionName(rstList.get(9).replace(SEPARATOR, ""));
+    } else {
+      result.setNumOfMembers(Integer.parseInt(rstList.get(9)));
+      result.setRegionName(rstList.get(10).replace(SEPARATOR, ""));
+    }
+
 
     return result;
   }

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -443,6 +443,8 @@ org/apache/geode/management/internal/beans/FileUploader$RemoteFile,false,filenam
 org/apache/geode/management/internal/beans/QueryDataFunction,true,1
 org/apache/geode/management/internal/beans/QueryDataFunction$LocalQueryFunction,true,1,id:java/lang/String,optimizeForWrite:boolean,regionName:java/lang/String,showMembers:boolean,this$0:org/apache/geode/management/internal/beans/QueryDataFunction
 org/apache/geode/management/internal/beans/stats/StatType,false
+org/apache/geode/management/internal/cli/functions/CacheRealizationFunction,true,6209080805559452304
+org/apache/geode/management/internal/cli/functions/RebalanceFunction,true,1
 org/apache/geode/management/internal/configuration/domain/SharedConfigurationStatus,false
 org/apache/geode/management/internal/configuration/functions/DownloadJarFunction,true,1
 org/apache/geode/management/internal/configuration/functions/GetClusterConfigurationFunction,false
@@ -453,7 +455,7 @@ org/apache/geode/management/internal/configuration/messages/ClusterManagementSer
 org/apache/geode/management/internal/exceptions/EntityExistsException,false
 org/apache/geode/management/internal/exceptions/EntityNotFoundException,false,statusOK:boolean
 org/apache/geode/management/internal/exceptions/NoMembersException,false
-org/apache/geode/management/internal/functions/CacheRealizationFunction,false
+org/apache/geode/management/internal/functions/CacheRealizationFunction,true,-2695517414081975343
 org/apache/geode/management/internal/functions/CliFunctionResult$StatusState,false
 org/apache/geode/management/internal/functions/GetMemberInformationFunction,true,1404642539058875565
 org/apache/geode/management/internal/functions/RebalanceFunction,true,1

--- a/geode-core/src/test/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformerTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheForClientAccess;
+import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.DistributedSystemMXBean;
 import org.apache.geode.management.ManagementService;
@@ -137,7 +138,8 @@ public class RebalanceOperationPerformerTest {
     List<Object> resultList = new ArrayList<>();
     resultList.add("0,1,2,3,4,5,6,7,8,9," + SEPARATOR + "region1");
     when(functionExecutor.execute(any(), any(), any())).thenReturn(resultList);
-
+    when(distributedMember1.getVersion()).thenReturn(KnownVersion.getCurrentVersion());
+    when(distributedMember2.getVersion()).thenReturn(KnownVersion.getCurrentVersion());
     RebalanceResult result =
         performer.executeRebalanceOnDS(managementService, cache, "true",
             Collections.emptyList(), functionExecutor);

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
@@ -107,7 +107,8 @@ public class RebalanceCommand extends GfshCommand {
     rsltList.add(6, String.valueOf(results.getPrimaryTransferTimeInMilliseconds()));
     rsltList.add(7, String.valueOf(results.getPrimaryTransfersCompleted()));
     rsltList.add(8, String.valueOf(results.getTimeInMilliseconds()));
-    rsltList.add(9, String.valueOf(results.getNumOfMembers()));
+    rsltList.add(9, results.getNumOfMembers() == -1 ? "Not Available"
+        : String.valueOf(results.getNumOfMembers()));
     String regionName = results.getRegionName();
     if (!regionName.startsWith(SEPARATOR)) {
       regionName = SEPARATOR + regionName;


### PR DESCRIPTION
   * Moved new child RebalanceFunction and CacheRealizationFunction to pre 1.12.0 locations.
   * While talking to pre-1.12.0 servers, the locators send the function from the old package.
   * While talking to 1.12.0 server, the new package function is used.
   * For RebalanceFunction and CacheRealizationFunction the serialVersionUID is set to the one create by 1.11.0 for old package location and serialVersionUID created by 1.12.0 for the later.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
