### PR TITLE
GEODE-9081: Remove transient allocation.

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -31,6 +31,7 @@ def dependentProjectNames = [
   ':geode-common',
   ':geode-connectors',
   ':geode-core',
+  ':geode-unsafe',
   ':geode-cq',
   ':geode-gfsh',
   ':geode-log4j',

--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/TomcatInstall.java
@@ -115,7 +115,7 @@ public class TomcatInstall extends ContainerInstall {
    */
   private static final String[] tomcatRequiredJars =
       {"antlr", "commons-io", "commons-lang", "commons-validator", "fastutil", "geode-common",
-          "geode-core", "geode-deployment-legacy", "geode-log4j", "geode-logging",
+          "geode-core", "geode-unsafe", "geode-deployment-legacy", "geode-log4j", "geode-logging",
           "geode-membership", "geode-management", "geode-serialization", "geode-tcp-server",
           "javax.transaction-api", "jgroups", "log4j-api", "log4j-core", "log4j-jul", "micrometer",
           "shiro-core", "jetty-server", "jetty-util", "jetty-http", "jetty-io"};

--- a/geode-unsafe/src/main/java/org/apache/geode/unsafe/internal/sun/nio/ch/DirectBuffer.java
+++ b/geode-unsafe/src/main/java/org/apache/geode/unsafe/internal/sun/nio/ch/DirectBuffer.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.unsafe.internal.sun.nio.ch;
+
+/**
+ * Provides access to methods on non-SDK class {@link sun.nio.ch.DirectBuffer}.
+ */
+public interface DirectBuffer {
+
+  /**
+   * @see sun.nio.ch.DirectBuffer#attachment()
+   * @param object to get attachment for
+   * @return returns attachment if object is {@link sun.nio.ch.DirectBuffer} otherwise null.
+   */
+  static Object attachment(final Object object) {
+    if (object instanceof sun.nio.ch.DirectBuffer) {
+      return ((sun.nio.ch.DirectBuffer) object).attachment();
+    }
+
+    return null;
+  }
+
+}

--- a/geode-unsafe/src/test/java/org/apache/geode/unsafe/internal/sun/nio/ch/DirectBufferTest.java
+++ b/geode-unsafe/src/test/java/org/apache/geode/unsafe/internal/sun/nio/ch/DirectBufferTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+
+package org.apache.geode.unsafe.internal.sun.nio.ch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+
+import org.junit.Test;
+
+public class DirectBufferTest {
+
+  @Test
+  public void attachmentIsNullForNonDirectBuffer() {
+    assertThat(DirectBuffer.attachment(null)).isNull();
+    assertThat(DirectBuffer.attachment(new Object())).isNull();
+    assertThat(DirectBuffer.attachment(ByteBuffer.allocate(1))).isNull();
+  }
+
+  @Test
+  public void attachmentIsNullForUnslicedDirectBuffer() {
+    assertThat(DirectBuffer.attachment(ByteBuffer.allocateDirect(1))).isNull();
+  }
+
+  @Test
+  public void attachmentIsRootBufferForDirectBufferSlice() {
+    final ByteBuffer root = ByteBuffer.allocateDirect(10);
+    final ByteBuffer slice = root.slice();
+
+    assertThat(DirectBuffer.attachment(slice)).isSameAs(root);
+  }
+
+}


### PR DESCRIPTION
* New geode-unsafe access to non-SDK API for DirectBuffer.
* Use geode-unsafe to access DirectBuffer.attachment().
* Removes latency of reflection.
* Removes transient Object[] allocation in Method.invoke().

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
