### PR TITLE
GEODE-9048 - Increase timeout in the dockerized tests, to avoid timeouts

### DIFF
--- a/buildSrc/src/main/java/com/pedjak/gradle/plugins/dockerizedtest/DockerizedExecHandle.java
+++ b/buildSrc/src/main/java/com/pedjak/gradle/plugins/dockerizedtest/DockerizedExecHandle.java
@@ -297,7 +297,7 @@ public class DockerizedExecHandle implements ExecHandle, ProcessSettings {
       while (stateIn(ExecHandleState.STARTING)) {
         LOGGER.debug("Waiting until process started: {}.", displayName);
         try {
-          if (!stateChanged.await(30, TimeUnit.SECONDS)) {
+          if (!stateChanged.await(10, TimeUnit.MINUTES)) {
             execHandleRunner.abortProcess();
             throw new RuntimeException("Giving up on " + execHandleRunner);
           }
@@ -520,10 +520,6 @@ public class DockerizedExecHandle implements ExecHandle, ProcessSettings {
 
     @Override
     public ExecResult assertNormalExitValue() throws ExecException {
-      // all exit values are ok
-//            if (exitValue != 0) {
-//                throw new ExecException(format("Process '%s' finished with non-zero exit value %d", displayName, exitValue));
-//            }
       return this;
     }
 
@@ -644,7 +640,7 @@ public class DockerizedExecHandle implements ExecHandle, ProcessSettings {
           .withStdErr(true)
           .withStdIn(stdInReadStream)
           .exec(attachContainerResultCallback);
-      if (!attachContainerResultCallback.awaitStarted(10, TimeUnit.SECONDS)) {
+      if (!attachContainerResultCallback.awaitStarted(2, TimeUnit.MINUTES)) {
         LOGGER.warn("Not attached to container " + containerId + " within 10secs");
         throw new RuntimeException("Not attached to container " + containerId + " within 10secs");
       }


### PR DESCRIPTION
Increase timeout in the dockerized tests, to avoid timeouts on processes that take a little longer to complete

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
