### PR TITLE
GEODE-8761: detect stuck ServerConnection threads

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -133,7 +133,7 @@ public abstract class ServerConnection implements Runnable {
    * will automatically register with the thread monitor the thread that is processing
    * the request. So no need to create a threadMonitorExecutor.
    */
-  protected AbstractExecutor threadMonitorExecutor;
+  private AbstractExecutor threadMonitorExecutor;
 
   public static ByteBuffer allocateCommBuffer(int size, Socket sock) {
     // I expect that size will almost always be the same value

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -129,8 +129,11 @@ public abstract class ServerConnection implements Runnable {
   /**
    * The threadMonitorExecutor for this server connection.
    * This will be null if acceptor is a selector.
+   * When a selector is used, the thread pool that is used to process client requests
+   * will automatically register with the thread monitor the thread that is processing
+   * the request. So no need to create a threadMonitorExecutor.
    */
-  protected final AbstractExecutor threadMonitorExecutor;
+  protected AbstractExecutor threadMonitorExecutor;
 
   public static ByteBuffer allocateCommBuffer(int size, Socket sock) {
     // I expect that size will almost always be the same value
@@ -315,15 +318,6 @@ public abstract class ServerConnection implements Runnable {
       }
     }
     threadMonitoring = getCache().getInternalDistributedSystem().getDM().getThreadMonitoring();
-    if (getAcceptor().isSelector()) {
-      // When a selector is used, the thread pool that is used to process client requests
-      // will automatically register with the thread monitor the thread that is processing
-      // the request. So no need to create a threadMonitorExecutor.
-      threadMonitorExecutor = null;
-    } else {
-      threadMonitorExecutor = threadMonitoring.createAbstractExecutor(ServerConnectionExecutor);
-      suspendThreadMonitoring();
-    }
   }
 
   public Acceptor getAcceptor() {
@@ -1246,6 +1240,8 @@ public abstract class ServerConnection implements Runnable {
         }
       }
     } else {
+      threadMonitorExecutor = threadMonitoring.createAbstractExecutor(ServerConnectionExecutor);
+      suspendThreadMonitoring();
       threadMonitoring.register(threadMonitorExecutor);
       try {
         while (processMessages && !crHelper.isShutdown()) {


### PR DESCRIPTION
The previous fix for GEODE-8761 ended up monitoring the thread that created the server connection
instead of the thread that was executing its run() method.
Now the threadMonitorExecutor is created in the run() method
which causes the correct thread id to be set on it.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
