### PR TITLE
GEODE-8963: update client/server on-wire version for 1.14.0

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
@@ -203,7 +203,6 @@ public class CommandInitializer implements CommandRegistry {
     allCommands.put(KnownVersion.GEODE_1_12_1, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_13_0, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_13_1, geode18Commands);
-    allCommands.put(KnownVersion.GEODE_1_14_0, geode18Commands);
 
     // as of GEODE_1_15_0 we only create new command sets when the
     // client/server protocol changes

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
@@ -249,7 +249,7 @@ public class KnownVersion extends AbstractVersion {
   @Immutable
   public static final KnownVersion GEODE_1_14_0 =
       new KnownVersion("GEODE", "1.14.0", (byte) 1, (byte) 14, (byte) 0, (byte) 0,
-          GEODE_1_14_0_ORDINAL, true);
+          GEODE_1_14_0_ORDINAL);
 
   private static final short GEODE_1_15_0_ORDINAL = 150;
 

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
@@ -66,9 +66,9 @@ public class KnownVersionJUnitTest {
     assertThat(KnownVersion.GEODE_1_13_1.getClientServerProtocolVersion())
         .isEqualTo(KnownVersion.GEODE_1_13_1);
     assertThat(KnownVersion.GEODE_1_14_0.getClientServerProtocolVersion())
-        .isEqualTo(KnownVersion.GEODE_1_14_0);
+        .isEqualTo(KnownVersion.GEODE_1_13_1);
     assertThat(KnownVersion.GEODE_1_15_0.getClientServerProtocolVersion())
-        .isEqualTo(KnownVersion.GEODE_1_14_0);
+        .isEqualTo(KnownVersion.GEODE_1_13_1);
   }
 
   private void compare(KnownVersion later, KnownVersion earlier) {


### PR DESCRIPTION
Changes have been made to the unreleased support/1.14 branch to mark
that version as using 1.13.1 for client/server communications.  This PR
updates develop to be consistent with the support branch.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
