### PR TITLE
GEODE-9067: register-interest done during rolling upgrade can take longer than needed

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -4559,18 +4559,6 @@ public class PartitionedRegion extends LocalRegion
         }
       }
 
-      // Handle old nodes for Rolling Upgrade support
-      Set<Integer> failedSet = handleOldNodes(nodeToBuckets, values, servConn);
-      // Add failed buckets to nodeToBuckets map so that these will be tried on
-      // remote nodes.
-      if (!failedSet.isEmpty()) {
-        for (Integer bId : failedSet) {
-          failures.put(bId, bucketKeys.get(bId));
-        }
-        updateNodeToBucketMap(nodeToBuckets, failures);
-        failures.clear();
-      }
-
       fetchRemoteEntries(nodeToBuckets, failures, values, servConn);
       if (!failures.isEmpty()) {
         if (retryTime == null) {
@@ -4734,14 +4722,6 @@ public class PartitionedRegion extends LocalRegion
       // remote nodes.
       updateNodeToBucketMap(nodeToBuckets, failures);
       failures.clear();
-
-      // Handle old nodes for Rolling Upgrade support
-      Set<Integer> ret = handleOldNodes(nodeToBuckets, values, servConn);
-      if (!ret.isEmpty()) {
-        failures.addAll(ret);
-        updateNodeToBucketMap(nodeToBuckets, failures);
-        failures.clear();
-      }
 
       localBuckets = nodeToBuckets.remove(getMyId());
       if (localBuckets != null && !localBuckets.isEmpty()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -232,7 +232,6 @@ import org.apache.geode.internal.cache.tier.sockets.BaseCommand;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
 import org.apache.geode.internal.cache.tier.sockets.VersionedObjectList;
-import org.apache.geode.internal.cache.tier.sockets.command.Get70;
 import org.apache.geode.internal.cache.versions.ConcurrentCacheModificationException;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
 import org.apache.geode.internal.cache.versions.VersionStamp;
@@ -4589,54 +4588,6 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
-  void fetchKeysAndValues(VersionedObjectList values, ServerConnection servConn,
-      Set<Integer> failures, InternalDistributedMember member,
-      HashMap<Integer, HashSet> bucketKeys, Set<Integer> buckets)
-      throws IOException {
-    for (Integer bucket : buckets) {
-      Set keys = null;
-      if (bucketKeys == null) {
-        try {
-          FetchKeysResponse fetchKeysResponse = getFetchKeysResponse(member, bucket);
-          keys = fetchKeysResponse.waitForKeys();
-        } catch (ForceReattemptException ignore) {
-          failures.add(bucket);
-        }
-      } else {
-        keys = bucketKeys.get(bucket);
-      }
-      if (keys != null) {
-        getValuesForKeys(values, servConn, keys);
-      }
-    }
-  }
-
-  FetchKeysResponse getFetchKeysResponse(InternalDistributedMember member,
-      Integer bucket)
-      throws ForceReattemptException {
-    return FetchKeysMessage.send(member, this, bucket, true);
-  }
-
-  void getValuesForKeys(VersionedObjectList values, ServerConnection servConn, Set keys)
-      throws IOException {
-    // TODO (ashetkar) Use single Get70 instance for all?
-    for (Object key : keys) {
-      Get70 command = (Get70) Get70.getCommand();
-      Get70.Entry ge = command.getValueAndIsObject(this, key, null, servConn);
-
-      if (ge.keyNotPresent) {
-        values.addObjectPartForAbsentKey(key, ge.value, ge.versionTag);
-      } else {
-        values.addObjectPart(key, ge.value, ge.isObject, ge.versionTag);
-      }
-
-      if (values.size() == BaseCommand.MAXIMUM_CHUNK_SIZE) {
-        BaseCommand.sendNewRegisterInterestResponseChunk(this, "keyList", values, false,
-            servConn);
-        values.clear();
-      }
-    }
-  }
 
   /**
    * Fetches entries from local and remote nodes and appends these to register-interest response.

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -25,11 +25,9 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -71,10 +69,7 @@ import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
-import org.apache.geode.internal.cache.partitioned.FetchKeysMessage;
 import org.apache.geode.internal.cache.partitioned.colocation.ColocationLoggerFactory;
-import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
-import org.apache.geode.internal.cache.tier.sockets.VersionedObjectList;
 
 @RunWith(JUnitParamsRunner.class)
 @SuppressWarnings({"deprecation", "unchecked", "unused"})
@@ -576,50 +571,6 @@ public class PartitionedRegionTest {
 
     assertThat(caughtException).isInstanceOf(TransactionDataRebalancedException.class)
         .hasMessage(PartitionedRegion.DATA_MOVED_BY_REBALANCE).hasCause(exception);
-  }
-
-  @Test
-  public void failuresSavedIfFetchKeysThrows() throws Exception {
-    PartitionedRegion spyPartitionedRegion = spy(partitionedRegion);
-
-    VersionedObjectList values = mock(VersionedObjectList.class);
-    ServerConnection serverConnection = mock(ServerConnection.class);
-    Set<Integer> failures = new HashSet<>();
-    InternalDistributedMember member = mock(InternalDistributedMember.class);
-    Set<Integer> buckets = new HashSet<>();
-    buckets.add(1);
-    doThrow(new ForceReattemptException("")).when(spyPartitionedRegion).getFetchKeysResponse(member,
-        1);
-
-    spyPartitionedRegion.fetchKeysAndValues(values, serverConnection, failures, member, null,
-        buckets);
-
-    verify(spyPartitionedRegion, never()).getValuesForKeys(values, serverConnection, null);
-    assertThat(failures.contains(1)).isTrue();
-  }
-
-  @Test
-  public void fetchKeysAndValuesInvokesGetValuesForKeys() throws Exception {
-    PartitionedRegion spyPartitionedRegion = spy(partitionedRegion);
-
-    VersionedObjectList values = mock(VersionedObjectList.class);
-    ServerConnection serverConnection = mock(ServerConnection.class);
-    Set<Integer> failures = new HashSet<>();
-    InternalDistributedMember member = mock(InternalDistributedMember.class);
-    Set<Integer> buckets = new HashSet<>();
-    buckets.add(1);
-    FetchKeysMessage.FetchKeysResponse fetchKeysResponse =
-        mock(FetchKeysMessage.FetchKeysResponse.class);
-    doReturn(fetchKeysResponse).when(spyPartitionedRegion).getFetchKeysResponse(member, 1);
-    Set keys = new HashSet();
-    when(fetchKeysResponse.waitForKeys()).thenReturn(keys);
-    doNothing().when(spyPartitionedRegion).getValuesForKeys(values, serverConnection, keys);
-
-    spyPartitionedRegion.fetchKeysAndValues(values, serverConnection, failures, member, null,
-        buckets);
-
-    verify(spyPartitionedRegion).getValuesForKeys(values, serverConnection, keys);
-    assertThat(failures.contains(1)).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Basically this code was being run to individually get keys for "older versions" that could have been done in bulk except this code didn't have a version limit. Older versions of the correct vintage are not supported anymore so this code should be (have been) removed. Unfortunately older versions for this code mean any previous version, so it was choosing the single entry approach when it should have been using the bulk approach. 

This gets rid of the single approach.