### PR TITLE
GEODE-8926: Calculate filter information after tx is applied to cache.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
@@ -1086,10 +1086,6 @@ public class FilterProfile implements DataSerializableFixedID {
     // bug #50809 - local routing for transactional ops must be done here
     // because the event isn't available later and we lose the old value for the entry
 
-    if (event.getOperation() == null) {
-      // A read op with detect read conflicts does not need filter routing.
-      return null;
-    }
     boolean processLocalProfile =
         event.getOperation().isEntry() && ((EntryEvent) event).getTransactionId() != null;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/FilterProfile.java
@@ -1085,12 +1085,16 @@ public class FilterProfile implements DataSerializableFixedID {
     FilterRoutingInfo frInfo = null;
     // bug #50809 - local routing for transactional ops must be done here
     // because the event isn't available later and we lose the old value for the entry
-    boolean processLocalProfile = false;
+
+    if (event.getOperation() == null) {
+      // A read op with detect read conflicts does not need filter routing.
+      return null;
+    }
+    boolean processLocalProfile =
+        event.getOperation().isEntry() && ((EntryEvent) event).getTransactionId() != null;
 
     CqService cqService = getCqService(event.getRegion());
     if (cqService.isRunning()) {
-      processLocalProfile =
-          event.getOperation().isEntry() && ((EntryEvent) event).getTransactionId() != null;
       frInfo = new FilterRoutingInfo();
       fillInCQRoutingInfo(event, processLocalProfile, peerProfiles, frInfo);
     }
@@ -1297,7 +1301,6 @@ public class FilterProfile implements DataSerializableFixedID {
    */
   public FilterRoutingInfo fillInInterestRoutingInfo(CacheEvent event, Profile[] profiles,
       FilterRoutingInfo filterRoutingInfo, Set cacheOpRecipients) {
-
     Set clientsInv = Collections.emptySet();
     Set clients = Collections.emptySet();
 
@@ -1884,6 +1887,7 @@ public class FilterProfile implements DataSerializableFixedID {
             if (logger.isDebugEnabled()) {
               logger.debug("Processing the filter profile request for : {}", this);
             }
+            fp.region = (LocalRegion) r;
             processRequest(fp);
           }
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -6083,7 +6083,8 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       }
 
       InternalCacheEvent ice = (InternalCacheEvent) event;
-      if (!isUsedForPartitionedRegionBucket()) {
+      if (!(this instanceof PartitionedRegion || isUsedForPartitionedRegionBucket())) {
+        // Do not generate local filter routing if partitioned region.
         generateLocalFilterRouting(ice);
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluator.java
@@ -881,6 +881,7 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
     int retry = 3;
     for (int i = 0; i < retry && (bucketIds.size() != bucketIdsToConsider.size()); i++) {
       bucketIds.clear();
+      nodeToBucketMap.clear();
       for (Integer bucketId : bucketIdsToConsider) {
         InternalDistributedMember primary = getPrimaryBucketOwner(bucketId);
         if (primary != null) {
@@ -945,7 +946,7 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
     return bucketIds;
   }
 
-  private InternalDistributedMember getPrimaryBucketOwner(Integer bid) {
+  InternalDistributedMember getPrimaryBucketOwner(Integer bid) {
     return pr.getBucketPrimary(bid.intValue());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluator.java
@@ -854,7 +854,7 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
    */
   private Map<InternalDistributedMember, List<Integer>> buildNodeToBucketMapForBuckets(
       final Set<Integer> bucketIdsToConsider) throws QueryException {
-    final HashMap<InternalDistributedMember, List<Integer>> ret = new HashMap();
+    final HashMap<InternalDistributedMember, List<Integer>> ret = new HashMap<>();
     if (bucketIdsToConsider.isEmpty()) {
       return ret;
     }
@@ -877,7 +877,7 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
 
   private List<Integer> findPrimaryBucketOwners(Set<Integer> bucketIdsToConsider,
       HashMap<InternalDistributedMember, List<Integer>> nodeToBucketMap) {
-    final List<Integer> bucketIds = new ArrayList();
+    final List<Integer> bucketIds = new ArrayList<>();
     int retry = 3;
     for (int i = 0; i < retry && (bucketIds.size() != bucketIdsToConsider.size()); i++) {
       bucketIds.clear();
@@ -901,17 +901,17 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
 
   private List<Integer> findBucketOwners(final Set<Integer> bucketIdsToConsider,
       HashMap<InternalDistributedMember, List<Integer>> nodeToBucketMap) {
-    final List<Integer> bucketIds = new ArrayList();
+    final List<Integer> bucketIds = new ArrayList<>();
     // Get all local buckets
     PartitionedRegionDataStore dataStore = this.pr.getDataStore();
     if (dataStore != null) {
       for (Integer bid : bucketIdsToConsider) {
         if (dataStore.isManagingBucket(bid)) {
-          bucketIds.add(Integer.valueOf(bid));
+          bucketIds.add(bid);
         }
       }
       if (bucketIds.size() > 0) {
-        List<Integer> localBucketIds = new ArrayList(bucketIds);
+        List<Integer> localBucketIds = new ArrayList<>(bucketIds);
         nodeToBucketMap.put(pr.getMyId(), localBucketIds);
         // All the buckets are hosted locally.
         if (localBucketIds.size() == bucketIdsToConsider.size()) {
@@ -926,10 +926,10 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
       allNodes.addAll(failedMembers);
     }
     int totalBucketsToQuery = bucketIdsToConsider.size();
-    for (Iterator dsItr = allNodes.iterator(); dsItr.hasNext()
+    for (Iterator<InternalDistributedMember> dsItr = allNodes.iterator(); dsItr.hasNext()
         && (bucketIds.size() < totalBucketsToQuery);) {
-      InternalDistributedMember nd = (InternalDistributedMember) dsItr.next();
-      final List<Integer> buckets = new ArrayList<Integer>();
+      InternalDistributedMember nd = dsItr.next();
+      final List<Integer> buckets = new ArrayList<>();
       for (Integer bid : bucketIdsToConsider) {
         if (!bucketIds.contains(bid)) {
           final Set owners = getBucketOwners(bid);
@@ -947,15 +947,15 @@ public class PartitionedRegionQueryEvaluator extends StreamingPartitionOperation
   }
 
   InternalDistributedMember getPrimaryBucketOwner(Integer bid) {
-    return pr.getBucketPrimary(bid.intValue());
+    return pr.getBucketPrimary(bid);
   }
 
   protected Set<InternalDistributedMember> getBucketOwners(Integer bid) {
-    return pr.getRegionAdvisor().getBucketOwners(bid.intValue());
+    return pr.getRegionAdvisor().getBucketOwners(bid);
   }
 
   protected ArrayList<InternalDistributedMember> getAllNodes(RegionAdvisor regionAdvisor) {
-    ArrayList<InternalDistributedMember> nodes = new ArrayList(regionAdvisor.adviseDataStore());
+    ArrayList<InternalDistributedMember> nodes = new ArrayList<>(regionAdvisor.adviseDataStore());
     Collections.shuffle(nodes);
     return nodes;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntryState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXEntryState.java
@@ -95,6 +95,8 @@ public class TXEntryState implements Releasable {
 
   private byte[] serializedPendingValue;
 
+  private EntryEventImpl pendingCallback;
+
   /**
    * Remember the callback argument for listener invocation
    */
@@ -1937,6 +1939,14 @@ public class TXEntryState implements Releasable {
    */
   int getSortValue() {
     return this.modSerialNum;
+  }
+
+  public EntryEventImpl getPendingCallback() {
+    return pendingCallback;
+  }
+
+  public void setPendingCallback(EntryEventImpl pendingCallback) {
+    this.pendingCallback = pendingCallback;
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -101,7 +101,7 @@ public class TXState implements TXStateInterface {
    * this transaction.
    */
   private int modSerialNum;
-  private final List<EntryEventImpl> pendingCallbacks = new ArrayList<EntryEventImpl>();
+  private final List<EntryEventImpl> pendingCallbacks = new ArrayList<>();
   // Access this variable should be in synchronized block.
   private boolean beforeCompletionCalled;
 
@@ -506,7 +506,6 @@ public class TXState implements TXStateInterface {
       List/* <TXEntryStateWithRegionAndKey> */ entries = generateEventOffsets();
       TXCommitMessage msg = null;
       try {
-
         /*
          * In order to preserve data consistency, we need to: 1. Modify the cache first
          * (applyChanges) 2. Ask for advice on who to send to (buildMessage) 3. Send out to other
@@ -514,8 +513,6 @@ public class TXState implements TXStateInterface {
          *
          * If this is done out of order, we will have problems with GII, split brain, and HA.
          */
-
-        attachFilterProfileInformation(entries);
 
         lockTXRegions(regions);
 
@@ -526,6 +523,8 @@ public class TXState implements TXStateInterface {
           if (this.internalAfterApplyChanges != null) {
             this.internalAfterApplyChanges.run();
           }
+
+          attachFilterProfileInformation(entries);
 
           // build and send the message
           msg = buildMessage();
@@ -605,6 +604,18 @@ public class TXState implements TXStateInterface {
               o.es.setFilterRoutingInfo(fri);
               Set set = bucket.getAdjunctReceivers(ev, Collections.EMPTY_SET, new HashSet(), fri);
               o.es.setAdjunctRecipients(set);
+
+              if (o.es.getPendingCallback() != null) {
+                if (fri != null) {
+                  // For tx host, local filter info was also calculated.
+                  // Set this local filter info in corresponding pending callback so that
+                  // notifyBridgeClient has correct routing info.
+                  FilterRoutingInfo.FilterInfo localRouting = fri.getLocalFilterInfo();
+                  o.es.getPendingCallback().setLocalFilterInfo(localRouting);
+                }
+                // do not hold pending callback reference after setting local routing.
+                o.es.setPendingCallback(null);
+              }
             } finally {
               ev.release();
             }
@@ -860,7 +871,11 @@ public class TXState implements TXStateInterface {
         this.internalDuringApplyChanges.run();
       }
       try {
+        int size = pendingCallbacks.size();
         o.es.applyChanges(o.r, o.key, this);
+        if (pendingCallbacks.size() - size == 1) {
+          o.es.setPendingCallback(pendingCallbacks.get(size));
+        }
       } catch (RegionDestroyedException ex) {
         // region was destroyed out from under us; after conflict checking
         // passed. So act as if the region destroy happened right after the

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -613,7 +613,7 @@ public class TXState implements TXStateInterface {
                   FilterRoutingInfo.FilterInfo localRouting = fri.getLocalFilterInfo();
                   o.es.getPendingCallback().setLocalFilterInfo(localRouting);
                 }
-                // do not hold pending callback reference after setting local routing.
+                // Do not hold pending callback reference in TXEntryState as it is no longer used.
                 o.es.setPendingCallback(null);
               }
             } finally {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TxCallbackEventFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TxCallbackEventFactoryImpl.java
@@ -42,7 +42,7 @@ public class TxCallbackEventFactoryImpl implements TxCallbackEventFactory {
       ClientProxyMembershipID bridgeContext,
       TXEntryState txEntryState, VersionTag versionTag,
       long tailKey) {
-    DistributedMember originator = null;
+    DistributedMember originator;
     // txId should not be null even on localOrigin
     Assert.assertTrue(txId != null);
     originator = txId.getMemberId();
@@ -57,8 +57,6 @@ public class TxCallbackEventFactoryImpl implements TxCallbackEventFactory {
         aCallbackArgument, txEntryState == null, originator);
     boolean returnedRetVal = false;
     try {
-
-
       if (bridgeContext != null) {
         retVal.setContext(bridgeContext);
       }
@@ -75,9 +73,7 @@ public class TxCallbackEventFactoryImpl implements TxCallbackEventFactory {
 
       FilterRoutingInfo.FilterInfo localRouting = null;
       boolean computeFilterInfo = false;
-      if (filterRoutingInfo == null) {
-        computeFilterInfo = true;
-      } else {
+      if (filterRoutingInfo != null) {
         localRouting = filterRoutingInfo.getLocalFilterInfo();
         if (localRouting != null) {
           // routing was computed in this VM but may need to perform local interest processing
@@ -91,8 +87,6 @@ public class TxCallbackEventFactoryImpl implements TxCallbackEventFactory {
           if (!computeFilterInfo) {
             retVal.setLocalFilterInfo(localRouting);
           }
-        } else {
-          computeFilterInfo = true;
         }
       }
       if (TxCallbackEventFactoryImpl.logger.isTraceEnabled()) {
@@ -109,32 +103,13 @@ public class TxCallbackEventFactoryImpl implements TxCallbackEventFactory {
         } else {
           retVal.setInvokePRCallbacks(false);
         }
-
-        if (computeFilterInfo) {
-          if (bucket.getBucketAdvisor().isPrimary()) {
-            if (TxCallbackEventFactoryImpl.logger.isTraceEnabled()) {
-              TxCallbackEventFactoryImpl.logger
-                  .trace("createCBEvent computing routing for primary bucket");
-            }
-            FilterProfile fp =
-                ((BucketRegion) internalRegion).getPartitionedRegion().getFilterProfile();
-            if (fp != null) {
-              FilterRoutingInfo fri = fp.getFilterRoutingInfoPart2(filterRoutingInfo, retVal);
-              if (fri != null) {
-                retVal.setLocalFilterInfo(fri.getLocalFilterInfo());
-              }
-            }
-          }
-        }
-      } else if (computeFilterInfo) { // not a bucket
-        if (TxCallbackEventFactoryImpl.logger.isTraceEnabled()) {
-          TxCallbackEventFactoryImpl.logger.trace("createCBEvent computing routing for non-bucket");
-        }
-        FilterProfile fp = internalRegion.getFilterProfile();
-        if (fp != null) {
-          retVal.setLocalFilterInfo(fp.getLocalFilterRouting(retVal));
-        }
       }
+      // No need to computeFilterInfo for primary bucket, as it is done
+      // during attach filter info after applying to cache.
+      // For secondary buckets, filter routing is calculated in the "remote" routing table.
+      // For replicate region, filter routing should be computed after entry commit
+      // is applied to cache, as concurrent register interest could occur.
+      // That computation occurs in notifyBridgeClient when no local routing is set.
       retVal.setTransactionId(txId);
       returnedRetVal = true;
       return retVal;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -1043,6 +1043,11 @@ public abstract class BaseCommand implements Command {
   private static void handleSingleton(LocalRegion region, Object entryKey,
       InterestResultPolicy policy, ServerConnection servConn) throws IOException {
     List<Object> keyList = new ArrayList<>(1);
+    if (region instanceof PartitionedRegion) {
+      keyList.add(entryKey);
+      handleListPR((PartitionedRegion) region, keyList, policy, servConn);
+      return;
+    }
     if (region != null) {
       if (region.containsKey(entryKey)
           || sendTombstonesInRIResults(servConn, policy) && region.containsTombstone(entryKey)) {
@@ -1318,7 +1323,8 @@ public abstract class BaseCommand implements Command {
    */
   private static void handleListPR(final PartitionedRegion region, final List<?> keyList,
       final InterestResultPolicy policy, final ServerConnection servConn) throws IOException {
-    final List<Object> newKeyList = new ArrayList<>(MAXIMUM_CHUNK_SIZE);
+    int chunkSize = keyList.size() < MAXIMUM_CHUNK_SIZE ? keyList.size() : MAXIMUM_CHUNK_SIZE;
+    final List<Object> newKeyList = new ArrayList<>(chunkSize);
     region.getKeysWithList(keyList, sendTombstonesInRIResults(servConn, policy),
         theSet -> appendInterestResponseKeys(region, keyList, uncheckedCast(theSet), newKeyList,
             servConn));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorTest.java
@@ -18,6 +18,7 @@ import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -247,7 +248,7 @@ public class PartitionedRegionQueryEvaluatorTest {
   @Test
   public void verifyPrimaryBucketNodesAreRetrievedForCqQuery() throws Exception {
     List<Integer> bucketList = createBucketList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    Set bucketSet = new HashSet<>(bucketList);
+    Set<Integer> bucketSet = new HashSet<>(bucketList);
     when(query.isCqQuery()).thenReturn(true);
     PartitionedRegionQueryEvaluator prqe =
         new PartitionedRegionQueryEvaluator(system, pr, query, mock(ExecutionContext.class),
@@ -271,51 +272,148 @@ public class PartitionedRegionQueryEvaluatorTest {
   @Test
   public void verifyPrimaryBucketNodesAreRetrievedForCqQueryWithRetry() throws Exception {
     List<Integer> bucketList = createBucketList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    Set bucketSet = new HashSet<>(bucketList);
+    int bucket1 = 1;
+    Set<Integer> bucketSet = new HashSet<>(bucketList);
     when(query.isCqQuery()).thenReturn(true);
     PartitionedRegionQueryEvaluator prqe =
         spy(new PartitionedRegionQueryEvaluator(system, pr, query, mock(ExecutionContext.class),
             null, new LinkedResultSet(), bucketSet));
 
     for (Integer bid : bucketList) {
-      if (bid == 1) {
-        when(prqe.getPrimaryBucketOwner(bid)).thenReturn(null).thenReturn(remoteNodeA);
+      if (bid == bucket1) {
+        doReturn(null).doReturn(remoteNodeA).when(prqe).getPrimaryBucketOwner(bid);
       } else {
-        when(prqe.getPrimaryBucketOwner(bid)).thenReturn(remoteNodeA);
+        doReturn(remoteNodeA).when(prqe).getPrimaryBucketOwner(bid);
       }
     }
 
     Map<InternalDistributedMember, List<Integer>> bnMap = prqe.buildNodeToBucketMap();
 
-    assertThat(bnMap.size()).isEqualTo(1);
+    assertThat(bnMap.size()).isEqualTo(bucket1);
     assertThat(bnMap.get(remoteNodeA).size()).isEqualTo(10);
-    // Called 3 times : 2 times in retry and once for setting the return value
-    verify(prqe, times(3)).getPrimaryBucketOwner(1);
+    verify(prqe, times(2)).getPrimaryBucketOwner(1);
   }
 
   @Test
-  public void exceptionIsThrownWhenPrimaryBucketNodeIsNotFoundForCqQuery() throws Exception {
+  public void exceptionIsThrownWhenPrimaryBucketNodeIsNotFoundForCqQuery() {
     List<Integer> bucketList = createBucketList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-    Set bucketSet = new HashSet<>(bucketList);
+    int bucket1 = 1;
+    Set<Integer> bucketSet = new HashSet<>(bucketList);
     when(query.isCqQuery()).thenReturn(true);
     PartitionedRegionQueryEvaluator prqe =
         spy(new PartitionedRegionQueryEvaluator(system, pr, query, mock(ExecutionContext.class),
             null, new LinkedResultSet(), bucketSet));
 
     for (Integer bid : bucketList) {
-      if (bid == 1) {
-        when(prqe.getPrimaryBucketOwner(bid)).thenReturn(null);
+      if (bid == bucket1) {
+        doReturn(null).when(prqe).getPrimaryBucketOwner(bid);
       } else {
-        when(prqe.getPrimaryBucketOwner(bid)).thenReturn(remoteNodeA);
+        doReturn(remoteNodeA).when(prqe).getPrimaryBucketOwner(bid);
       }
     }
 
-    assertThatThrownBy(() -> prqe.buildNodeToBucketMap()).isInstanceOf(QueryException.class)
+    assertThatThrownBy(prqe::buildNodeToBucketMap).isInstanceOf(QueryException.class)
         .hasMessageContaining(
             "Data loss detected, unable to find the hosting  node for some of the dataset.");
 
-    // Called 3 times : 2 times in retry and once for setting the return value
-    verify(prqe, times(4)).getPrimaryBucketOwner(1);
+    verify(prqe, times(3)).getPrimaryBucketOwner(bucket1);
+  }
+
+  @Test
+  public void verifyLocalBucketNodesAreRetrievedForQuery() throws Exception {
+    List<Integer> bucketList = createBucketList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    PartitionedRegionDataStore dataStore = mock(PartitionedRegionDataStore.class);
+    Set<Integer> bucketSet = new HashSet<>(bucketList);
+    for (Integer bid : bucketList) {
+      when(dataStore.isManagingBucket(bid)).thenReturn(true);
+    }
+    when(pr.getDataStore()).thenReturn(dataStore);
+    PartitionedRegionQueryEvaluator prqe =
+        new PartitionedRegionQueryEvaluator(system, pr, query, mock(ExecutionContext.class),
+            null, new LinkedResultSet(), bucketSet);
+
+    Map<InternalDistributedMember, List<Integer>> bnMap = prqe.buildNodeToBucketMap();
+
+    assertThat(bnMap.size()).isEqualTo(1);
+    assertThat(bnMap.get(localNode).size()).isEqualTo(10);
+  }
+
+  @Test
+  public void verifyAllBucketsAreRetrievedFromSingleRemoteNode() throws Exception {
+    List<Integer> bucketList = createBucketList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    Set<Integer> bucketSet = new HashSet<>(bucketList);
+    when(pr.getDataStore()).thenReturn(null);
+    RegionAdvisor regionAdvisor = mock(RegionAdvisor.class);
+    Set<InternalDistributedMember> nodes = new HashSet<>(allNodes);
+    when(regionAdvisor.adviseDataStore()).thenReturn(nodes);
+    for (Integer bid : bucketList) {
+      when(regionAdvisor.getBucketOwners(bid)).thenReturn(nodes);
+    }
+    when(pr.getRegionAdvisor()).thenReturn(regionAdvisor);
+    PartitionedRegionQueryEvaluator prqe =
+        new PartitionedRegionQueryEvaluator(system, pr, query, mock(ExecutionContext.class),
+            null, new LinkedResultSet(), bucketSet);
+
+    Map<InternalDistributedMember, List<Integer>> bnMap = prqe.buildNodeToBucketMap();
+
+    assertThat(bnMap.size()).isEqualTo(1);
+    bnMap.keySet().forEach(x -> assertThat(bnMap.get(x).size()).isEqualTo(10));
+  }
+
+  @Test
+  public void verifyAllBucketsAreRetrievedFromMultipleRemoteNodes() throws Exception {
+    List<Integer> bucketList = createBucketList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    Set<Integer> bucketSet = new HashSet<>(bucketList);
+    when(pr.getDataStore()).thenReturn(null);
+    RegionAdvisor regionAdvisor = mock(RegionAdvisor.class);
+    Set<InternalDistributedMember> nodes = new HashSet<>(allNodes);
+    when(regionAdvisor.adviseDataStore()).thenReturn(nodes);
+    Set<InternalDistributedMember> nodesA = new HashSet<>();
+    nodesA.add(remoteNodeA);
+    Set<InternalDistributedMember> nodesB = new HashSet<>();
+    nodesB.add(remoteNodeB);
+    for (Integer bid : bucketList) {
+      if (bid % 2 == 0) {
+        when(regionAdvisor.getBucketOwners(bid)).thenReturn(nodesA);
+      } else {
+        when(regionAdvisor.getBucketOwners(bid)).thenReturn(nodesB);
+      }
+    }
+    when(pr.getRegionAdvisor()).thenReturn(regionAdvisor);
+    PartitionedRegionQueryEvaluator prqe =
+        new PartitionedRegionQueryEvaluator(system, pr, query, mock(ExecutionContext.class),
+            null, new LinkedResultSet(), bucketSet);
+
+    Map<InternalDistributedMember, List<Integer>> bnMap = prqe.buildNodeToBucketMap();
+
+    assertThat(bnMap.size()).isEqualTo(2);
+    bnMap.keySet().forEach(x -> {
+      assertThat(x.equals(remoteNodeA) || x.equals(remoteNodeB)).isTrue();
+      assertThat(bnMap.get(x).size()).isEqualTo(5);
+    });
+  }
+
+  @Test
+  public void exceptionIsThrownWhenNodesAreNotFoundForQueryBuckets() {
+    List<Integer> bucketList = createBucketList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    Set<Integer> bucketSet = new HashSet<>(bucketList);
+    when(pr.getDataStore()).thenReturn(null);
+    RegionAdvisor regionAdvisor = mock(RegionAdvisor.class);
+    Set<InternalDistributedMember> nodes = new HashSet<>(allNodes);
+    when(regionAdvisor.adviseDataStore()).thenReturn(nodes);
+    for (Integer bid : bucketList) {
+      if (bid != 1) {
+        when(regionAdvisor.getBucketOwners(bid)).thenReturn(nodes);
+      }
+    }
+    when(pr.getRegionAdvisor()).thenReturn(regionAdvisor);
+    PartitionedRegionQueryEvaluator prqe =
+        new PartitionedRegionQueryEvaluator(system, pr, query, mock(ExecutionContext.class),
+            null, new LinkedResultSet(), bucketSet);
+
+    assertThatThrownBy(prqe::buildNodeToBucketMap).isInstanceOf(QueryException.class)
+        .hasMessageContaining(
+            "Data loss detected, unable to find the hosting  node for some of the dataset.");
   }
 
   private Map<InternalDistributedMember, List<Integer>> createFakeBucketMap() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionQueryEvaluatorTest.java
@@ -289,9 +289,9 @@ public class PartitionedRegionQueryEvaluatorTest {
 
     Map<InternalDistributedMember, List<Integer>> bnMap = prqe.buildNodeToBucketMap();
 
-    assertThat(bnMap.size()).isEqualTo(bucket1);
+    assertThat(bnMap.size()).isEqualTo(1);
     assertThat(bnMap.get(remoteNodeA).size()).isEqualTo(10);
-    verify(prqe, times(2)).getPrimaryBucketOwner(1);
+    verify(prqe, times(2)).getPrimaryBucketOwner(bucket1);
   }
 
   @Test
@@ -388,7 +388,9 @@ public class PartitionedRegionQueryEvaluatorTest {
 
     assertThat(bnMap.size()).isEqualTo(2);
     bnMap.keySet().forEach(x -> {
-      assertThat(x.equals(remoteNodeA) || x.equals(remoteNodeB)).isTrue();
+      assertThat(x).satisfiesAnyOf(
+          member -> assertThat(member).isEqualTo(remoteNodeA),
+          member -> assertThat(member).isEqualTo(remoteNodeB));
       assertThat(bnMap.get(x).size()).isEqualTo(5);
     });
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
@@ -19,9 +19,12 @@ import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabl
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -29,12 +32,15 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+
 import javax.transaction.Status;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.mockito.InOrder;
 
 import org.apache.geode.cache.CommitConflictException;
 import org.apache.geode.cache.EntryNotFoundException;
@@ -90,6 +96,26 @@ public class TXStateTest {
 
     assertThatThrownBy(() -> txState.doAfterCompletionCommit())
         .isSameAs(transactionDataNodeHasDepartedException);
+  }
+
+  @Test
+  public void attacheFilterProfileAfterApplyingChagnes() {
+    TXState txState = spy(new TXState(txStateProxy, false, disabledClock()));
+    ArrayList entries = mock(ArrayList.class);
+    doReturn(entries).when(txState).generateEventOffsets();
+    doNothing().when(txState).attachFilterProfileInformation(entries);
+    doNothing().when(txState).applyChanges(entries);
+    TXCommitMessage txCommitMessage = mock(TXCommitMessage.class);
+    doReturn(txCommitMessage).when(txState).buildMessage();
+
+    txState.commit();
+
+    InOrder inOrder = inOrder(txState, txCommitMessage);
+    inOrder.verify(txState).applyChanges(any());
+    inOrder.verify(txState).attachFilterProfileInformation(any());
+    inOrder.verify(txState).buildMessage();
+    inOrder.verify(txCommitMessage).send(any());
+    inOrder.verify(txState).firePendingCallbacks();
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
@@ -99,7 +99,7 @@ public class TXStateTest {
   }
 
   @Test
-  public void attacheFilterProfileAfterApplyingChanges() {
+  public void attachFilterProfileAfterApplyingChanges() {
     TXState txState = spy(new TXState(txStateProxy, false, disabledClock()));
     doReturn(new ArrayList()).when(txState).generateEventOffsets();
     doNothing().when(txState).attachFilterProfileInformation(any());

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TXStateTest.java
@@ -99,12 +99,11 @@ public class TXStateTest {
   }
 
   @Test
-  public void attacheFilterProfileAfterApplyingChagnes() {
+  public void attacheFilterProfileAfterApplyingChanges() {
     TXState txState = spy(new TXState(txStateProxy, false, disabledClock()));
-    ArrayList entries = mock(ArrayList.class);
-    doReturn(entries).when(txState).generateEventOffsets();
-    doNothing().when(txState).attachFilterProfileInformation(entries);
-    doNothing().when(txState).applyChanges(entries);
+    doReturn(new ArrayList()).when(txState).generateEventOffsets();
+    doNothing().when(txState).attachFilterProfileInformation(any());
+    doNothing().when(txState).applyChanges(any());
     TXCommitMessage txCommitMessage = mock(TXCommitMessage.class);
     doReturn(txCommitMessage).when(txState).buildMessage();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/FilterProfileJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/FilterProfileJUnitTest.java
@@ -49,6 +49,7 @@ public class FilterProfileJUnitTest {
     when(mockCache.getCacheServers()).thenReturn(Collections.emptyList());
     when(mockRegion.getGemFireCache()).thenReturn(mockCache);
     fprofile = new FilterProfile(mockRegion);
+    when(mockRegion.getFilterProfile()).thenReturn(fprofile);
   }
 
   @Test

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionTxDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionTxDUnitTest.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.cq.dunit;
+
+
+import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.InterestResultPolicy;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.query.CqAttributes;
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqListener;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.SelectResults;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.TXManagerImpl;
+import org.apache.geode.internal.cache.TXState;
+import org.apache.geode.internal.cache.TXStateInterface;
+import org.apache.geode.internal.cache.TXStateProxyImpl;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.DistributedBlackboard;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
+
+@Category(ClientSubscriptionTest.class)
+public class PartitionedRegionTxDUnitTest implements Serializable {
+  private final String REGION_NAME = "region";
+  private MemberVM locator;
+  private MemberVM server1;
+  private MemberVM server2;
+  private ClientVM client;
+
+  @Rule
+  public DistributedBlackboard blackboard = new DistributedBlackboard();
+
+  @Rule
+  public ClusterStartupRule clusterStartupRule = new ClusterStartupRule();
+
+  @Test
+  public void verifyCqRegistrationWorksDuringTxCommit() throws Exception {
+    blackboard.setMailbox("CqQueryResultCount", 0);
+    blackboard.setMailbox("CqEvents", 0);
+
+    Properties properties = new Properties();
+    locator = clusterStartupRule.startLocatorVM(0, new Properties());
+    server1 = clusterStartupRule.startServerVM(1, properties, locator.getPort());
+    server2 = clusterStartupRule.startServerVM(2, properties, locator.getPort());
+    client = clusterStartupRule.startClientVM(3,
+        cacheRule -> cacheRule.withServerConnection(server2.getPort()).withPoolSubscription(true));
+
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      Region<Object, Object> region =
+          cache.createRegionFactory(RegionShortcut.PARTITION).setPartitionAttributes(
+              new PartitionAttributesFactory().setRedundantCopies(1).setTotalNumBuckets(1).create())
+              .create(REGION_NAME);
+
+      // Force primary bucket to get created.
+      region.put("Key-1", "value-1");
+      region.destroy("Key-1");
+    });
+
+    server2.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      cache.createRegionFactory(RegionShortcut.PARTITION).setPartitionAttributes(
+          new PartitionAttributesFactory().setRedundantCopies(1).setTotalNumBuckets(1).create())
+          .create(REGION_NAME);
+    });
+
+    AsyncInvocation<?> serverAsync = server1.invokeAsync(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      TXManagerImpl txManager = (TXManagerImpl) cache.getCacheTransactionManager();
+      txManager.begin();
+
+      TXStateInterface txState =
+          ((TXStateProxyImpl) txManager.getTXState()).getRealDeal(null, null);
+
+      ((TXState) txState).setDuringApplyChanges(() -> {
+        try {
+          blackboard.signalGate("StartCQ");
+          blackboard.waitForGate("RegistrationFinished");
+        } catch (TimeoutException | InterruptedException e) {
+          // Do nothing
+        }
+      });
+
+      cache.getRegion(REGION_NAME).put("Key-1", "value-1");
+      txManager.commit();
+    });
+
+    client.invoke(() -> {
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      clientCache.createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create(REGION_NAME);
+
+      QueryService queryService = clientCache.getQueryService();
+      CqAttributesFactory cqaf = new CqAttributesFactory();
+      TestCqListener testListener = new TestCqListener();
+      cqaf.addCqListener(testListener);
+      CqAttributes cqAttributes = cqaf.create();
+
+      blackboard.waitForGate("StartCQ");
+      SelectResults cqResults = queryService
+          .newCq("Select * from " + SEPARATOR + REGION_NAME, cqAttributes)
+          .executeWithInitialResults();
+      blackboard.signalGate("RegistrationFinished");
+      blackboard.setMailbox("CqQueryResultCount", cqResults.asList().size());
+    });
+
+    GeodeAwaitility.await().untilAsserted(() -> {
+      Integer CqQueryResultCount = blackboard.getMailbox("CqQueryResultCount");
+      Integer CqEvents = blackboard.getMailbox("CqEvents");
+      assertThat(CqQueryResultCount + CqEvents).isEqualTo(1);
+    });
+
+    serverAsync.await();
+  }
+
+  @Test
+  public void verifyCqEventInvocationIfTxCommitFromClient() throws Exception {
+    blackboard.setMailbox("CqEvents", 0);
+
+    Properties properties = new Properties();
+    locator = clusterStartupRule.startLocatorVM(0, new Properties());
+    server1 = clusterStartupRule.startServerVM(1, properties, locator.getPort());
+    server2 = clusterStartupRule.startServerVM(2, properties, locator.getPort());
+    client = clusterStartupRule.startClientVM(3,
+        cacheRule -> cacheRule.withServerConnection(server1.getPort()).withPoolSubscription(true));
+
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      Region<Object, Object> region =
+          cache.createRegionFactory(RegionShortcut.PARTITION).setPartitionAttributes(
+              new PartitionAttributesFactory().setRedundantCopies(1).setTotalNumBuckets(1).create())
+              .create(REGION_NAME);
+
+      // Force primary bucket to get created.
+      region.put("Key-1", "value-1");
+    });
+
+    server2.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      cache.createRegionFactory(RegionShortcut.PARTITION).setPartitionAttributes(
+          new PartitionAttributesFactory().setRedundantCopies(1).setTotalNumBuckets(1).create())
+          .create(REGION_NAME);
+    });
+
+    client.invoke(() -> {
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      clientCache.createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create(REGION_NAME);
+
+      QueryService queryService = clientCache.getQueryService();
+      CqAttributesFactory cqaf = new CqAttributesFactory();
+      TestCqListener testListener = new TestCqListener();
+      cqaf.addCqListener(testListener);
+      CqAttributes cqAttributes = cqaf.create();
+
+      queryService.newCq("Select * from " + SEPARATOR + REGION_NAME, cqAttributes)
+          .executeWithInitialResults();
+    });
+
+    client.invoke(() -> {
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      TXManagerImpl txManager = (TXManagerImpl) clientCache.getCacheTransactionManager();
+      txManager.begin();
+
+      clientCache.getRegion(REGION_NAME).destroy("Key-1");
+      txManager.commit();
+    });
+
+    GeodeAwaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+      Integer CqEvents = blackboard.getMailbox("CqEvents");
+      assertThat(CqEvents).isEqualTo(1);
+    });
+  }
+
+  @Test
+  public void verifyInterestRegistrationWorksDuringTxCommit() throws Exception {
+    Properties properties = new Properties();
+    locator = clusterStartupRule.startLocatorVM(0, new Properties());
+    server1 = clusterStartupRule.startServerVM(1, properties, locator.getPort());
+    server2 = clusterStartupRule.startServerVM(2, properties, locator.getPort());
+    client = clusterStartupRule.startClientVM(3,
+        cacheRule -> cacheRule.withServerConnection(server2.getPort()).withPoolSubscription(true));
+
+    server1.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      Region<Object, Object> region =
+          cache.createRegionFactory(RegionShortcut.PARTITION).setPartitionAttributes(
+              new PartitionAttributesFactory().setRedundantCopies(1).setTotalNumBuckets(1).create())
+              .create(REGION_NAME);
+
+      // Force primary bucket to get created.
+      region.put("Key-1", "value-1");
+      region.destroy("Key-1");
+    });
+
+    server2.invoke(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      cache.createRegionFactory(RegionShortcut.PARTITION).setPartitionAttributes(
+          new PartitionAttributesFactory().setRedundantCopies(1).setTotalNumBuckets(1).create())
+          .create(REGION_NAME);
+    });
+
+    AsyncInvocation serverAsync = server1.invokeAsync(() -> {
+      InternalCache cache = ClusterStartupRule.getCache();
+      TXManagerImpl txManager = (TXManagerImpl) cache.getCacheTransactionManager();
+      txManager.begin();
+
+      TXStateInterface txState =
+          ((TXStateProxyImpl) txManager.getTXState()).getRealDeal(null, null);
+
+      ((TXState) txState).setDuringApplyChanges(() -> {
+        try {
+          blackboard.signalGate("StartReg");
+          blackboard.waitForGate("RegistrationFinished");
+        } catch (TimeoutException | InterruptedException e) {
+          // Do nothing
+        }
+      });
+
+      cache.getRegion(REGION_NAME).put("Key-5", "value-1");
+      txManager.commit();
+    });
+
+    client.invoke(() -> {
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Object, Object> region =
+          clientCache.createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY)
+              .create(REGION_NAME);
+      blackboard.waitForGate("StartReg");
+      region.registerInterest("Key-5", InterestResultPolicy.KEYS_VALUES);
+      region.registerInterest("Key-6", InterestResultPolicy.KEYS_VALUES);
+      blackboard.signalGate("RegistrationFinished");
+
+      GeodeAwaitility.await().untilAsserted(() -> assertThat(region.size()).isEqualTo(1));
+    });
+
+    serverAsync.await();
+  }
+
+  private class TestCqListener implements CqListener, Serializable {
+
+    int numEvents = 0;
+
+    @Override
+    public void onEvent(CqEvent aCqEvent) {
+      numEvents++;
+      blackboard.setMailbox("CqEvents", numEvents);
+    }
+
+    @Override
+    public void onError(CqEvent aCqEvent) {}
+  }
+
+}


### PR DESCRIPTION
  * Calculate filter routing on tx host node for partitioned regions after tx is applied to cache.
    This is to avoid concurrent register interest or cq registration miss the operations either
    from snapshot/query results or through client cache update.
  * Register interest snapshot taken or cq query with inital results are taken on primary buckets now
    to make sure the results are correct.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
