### PR TITLE
Back-port GEODE-7245 and GEODE-8972 to support/1.14

### DIFF
--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/Membership.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/Membership.java
@@ -243,13 +243,6 @@ public interface Membership<ID extends MemberIdentifier> {
    */
   Throwable getShutdownCause();
 
-  /**
-   * If this member is shunned, ensure that a warning is generated at least once.
-   *
-   * @param mbr the member that may be shunned
-   */
-  void warnShun(ID mbr);
-
   boolean addSurpriseMember(ID mbr);
 
   /**


### PR DESCRIPTION
Back-porting these 2 fixes together as both of them change the same class (GMSMembership)

GEODE-7245:

This change replaces most uses of `latestViewReadLock` with a volatile read of the `latestView`.
It also makes access to `shutdownMembers` synchronized. Currently, modification of `shutdownMembers` is done under a sync but access isn't synchronized.

(cherry picked from commit [477ffba](https://github.com/apache/geode/commit/477ffba8e155dca0bdeeefd312b6b32b4b481100))

GEODE-8972:

This change removes the `shunnedMembers` collection from `GMSMembership` that is used to track the IDs of nodes that are no longer part of the cluster. This collection is no longer needed since we can tell if a node is old by comparing the view ID in its identifier to that of the current view (called `latestView` in that class).

(cherry picked from commit [c2fc107](https://github.com/apache/geode/commit/c2fc107bad1de221157072470e2a6ad426533f20))

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
