### PR TITLE
GEODE-8965  Support Redis-style OOM error message

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -47,6 +47,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.control.InternalResourceManager.ResourceType;
 import org.apache.geode.internal.cache.control.MemoryThresholds.MemoryState;
 import org.apache.geode.internal.cache.control.ResourceAdvisor.ResourceManagerProfile;
+import org.apache.geode.internal.cache.execute.AllowExecutionInLowMemory;
 import org.apache.geode.internal.statistics.GemFireStatSampler;
 import org.apache.geode.internal.statistics.LocalStatListener;
 import org.apache.geode.internal.statistics.StatisticsManager;
@@ -711,7 +712,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
 
   public LowMemoryException createLowMemoryIfNeeded(Function function,
       Set<? extends DistributedMember> memberSet) {
-    if (function.optimizeForWrite()
+    if (function.optimizeForWrite() && !(function instanceof AllowExecutionInLowMemory)
         && !MemoryThresholds.isLowMemoryExceptionDisabled()) {
       Set<DistributedMember> criticalMembersFrom = getHeapCriticalMembersFrom(memberSet);
       if (!criticalMembersFrom.isEmpty()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/AllowExecutionInLowMemory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/AllowExecutionInLowMemory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.execute;
+
+
+/**
+ * An internal marker interface used to allow functions to run in low-memory conditions.
+ */
+public interface AllowExecutionInLowMemory extends InternalFunction<Object[]> {
+
+}

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -120,7 +120,7 @@ public class OutOfMemoryDUnitTest {
 
     fillMemory(jedis1, MAX_ITERATION_COUNT, false);
 
-    assertThatThrownBy(() -> jedis2.set("oneMoreKey", "value")).hasMessageContaining("OOM");
+    assertThatThrownBy(() -> jedis2.set("oneMoreKey", valueString)).hasMessageContaining("OOM");
   }
 
   @Test

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis;
+
+import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.Properties;
+
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisException;
+
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+@SuppressWarnings("unchecked")
+public class OutOfMemoryDUnitTest {
+
+  @ClassRule
+  public static RedisClusterStartupRule clusterStartUp = new RedisClusterStartupRule(4);
+
+  @Rule
+  public ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  private static final String expectedEx = "Member: .*? above .*? critical threshold";
+  public static final String FILLER_KEY = "fillerKey-";
+  private static final String LOCAL_HOST = "127.0.0.1";
+  public static final int KEY_TTL_SECONDS = 10;
+  private static final int MAX_ITERATION_COUNT = 4000;
+  public static final int VALUE_SIZE = 128 * 1024;
+  private static final int JEDIS_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+  private static Jedis jedis1;
+  private static Jedis jedis2;
+
+  private static Properties locatorProperties;
+  private static Properties serverProperties;
+
+  private static MemberVM locator;
+  private static MemberVM server1;
+  private static MemberVM server2;
+
+  private static int redisServerPort1;
+  private static int redisServerPort2;
+  private static String valueString = "";
+
+  @BeforeClass
+  public static void classSetup() {
+    IgnoredException.addIgnoredException(expectedEx);
+    locatorProperties = new Properties();
+    serverProperties = new Properties();
+    locatorProperties.setProperty(MAX_WAIT_TIME_RECONNECT, "15000");
+
+    locator = clusterStartUp.startLocatorVM(0, locatorProperties);
+    server1 = clusterStartUp.startRedisVM(1, serverProperties, locator.getPort());
+    server2 = clusterStartUp.startRedisVM(2, serverProperties, locator.getPort());
+
+    server1.getVM().invoke(() -> {
+      RedisClusterStartupRule.getCache().getResourceManager().setCriticalHeapPercentage(5.0F);
+    });
+    server2.getVM().invoke(() -> {
+      RedisClusterStartupRule.getCache().getResourceManager().setCriticalHeapPercentage(5.0F);
+    });
+
+    redisServerPort1 = clusterStartUp.getRedisPort(1);
+    redisServerPort2 = clusterStartUp.getRedisPort(2);
+
+    jedis1 = new Jedis(LOCAL_HOST, redisServerPort1, JEDIS_TIMEOUT);
+    jedis2 = new Jedis(LOCAL_HOST, redisServerPort2, JEDIS_TIMEOUT);
+
+    char[] largeCharData = new char[VALUE_SIZE];
+    Arrays.fill(largeCharData, 'a');
+    valueString = new String(largeCharData);
+
+  }
+
+  @Before
+  public void testSetup() {
+    jedis1.flushAll();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    jedis1.disconnect();
+    jedis2.disconnect();
+
+    server1.stop();
+    server2.stop();
+  }
+
+  @Test
+  public void shouldReturnOOMError_forWriteOperations_whenThresholdReached() {
+    IgnoredException.addIgnoredException(expectedEx);
+    IgnoredException.addIgnoredException("LowMemoryException");
+
+    fillMemory(jedis1, MAX_ITERATION_COUNT, false);
+
+    assertThatThrownBy(() -> jedis2.set("oneMoreKey", "value")).hasMessageContaining("OOM");
+  }
+
+  @Test
+  public void shouldAllowDeleteOperations_afterThresholdReached() {
+    IgnoredException.addIgnoredException(expectedEx);
+    IgnoredException.addIgnoredException("LowMemoryException");
+
+    fillMemory(jedis1, MAX_ITERATION_COUNT, false);
+
+    assertThatNoException().isThrownBy(() -> jedis2.del(FILLER_KEY + 1));
+  }
+
+  @Test
+  public void shouldAllowExpiration_afterThresholdReached() {
+    IgnoredException.addIgnoredException(expectedEx);
+    IgnoredException.addIgnoredException("LowMemoryException");
+
+    fillMemory(jedis1, MAX_ITERATION_COUNT, true);
+
+    GeodeAwaitility.await().until(() -> jedis2.ttl(FILLER_KEY + 1) == -2);
+  }
+
+  // TODO: test that write operations become allowed after memory has dropped
+  // below critical levels. Difficult to do right now because of vagaries of the
+  // Java garbage collector.
+
+  private int fillMemory(Jedis jedis, int maxIterations, boolean withExpiration) {
+    int i = 0;
+    while (i < maxIterations) {
+      try {
+        if (withExpiration) {
+          jedis.setex(FILLER_KEY + i, KEY_TTL_SECONDS, valueString);
+        } else {
+          jedis.set(FILLER_KEY + i, valueString);
+        }
+      } catch (JedisException je) {
+        assertThat(je).hasMessageContaining("OOM command not allowed");
+        break;
+      }
+      i++;
+    }
+    assertThat(i).isLessThan(maxIterations);
+    return i;
+  }
+
+  // TODO: use this when write testing figured out
+  private void deleteKeysToClearMemory(Jedis jedis, int keysToDelete) {
+    for (int i = 0; i < keysToDelete; i++) {
+      assertThat(jedis.del(FILLER_KEY + i)).isEqualTo(1);
+    }
+  }
+}

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -125,21 +125,33 @@ public class OutOfMemoryDUnitTest {
     IgnoredException.addIgnoredException(expectedEx);
     IgnoredException.addIgnoredException("LowMemoryException");
 
+    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
+    memoryPressureThread.start();
+
     fillMemory(jedis2, false);
 
     assertThatNoException().isThrownBy(() -> jedis2.del(FILLER_KEY + 1));
+
+    memoryPressureThread.interrupt();
+    memoryPressureThread.join();
   }
 
   @Test
-  public void shouldAllowExpiration_afterThresholdReached() {
+  public void shouldAllowExpiration_afterThresholdReached() throws InterruptedException {
     IgnoredException.addIgnoredException(expectedEx);
     IgnoredException.addIgnoredException("LowMemoryException");
+
+    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
+    memoryPressureThread.start();
 
     fillMemory(jedis2, true);
 
     await().untilAsserted(() -> {
       assertThat(jedis2.ttl(FILLER_KEY + 1)).isEqualTo(-2);
     });
+
+    memoryPressureThread.interrupt();
+    memoryPressureThread.join();
   }
 
   // TODO: test that write operations become allowed after memory has dropped

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -49,6 +49,8 @@ public class RedisConstants {
   public static final String ERROR_SYNTAX = "syntax error";
   public static final String ERROR_INVALID_EXPIRE_TIME = "invalid expire time in set";
   public static final String ERROR_NOT_A_VALID_FLOAT = "value is not a valid float";
+  public static final String ERROR_OOM_COMMAND_NOT_ALLOWED =
+      "command not allowed when used memory > 'maxmemory'";
 
   public static final String ERROR_UNKNOWN_SLOWLOG_SUBCOMMAND =
       "Unknown subcommand or wrong number of arguments for '%s'. Try SLOWLOG HELP.";

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
@@ -121,6 +121,10 @@ public class RedisResponse {
     return new RedisResponse((bba) -> Coder.getErrorResponse(bba, error));
   }
 
+  public static RedisResponse oom(String error) {
+    return new RedisResponse((bba) -> Coder.getOOMResponse(bba, error));
+  }
+
   public static RedisResponse customError(String error) {
     return new RedisResponse((bba) -> Coder.getCustomErrorResponse(bba, error));
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/SingleResultRedisFunction.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/executor/SingleResultRedisFunction.java
@@ -18,12 +18,12 @@ package org.apache.geode.redis.internal.executor;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.internal.cache.PartitionedRegion;
-import org.apache.geode.internal.cache.execute.InternalFunction;
+import org.apache.geode.internal.cache.execute.AllowExecutionInLowMemory;
 import org.apache.geode.internal.cache.execute.RegionFunctionContextImpl;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisData;
 
-public abstract class SingleResultRedisFunction implements InternalFunction<Object[]> {
+public abstract class SingleResultRedisFunction implements AllowExecutionInLowMemory {
 
   private final transient PartitionedRegion partitionedRegion;
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -88,6 +88,9 @@ public class Coder {
   @MakeImmutable
   public static final byte[] err = stringToBytes("ERR ");
   @MakeImmutable
+  public static final byte[] oom = stringToBytes("OOM ");
+
+  @MakeImmutable
   public static final byte[] wrongType = stringToBytes("WRONGTYPE ");
 
   /**
@@ -273,6 +276,16 @@ public class Coder {
     ByteBuf response = alloc.buffer(errorAr.length + 25);
     response.writeByte(ERROR_ID);
     response.writeBytes(err);
+    response.writeBytes(errorAr);
+    response.writeBytes(CRLFar);
+    return response;
+  }
+
+  public static ByteBuf getOOMResponse(ByteBufAllocator alloc, String error) {
+    byte[] errorAr = stringToBytes(error);
+    ByteBuf response = alloc.buffer(errorAr.length + 25);
+    response.writeByte(ERROR_ID);
+    response.writeBytes(oom);
     response.writeBytes(errorAr);
     response.writeBytes(CRLFar);
     return response;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -39,6 +39,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.ForcedDisconnectException;
 import org.apache.geode.cache.CacheClosedException;
+import org.apache.geode.cache.LowMemoryException;
 import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.distributed.DistributedSystemDisconnectedException;
@@ -232,6 +233,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       response = RedisResponse.error(cause.getMessage());
     } else if (cause instanceof RedisDataTypeMismatchException) {
       response = RedisResponse.wrongType(cause.getMessage());
+    } else if (cause instanceof LowMemoryException) {
+      response = RedisResponse.oom(RedisConstants.ERROR_OOM_COMMAND_NOT_ALLOWED);
     } else if (cause instanceof DecoderException
         && cause.getCause() instanceof RedisCommandParserException) {
       response = RedisResponse.error(RedisConstants.PARSING_EXCEPTION_MESSAGE);


### PR DESCRIPTION
This allows behavior simulating the Redis "noevict" out-of-memory policy. Operations that exceed the Geode configuration value of "critical-heap-percentage" will return a Redis-style "OOM" error message, which clients can respond to.

Because we want to allow things like deleting and expiring Redis keys, this add an "AllowExecutionInLowMemory" interface that allows functions to attempt to execute even in low memory conditions. This way, operations that free memory will be allowed, but operations that attempt to allocate new memory will still fail with LowMemoryException.