### PR TITLE
GEODE-9004: Fix issues in queries targeting a Map field

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/INOperatorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/INOperatorJUnitTest.java
@@ -225,11 +225,11 @@ public class INOperatorJUnitTest {
 
     q = CacheUtils.getQueryService().newQuery(" UNDEFINED IN SET(UNDEFINED)");
     result = q.execute();
-    assertThat(result).isEqualTo(QueryService.UNDEFINED);
+    assertThat(result).isEqualTo(TRUE);
 
     q = CacheUtils.getQueryService().newQuery(" UNDEFINED IN SET(UNDEFINED,UNDEFINED)");
     result = q.execute();
-    assertThat(result).isEqualTo(QueryService.UNDEFINED);
+    assertThat(result).isEqualTo(TRUE);
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/IndexOperatorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/IndexOperatorJUnitTest.java
@@ -19,6 +19,7 @@
  */
 package org.apache.geode.cache.query.functional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -145,8 +146,7 @@ public class IndexOperatorJUnitTest {
     map.put("0", new Integer(11));
     map.put("1", new Integer(12));
     Object result = runQuery(map, null);
-    if (result != null)
-      fail();
+    assertThat(result).isEqualTo(QueryService.UNDEFINED);
   }
 
   @Test
@@ -171,8 +171,7 @@ public class IndexOperatorJUnitTest {
     map.put("0", new Integer(11));
     map.put("1", new Integer(12));
     Object result = runQuery(map, QueryService.UNDEFINED);
-    if (result != null)
-      fail();
+    assertThat(result).isEqualTo(QueryService.UNDEFINED);
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
@@ -477,15 +477,43 @@ public class CompactRangeIndexJUnitTest {
     p4.positions.put("SUN", null);
     region.put("KEY-" + 4, p4);
 
-    // execute query and check result size
+    // execute query for null value and check result size
     QueryService qs = utils.getCache().getQueryService();
     SelectResults<Object> results = UncheckedUtils.uncheckedCast(qs
         .newQuery(
             "Select * from " + SEPARATOR + "exampleRegion r where r.positions['SUN'] = null")
         .execute());
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.contains(p4)).isTrue();
+
+    // execute query for not null value and check result size
+    results = UncheckedUtils.uncheckedCast(qs
+        .newQuery(
+            "Select * from " + SEPARATOR + "exampleRegion r where r.positions['SUN'] != null")
+        .execute());
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(results.contains(p1)).isTrue();
+    assertThat(results.contains(p2)).isTrue();
+    assertThat(results.contains(p3)).isTrue();
+
+    // execute query for defined values and check result size
+    results = UncheckedUtils.uncheckedCast(qs
+        .newQuery(
+            "Select * from " + SEPARATOR + "exampleRegion r where is_defined(r.positions['SUN'])")
+        .execute());
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.contains(p1)).isTrue();
+    assertThat(results.contains(p4)).isTrue();
+
+    // execute query for undefined values and check result size
+    results = UncheckedUtils.uncheckedCast(qs
+        .newQuery(
+            "Select * from " + SEPARATOR + "exampleRegion r where is_undefined(r.positions['SUN'])")
+        .execute());
     assertThat(results.size()).isEqualTo(2);
     assertThat(results.contains(p2)).isTrue();
-    assertThat(results.contains(p4)).isTrue();
+    assertThat(results.contains(p3)).isTrue();
+
   }
 
   private void putValues(int num) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
@@ -449,7 +449,7 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(0, mapIndexStats.getReadLockCount());
 
-    assertEquals(100, mapIndexStats.getTotalUses());
+    assertEquals(0, mapIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));
@@ -689,7 +689,7 @@ public class IndexStatisticsJUnitTest {
       query.execute();
     }
 
-    assertEquals(100, mapIndexStats.getTotalUses());
+    assertEquals(0, mapIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
@@ -370,7 +370,7 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(0, keyIndexStats.getReadLockCount());
 
-    assertEquals(100, keyIndexStats.getTotalUses());
+    assertEquals(0, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
@@ -370,6 +370,7 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(0, keyIndexStats.getReadLockCount());
 
+    // Index should not be used as the conditions on the indexed keys are "!="
     assertEquals(0, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
@@ -449,6 +450,7 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(0, mapIndexStats.getReadLockCount());
 
+    // Index should not be used as the conditions on the indexed keys are "!="
     assertEquals(0, mapIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
@@ -689,6 +691,7 @@ public class IndexStatisticsJUnitTest {
       query.execute();
     }
 
+    // Index should not be used as the conditions on the indexed keys are "!="
     assertEquals(0, mapIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
@@ -439,16 +439,16 @@ public class MapRangeIndexMaintenanceJUnitTest {
         ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
 
     // The number of keys must be equal to the number of different values the
-    // positions map takes for each key (null not included)
+    // positions map takes for each key
     // for each entry in the region:
-    // "something", null, "nothing", "more", "hey", "tip"
+    // "something", null, "nothing", "more", "empty", "hey", "tip"
     assertThat(keys).isEqualTo(7);
     // The number of mapIndexKeys must be equal to the number of different keys
     // that appear in entries of the region:
     // "IBM", "ERICSSON", "HP", "SUN", null
     assertThat(mapIndexKeys).isEqualTo(5);
     // The number of values must be equal to the number of values the
-    // positions map takes for each key (null not included)
+    // positions map takes for each key
     // for each entry in the region:
     // "something", null, "nothing", "more", "empty", "hey", "more", "tip"
     assertThat(values).isEqualTo(8);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
@@ -273,8 +273,8 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
-    assertEquals(100 /* Execution time */, keyIndexStats.getTotalUses());
+    // Index should not be used
+    assertEquals(0, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));
@@ -585,8 +585,7 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
-    assertEquals((100 /* Execution time */), keyIndexStats.getTotalUses());
+    assertEquals((0 /* Execution time */), keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
@@ -273,7 +273,7 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Index should not be used
+    // Index should not be used as the conditions on the indexed keys are "!="
     assertEquals(0, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
@@ -348,7 +348,7 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Indexes should not be used
+    // Index should not be used as the conditions on the indexed keys are "!="
     assertEquals(0 /* Execution time */, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
@@ -585,6 +585,7 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
+    // Index should not be used as the conditions on the indexed keys are "!="
     assertEquals((0 /* Execution time */), keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
@@ -666,7 +667,7 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Indexes should not be used
+    // Index should not be used as the conditions on the indexed keys are "!="
     assertEquals(0 /* Execution time */, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
@@ -348,8 +348,8 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
-    assertEquals(100 /* Execution time */, keyIndexStats.getTotalUses());
+    // Indexes should not be used
+    assertEquals(0 /* Execution time */, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));
@@ -666,8 +666,8 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
-    assertEquals(100 /* Execution time */, keyIndexStats.getTotalUses());
+    // Indexes should not be used
+    assertEquals(0 /* Execution time */, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
@@ -31,7 +31,7 @@ import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.Struct;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.cache.query.internal.index.AbstractIndex;
-import org.apache.geode.cache.query.internal.index.CompactMapRangeIndex;
+import org.apache.geode.cache.query.internal.index.AbstractMapIndex;
 import org.apache.geode.cache.query.internal.index.IndexData;
 import org.apache.geode.cache.query.internal.index.IndexProtocol;
 import org.apache.geode.cache.query.internal.index.IndexUtils;
@@ -656,7 +656,8 @@ public class CompiledComparison extends AbstractCompiledValue
       }
 
       // Do not use indexes when map index and != condition
-      if (indexData != null && indexData.getIndex() instanceof CompactMapRangeIndex
+      if (indexData != null
+          && (indexData.getIndex() instanceof AbstractMapIndex)
           && this._operator == TOK_NE) {
         Index prIndex = ((AbstractIndex) indexData.getIndex()).getPRIndex();
         if (prIndex != null) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
@@ -22,6 +22,7 @@ import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.AmbiguousNameException;
 import org.apache.geode.cache.query.FunctionDomainException;
+import org.apache.geode.cache.query.Index;
 import org.apache.geode.cache.query.IndexType;
 import org.apache.geode.cache.query.NameResolutionException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
@@ -29,9 +30,12 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.Struct;
 import org.apache.geode.cache.query.TypeMismatchException;
+import org.apache.geode.cache.query.internal.index.AbstractIndex;
+import org.apache.geode.cache.query.internal.index.CompactMapRangeIndex;
 import org.apache.geode.cache.query.internal.index.IndexData;
 import org.apache.geode.cache.query.internal.index.IndexProtocol;
 import org.apache.geode.cache.query.internal.index.IndexUtils;
+import org.apache.geode.cache.query.internal.index.PartitionedIndex;
 import org.apache.geode.cache.query.internal.parse.OQLLexerTokenTypes;
 import org.apache.geode.cache.query.internal.types.StructTypeImpl;
 import org.apache.geode.cache.query.internal.types.TypeUtils;
@@ -642,13 +646,25 @@ public class CompiledComparison extends AbstractCompiledValue
     } else {
       CompiledValue path = pAndK._path;
       CompiledValue indexKey = pAndK._key;
-      IndexData indexData = null;
+      IndexData indexData;
       // CompiledLike should not use HashIndex and PrimarKey Index.
       if (this instanceof CompiledLike) {
         indexData =
             QueryUtils.getAvailableIndexIfAny(path, context, OQLLexerTokenTypes.LITERAL_like);
       } else {
         indexData = QueryUtils.getAvailableIndexIfAny(path, context, this._operator);
+      }
+
+      // Do not use indexes when map index and != condition
+      if (indexData != null && indexData.getIndex() instanceof CompactMapRangeIndex
+          && this._operator == TOK_NE) {
+        Index prIndex = ((AbstractIndex) indexData.getIndex()).getPRIndex();
+        if (prIndex != null) {
+          ((PartitionedIndex) prIndex).releaseIndexReadLockForRemove();
+        } else {
+          ((AbstractIndex) indexData.getIndex()).releaseIndexReadLockForRemove();
+        }
+        return null;
       }
 
       IndexProtocol index = null;

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledConstruction.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledConstruction.java
@@ -23,7 +23,6 @@ import org.apache.geode.cache.query.AmbiguousNameException;
 import org.apache.geode.cache.query.FunctionDomainException;
 import org.apache.geode.cache.query.NameResolutionException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
-import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.internal.Assert;
 
@@ -64,9 +63,6 @@ public class CompiledConstruction extends AbstractCompiledValue {
     for (Iterator itr = this.args.iterator(); itr.hasNext();) {
       CompiledValue cv = (CompiledValue) itr.next();
       Object eval = cv.evaluate(context);
-      if (eval == QueryService.UNDEFINED) {
-        return QueryService.UNDEFINED;
-      }
       newSet.add(eval);
     }
     return newSet;

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledIndexOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledIndexOperation.java
@@ -104,7 +104,10 @@ public class CompiledIndexOperation extends AbstractCompiledValue implements Map
     }
 
     if (rcvr instanceof Map) {
-      return ((Map) rcvr).get(index);
+      if (((Map<?, ?>) rcvr).containsKey(index)) {
+        return ((Map) rcvr).get(index);
+      }
+      return QueryService.UNDEFINED;
     }
     if ((rcvr instanceof List) || rcvr.getClass().isArray() || (rcvr instanceof String)) {
       if (!(index instanceof Integer)) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/ResultsCollectionPdxDeserializerWrapper.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/ResultsCollectionPdxDeserializerWrapper.java
@@ -217,5 +217,4 @@ public class ResultsCollectionPdxDeserializerWrapper implements SelectResults {
   public void setElementType(ObjectType elementType) {
     results.setElementType(elementType);
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactMapRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactMapRangeIndex.java
@@ -112,9 +112,9 @@ public class CompactMapRangeIndex extends AbstractMapIndex {
       removeOldMappings(((Map) key).keySet(), entry);
     } else {
       for (Object mapKey : mapKeys) {
-        Object indexKey = ((Map) key).get(mapKey);
-        if (indexKey != null) {
+        if (((Map) key).containsKey(mapKey)) {
           // Do not convert to IndexManager.NULL. We are only interested in specific keys
+          Object indexKey = ((Map) key).get(mapKey);
           this.saveIndexAddition(mapKey, indexKey, value, entry);
         }
       }

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
@@ -183,14 +183,17 @@ public class Portfolio implements Serializable, DataSerializable {
 
   public String toString() {
     String out =
-        "Portfolio [ID=" + ID + " status=" + status + " type=" + type + " pkid=" + pkid + "\n ";
-    Iterator iter = positions.entrySet().iterator();
-    while (iter.hasNext()) {
-      Map.Entry entry = (Map.Entry) iter.next();
-      out += entry.getKey() + ":" + entry.getValue() + ", ";
+        "Portfolio [ID=" + ID + " status=" + status + " type=" + type + " pkid=" + pkid
+            + System.lineSeparator();
+    if (positions != null) {
+      Iterator iter = positions.entrySet().iterator();
+      while (iter.hasNext()) {
+        Map.Entry entry = (Map.Entry) iter.next();
+        out += entry.getKey() + ":" + entry.getValue() + ", ";
+      }
+      out += System.lineSeparator() + " P1:" + position1 + ", P2:" + position2;
     }
-    out += "\n P1:" + position1 + ", P2:" + position2;
-    return out + "\n]";
+    return out + System.lineSeparator() + "]";
   }
 
   /**


### PR DESCRIPTION
Queries in which map fields are involved
in the condition, sometimes do not return the same entries
if map indexes are used, compared to when map indexes
are not used.

Differences were found when the condition on the
map field was of type '!=' and also when the condition
on the map field was comparing the value with null.

Example1:
Running a query with the following condition:
positions['SUN'] = null

in a region with the following entries:
entry1.positions=null
entry2.positions={'a'=>'b'}
entry3.positions={'SUN'=>null}

- will return entry1 and entry3 if there are no
  indexes defined.
- will return no entries if the following index is defined:
  positions['SUN','c']
- will return entry3 if the following index is defined:
  positions[*]

Example2:
Running a query with the following condition:
positions['SUN'] != '3'

in a region with the following entries:
entry1.positions=null
entry2.positions={'a'=>'b'}
entry3.positions={'SUN'=>'4'}
entry4.positions={'SUN'=>'3'}
entry5.positions={'SUN'=>null}

- will return all entries except for entry4 if:
  there are no indexes defined.
- will return entry3 if the following index is defined:
  positions['SUN','c']
- will return entry3 and entry5 if the following index is defined:
  positions[*]

In order to have the same results for these
queries no matter if indexes are used,
the following changes have been made:
- When running queries, the result of getting the
value from a Map that does not contain the key used
to access the value will be
considered UNDEFINED instead of null.
This will imply that queries where the condition is
positions['SUN'] = null will not return entries
that do not have the 'SUN' key in the positions Map.

- Queries with map indexes will not be able to use
the indexes if the query is of type '!=' against
any of the indexed map fields.
Example:
for index positions['SUN', 'ERIC'] or
positions[*]
the following query will not use indexes:
positions['SUN'] != '44'

These changes must be documented accordingly
in the corresponding indexes section.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
