### PR TITLE
GEODE-8998: fix NPE caused by thread-monitor-enabled=false (#6083)

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/ThreadMonitorDisabledDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/ThreadMonitorDisabledDistributedTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.cache;
+
+import static java.util.Arrays.asList;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.ConfigurationProperties.THREAD_MONITOR_ENABLED;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.rules.DistributedRule.getLocators;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedReference;
+
+@SuppressWarnings("serial")
+public class ThreadMonitorDisabledDistributedTest implements Serializable {
+  public static final String REGION_NAME = "testRegion";
+
+  @Rule
+  public DistributedReference<Cache> cache = new DistributedReference<>();
+
+  @Before
+  public void setUp() {
+    Properties configProperties = new Properties();
+    configProperties.setProperty(LOCATORS, getLocators());
+    configProperties.setProperty(THREAD_MONITOR_ENABLED, "false");
+
+    for (VM vm : asList(getVM(0), getVM(1))) {
+      vm.invoke(() -> {
+        cache.set(new CacheFactory(configProperties).create());
+        RegionFactory<Object, Object> factory =
+            cache.get().createRegionFactory(RegionShortcut.REPLICATE);
+        factory.create(REGION_NAME);
+      });
+    }
+  }
+
+  /**
+   * With thread-monitor-enabled==false the p2p reader died with
+   * a NullPointerException. This test verifies that p2p messaging
+   * works with thread monitoring disabled.
+   */
+  @Test
+  public void regionPutWorksWithThreadMonitorDisabled() {
+    for (VM vm : asList(getVM(0))) {
+      vm.invoke(() -> {
+        Region<Object, Object> region = cache.get().getRegion(REGION_NAME);
+        region.put("key", "value");
+      });
+    }
+    for (VM vm : asList(getVM(0), getVM(1))) {
+      vm.invoke(() -> {
+        Region<Object, Object> region = cache.get().getRegion(REGION_NAME);
+        assertThat(region.get("key")).isEqualTo("value");
+      });
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoringImplDummy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoringImplDummy.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.monitoring;
 
 import java.util.concurrent.ConcurrentMap;
 
+import org.apache.geode.annotations.Immutable;
 import org.apache.geode.internal.monitoring.executor.AbstractExecutor;
 
 public class ThreadsMonitoringImplDummy implements ThreadsMonitoring {
@@ -32,9 +33,18 @@ public class ThreadsMonitoringImplDummy implements ThreadsMonitoring {
   @Override
   public void endMonitor() {}
 
+  private static class DummyExecutor extends AbstractExecutor {
+    @Immutable
+    private static final DummyExecutor SINGLETON = new DummyExecutor();
+
+    private DummyExecutor() {
+      super("DummyExecutor", 0L);
+    }
+  }
+
   @Override
   public AbstractExecutor createAbstractExecutor(Mode mode) {
-    return null;
+    return DummyExecutor.SINGLETON;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/AbstractExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/AbstractExecutor.java
@@ -21,7 +21,6 @@ import java.text.SimpleDateFormat;
 
 import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 public abstract class AbstractExecutor {
@@ -38,8 +37,7 @@ public abstract class AbstractExecutor {
     this(groupName, Thread.currentThread().getId());
   }
 
-  @VisibleForTesting
-  AbstractExecutor(String groupName, long threadID) {
+  protected AbstractExecutor(String groupName, long threadID) {
     this.groupName = groupName;
     this.startTime = 0;
     this.numIterationsStuck = 0;


### PR DESCRIPTION
If thread monitoring is enable, the Connection class will not get a DummyExecutor
instead of null thus preventing the NPE.

(cherry picked from commit c650095d74ca0b88a33a1089a0e0caa331b42ea0)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
