### PR TITLE
GEODE-9046: Refactor null redis structures to separate classes

### DIFF
--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/CommandHelper.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/CommandHelper.java
@@ -16,12 +16,12 @@
 
 package org.apache.geode.redis.internal.data;
 
+import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_HASH;
+import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_SET;
+import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_STRING;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_HASH;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SET;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_STRING;
-import static org.apache.geode.redis.internal.data.RedisHash.NULL_REDIS_HASH;
-import static org.apache.geode.redis.internal.data.RedisSet.NULL_REDIS_SET;
-import static org.apache.geode.redis.internal.data.RedisString.NULL_REDIS_STRING;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.redis.internal.RedisConstants;
@@ -65,7 +65,7 @@ public class CommandHelper {
   }
 
   RedisData getRedisData(ByteArrayWrapper key) {
-    return getRedisData(key, RedisData.NULL_REDIS_DATA);
+    return getRedisData(key, NullRedisDataStructures.NULL_REDIS_DATA);
   }
 
   RedisData getRedisData(ByteArrayWrapper key, RedisData notFoundValue) {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisDataStructures.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisDataStructures.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.data;
+
+public class NullRedisDataStructures {
+  public static final NullRedisString NULL_REDIS_STRING = new NullRedisString();
+  public static final NullRedisSet NULL_REDIS_SET = new NullRedisSet();
+  public static final NullRedisHash NULL_REDIS_HASH = new NullRedisHash();
+  public static final NullRedisData NULL_REDIS_DATA = new NullRedisData();
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
@@ -22,7 +22,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
 
 public interface RedisData extends Delta, DataSerializableFixedID {
-  NullRedisData NULL_REDIS_DATA = new NullRedisData();
+
 
   /**
    * Returns true if this instance does not exist.

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -54,7 +54,6 @@ import org.apache.geode.redis.internal.delta.RemsDeltaInfo;
 import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisHash extends AbstractRedisData {
-  public static final RedisHash NULL_REDIS_HASH = new NullRedisHash();
   private HashMap<ByteArrayWrapper, ByteArrayWrapper> hash;
   private ConcurrentHashMap<UUID, List<ByteArrayWrapper>> hScanSnapShots;
   private ConcurrentHashMap<UUID, Long> hScanSnapShotCreationTimes;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -47,7 +47,6 @@ import org.apache.geode.redis.internal.delta.RemsDeltaInfo;
 
 public class RedisSet extends AbstractRedisData {
 
-  public static final NullRedisSet NULL_REDIS_SET = new NullRedisSet();
   private HashSet<ByteArrayWrapper> members;
 
   @SuppressWarnings("unchecked")

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSetCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSetCommandsFunctionExecutor.java
@@ -16,7 +16,7 @@
 
 package org.apache.geode.redis.internal.data;
 
-import static org.apache.geode.redis.internal.data.RedisSet.NULL_REDIS_SET;
+import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_SET;
 
 import java.math.BigInteger;
 import java.util.ArrayList;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -35,7 +35,6 @@ import org.apache.geode.redis.internal.executor.string.SetOptions;
 import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisString extends AbstractRedisData {
-  public static final NullRedisString NULL_REDIS_STRING = new NullRedisString();
 
   private int appendSequence;
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisStringCommandsFunctionExecutor.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/data/RedisStringCommandsFunctionExecutor.java
@@ -15,7 +15,7 @@
 
 package org.apache.geode.redis.internal.data;
 
-import static org.apache.geode.redis.internal.data.RedisString.NULL_REDIS_STRING;
+import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_STRING;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -102,7 +102,7 @@ public class RedisHashTest {
   @Test
   public void equals_returnsTrue_givenDifferentEmptyHashes() {
     RedisHash o1 = new RedisHash(Collections.emptyList());
-    RedisHash o2 = RedisHash.NULL_REDIS_HASH;
+    RedisHash o2 = NullRedisDataStructures.NULL_REDIS_HASH;
     assertThat(o1).isEqualTo(o2);
     assertThat(o2).isEqualTo(o1);
   }

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -93,7 +93,7 @@ public class RedisSetTest {
   @Test
   public void equals_returnsTrue_givenDifferentEmptySets() {
     RedisSet o1 = new RedisSet(Collections.emptyList());
-    RedisSet o2 = RedisSet.NULL_REDIS_SET;
+    RedisSet o2 = NullRedisDataStructures.NULL_REDIS_SET;
     assertThat(o1).isEqualTo(o2);
     assertThat(o2).isEqualTo(o1);
   }


### PR DESCRIPTION
	* NULL_REDIS_STRING, NULL_REDIS_HASH, NULL_REDIS_SET, and NULL_REDIS_DATA are moved to a separate class
	* This is done so that super classes do not reference subclasses to avoid class loading deadlocks.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
