### PR TITLE
GEODE-6143: Use Mockito.when instead of PowerMockito.when

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockGrantor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockGrantor.java
@@ -579,7 +579,7 @@ public class DLockGrantor {
   }
 
   @VisibleForTesting
-  Map getMembersDepartedTimeRecords() {
+  Map<InternalDistributedMember, Long> getMembersDepartedTimeRecords() {
     return membersDepartedTime;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
@@ -33,13 +33,12 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 
 public class DLockGrantorTest {
   private DLockService dLockService;
-  private DistributionManager distributionManager;
   private DLockGrantor grantor;
 
   @Before
   public void setup() {
     dLockService = mock(DLockService.class, RETURNS_DEEP_STUBS);
-    distributionManager = mock(DistributionManager.class);
+    DistributionManager distributionManager = mock(DistributionManager.class);
     when(dLockService.getDistributionManager()).thenReturn(distributionManager);
     CancelCriterion cancelCriterion = mock(CancelCriterion.class);
     when(distributionManager.getCancelCriterion()).thenReturn(cancelCriterion);

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
@@ -21,7 +21,7 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/geode-core/src/test/java/org/apache/geode/management/internal/LocalManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/LocalManagerTest.java
@@ -50,7 +50,6 @@ public class LocalManagerTest {
   private InternalRegionFactory regionFactory2;
   private StatisticsFactory statisticsFactory;
   private StatisticsClock statisticsClock;
-  private InternalCacheForClientAccess cacheForClientAccess;
 
   @Before
   public void setUp() throws Exception {
@@ -62,7 +61,7 @@ public class LocalManagerTest {
     regionFactory2 = mock(InternalRegionFactory.class);
     statisticsFactory = mock(StatisticsFactory.class);
     statisticsClock = mock(StatisticsClock.class);
-    cacheForClientAccess = mock(InternalCacheForClientAccess.class);
+    InternalCacheForClientAccess cacheForClientAccess = mock(InternalCacheForClientAccess.class);
     DistributedSystemMXBean distributedSystemMXBean = mock(DistributedSystemMXBean.class);
     DistributionConfig config = mock(DistributionConfig.class);
 
@@ -83,7 +82,7 @@ public class LocalManagerTest {
   }
 
   @Test
-  public void startLocalManagementCreatesMonitoringRegion() throws Exception {
+  public void startLocalManagementCreatesMonitoringRegion() {
     InternalDistributedMember member = member(1, 20);
     when(system.getDistributedMember()).thenReturn(member);
     LocalManager localManager =
@@ -95,7 +94,7 @@ public class LocalManagerTest {
   }
 
   @Test
-  public void addMemberArtifactsCreatesMonitoringRegionWithHasOwnStats() throws Exception {
+  public void addMemberArtifactsCreatesMonitoringRegionWithHasOwnStats() {
     InternalDistributedMember member = member(2, 40);
     when(system.getDistributedMember()).thenReturn(member);
     LocalManager localManager =
@@ -110,7 +109,7 @@ public class LocalManagerTest {
   }
 
   @Test
-  public void addMemberArtifactsCreatesNotificationRegion() throws Exception {
+  public void addMemberArtifactsCreatesNotificationRegion() {
     InternalDistributedMember member = member(3, 60);
     when(system.getDistributedMember()).thenReturn(member);
     LocalManager localManager =
@@ -122,7 +121,7 @@ public class LocalManagerTest {
   }
 
   @Test
-  public void addMemberArtifactsCreatesNotificationRegionWithHasOwnStats() throws Exception {
+  public void addMemberArtifactsCreatesNotificationRegionWithHasOwnStats() {
     InternalDistributedMember member = member(4, 80);
     when(system.getDistributedMember()).thenReturn(member);
     LocalManager localManager =

--- a/geode-core/src/test/java/org/apache/geode/management/internal/LocalManagerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/LocalManagerTest.java
@@ -18,7 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizerTest.java
@@ -22,7 +22,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/realizers/RegionConfigRealizerTest.java
@@ -76,7 +76,7 @@ public class RegionConfigRealizerTest {
   }
 
   @Test
-  public void getRegionFactory() throws Exception {
+  public void getRegionFactory() {
     config.setType(RegionType.REPLICATE);
     config.setDiskStoreName("diskstore");
     config.setKeyConstraint("java.lang.String");
@@ -91,7 +91,7 @@ public class RegionConfigRealizerTest {
 
 
   @Test
-  public void createPartitionRegion() throws Exception {
+  public void createPartitionRegion() {
     config.setType(RegionType.PARTITION);
     config.setRedundantCopies(2);
 
@@ -104,7 +104,7 @@ public class RegionConfigRealizerTest {
   }
 
   @Test
-  public void getRegionFactoryWhenValueNotSet() throws Exception {
+  public void getRegionFactoryWhenValueNotSet() {
     config.setType(RegionType.REPLICATE);
     config.setDiskStoreName(null);
     config.setKeyConstraint(null);


### PR DESCRIPTION
Inspired by @kirklund's email about not using PowerMockito, I saw there were some easy ones to change in 30 minutes, so here's a PR

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?
It is two commits to show the actual change and some cleanup.  The person who merges may squash if they like
- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
