### PR TITLE
GEODE-9040: Shutdown ExecutorService when the SingleThreadColocationLogger is stopped

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/colocation/SingleThreadColocationLogger.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/colocation/SingleThreadColocationLogger.java
@@ -63,7 +63,7 @@ public class SingleThreadColocationLogger implements ColocationLogger {
     this(region, delayMillis, intervalMillis, LOGGER::warn,
         pr -> getAllColocationRegions(pr).keySet(),
         newSingleThreadExecutor(
-            runnable -> new LoggingThread("ColocationLogger for " + region.getName(), false,
+            runnable -> new LoggingThread("ColocationLogger for " + region.getName(), true,
                 runnable)));
   }
 
@@ -95,6 +95,7 @@ public class SingleThreadColocationLogger implements ColocationLogger {
   public void stop() {
     synchronized (lock) {
       missingChildren.clear();
+      executorService.shutdownNow();
       lock.notifyAll();
     }
   }
@@ -149,6 +150,11 @@ public class SingleThreadColocationLogger implements ColocationLogger {
   @VisibleForTesting
   List<String> getMissingChildren() {
     return new ArrayList<>(missingChildren);
+  }
+
+  @VisibleForTesting
+  ExecutorService getExecutorService() {
+    return executorService;
   }
 
   private Runnable checkForMissingColocatedRegionRunnable() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/colocation/SingleThreadColocationLoggerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/colocation/SingleThreadColocationLoggerTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.internal.cache.partitioned.colocation;
 import static java.lang.System.lineSeparator;
 import static java.util.Collections.singleton;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -212,5 +213,19 @@ public class SingleThreadColocationLoggerTest {
 
     assertThat(colocationLogger.getMissingChildren())
         .isEmpty();
+  }
+
+  @Test
+  public void stopTerminatesExecutorService() {
+    SingleThreadColocationLogger colocationLogger =
+        new SingleThreadColocationLogger(region, 500, 1000, logger,
+            allColocationRegionsProvider, executorService);
+    colocationLogger.start();
+
+    colocationLogger.stop();
+
+    // Wait until the ExecutorService is terminated
+    await().untilAsserted(
+        () -> assertThat(colocationLogger.getExecutorService().isTerminated()).isTrue());
   }
 }


### PR DESCRIPTION
(cherry picked from commit d7342cd0266010313a245920dee8e82034593608)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
