### PR TITLE
GEODE-6143: Remove powermock from gfsh and lucene

### DIFF
--- a/geode-gfsh/build.gradle
+++ b/geode-gfsh/build.gradle
@@ -38,8 +38,6 @@ dependencies {
 //    //Find bugs is used in multiple places in the code to suppress findbugs warnings
     testImplementation('com.github.stephenc.findbugs:findbugs-annotations')
     testImplementation('org.springframework:spring-test')
-    integrationTestImplementation('org.powermock:powermock-module-junit4')
-    integrationTestImplementation('org.powermock:powermock-api-mockito2')
     testImplementation(project(':geode-junit'))
 
     integrationTestImplementation(project(':geode-dunit'))

--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -51,9 +51,6 @@ dependencies {
   testImplementation('pl.pragmatists:JUnitParams')
   testImplementation('com.pholser:junit-quickcheck-core')
   testImplementation('com.carrotsearch.randomizedtesting:randomizedtesting-runner')
-  testImplementation('org.powermock:powermock-core')
-  testImplementation('org.powermock:powermock-module-junit4')
-  testImplementation('org.powermock:powermock-api-mockito2')
 
 
   distributedTestImplementation(project(':geode-junit'))


### PR DESCRIPTION
- it is no longer needed in those projects

Authored-by: M. Oleske <michael@oleske.engineer>

tagging @DonalEvans and @kirklund  since they have done a lot of the real work recently in removing powermock

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
