### PR TITLE
GEODE-9030: Modified PartitionedIndex to reset arbitraryBucketIndex

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/InequalityQueryWithRebalanceDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/InequalityQueryWithRebalanceDistributedTest.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.dunit;
+
+import static org.apache.geode.cache.Region.SEPARATOR;
+
+import java.io.Serializable;
+import java.util.stream.IntStream;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.EntryOperation;
+import org.apache.geode.cache.PartitionResolver;
+import org.apache.geode.cache.Region;
+import org.apache.geode.pdx.PdxReader;
+import org.apache.geode.pdx.PdxSerializable;
+import org.apache.geode.pdx.PdxWriter;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.OQLIndexTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+@Category({OQLIndexTest.class})
+public class InequalityQueryWithRebalanceDistributedTest implements Serializable {
+
+  private String regionName;
+
+  private static MemberVM locator;
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
+
+  @ClassRule
+  public static ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    locator = cluster.startLocatorVM(0);
+    gfsh.connectAndVerify(locator);
+  }
+
+  @Before
+  public void before() throws Exception {
+    regionName = getClass().getSimpleName() + "_" + testName.getMethodName() + "_region";
+  }
+
+  @Test
+  public void testArbitraryBucketIndexUpdatedAfterBucketMoved() {
+    // Start server1
+    MemberVM server1 = cluster.startServerVM(1, locator.getPort());
+
+    // Create the region
+    createRegion();
+
+    // Create the index
+    createIndex();
+
+    // Load entries
+    server1.invoke(this::loadRegion);
+
+    // Start server2
+    cluster.startServerVM(2, locator.getPort());
+
+    // Wait for server2 to create the region MBean
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 2);
+
+    // Invoke rebalance
+    rebalance();
+
+    // Execute query
+    executeQuery();
+  }
+
+  private void createRegion() {
+    gfsh.executeAndAssertThat("create region --name=" + regionName
+        + " --type=PARTITION  --total-num-buckets=2 --partition-resolver="
+        + IsolatingPartitionResolver.class.getName()).statusIsSuccess();
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 1);
+  }
+
+  private void createIndex() {
+    gfsh.executeAndAssertThat("create index --region=" + regionName
+        + " --name=tradeStatus --expression=tradeStatus.toString()").statusIsSuccess();
+  }
+
+  private void loadRegion() {
+    Region<Integer, Trade> region = ClusterStartupRule.getCache().getRegion(regionName);
+    IntStream.range(0, 10).forEach(i -> region.put(i,
+        new Trade(String.valueOf(i), "aId1", i % 2 == 0 ? TradeStatus.OPEN : TradeStatus.CLOSED)));
+  }
+
+  private void rebalance() {
+    gfsh.executeAndAssertThat("rebalance").statusIsSuccess();
+  }
+
+  private void executeQuery() {
+    gfsh.executeAndAssertThat("query --query=\"SELECT * FROM " + SEPARATOR + regionName
+        + " WHERE arrangementId = 'aId1' AND tradeStatus.toString() != 'CLOSED'\"")
+        .statusIsSuccess();
+  }
+
+  public enum TradeStatus {
+    OPEN,
+    CLOSED
+  }
+
+  public static class Trade implements PdxSerializable {
+
+    public String id;
+
+    public String arrangementId;
+
+    public TradeStatus tradeStatus;
+
+    public Trade() {}
+
+    public Trade(String id, String arrangementId, TradeStatus tradeStatus) {
+      this.id = id;
+      this.arrangementId = arrangementId;
+      this.tradeStatus = tradeStatus;
+    }
+
+    @Override
+    public void toData(PdxWriter writer) {
+      writer.writeString("id", this.id);
+      writer.writeString("arrangementId", this.arrangementId);
+      writer.writeObject("tradeStatus", this.tradeStatus);
+    }
+
+    @Override
+    public void fromData(PdxReader reader) {
+      this.id = reader.readString("id");
+      this.arrangementId = reader.readString("arrangementId");
+      this.tradeStatus = (TradeStatus) reader.readObject("tradeStatus");
+    }
+  }
+
+  public static class IsolatingPartitionResolver implements PartitionResolver<Integer, Trade> {
+
+    public IsolatingPartitionResolver() {}
+
+    public Object getRoutingObject(EntryOperation<Integer, Trade> operation) {
+      // Route key=0 to bucket 0 and all other keys to bucket 1
+      return operation.getKey() == 0 ? 0 : 1;
+    }
+
+    public String getName() {
+      return getClass().getSimpleName();
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/PartitionedIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/PartitionedIndex.java
@@ -132,7 +132,7 @@ public class PartitionedIndex extends AbstractIndex {
         }
       }
       if (index == arbitraryBucketIndex) {
-        setArbitraryBucketIndex(retrieveArbitraryBucketIndex());
+        resetArbitraryBucketIndex(retrieveArbitraryBucketIndex());
       }
     }
   }
@@ -182,6 +182,10 @@ public class PartitionedIndex extends AbstractIndex {
     if (arbitraryBucketIndex == null) {
       arbitraryBucketIndex = index;
     }
+  }
+
+  private void resetArbitraryBucketIndex(Index index) {
+    arbitraryBucketIndex = index;
   }
 
   public Index retrieveArbitraryBucketIndex() {


### PR DESCRIPTION
(cherry picked from commit d7342cd0266010313a245920dee8e82034593608)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
