### PR TITLE
GEODE-9037: Do not expose unsupported commands in Geode compatibility with Redis

### DIFF
--- a/ci/scripts/execute_redis_tests.sh
+++ b/ci/scripts/execute_redis_tests.sh
@@ -31,7 +31,7 @@ git apply ${REDIS_PATCH}
 export JAVA_HOME=${JAVA_TEST_PATH}
 
 ../geode-assembly/build/install/apache-geode/bin/gfsh start server \
-  --J=-Denable-redis-unsupported-commands=true \
+  --J=-Denable-unsupported-commands=true \
   --name=server1 \
   --compatible-with-redis-port=6380 \
   --compatible-with-redis-bind-address=127.0.0.1 \
@@ -45,7 +45,7 @@ failCount=0
 
 
 ../geode-assembly/build/install/apache-geode/bin/gfsh start server \
-  --J=-Denable-redis-unsupported-commands=true \
+  --J=-Denable-unsupported-commands=true \
   --name=server2 \
   --server-port=0 \
   --compatible-with-redis-port=6379 \

--- a/geode-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
@@ -31,7 +31,7 @@ public class GeodeRedisServerRule extends SerializableExternalResource {
   private GemFireCache cache;
   private GeodeRedisServer server;
   private CacheFactory cacheFactory;
-
+  private Boolean enableUnsupportedCommands = true;
 
   public GeodeRedisServerRule() {
     cacheFactory = new CacheFactory();
@@ -40,14 +40,16 @@ public class GeodeRedisServerRule extends SerializableExternalResource {
     cacheFactory.set(LOCATORS, "");
   }
 
+  public void setEnableUnsupportedCommands(boolean allow) {
+    this.server.setAllowUnsupportedCommands(allow);
+  }
+
   @Override
   protected void before() {
     cache = cacheFactory.create();
     server = new GeodeRedisServer("localhost", 0, (InternalCache) cache);
-    server.setAllowUnsupportedCommands(true);
+    server.setAllowUnsupportedCommands(enableUnsupportedCommands);
   }
-
-
 
   public GeodeRedisServerRule withProperty(String property, String value) {
     cacheFactory.set(property, value);

--- a/geode-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -38,7 +38,8 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
 
   public MemberVM startRedisVM(int index, int... locatorPort) {
     return startServerVM(index, r -> withRedis(r)
-        .withConnectionToLocator(locatorPort));
+        .withConnectionToLocator(locatorPort)
+        .withSystemProperty("enable-unsupported-commands", "true"));
   }
 
 
@@ -62,7 +63,7 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
     return rule.withProperty(REDIS_BIND_ADDRESS, "localhost")
         .withProperty(REDIS_PORT, "0")
         .withProperty(REDIS_ENABLED, "true")
-        .withSystemProperty(GeodeRedisServer.ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM,
+        .withSystemProperty(GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM,
             "true");
   }
 
@@ -70,7 +71,7 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
     return rule.withProperty(REDIS_BIND_ADDRESS, "localhost")
         .withProperty(REDIS_PORT, redisPort)
         .withProperty(REDIS_ENABLED, "true")
-        .withSystemProperty(GeodeRedisServer.ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM,
+        .withSystemProperty(GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM,
             "true");
   }
 

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/CrashAndNoRepeatDUnitTest.java
@@ -21,7 +21,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
-import static org.apache.geode.redis.internal.GeodeRedisServer.ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM;
+import static org.apache.geode.redis.internal.GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
@@ -90,7 +90,7 @@ public class CrashAndNoRepeatDUnitTest {
             .withProperty(REDIS_ENABLED, "true")
             .withProperty(LOG_LEVEL, log_level)
             .withProperty(REDIS_BIND_ADDRESS, "localhost")
-            .withSystemProperty(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, "true")
+            .withSystemProperty(ENABLE_UNSUPPORTED_COMMANDS_PARAM, "true")
             .withConnectionToLocator(locatorPort));
     redisPorts[0] = getPort(server1);
 
@@ -99,7 +99,7 @@ public class CrashAndNoRepeatDUnitTest {
             .withProperty(REDIS_ENABLED, "true")
             .withProperty(LOG_LEVEL, log_level)
             .withProperty(REDIS_BIND_ADDRESS, "localhost")
-            .withSystemProperty(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, "true")
+            .withSystemProperty(ENABLE_UNSUPPORTED_COMMANDS_PARAM, "true")
             .withConnectionToLocator(locatorPort));
     redisPorts[1] = getPort(server2);
 
@@ -108,7 +108,7 @@ public class CrashAndNoRepeatDUnitTest {
             .withProperty(REDIS_ENABLED, "true")
             .withProperty(LOG_LEVEL, log_level)
             .withProperty(REDIS_BIND_ADDRESS, "localhost")
-            .withSystemProperty(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, "true")
+            .withSystemProperty(ENABLE_UNSUPPORTED_COMMANDS_PARAM, "true")
             .withConnectionToLocator(locatorPort));
     redisPorts[2] = getPort(server3);
 
@@ -132,7 +132,7 @@ public class CrashAndNoRepeatDUnitTest {
         x -> x.withProperty(REDIS_PORT, redisPort + "")
             .withProperty(REDIS_ENABLED, "true")
             .withProperty(REDIS_BIND_ADDRESS, "localhost")
-            .withSystemProperty(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, "true")
+            .withSystemProperty(ENABLE_UNSUPPORTED_COMMANDS_PARAM, "true")
             .withConnectionToLocator(locatorPort));
   }
 

--- a/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
+++ b/geode-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
@@ -20,7 +20,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PORT;
-import static org.apache.geode.redis.internal.GeodeRedisServer.ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM;
+import static org.apache.geode.redis.internal.GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -98,7 +98,7 @@ public class HashesAndCrashesDUnitTest {
         x -> x.withProperty(REDIS_PORT, redisPort1)
             .withProperty(REDIS_ENABLED, "true")
             .withProperty(REDIS_BIND_ADDRESS, "localhost")
-            .withSystemProperty(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, "true")
+            .withSystemProperty(ENABLE_UNSUPPORTED_COMMANDS_PARAM, "true")
             .withConnectionToLocator(locatorPort));
 
     String redisPort2 = redisPorts[1] + "";
@@ -106,7 +106,7 @@ public class HashesAndCrashesDUnitTest {
         x -> x.withProperty(REDIS_PORT, redisPort2)
             .withProperty(REDIS_ENABLED, "true")
             .withProperty(REDIS_BIND_ADDRESS, "localhost")
-            .withSystemProperty(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, "true")
+            .withSystemProperty(ENABLE_UNSUPPORTED_COMMANDS_PARAM, "true")
             .withConnectionToLocator(locatorPort));
 
     String redisPort3 = redisPorts[2] + "";
@@ -114,7 +114,7 @@ public class HashesAndCrashesDUnitTest {
         x -> x.withProperty(REDIS_PORT, redisPort3)
             .withProperty(REDIS_ENABLED, "true")
             .withProperty(REDIS_BIND_ADDRESS, "localhost")
-            .withSystemProperty(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, "true")
+            .withSystemProperty(ENABLE_UNSUPPORTED_COMMANDS_PARAM, "true")
             .withConnectionToLocator(locatorPort));
 
     gfsh.connectAndVerify(locator);
@@ -158,7 +158,7 @@ public class HashesAndCrashesDUnitTest {
         x -> x.withProperty(REDIS_PORT, redisPort + "")
             .withProperty(REDIS_ENABLED, "true")
             .withProperty(REDIS_BIND_ADDRESS, "localhost")
-            .withSystemProperty(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, "true")
+            .withSystemProperty(ENABLE_UNSUPPORTED_COMMANDS_PARAM, "true")
             .withConnectionToLocator(locatorPort));
   }
 

--- a/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/common/UnsupportedCommandsIntegrationTest.java
+++ b/geode-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/common/UnsupportedCommandsIntegrationTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.common;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_COMMAND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.rules.RedisPortSupplier;
+
+
+public class UnsupportedCommandsIntegrationTest
+    implements RedisPortSupplier {
+
+  protected static Jedis jedis;
+
+  private static final int REDIS_CLIENT_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
+
+  @Before
+  public void setUp() {
+    jedis = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @Test
+  public void shouldNotError_givenCallToUnsupportedCommand_whenEnableUnSupportedCommandsFlagSet() {
+    server.setEnableUnsupportedCommands(true);
+
+    final String NEW_VALUE = "new value";
+    jedis.set("key", "value");
+
+    jedis.getSet("key", NEW_VALUE);
+
+    String actual = jedis.get("key");
+    assertThat(actual).isEqualTo(NEW_VALUE);
+  }
+
+  @Test
+  public void shouldReturnUnknownCommandMessage_givenCallToUnsupportedCommand_whenEnableUnSupportedCommandsFlagNotSet() {
+    server.setEnableUnsupportedCommands(false);
+
+    final String KEY = "key";
+    final String NEW_VALUE = "changed value";
+    final String EXPECTED_ERROR_MSG =
+        String.format(ERROR_UNKNOWN_COMMAND, "GETSET", "`" + KEY + "`", NEW_VALUE);
+    jedis.set(KEY, "value");
+
+    assertThatThrownBy(
+        () -> jedis.getSet(KEY, NEW_VALUE))
+            .hasMessageContaining(EXPECTED_ERROR_MSG);
+  }
+
+  @Test
+  public void shouldReturnUnknownCommandMessage_givenCallToInternalCommand_whenEnableUnSupportedCommandsFlagNotSet() {
+    server.setEnableUnsupportedCommands(false);
+
+    final String TEST_PARAMETER = "this is only a test";
+    final String EXPECTED_ERROR_MSG =
+        String.format(ERROR_UNKNOWN_COMMAND, InternalCommands.INTERNALPTTL,
+            "`" + TEST_PARAMETER + "`");
+
+    assertThatThrownBy(
+        () -> jedis.sendCommand(InternalCommands.INTERNALPTTL, TEST_PARAMETER))
+            .hasMessageContaining(EXPECTED_ERROR_MSG);
+  }
+
+  @Test
+  public void shouldReturnUnknownCommandMessage_givenCallToInternalCommand_whenEnableUnSupportedCommandsFlagSet() {
+    server.setEnableUnsupportedCommands(true);
+
+    final String TEST_PARAMETER = " this is only a test";
+    final String EXPECTED_ERROR_MSG =
+        String.format(ERROR_UNKNOWN_COMMAND, InternalCommands.INTERNALTYPE,
+            "`" + TEST_PARAMETER + "`");
+
+    assertThatThrownBy(
+        () -> jedis.sendCommand(InternalCommands.INTERNALTYPE, TEST_PARAMETER))
+            .hasMessageContaining(EXPECTED_ERROR_MSG);
+  }
+
+  @After
+  public void tearDown() {
+    server.setEnableUnsupportedCommands(true);
+    jedis.flushAll();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    jedis.close();
+  }
+
+  private enum InternalCommands implements ProtocolCommand {
+    INTERNALPTTL("INTERNALPTTL"),
+    INTERNALTYPE("INTERNALTYPE");
+
+    private final byte[] raw;
+
+    InternalCommands(String command) {
+      this.raw = SafeEncoder.encode(command);
+    }
+
+    @Override
+    public byte[] getRaw() {
+      return raw;
+    }
+  }
+}

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Cache;
-import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
@@ -46,33 +45,22 @@ import org.apache.geode.redis.internal.statistics.RedisStats;
  * sent back to the client. The default connection port is 6379 but that can be altered when run
  * through gfsh or started through the provided static main class.
  */
-
 public class GeodeRedisServer {
+
   /**
    * The default Redis port as specified by their protocol, {@code DEFAULT_REDIS_SERVER_PORT}
    */
   public static final int DEFAULT_REDIS_SERVER_PORT = 6379;
-
-  public static final String ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM =
-      "enable-redis-unsupported-commands";
-
+  public static final String ENABLE_UNSUPPORTED_COMMANDS_PARAM = "enable-unsupported-commands";
+  private static boolean unsupportedCommandsEnabled;
   private static final Logger logger = LogService.getLogger();
-
-
-  private final boolean ENABLE_REDIS_UNSUPPORTED_COMMANDS =
-      Boolean.getBoolean(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM);
-
   private final PassiveExpirationManager passiveExpirationManager;
-
   private final NettyRedisServer nettyRedisServer;
-
   private final RegionProvider regionProvider;
   private final PubSub pubSub;
   private final RedisStats redisStats;
   private final ExecutorService redisCommandExecutor;
-
   private boolean shutdown;
-
 
   /**
    * Constructor for {@code GeodeRedisServer} that will configure the server to bind to the given
@@ -84,10 +72,8 @@ public class GeodeRedisServer {
    *        argument is less than 0. If the port is 0 a random port is assigned.
    */
   public GeodeRedisServer(String bindAddress, int port, InternalCache cache) {
-    if (ENABLE_REDIS_UNSUPPORTED_COMMANDS) {
-      logUnsupportedCommandWarning();
-    }
 
+    unsupportedCommandsEnabled = Boolean.getBoolean(ENABLE_UNSUPPORTED_COMMANDS_PARAM);
     pubSub = new PubSubImpl(new Subscriptions());
     redisStats = createStats(cache);
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
@@ -96,9 +82,13 @@ public class GeodeRedisServer {
     CommandFunction.register(regionProvider.getDataRegion(), stripedExecutor, redisStats);
     RenameFunction.register(regionProvider.getDataRegion(), stripedExecutor, redisStats);
     RedisCommandFunction.register();
+
     passiveExpirationManager =
         new PassiveExpirationManager(regionProvider.getDataRegion(), redisStats);
-    redisCommandExecutor = LoggingExecutors.newCachedThreadPool("GeodeRedisServer-Command-", true);
+
+    redisCommandExecutor =
+        LoggingExecutors.newCachedThreadPool("GeodeRedisServer-Command-", true);
+
     nettyRedisServer = new NettyRedisServer(() -> cache.getInternalDistributedSystem().getConfig(),
         regionProvider, pubSub,
         this::allowUnsupportedCommands, this::shutdown, port, bindAddress, redisStats,
@@ -108,15 +98,6 @@ public class GeodeRedisServer {
   @VisibleForTesting
   public int getSubscriptionCount() {
     return ((PubSubImpl) pubSub).getSubscriptionCount();
-  }
-
-  public void setAllowUnsupportedCommands(boolean allowUnsupportedCommands) {
-    Region<String, Object> configRegion = regionProvider.getConfigRegion();
-    configRegion.put(GeodeRedisServer.ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM,
-        allowUnsupportedCommands);
-    if (allowUnsupportedCommands) {
-      logUnsupportedCommandWarning();
-    }
   }
 
   private static RedisStats createStats(InternalCache cache) {
@@ -142,16 +123,13 @@ public class GeodeRedisServer {
     return dataStoreBytesInUse;
   }
 
-  /**
-   * Precedence of the internal property overrides the global system property.
-   */
-  public boolean allowUnsupportedCommands() {
-    return (boolean) regionProvider.getConfigRegion()
-        .getOrDefault(ENABLE_REDIS_UNSUPPORTED_COMMANDS_PARAM, ENABLE_REDIS_UNSUPPORTED_COMMANDS);
+  @VisibleForTesting
+  public void setAllowUnsupportedCommands(boolean allowUnsupportedCommands) {
+    this.unsupportedCommandsEnabled = allowUnsupportedCommands;
   }
 
-  private void logUnsupportedCommandWarning() {
-    logger.warn("Unsupported commands enabled. Unsupported commands have not been fully tested.");
+  public boolean allowUnsupportedCommands() {
+    return this.unsupportedCommandsEnabled;
   }
 
   public RegionProvider getRegionProvider() {

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandSupportLevel.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandSupportLevel.java
@@ -19,7 +19,6 @@ package org.apache.geode.redis.internal;
 public enum RedisCommandSupportLevel {
   SUPPORTED,
   UNSUPPORTED,
-  UNIMPLEMENTED,
   UNKNOWN,
   INTERNAL
 }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal;
 
 import static org.apache.geode.redis.internal.RedisCommandSupportLevel.INTERNAL;
 import static org.apache.geode.redis.internal.RedisCommandSupportLevel.SUPPORTED;
-import static org.apache.geode.redis.internal.RedisCommandSupportLevel.UNIMPLEMENTED;
 import static org.apache.geode.redis.internal.RedisCommandSupportLevel.UNSUPPORTED;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 
@@ -211,26 +210,21 @@ public enum RedisCommandType {
   INTERNALSMEMBERS(new UnknownExecutor(), INTERNAL, new ExactParameterRequirements(3)),
 
   /***************************************
-   *** Unsupported Commands ***
+   ******** Unsupported Commands *********
    ***************************************/
 
-  /***************************************
-   *************** Connection *************
-   ***************************************/
+  /*************** Connection *************/
 
   ECHO(new EchoExecutor(), UNSUPPORTED, new ExactParameterRequirements(2)),
   SELECT(new SelectExecutor(), UNSUPPORTED, new ExactParameterRequirements(2)),
 
-  /***************************************
-   *************** Keys ******************
-   ***************************************/
+  /*************** Keys ******************/
 
-  SCAN(new ScanExecutor(), UNSUPPORTED, new EvenParameterRequirements(ERROR_SYNTAX).and(new MinimumParameterRequirements(2))),
+  SCAN(new ScanExecutor(), UNSUPPORTED,
+      new EvenParameterRequirements(ERROR_SYNTAX).and(new MinimumParameterRequirements(2))),
   UNLINK(new DelExecutor(), UNSUPPORTED, new MinimumParameterRequirements(2)),
 
-  /***************************************
-   ************** Strings ****************
-   ***************************************/
+  /************** Strings ****************/
 
   BITCOUNT(new BitCountExecutor(), UNSUPPORTED, new MinimumParameterRequirements(2)),
   BITOP(new BitOpExecutor(), UNSUPPORTED, new MinimumParameterRequirements(4)),
@@ -246,9 +240,7 @@ public enum RedisCommandType {
   SETEX(new SetEXExecutor(), UNSUPPORTED, new ExactParameterRequirements(4)),
   SETRANGE(new SetRangeExecutor(), UNSUPPORTED, new ExactParameterRequirements(4)),
 
-  /***************************************
-   **************** Sets *****************
-   ***************************************/
+  /**************** Sets *****************/
 
   SCARD(new SCardExecutor(), UNSUPPORTED, new ExactParameterRequirements(2)),
   SDIFF(new SDiffExecutor(), UNSUPPORTED, new MinimumParameterRequirements(2)),
@@ -265,9 +257,7 @@ public enum RedisCommandType {
   SUNION(new SUnionExecutor(), UNSUPPORTED, new MinimumParameterRequirements(2)),
   SUNIONSTORE(new SUnionStoreExecutor(), UNSUPPORTED, new MinimumParameterRequirements(3)),
 
-  /***************************************
-   *************** Server ****************
-   ***************************************/
+  /*************** Server ****************/
 
   DBSIZE(new DBSizeExecutor(), UNSUPPORTED, new ExactParameterRequirements(1)),
   FLUSHALL(new FlushAllExecutor(), UNSUPPORTED, new MaximumParameterRequirements(2, ERROR_SYNTAX)),
@@ -275,119 +265,8 @@ public enum RedisCommandType {
   SHUTDOWN(new ShutDownExecutor(), UNSUPPORTED, new MaximumParameterRequirements(2, ERROR_SYNTAX)),
   TIME(new TimeExecutor(), UNSUPPORTED, new ExactParameterRequirements(1)),
 
-  /////////// UNIMPLEMENTED /////////////////////
-
-  ACL(null, UNIMPLEMENTED),
-  BGREWRITEAOF(null, UNIMPLEMENTED),
-  BGSAVE(null, UNIMPLEMENTED),
-  BITFIELD(null, UNIMPLEMENTED),
-  BLPOP(null, UNIMPLEMENTED),
-  BRPOP(null, UNIMPLEMENTED),
-  BRPOPLPUSH(null, UNIMPLEMENTED),
-  BZPOPMIN(null, UNIMPLEMENTED),
-  BZPOPMAX(null, UNIMPLEMENTED),
-  CLIENT(null, UNIMPLEMENTED),
-  CLUSTER(null, UNIMPLEMENTED),
-  COMMAND(null, UNIMPLEMENTED),
-  CONFIG(null, UNIMPLEMENTED),
-  DEBUG(null, UNIMPLEMENTED),
-  DISCARD(null, UNIMPLEMENTED),
-  DUMP(null, UNIMPLEMENTED),
-  EVAL(null, UNIMPLEMENTED),
-  EVALSHA(null, UNIMPLEMENTED),
-  EXEC(null, UNIMPLEMENTED),
-  GEOADD(null, UNIMPLEMENTED),
-  GEOHASH(null, UNIMPLEMENTED),
-  GEOPOS(null, UNIMPLEMENTED),
-  GEODIST(null, UNIMPLEMENTED),
-  GEORADIUS(null, UNIMPLEMENTED),
-  GEORADIUSBYMEMBER(null, UNIMPLEMENTED),
-  LATENCY(null, UNIMPLEMENTED),
-  LASTSAVE(null, UNIMPLEMENTED),
-  LINDEX(null, UNIMPLEMENTED),
-  LINSERT(null, UNIMPLEMENTED),
-  LLEN(null, UNIMPLEMENTED),
-  LOLWUT(null, UNIMPLEMENTED),
-  LPOP(null, UNIMPLEMENTED),
-  LPUSH(null, UNIMPLEMENTED),
-  LPUSHX(null, UNIMPLEMENTED),
-  LRANGE(null, UNIMPLEMENTED),
-  LREM(null, UNIMPLEMENTED),
-  LSET(null, UNIMPLEMENTED),
-  LTRIM(null, UNIMPLEMENTED),
-  MEMORY(null, UNIMPLEMENTED),
-  MIGRATE(null, UNIMPLEMENTED),
-  MODULE(null, UNIMPLEMENTED),
-  MONITOR(null, UNIMPLEMENTED),
-  MOVE(null, UNIMPLEMENTED),
-  MULTI(null, UNIMPLEMENTED),
-  OBJECT(null, UNIMPLEMENTED),
-  PFADD(null, UNIMPLEMENTED),
-  PFCOUNT(null, UNIMPLEMENTED),
-  PFMERGE(null, UNIMPLEMENTED),
-  PSYNC(null, UNIMPLEMENTED),
-  PUBSUB(null, UNIMPLEMENTED),
-  RANDOMKEY(null, UNIMPLEMENTED),
-  READONLY(null, UNIMPLEMENTED),
-  READWRITE(null, UNIMPLEMENTED),
-  RENAMENX(null, UNIMPLEMENTED),
-  RESTORE(null, UNIMPLEMENTED),
-  ROLE(null, UNIMPLEMENTED),
-  RPOP(null, UNIMPLEMENTED),
-  RPOPLPUSH(null, UNIMPLEMENTED),
-  RPUSH(null, UNIMPLEMENTED),
-  RPUSHX(null, UNIMPLEMENTED),
-  SAVE(null, UNIMPLEMENTED),
-  SCRIPT(null, UNIMPLEMENTED),
-  SLAVEOF(null, UNIMPLEMENTED),
-  REPLICAOF(null, UNIMPLEMENTED),
-  SORT(null, UNIMPLEMENTED),
-  STRALGO(null, UNIMPLEMENTED),
-  SWAPDB(null, UNIMPLEMENTED),
-  SYNC(null, UNIMPLEMENTED),
-  TOUCH(null, UNIMPLEMENTED),
-  UNWATCH(null, UNIMPLEMENTED),
-  WAIT(null, UNIMPLEMENTED),
-  WATCH(null, UNIMPLEMENTED),
-  XINFO(null, UNIMPLEMENTED),
-  XADD(null, UNIMPLEMENTED),
-  XTRIM(null, UNIMPLEMENTED),
-  XDEL(null, UNIMPLEMENTED),
-  XRANGE(null, UNIMPLEMENTED),
-  XREVRANGE(null, UNIMPLEMENTED),
-  XLEN(null, UNIMPLEMENTED),
-  XREAD(null, UNIMPLEMENTED),
-  XGROUP(null, UNIMPLEMENTED),
-  XREADGROUP(null, UNIMPLEMENTED),
-  XACK(null, UNIMPLEMENTED),
-  XCLAIM(null, UNIMPLEMENTED),
-  XPENDING(null, UNIMPLEMENTED),
-  ZADD(null, UNIMPLEMENTED),
-  ZCARD(null, UNIMPLEMENTED),
-  ZCOUNT(null, UNIMPLEMENTED),
-  ZINCRBY(null, UNIMPLEMENTED),
-  ZINTERSTORE(null, UNIMPLEMENTED),
-  ZLEXCOUNT(null, UNIMPLEMENTED),
-  ZPOPMAX(null, UNIMPLEMENTED),
-  ZPOPMIN(null, UNIMPLEMENTED),
-  ZRANGE(null, UNIMPLEMENTED),
-  ZRANGEBYLEX(null, UNIMPLEMENTED),
-  ZREVRANGEBYLEX(null, UNIMPLEMENTED),
-  ZRANGEBYSCORE(null, UNIMPLEMENTED),
-  ZRANK(null, UNIMPLEMENTED),
-  ZREM(null, UNIMPLEMENTED),
-  ZREMRANGEBYLEX(null, UNIMPLEMENTED),
-  ZREMRANGEBYRANK(null, UNIMPLEMENTED),
-  ZREMRANGEBYSCORE(null, UNIMPLEMENTED),
-  ZREVRANGE(null, UNIMPLEMENTED),
-  ZREVRANGEBYSCORE(null, UNIMPLEMENTED),
-  ZREVRANK(null, UNIMPLEMENTED),
-  ZSCORE(null, UNIMPLEMENTED),
-  ZUNIONSCORE(null, UNIMPLEMENTED),
-  ZSCAN(null, UNIMPLEMENTED),
-
   /***************************************
-   *** Unknown Commands ***
+   *********** Unknown Commands **********
    ***************************************/
   UNKNOWN(new UnknownExecutor(), RedisCommandSupportLevel.UNKNOWN);
 
@@ -422,9 +301,6 @@ public enum RedisCommandType {
     return supportLevel == UNSUPPORTED;
   }
 
-  public boolean isUnimplemented() {
-    return supportLevel == UNIMPLEMENTED;
-  }
 
   public boolean isInternal() {
     return supportLevel == INTERNAL;

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
@@ -77,10 +77,6 @@ public class Command {
     return commandType.isUnsupported();
   }
 
-  public boolean isUnimplemented() {
-    return commandType.isUnimplemented();
-  }
-
   public boolean isUnknown() {
     return commandType.isUnknown();
   }

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -53,6 +53,7 @@ import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.executor.CommandFunction;
 import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.executor.UnknownExecutor;
 import org.apache.geode.redis.internal.pubsub.PubSub;
 import org.apache.geode.redis.internal.statistics.RedisStats;
 
@@ -285,6 +286,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
             channel.remoteAddress().toString());
       }
 
+      // Note: Some Redis 6 clients look for an 'unknown command' error when
+      // connecting to Redis <= 5 servers. So we need to check for unknown BEFORE auth.
       if (command.isUnknown()) {
         writeToChannel(command.execute(this));
         return;
@@ -296,15 +299,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       }
 
       if (command.isUnsupported() && !allowUnsupportedCommands()) {
-        writeToChannel(
-            RedisResponse
-                .error(command.getCommandType() + RedisConstants.ERROR_UNSUPPORTED_COMMAND));
-        return;
-      }
-
-      if (command.isUnimplemented()) {
-        logger.info("Failed " + command.getCommandType() + " because it is not implemented.");
-        writeToChannel(RedisResponse.error(command.getCommandType() + " is not implemented."));
+        writeToChannel(new UnknownExecutor().executeCommand(command, this));
         return;
       }
 
@@ -331,7 +326,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     }
   }
 
-  private boolean allowUnsupportedCommands() {
+  public boolean allowUnsupportedCommands() {
     return allowUnsupportedSupplier.get();
   }
 

--- a/geode-redis/src/main/java/org/apache/geode/redis/internal/statistics/GeodeRedisStats.java
+++ b/geode-redis/src/main/java/org/apache/geode/redis/internal/statistics/GeodeRedisStats.java
@@ -158,11 +158,6 @@ public class GeodeRedisStats {
       ArrayList<StatisticDescriptor> descriptorList) {
 
     for (RedisCommandType command : RedisCommandType.values()) {
-
-      if (command.isUnimplemented()) {
-        continue;
-      }
-
       String name = command.name().toLowerCase();
       String statName = name + "Time";
       String statDescription =
@@ -177,11 +172,6 @@ public class GeodeRedisStats {
   private static void fillListWithCompletedCommandDescriptors(StatisticsTypeFactory factory,
       ArrayList<StatisticDescriptor> descriptorList) {
     for (RedisCommandType command : RedisCommandType.values()) {
-
-      if (command.isUnimplemented()) {
-        continue;
-      }
-
       String name = command.name().toLowerCase();
       String statName = name + "Completed";
       String statDescription = "Total number of redis '" + name
@@ -194,11 +184,6 @@ public class GeodeRedisStats {
 
   private static void fillCompletedIdMap(StatisticsType type) {
     for (RedisCommandType command : RedisCommandType.values()) {
-
-      if (command.isUnimplemented()) {
-        continue;
-      }
-
       String name = command.name().toLowerCase();
       String statName = name + "Completed";
 
@@ -259,11 +244,6 @@ public class GeodeRedisStats {
 
   private static void fillTimeIdMap(StatisticsType type) {
     for (RedisCommandType command : RedisCommandType.values()) {
-
-      if (command.isUnimplemented()) {
-        continue;
-      }
-
       String name = command.name().toLowerCase();
       String statName = name + "Time";
       timeCommandStatIds.put(command, type.nameToId(statName));

--- a/geode-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -119,117 +119,6 @@ public class SupportedCommandsJUnitTest {
       "UNLINK",
   };
 
-  private final String[] unImplementedCommands = new String[] {
-      "ACL",
-      "BGREWRITEAOF",
-      "BGSAVE",
-      "BITFIELD",
-      "BLPOP",
-      "BRPOP",
-      "BRPOPLPUSH",
-      "BZPOPMIN",
-      "BZPOPMAX",
-      "CLIENT",
-      "CLUSTER",
-      "COMMAND",
-      "CONFIG",
-      "DEBUG",
-      "DISCARD",
-      "DUMP",
-      "EVAL",
-      "EVALSHA",
-      "EXEC",
-      "GEOADD",
-      "GEOHASH",
-      "GEOPOS",
-      "GEODIST",
-      "GEORADIUS",
-      "GEORADIUSBYMEMBER",
-      "LATENCY",
-      "LASTSAVE",
-      "LINDEX",
-      "LINSERT",
-      "LLEN",
-      "LOLWUT",
-      "LPOP",
-      "LPUSH",
-      "LPUSHX",
-      "LRANGE",
-      "LREM",
-      "LSET",
-      "LTRIM",
-      "MEMORY",
-      "MIGRATE",
-      "MODULE",
-      "MONITOR",
-      "MOVE",
-      "MULTI",
-      "OBJECT",
-      "PFADD",
-      "PFCOUNT",
-      "PFMERGE",
-      "PSYNC",
-      "PUBSUB",
-      "RANDOMKEY",
-      "READONLY",
-      "READWRITE",
-      "RENAMENX",
-      "RESTORE",
-      "ROLE",
-      "RPOP",
-      "RPOPLPUSH",
-      "RPUSH",
-      "RPUSHX",
-      "SAVE",
-      "SCRIPT",
-      "SLAVEOF",
-      "REPLICAOF",
-      "SORT",
-      "STRALGO",
-      "SWAPDB",
-      "SYNC",
-      "TOUCH",
-      "UNWATCH",
-      "WAIT",
-      "WATCH",
-      "XINFO",
-      "XADD",
-      "XTRIM",
-      "XDEL",
-      "XRANGE",
-      "XREVRANGE",
-      "XLEN",
-      "XREAD",
-      "XGROUP",
-      "XREADGROUP",
-      "XACK",
-      "XCLAIM",
-      "XPENDING",
-      "ZADD",
-      "ZCARD",
-      "ZCOUNT",
-      "ZINCRBY",
-      "ZINTERSTORE",
-      "ZLEXCOUNT",
-      "ZPOPMAX",
-      "ZPOPMIN",
-      "ZRANGE",
-      "ZRANGEBYLEX",
-      "ZREVRANGEBYLEX",
-      "ZRANGEBYSCORE",
-      "ZRANK",
-      "ZREM",
-      "ZREMRANGEBYLEX",
-      "ZREMRANGEBYRANK",
-      "ZREMRANGEBYSCORE",
-      "ZREVRANGE",
-      "ZREVRANGEBYSCORE",
-      "ZREVRANK",
-      "ZSCORE",
-      "ZUNIONSCORE",
-      "ZSCAN"
-  };
-
   private final String[] unknownCommands = new String[] {
       "UNKNOWN"
   };
@@ -269,20 +158,6 @@ public class SupportedCommandsJUnitTest {
   }
 
   @Test
-  public void crossCheckAllUnimplementedCommands_areMarkedUnimplemented() {
-    for (String commandName : unImplementedCommands) {
-      List<byte[]> args = new ArrayList<>();
-      args.add(commandName.getBytes());
-
-      Command command = new Command(args);
-
-      assertThat(command.isUnimplemented())
-          .as("Command " + commandName + " should be unimplemented")
-          .isTrue();
-    }
-  }
-
-  @Test
   public void checkAllImplementedCommands_areIncludedInBothSupportedAndUnsupportedLists() {
     List<String> allCommands = new ArrayList<>(asList(supportedCommands));
     allCommands.addAll(asList(unSupportedCommands));
@@ -298,7 +173,6 @@ public class SupportedCommandsJUnitTest {
   public void checkAllDefinedCommands_areIncludedInAllLists() {
     List<String> allCommands = new ArrayList<>(asList(supportedCommands));
     allCommands.addAll(asList(unSupportedCommands));
-    allCommands.addAll(asList(unImplementedCommands));
     allCommands.addAll(asList(unknownCommands));
     allCommands.addAll(asList(internalCommands));
 
@@ -321,14 +195,12 @@ public class SupportedCommandsJUnitTest {
 
   private List<RedisCommandType> getAllImplementedCommands() {
     List<RedisCommandType> implementedCommands = new ArrayList<>(asList(RedisCommandType.values()));
-    implementedCommands.removeIf(RedisCommandType::isUnimplemented);
     implementedCommands.removeIf(RedisCommandType::isInternal);
     return implementedCommands;
   }
 
   private List<RedisCommandType> getAllInternalCommands() {
     List<RedisCommandType> internalCommands = new ArrayList<>(asList(RedisCommandType.values()));
-    internalCommands.removeIf(RedisCommandType::isUnimplemented);
     internalCommands.removeIf(RedisCommandType::isSupported);
     internalCommands.removeIf(RedisCommandType::isUnsupported);
 


### PR DESCRIPTION
        *update handling of unsupported commands

Co-authored-by: Ray Ingles <ringles@vmware.com>
Co-authored-by: john Hutchison <hutchisonjo@vmware.com>