### PR TITLE
GEODE-6143: Remove powermock from geode-pulse

### DIFF
--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -105,9 +105,6 @@ dependencies {
     exclude module: 'geode-core'
   }
   testImplementation('org.springframework:spring-test')
-  testImplementation('org.powermock:powermock-core')
-  testImplementation('org.powermock:powermock-module-junit4')
-  testImplementation('org.powermock:powermock-api-mockito2')
 
 
   integrationTestImplementation(project(':geode-core'))
@@ -120,9 +117,6 @@ dependencies {
 
   integrationTestImplementation(project(':geode-pulse'))
   integrationTestImplementation(project(':geode-pulse:geode-pulse-test'))
-  integrationTestImplementation('org.powermock:powermock-core')
-  integrationTestImplementation('org.powermock:powermock-module-junit4')
-  integrationTestImplementation('org.powermock:powermock-api-mockito2')
   integrationTestImplementation('org.springframework:spring-test')
   integrationTestImplementation('org.springframework:spring-webmvc')
   integrationTestImplementation('org.springframework.security:spring-security-test')


### PR DESCRIPTION
Removing powermock from build.gradle in geode-pulse. 
No tests use it in this module.