### PR TITLE
GEODE-9051: Added a feature to measure the Tenured heap consumption

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -16,8 +16,10 @@ package org.apache.geode.internal.cache.control;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryNotificationInfo;
 import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryType;
+import java.lang.management.MemoryUsage;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -30,6 +32,7 @@ import javax.management.ListenerNotFoundException;
 import javax.management.Notification;
 import javax.management.NotificationEmitter;
 import javax.management.NotificationListener;
+import javax.management.openmbean.CompositeData;
 
 import org.apache.logging.log4j.Logger;
 
@@ -670,11 +673,30 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
         // Not using the information given by the notification in favor
         // of constructing fresh information ourselves.
         if (!testDisableMemoryUpdates) {
+          try {
+            String notifType = notification.getType();
+            if (notifType.equals(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED) ||
+                notifType.equals(MemoryNotificationInfo.MEMORY_COLLECTION_THRESHOLD_EXCEEDED)) {
+              // retrieve the memory notification information
+              CompositeData cd = (CompositeData) notification.getUserData();
+              MemoryNotificationInfo info = MemoryNotificationInfo.from(cd);
+              MemoryUsage usage = info.getUsage();
+              long usedBytes = usage.getUsed();
+              logger.info(
+                  "A tenured heap garbage collection has occurred.  New tenured heap consumption: "
+                      +
+                      usedBytes);
+            }
+          } catch (Exception e) {
+            logger.info(
+                "An Exception occureed while attempting to print out tenured heap consumption", e);
+          }
           updateStateAndSendEvent();
         }
       }
     });
   }
+
 
   protected Set<DistributedMember> getHeapCriticalMembersFrom(
       Set<? extends DistributedMember> members) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/InternalResourceManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/InternalResourceManager.java
@@ -149,7 +149,8 @@ public class InternalResourceManager implements ResourceManager {
 
     // Create the monitors
     Map<ResourceType, ResourceMonitor> tempMonitors = new HashMap<>();
-    tempMonitors.put(ResourceType.HEAP_MEMORY, new HeapMemoryMonitor(this, cache, stats));
+    tempMonitors.put(ResourceType.HEAP_MEMORY,
+        new HeapMemoryMonitor(this, cache, stats, new TenuredHeapConsumptionMonitor()));
     tempMonitors.put(ResourceType.OFFHEAP_MEMORY,
         new OffHeapMemoryMonitor(this, cache, cache.getOffHeapStore(), stats));
     resourceMonitors = Collections.unmodifiableMap(tempMonitors);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/TenuredHeapConsumptionMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/TenuredHeapConsumptionMonitor.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.cache.control;
+
+import java.lang.management.MemoryNotificationInfo;
+import java.lang.management.MemoryUsage;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import javax.management.Notification;
+import javax.management.openmbean.CompositeData;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.logging.internal.log4j.api.LogService;
+
+
+class TenuredHeapConsumptionMonitor {
+
+  private static final Logger logger = LogService.getLogger();
+  private final BiConsumer<String, Throwable> infoLogger;
+  private final Function<CompositeData, MemoryNotificationInfo> memoryNotificationInfoFactory;
+
+  TenuredHeapConsumptionMonitor() {
+    this(logger::info, MemoryNotificationInfo::from);
+  }
+
+  @VisibleForTesting
+  TenuredHeapConsumptionMonitor(BiConsumer<String, Throwable> infoLogger,
+      Function<CompositeData, MemoryNotificationInfo> memoryNotificationInfoFactory) {
+    this.infoLogger = infoLogger;
+    this.memoryNotificationInfoFactory = memoryNotificationInfoFactory;
+  }
+
+  void checkTenuredHeapConsumption(Notification notification) {
+    try {
+      String type = notification.getType();
+      if (type.equals(MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED) ||
+          type.equals(MemoryNotificationInfo.MEMORY_COLLECTION_THRESHOLD_EXCEEDED)) {
+        // retrieve the memory notification information
+        CompositeData compositeData = (CompositeData) notification.getUserData();
+        MemoryNotificationInfo info = memoryNotificationInfoFactory.apply(compositeData);
+        MemoryUsage usage = info.getUsage();
+        long usedBytes = usage.getUsed();
+        infoLogger.accept(
+            "A tenured heap garbage collection has occurred.  New tenured heap consumption: "
+                +
+                usedBytes,
+            null);
+      }
+    } catch (Exception e) {
+      infoLogger.accept(
+          "An Exception occurred while attempting to log tenured heap consumption", e);
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/HeapMemoryMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/HeapMemoryMonitorTest.java
@@ -68,7 +68,7 @@ public class HeapMemoryMonitorTest {
     when(internalCache.getMyId()).thenReturn(myself);
 
     heapMonitor = new HeapMemoryMonitor(mock(InternalResourceManager.class), internalCache,
-        mock(ResourceManagerStats.class));
+        mock(ResourceManagerStats.class), mock(TenuredHeapConsumptionMonitor.class));
     previousMemoryStateChangeTolerance = heapMonitor.getMemoryStateChangeTolerance();
     heapMonitor.setMemoryStateChangeTolerance(memoryStateChangeTolerance);
     memberSet = new HashSet<>();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/TenuredHeapConsumptionMonitorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/TenuredHeapConsumptionMonitorTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import static java.lang.management.MemoryNotificationInfo.MEMORY_COLLECTION_THRESHOLD_EXCEEDED;
+import static java.lang.management.MemoryNotificationInfo.MEMORY_THRESHOLD_EXCEEDED;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.management.MemoryNotificationInfo;
+import java.lang.management.MemoryUsage;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+import javax.management.Notification;
+import javax.management.openmbean.CompositeData;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.Pool;
+import org.apache.geode.internal.cache.GemFireCacheImpl;
+
+public class TenuredHeapConsumptionMonitorTest {
+
+  private BiConsumer<String, Throwable> infoLogger;
+  private Function<CompositeData, MemoryNotificationInfo> memoryNotificationInfoFactory;
+  private Notification notification;
+
+
+  @Before
+  public void setUp() {
+    infoLogger = mock(BiConsumer.class);
+    memoryNotificationInfoFactory = mock(Function.class);
+
+
+  }
+
+  private void notificationType(String type) {
+    notification = new Notification(type, this, 1);
+    ClientCache clientCache;
+    clientCache = new ClientCacheFactory().create();
+    GemFireCacheImpl gfc = (GemFireCacheImpl) clientCache;
+    Pool defPool = gfc.getDefaultPool();
+    MemoryUsage usage = new MemoryUsage(50, 50, 50, 100);
+    MemoryNotificationInfo memoryNotificationInfo =
+        new MemoryNotificationInfo(defPool.getName(), usage, 1);
+    when(memoryNotificationInfoFactory.apply(any())).thenReturn(memoryNotificationInfo);
+    TenuredHeapConsumptionMonitor monitor =
+        new TenuredHeapConsumptionMonitor(infoLogger, memoryNotificationInfoFactory);
+
+    monitor.checkTenuredHeapConsumption(notification);
+
+  }
+
+  @Test
+  public void assertIfTenuredGCLogMessageIsPrintedAfterGCAndWhenMemoryThresholdExceeds() {
+    notificationType(MEMORY_THRESHOLD_EXCEEDED);
+    verify(infoLogger).accept(
+        eq("A tenured heap garbage collection has occurred.  New tenured heap consumption: 50"),
+        isNull());
+
+
+  }
+
+  @Test
+  public void assertIfTenuredGCLogMessageIsPrintedAfterGCAndWhenMemoryCollectionThresholdExceeds() {
+    notificationType(MEMORY_COLLECTION_THRESHOLD_EXCEEDED);
+    verify(infoLogger).accept(
+        eq("A tenured heap garbage collection has occurred.  New tenured heap consumption: 50"),
+        isNull());
+
+
+  }
+}


### PR DESCRIPTION
This feature prints out the tenured heap in the logs after the garbage collection. It works with JDK 1.8 build 212 and above.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
