### PR TITLE
GEODE-8963: backport to support/1.14

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ClientSideHandshakeImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ClientSideHandshakeImpl.java
@@ -355,7 +355,10 @@ public class ClientSideHandshakeImpl extends Handshake implements ClientSideHand
         // for testing
         VersioningIO.writeOrdinal(hdos, overrideClientVersion, true);
       } else {
-        VersioningIO.writeOrdinal(hdos, currentClientVersion.ordinal(), true);
+        VersioningIO.writeOrdinal(hdos,
+            communicationMode.isWAN() ? KnownVersion.CURRENT_ORDINAL
+                : currentClientVersion.ordinal(),
+            true);
       }
 
       hdos.writeByte(replyCode);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/ConnectionProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/ConnectionProxy.java
@@ -19,17 +19,8 @@ import org.apache.geode.internal.serialization.KnownVersion;
 
 /**
  * Provides the version of the client.
- *
- * @since GemFire 2.0.2
  */
-@SuppressWarnings("deprecation")
 public interface ConnectionProxy {
-
-  /**
-   * The GFE version of the client.
-   *
-   * @since GemFire 5.7
-   */
   @Immutable
-  KnownVersion VERSION = KnownVersion.CURRENT;
+  KnownVersion VERSION = KnownVersion.CURRENT.getClientServerProtocolVersion();
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
@@ -206,6 +206,9 @@ public class CommandInitializer implements CommandRegistry {
 
     allCommands.put(KnownVersion.GEODE_1_14_0, geode18Commands);
 
+    // as of GEODE_1_14_0 we only create new command sets when the
+    // client/server protocol changes
+
     return allCommands;
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -1021,7 +1021,13 @@ public abstract class ServerConnection implements Runnable {
   void initializeCommands() {
     // The commands are cached here, but are just referencing the ones stored in the
     // CommandInitializer
-    commands = CommandInitializer.getDefaultInstance().get(getClientVersion());
+    KnownVersion clientVersion = getClientVersion();
+    // WAN uses KnownVersion.CURRENT, but that might not have a command table, so we look
+    // for one that does
+    if (!clientVersion.hasClientServerProtocolChange()) {
+      clientVersion = clientVersion.getClientServerProtocolVersion();
+    }
+    commands = CommandInitializer.getDefaultInstance().get(clientVersion);
   }
 
   private Command getCommand(Integer messageType) {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializerTest.java
@@ -89,11 +89,12 @@ public class CommandInitializerTest {
 
   @Test
   public void testCommandMapContainsAllVersions() {
-    for (KnownVersion version : KnownVersion.getAllVersions()) {
-      if (version.isNotOlderThan(KnownVersion.OLDEST)) {
+    for (KnownVersion productVersion : KnownVersion.getAllVersions()) {
+      KnownVersion protocolVersion = productVersion.getClientServerProtocolVersion();
+      if (protocolVersion.isNotOlderThan(KnownVersion.OLDEST)) {
         org.junit.Assert.assertNotNull(
-            "Please add a command set for " + version + " of Geode to CommandInitializer",
-            CommandInitializer.getDefaultInstance().get(version));
+            "Please add a command set for " + protocolVersion + " of Geode to CommandInitializer",
+            CommandInitializer.getDefaultInstance().get(protocolVersion));
       }
     }
   }
@@ -206,7 +207,8 @@ public class CommandInitializerTest {
   @Test
   public void commandMapUnmodifiable() {
     final CommandInitializer commandInitializer = new CommandInitializer();
-    final Map<Integer, Command> commands = commandInitializer.get(KnownVersion.CURRENT);
+    final Map<Integer, Command> commands =
+        commandInitializer.get(KnownVersion.CURRENT.getClientServerProtocolVersion());
     assertThatThrownBy(() -> commands.put(1, Put70.getCommand()))
         .isInstanceOf(UnsupportedOperationException.class);
   }
@@ -215,10 +217,11 @@ public class CommandInitializerTest {
   public void newlyRegisteredCommandsVisibleInCommandMap() {
     final Command command = mock(Command.class);
     Map<KnownVersion, Command> newCommandMap = new HashMap<>();
-    newCommandMap.put(KnownVersion.CURRENT, command);
+    newCommandMap.put(KnownVersion.CURRENT.getClientServerProtocolVersion(), command);
 
     final CommandInitializer commandInitializer = new CommandInitializer();
-    final Map<Integer, Command> commands = commandInitializer.get(KnownVersion.CURRENT);
+    final Map<Integer, Command> commands =
+        commandInitializer.get(KnownVersion.CURRENT.getClientServerProtocolVersion());
     assertThat(commands).doesNotContainKeys(-2);
     commandInitializer.register(-2, newCommandMap);
     assertThat(commands).containsEntry(-2, command);

--- a/geode-cq/src/upgradeTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
+++ b/geode-cq/src/upgradeTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
@@ -16,11 +16,13 @@ package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.lang.reflect.Method;
 import java.net.ConnectException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -44,8 +46,11 @@ import org.apache.geode.cache.query.CqListener;
 import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.internal.cache.LocalRegion;
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.internal.serialization.Versioning;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
@@ -79,9 +84,49 @@ public class ClientServerMiscBCDUnitTest extends ClientServerMiscDUnitTestBase {
   void createClientCacheAndVerifyPingIntervalIsSet(String host, int port) throws Exception {
     // this functionality was introduced in 1.5. If we let the test run in older
     // clients it will throw a NoSuchMethodError
-    if (VersionManager.getInstance().getCurrentVersionOrdinal() >= 80 /* GEODE_1_5_0 */) {
+    if (VersionManager.getInstance().getCurrentVersionOrdinal() >= 80 /*
+                                                                       * KnownVersion.GEODE_1_5_0
+                                                                       * .ordinal()
+                                                                       */) {
       super.createClientCacheAndVerifyPingIntervalIsSet(host, port);
     }
+  }
+
+  /**
+   * A client should advertise its protocol version, which may not be the same
+   * as its product version.
+   */
+  @Test
+  public void testClientProtocolVersion() {
+    int serverPort = initServerCache(true);
+    VM client1 = Host.getHost(0).getVM(testVersion, 1);
+    String hostname = NetworkUtils.getServerHostName();
+    short ordinal = client1.invoke("create client1 cache", () -> {
+      createClientCache(hostname, serverPort);
+      populateCache();
+      registerInterest();
+      InternalDistributedMember distributedMember = (InternalDistributedMember) static_cache
+          .getDistributedSystem().getDistributedMember();
+      // older versions of Geode have a different Version class so we have to use reflection here
+      try {
+        Method getter = InternalDistributedMember.class.getMethod("getVersionObject");
+        Object versionObject = getter.invoke(distributedMember);
+        Method getOrdinal = versionObject.getClass().getMethod("ordinal");
+        return (Short) getOrdinal.invoke(versionObject);
+      } catch (NoSuchMethodException ignore) {
+      }
+      // newer versions can be accessed directly
+      return distributedMember.getVersionOrdinal();
+    });
+    short protocolOrdinal = server1.invoke("fetch client's protocol version",
+        () -> CacheClientNotifier.getInstance().getClientProxies()
+            .iterator().next().getVersion().ordinal());
+    KnownVersion clientProductVersion = Versioning.getKnownVersionOrDefault(
+        Versioning.getVersion(ordinal), null);
+    KnownVersion clientProtocolVersion = Versioning.getKnownVersionOrDefault(
+        Versioning.getVersion(protocolOrdinal), null);
+    assertThat(clientProductVersion.getClientServerProtocolVersion())
+        .isEqualTo(clientProtocolVersion);
   }
 
   @Test

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
@@ -46,6 +46,7 @@ public class KnownVersion extends AbstractVersion {
   private final byte minor;
   private final byte release;
   private final byte patch;
+  private final boolean modifiesClientServerProtocol;
 
   public static final int HIGHEST_VERSION = 125;
 
@@ -60,35 +61,37 @@ public class KnownVersion extends AbstractVersion {
 
   @Immutable
   public static final KnownVersion TOKEN =
-      new KnownVersion("", "TOKEN", (byte) -1, (byte) 0, (byte) 0, (byte) 0, TOKEN_ORDINAL);
+      new KnownVersion("", "TOKEN", (byte) -1, (byte) 0, (byte) 0, (byte) 0, TOKEN_ORDINAL, true);
 
   private static final short GFE_70_ORDINAL = 19;
 
   @Immutable
   @Deprecated
   public static final KnownVersion GFE_70 =
-      new KnownVersion("GFE", "7.0", (byte) 7, (byte) 0, (byte) 0, (byte) 0, GFE_70_ORDINAL);
+      new KnownVersion("GFE", "7.0", (byte) 7, (byte) 0, (byte) 0, (byte) 0, GFE_70_ORDINAL, true);
 
   private static final short GFE_701_ORDINAL = 20;
 
   @Immutable
   @Deprecated
   public static final KnownVersion GFE_701 =
-      new KnownVersion("GFE", "7.0.1", (byte) 7, (byte) 0, (byte) 1, (byte) 0, GFE_701_ORDINAL);
+      new KnownVersion("GFE", "7.0.1", (byte) 7, (byte) 0, (byte) 1, (byte) 0, GFE_701_ORDINAL,
+          true);
 
   private static final short GFE_7099_ORDINAL = 21;
 
   @Immutable
   @Deprecated
   public static final KnownVersion GFE_7099 =
-      new KnownVersion("GFE", "7.0.99", (byte) 7, (byte) 0, (byte) 99, (byte) 0, GFE_7099_ORDINAL);
+      new KnownVersion("GFE", "7.0.99", (byte) 7, (byte) 0, (byte) 99, (byte) 0, GFE_7099_ORDINAL,
+          true);
 
   private static final short GFE_71_ORDINAL = 22;
 
   @Immutable
   @Deprecated
   public static final KnownVersion GFE_71 =
-      new KnownVersion("GFE", "7.1", (byte) 7, (byte) 1, (byte) 0, (byte) 0, GFE_71_ORDINAL);
+      new KnownVersion("GFE", "7.1", (byte) 7, (byte) 1, (byte) 0, (byte) 0, GFE_71_ORDINAL, true);
 
   // 23-29 available for 7.x variants
 
@@ -97,7 +100,7 @@ public class KnownVersion extends AbstractVersion {
   @Immutable
   @Deprecated
   public static final KnownVersion GFE_80 =
-      new KnownVersion("GFE", "8.0", (byte) 8, (byte) 0, (byte) 0, (byte) 0, GFE_80_ORDINAL);
+      new KnownVersion("GFE", "8.0", (byte) 8, (byte) 0, (byte) 0, (byte) 0, GFE_80_ORDINAL, true);
 
   // 31-34 available for 8.0.x variants
 
@@ -106,13 +109,14 @@ public class KnownVersion extends AbstractVersion {
   @Immutable
   @Deprecated
   public static final KnownVersion GFE_8009 =
-      new KnownVersion("GFE", "8.0.0.9", (byte) 8, (byte) 0, (byte) 0, (byte) 9, GFE_8009_ORDINAL);
+      new KnownVersion("GFE", "8.0.0.9", (byte) 8, (byte) 0, (byte) 0, (byte) 9, GFE_8009_ORDINAL,
+          true);
 
   private static final short GFE_81_ORDINAL = 35;
 
   @Immutable
   public static final KnownVersion GFE_81 =
-      new KnownVersion("GFE", "8.1", (byte) 8, (byte) 1, (byte) 0, (byte) 0, GFE_81_ORDINAL);
+      new KnownVersion("GFE", "8.1", (byte) 8, (byte) 1, (byte) 0, (byte) 0, GFE_81_ORDINAL, true);
 
   // 36-39 available for 8.1.x variants
 
@@ -122,7 +126,7 @@ public class KnownVersion extends AbstractVersion {
 
   @Immutable
   public static final KnownVersion GFE_90 =
-      new KnownVersion("GFE", "9.0", (byte) 9, (byte) 0, (byte) 0, (byte) 0, GFE_90_ORDINAL);
+      new KnownVersion("GFE", "9.0", (byte) 9, (byte) 0, (byte) 0, (byte) 0, GFE_90_ORDINAL, true);
 
   // prior to v1.2.0 GEODE_1_1_0 was named GFE_91. This was used for both the rel/v1.1.0
   // and rel/v1.1.1 releases
@@ -131,7 +135,7 @@ public class KnownVersion extends AbstractVersion {
   @Immutable
   public static final KnownVersion GEODE_1_1_0 =
       new KnownVersion("GEODE", "1.1.0", (byte) 1, (byte) 1, (byte) 0, (byte) 0,
-          GEODE_1_1_0_ORDINAL);
+          GEODE_1_1_0_ORDINAL, true);
 
   // This ordinal was never used
   private static final short GEODE_1_1_1_ORDINAL = 55;
@@ -139,63 +143,63 @@ public class KnownVersion extends AbstractVersion {
   @Immutable
   public static final KnownVersion GEODE_1_1_1 =
       new KnownVersion("GEODE", "1.1.1", (byte) 1, (byte) 1, (byte) 1, (byte) 0,
-          GEODE_1_1_1_ORDINAL);
+          GEODE_1_1_1_ORDINAL, true);
 
   private static final short GEODE_1_2_0_ORDINAL = 65;
 
   @Immutable
   public static final KnownVersion GEODE_1_2_0 =
       new KnownVersion("GEODE", "1.2.0", (byte) 1, (byte) 2, (byte) 0, (byte) 0,
-          GEODE_1_2_0_ORDINAL);
+          GEODE_1_2_0_ORDINAL, true);
 
   private static final short GEODE_1_3_0_ORDINAL = 70;
 
   @Immutable
   public static final KnownVersion GEODE_1_3_0 =
       new KnownVersion("GEODE", "1.3.0", (byte) 1, (byte) 3, (byte) 0, (byte) 0,
-          GEODE_1_3_0_ORDINAL);
+          GEODE_1_3_0_ORDINAL, true);
 
   private static final short GEODE_1_4_0_ORDINAL = 75;
 
   @Immutable
   public static final KnownVersion GEODE_1_4_0 =
       new KnownVersion("GEODE", "1.4.0", (byte) 1, (byte) 4, (byte) 0, (byte) 0,
-          GEODE_1_4_0_ORDINAL);
+          GEODE_1_4_0_ORDINAL, true);
 
   private static final short GEODE_1_5_0_ORDINAL = 80;
 
   @Immutable
   public static final KnownVersion GEODE_1_5_0 =
       new KnownVersion("GEODE", "1.5.0", (byte) 1, (byte) 5, (byte) 0, (byte) 0,
-          GEODE_1_5_0_ORDINAL);
+          GEODE_1_5_0_ORDINAL, true);
 
   private static final short GEODE_1_6_0_ORDINAL = 85;
 
   @Immutable
   public static final KnownVersion GEODE_1_6_0 =
       new KnownVersion("GEODE", "1.6.0", (byte) 1, (byte) 6, (byte) 0, (byte) 0,
-          GEODE_1_6_0_ORDINAL);
+          GEODE_1_6_0_ORDINAL, true);
 
   private static final short GEODE_1_7_0_ORDINAL = 90;
 
   @Immutable
   public static final KnownVersion GEODE_1_7_0 =
       new KnownVersion("GEODE", "1.7.0", (byte) 1, (byte) 7, (byte) 0, (byte) 0,
-          GEODE_1_7_0_ORDINAL);
+          GEODE_1_7_0_ORDINAL, true);
 
   private static final short GEODE_1_8_0_ORDINAL = 95;
 
   @Immutable
   public static final KnownVersion GEODE_1_8_0 =
       new KnownVersion("GEODE", "1.8.0", (byte) 1, (byte) 8, (byte) 0, (byte) 0,
-          GEODE_1_8_0_ORDINAL);
+          GEODE_1_8_0_ORDINAL, true);
 
   private static final short GEODE_1_9_0_ORDINAL = 100;
 
   @Immutable
   public static final KnownVersion GEODE_1_9_0 =
       new KnownVersion("GEODE", "1.9.0", (byte) 1, (byte) 9, (byte) 0, (byte) 0,
-          GEODE_1_9_0_ORDINAL);
+          GEODE_1_9_0_ORDINAL, true);
 
 
   private static final byte GEODE_1_10_0_ORDINAL = 105;
@@ -203,49 +207,49 @@ public class KnownVersion extends AbstractVersion {
   @Immutable
   public static final KnownVersion GEODE_1_10_0 =
       new KnownVersion("GEODE", "1.10.0", (byte) 1, (byte) 10, (byte) 0, (byte) 0,
-          GEODE_1_10_0_ORDINAL);
+          GEODE_1_10_0_ORDINAL, true);
 
   private static final short GEODE_1_11_0_ORDINAL = 110;
 
   @Immutable
   public static final KnownVersion GEODE_1_11_0 =
       new KnownVersion("GEODE", "1.11.0", (byte) 1, (byte) 11, (byte) 0, (byte) 0,
-          GEODE_1_11_0_ORDINAL);
+          GEODE_1_11_0_ORDINAL, true);
 
   private static final short GEODE_1_12_0_ORDINAL = 115;
 
   @Immutable
   public static final KnownVersion GEODE_1_12_0 =
       new KnownVersion("GEODE", "1.12.0", (byte) 1, (byte) 12, (byte) 0, (byte) 0,
-          GEODE_1_12_0_ORDINAL);
+          GEODE_1_12_0_ORDINAL, true);
 
   private static final short GEODE_1_12_1_ORDINAL = 116;
 
   @Immutable
   public static final KnownVersion GEODE_1_12_1 =
       new KnownVersion("GEODE", "1.12.1", (byte) 1, (byte) 12, (byte) 1, (byte) 0,
-          GEODE_1_12_1_ORDINAL);
+          GEODE_1_12_1_ORDINAL, true);
 
   private static final short GEODE_1_13_0_ORDINAL = 120;
 
   @Immutable
   public static final KnownVersion GEODE_1_13_0 =
       new KnownVersion("GEODE", "1.13.0", (byte) 1, (byte) 13, (byte) 0, (byte) 0,
-          GEODE_1_13_0_ORDINAL);
+          GEODE_1_13_0_ORDINAL, true);
 
   private static final short GEODE_1_13_1_ORDINAL = 121;
 
   @Immutable
   public static final KnownVersion GEODE_1_13_1 =
       new KnownVersion("GEODE", "1.13.1", (byte) 1, (byte) 13, (byte) 1, (byte) 0,
-          GEODE_1_13_1_ORDINAL);
+          GEODE_1_13_1_ORDINAL, true);
 
   private static final short GEODE_1_14_0_ORDINAL = 125;
 
   @Immutable
   public static final KnownVersion GEODE_1_14_0 =
       new KnownVersion("GEODE", "1.14.0", (byte) 1, (byte) 14, (byte) 0, (byte) 0,
-          GEODE_1_14_0_ORDINAL);
+          GEODE_1_14_0_ORDINAL, true);
 
   /* NOTE: when adding a new version bump the ordinal by 5. Ordinals can be short ints */
 
@@ -269,17 +273,22 @@ public class KnownVersion extends AbstractVersion {
   public static final short CURRENT_ORDINAL = CURRENT.ordinal();
 
   /**
-   * version ordinal for test Backward compatibility.
+   * an invalid KnownVersion used for tests and instead of null values
    */
   private static final short validOrdinalForTesting = 2;
 
   @Immutable
   public static final KnownVersion TEST_VERSION =
       new KnownVersion("TEST", "VERSION", (byte) 0, (byte) 0,
-          (byte) 0, (byte) 0, validOrdinalForTesting);
+          (byte) 0, (byte) 0, validOrdinalForTesting, true);
 
   private KnownVersion(String productName, String name, byte major, byte minor, byte release,
       byte patch, short ordinal) {
+    this(productName, name, major, minor, release, patch, ordinal, false);
+  }
+
+  private KnownVersion(String productName, String name, byte major, byte minor, byte release,
+      byte patch, short ordinal, boolean modifiesClientServerProtocol) {
     super(ordinal);
     this.productName = productName;
     this.name = name;
@@ -287,17 +296,27 @@ public class KnownVersion extends AbstractVersion {
     this.minor = minor;
     this.release = release;
     this.patch = patch;
+    this.modifiesClientServerProtocol = modifiesClientServerProtocol;
 
     methodSuffix = this.productName + "_" + this.major + "_" + this.minor + "_" + this.release + "_"
         + this.patch;
 
     if (ordinal != TOKEN_ORDINAL) {
-      VALUES[ordinal()] = this;
+      VALUES[ordinal] = this;
     }
   }
 
   public static KnownVersion getCurrentVersion() {
     return CURRENT;
+  }
+
+  public KnownVersion getClientServerProtocolVersion() {
+    for (short i = ordinal(); i >= 0; i--) {
+      if (VALUES[i] != null && VALUES[i].modifiesClientServerProtocol) {
+        return VALUES[i];
+      }
+    }
+    throw new IllegalStateException("There is no valid clientServerProtocolVersion for " + this);
   }
 
   public static String unsupportedVersionMessage(final short ordinal) {
@@ -353,4 +372,7 @@ public class KnownVersion extends AbstractVersion {
     return VALUES[ordinal];
   }
 
+  public boolean hasClientServerProtocolChange() {
+    return modifiesClientServerProtocol;
+  }
 }

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
@@ -44,6 +44,30 @@ public class KnownVersionJUnitTest {
     compare(KnownVersion.GEODE_1_14_0, KnownVersion.GEODE_1_13_1);
   }
 
+  @Test
+  public void testClientServerProtocolVersion() {
+    assertThat(KnownVersion.GEODE_1_7_0.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_7_0);
+    assertThat(KnownVersion.GEODE_1_8_0.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_8_0);
+    assertThat(KnownVersion.GEODE_1_9_0.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_9_0);
+    assertThat(KnownVersion.GEODE_1_10_0.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_10_0);
+    assertThat(KnownVersion.GEODE_1_11_0.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_11_0);
+    assertThat(KnownVersion.GEODE_1_12_0.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_12_0);
+    assertThat(KnownVersion.GEODE_1_12_1.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_12_1);
+    assertThat(KnownVersion.GEODE_1_13_0.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_13_0);
+    assertThat(KnownVersion.GEODE_1_13_1.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_13_1);
+    assertThat(KnownVersion.GEODE_1_14_0.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_14_0);
+  }
+
   private void compare(KnownVersion later, KnownVersion earlier) {
     assertThat(later).isEqualTo(later);
     assertThat(later).isNotEqualTo(earlier);


### PR DESCRIPTION
[This will require a subsequent change in develop to update KnownVersion 1.15]

A client's version is used for deserializing data received from the client and for
serializing data sent to the client. It is also used to locate the map of Commands
used to process client requests. Every time we cut a new release we bump this version
in KnownVersions and create a new map of Commands, even though client/server
communications protocols rarely change.

This PR changes KnownVersions to hold a client/server protocol version that is
used to identify clients for command-table selection and serialization rather than
the client's CURRENT_VERSION.

Altered KnownVersions to just mark each version that has client/server
protocol changes rather than store the last one having changes in the
more recent instances.  Release managers can continue to use the old
constructor and coders can change to the new constructor if necessary
during the course of a release.

(cherry picked from commit dc3ed8c1af4389f60c8ad8e35c43a72731869dcc)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
