### PR TITLE
GEODE-8859: Fix redis-compatability data structure bucket memory-usag…

### DIFF
--- a/geode-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -63,6 +63,13 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
     return getRedisPort(getMember(vmNumber));
   }
 
+  public Long getDataStoreBytesInUseForDataRegion(MemberVM vm) {
+    return vm.invoke(() -> {
+      GeodeRedisService service = ClusterStartupRule.getCache().getService(GeodeRedisService.class);
+      return service.getDataStoreBytesInUseForDataRegion();
+    });
+  }
+
   public int getRedisPort(MemberVM vm) {
     return vm.invoke(() -> {
       GeodeRedisService service = ClusterStartupRule.getCache().getService(GeodeRedisService.class);

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+
+package org.apache.geode.redis.internal.data;
+
+import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+
+public class PartitionedRegionStatsUpdateTest {
+
+  @ClassRule
+  public static RedisClusterStartupRule clusterStartUpRule = new RedisClusterStartupRule(2);
+
+  private static MemberVM server1;
+  private static final String LOCAL_HOST = "127.0.0.1";
+  private static final int JEDIS_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+
+  private static Jedis jedis1;
+
+  @BeforeClass
+  public static void classSetup() {
+    Properties locatorProperties = new Properties();
+    locatorProperties.setProperty(MAX_WAIT_TIME_RECONNECT, "15000");
+
+    MemberVM locator = clusterStartUpRule.startLocatorVM(0, locatorProperties);
+    int locatorPort = locator.getPort();
+
+    server1 = clusterStartUpRule.startRedisVM(1, locatorPort);
+    int redisServerPort1 = clusterStartUpRule.getRedisPort(1);
+
+    jedis1 = new Jedis(LOCAL_HOST, redisServerPort1, JEDIS_TIMEOUT);
+  }
+
+  @Test
+  public void should_showIncreaseInDatastoreBytesInUse_givenValueSizeIncreases() {
+    String KEY = "key";
+    String LONG_APPEND_VALUE = String.valueOf(Integer.MAX_VALUE);
+    jedis1.set(KEY, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.append(KEY, LONG_APPEND_VALUE);
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+    assertThat(initialDataStoreBytesInUse).isLessThan(finalDataStoreBytesInUse);
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -23,6 +23,7 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
@@ -132,6 +133,13 @@ public class GeodeRedisServer {
   @VisibleForTesting
   public RedisStats getStats() {
     return redisStats;
+  }
+
+  @VisibleForTesting
+  protected Long getDataStoreBytesInUseForDataRegion() {
+    PartitionedRegion dataRegion = (PartitionedRegion) this.getRegionProvider().getDataRegion();
+    long dataStoreBytesInUse = dataRegion.getPrStats().getDataStoreBytesInUse();
+    return dataStoreBytesInUse;
   }
 
   /**

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ResourceEvent;
@@ -100,6 +101,11 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
 
   public int getPort() {
     return redisServer.getPort();
+  }
+
+  @VisibleForTesting
+  public Long getDataStoreBytesInUseForDataRegion() {
+    return redisServer.getDataStoreBytesInUseForDataRegion();
   }
 
   public void setEnableUnsupported(boolean unsupported) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
@@ -60,4 +60,8 @@ public interface RedisData extends Delta, DataSerializable {
   boolean rename(Region<ByteArrayWrapper, RedisData> region, ByteArrayWrapper oldKey,
       ByteArrayWrapper newKey);
 
+  default boolean getForceRecalculateSize() {
+    return true;
+  }
+
 }


### PR DESCRIPTION
…e reporting (#6084)

- Implement default getForceReCalculateSize in RedisData interface
- Expose dataStoreBytesInUse on GeodeRedisServer
- Expose dataStoreBytesInUse on GeodeRedisService
- Expose dataStoreBytesInUse on RedisClusterStartupRule

Authored-by: john Hutchison <hutchisonjo@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
