### PR TITLE
GEODE-8946: User Guide - add Upgrade link to Getting Started page

### DIFF
--- a/geode-docs/getting_started/book_intro.html.md.erb
+++ b/geode-docs/getting_started/book_intro.html.md.erb
@@ -31,6 +31,8 @@ A tutorial demonstrates features, and a main features section describes key func
 
     Each host of <%=vars.product_name_long%> that meets a small set of prerequisites may follow the provided installation instructions.
 
+-   **[Upgrading <%=vars.product_name_long%>](upgrade/upgrade_overview.html)**
+
 -   **[<%=vars.product_name_long%> in 15 Minutes or Less](15_minute_quickstart_gfsh.html)**
 
     Need a quick introduction to <%=vars.product_name_long%>? Take this brief tour to try out basic features and functionality.


### PR DESCRIPTION
Loose end from previous PR: Add an entry on the top-level Getting Started page to the Upgrade section