### PR TITLE
GEODE-8343: Fix 'Function execution' main doc page

### DIFF
--- a/geode-docs/developing/function_exec/chapter_overview.html.md.erb
+++ b/geode-docs/developing/function_exec/chapter_overview.html.md.erb
@@ -19,15 +19,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-A function is a body of code that resides on a server and that an application can invoke from a client or from another server without the need to send the function code itself. The caller can direct a data-dependent function to operate on a particular dataset, or can direct a data-independent function to operate on a particular server, member, or member group.
+<a id="function_exec__section_CBD5B04ACC554029B5C710CE8E244FEA"></a>A function is a body of code that resides on a server and that an application can invoke from a client or from another server without the need to send the function code itself. The caller can direct a data-dependent function to operate on a particular dataset, or can direct a data-independent function to operate on a particular server, member, or member group.
 
-<a id="function_exec__section_CBD5B04ACC554029B5C710CE8E244FEA">The function execution service provides solutions for a variety of use cases, including:</a>
+The function execution service provides solutions for a variety of use cases, including:
 
 -   An application needs to perform an operation on the data associated with a key. A registered server-side function can retrieve the data, operate on it, and put it back, with all processing performed locally to the server.
 -   An application needs to initialize some of its components once on each server, which might be used later by executed functions.
 -   A third-party service, such as a messaging service, requires initialization and startup.
 -   Any arbitrary aggregation operation requires iteration over local data sets that can be done more efficiently through a single call to the cache server.
 -   An external resource needs provisioning that can be done by executing a function on a server.
+
+Check the following sections for more information:
 
 -   **[How Function Execution Works](how_function_execution_works.html)**
 


### PR DESCRIPTION
Fix for https://geode.apache.org/docs/guide/113/developing/function_exec/chapter_overview.html

- Removal of the link from the first sentence before the list.
- Chapter sections are shown as part of the list of use cases solved by function execution. I have introduced a sentence just to separate both lists.

