### PR TITLE
[WIP DO NOT REVIEW] GEODE-9004: Fix issues with map indexes but allow map index to be use…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/INOperatorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/INOperatorJUnitTest.java
@@ -225,11 +225,11 @@ public class INOperatorJUnitTest {
 
     q = CacheUtils.getQueryService().newQuery(" UNDEFINED IN SET(UNDEFINED)");
     result = q.execute();
-    assertThat(result).isEqualTo(QueryService.UNDEFINED);
+    assertThat(result).isEqualTo(TRUE);
 
     q = CacheUtils.getQueryService().newQuery(" UNDEFINED IN SET(UNDEFINED,UNDEFINED)");
     result = q.execute();
-    assertThat(result).isEqualTo(QueryService.UNDEFINED);
+    assertThat(result).isEqualTo(TRUE);
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/IndexOperatorJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/functional/IndexOperatorJUnitTest.java
@@ -19,6 +19,7 @@
  */
 package org.apache.geode.cache.query.functional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
@@ -145,8 +146,7 @@ public class IndexOperatorJUnitTest {
     map.put("0", new Integer(11));
     map.put("1", new Integer(12));
     Object result = runQuery(map, null);
-    if (result != null)
-      fail();
+    assertThat(result).isEqualTo(QueryService.UNDEFINED);
   }
 
   @Test
@@ -171,8 +171,7 @@ public class IndexOperatorJUnitTest {
     map.put("0", new Integer(11));
     map.put("1", new Integer(12));
     Object result = runQuery(map, QueryService.UNDEFINED);
-    if (result != null)
-      fail();
+    assertThat(result).isEqualTo(QueryService.UNDEFINED);
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
@@ -477,15 +477,43 @@ public class CompactRangeIndexJUnitTest {
     p4.positions.put("SUN", null);
     region.put("KEY-" + 4, p4);
 
-    // execute query and check result size
+    // execute query for null value and check result size
     QueryService qs = utils.getCache().getQueryService();
     SelectResults<Object> results = UncheckedUtils.uncheckedCast(qs
         .newQuery(
             "Select * from " + SEPARATOR + "exampleRegion r where r.positions['SUN'] = null")
         .execute());
+    assertThat(results.size()).isEqualTo(1);
+    assertThat(results.contains(p4)).isTrue();
+
+    // execute query for not null value and check result size
+    results = UncheckedUtils.uncheckedCast(qs
+        .newQuery(
+            "Select * from " + SEPARATOR + "exampleRegion r where r.positions['SUN'] != null")
+        .execute());
+    assertThat(results.size()).isEqualTo(3);
+    assertThat(results.contains(p1)).isTrue();
+    assertThat(results.contains(p2)).isTrue();
+    assertThat(results.contains(p3)).isTrue();
+
+    // execute query for defined values and check result size
+    results = UncheckedUtils.uncheckedCast(qs
+        .newQuery(
+            "Select * from " + SEPARATOR + "exampleRegion r where is_defined(r.positions['SUN'])")
+        .execute());
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.contains(p1)).isTrue();
+    assertThat(results.contains(p4)).isTrue();
+
+    // execute query for undefined values and check result size
+    results = UncheckedUtils.uncheckedCast(qs
+        .newQuery(
+            "Select * from " + SEPARATOR + "exampleRegion r where is_undefined(r.positions['SUN'])")
+        .execute());
     assertThat(results.size()).isEqualTo(2);
     assertThat(results.contains(p2)).isTrue();
-    assertThat(results.contains(p4)).isTrue();
+    assertThat(results.contains(p3)).isTrue();
+
   }
 
   private void putValues(int num) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexMaintenanceJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexMaintenanceJUnitTest.java
@@ -686,7 +686,7 @@ public class IndexMaintenanceJUnitTest {
     // Test index maintenance
     // addition of new Portfolio object
     Map<Object, AbstractIndex> indxMap = mri.getRangeIndexHolderForTesting();
-    assertEquals(indxMap.size(), 3);
+    assertEquals(indxMap.size(), 4);
     for (int j = 1; j <= 3; ++j) {
       assertTrue(indxMap.containsKey("key" + j));
       RangeIndex rng = (RangeIndex) indxMap.get("key" + j);
@@ -717,7 +717,7 @@ public class IndexMaintenanceJUnitTest {
       mkid.maap.put("key" + j, "val" + j);
     }
     testRgn.put(ID, mkid);
-    assertEquals(indxMap.size(), 3);
+    assertEquals(indxMap.size(), 4);
     for (int j = 1; j <= 3; ++j) {
       assertTrue(indxMap.containsKey("key" + j));
       RangeIndex rng = (RangeIndex) indxMap.get("key" + j);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
@@ -345,19 +345,18 @@ public class IndexStatisticsJUnitTest {
     IndexStatistics keyIndexStats = keyIndex3.getStatistics();
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(102, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 100; i++) {
       region.put(Integer.toString(i), new Portfolio(i, i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(102, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -377,24 +376,24 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(52, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(52, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
@@ -424,8 +423,8 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, mapIndexStats.getNumberOfKeys());
-    assertEquals(100, mapIndexStats.getNumberOfValues());
-    assertEquals(100, mapIndexStats.getNumUpdates());
+    assertEquals(200, mapIndexStats.getNumberOfValues());
+    assertEquals(200, mapIndexStats.getNumUpdates());
 
 
     Position.cnt = 0;
@@ -435,8 +434,8 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, mapIndexStats.getNumberOfKeys());
-    assertEquals(100, mapIndexStats.getNumberOfValues());
-    assertEquals(200, mapIndexStats.getNumUpdates());
+    assertEquals(200, mapIndexStats.getNumberOfValues());
+    assertEquals(400, mapIndexStats.getNumUpdates());
     String queryStr =
         "select * from " + SEPARATOR
             + "portfolio where positions['DELL'] != NULL OR positions['YHOO'] != NULL";
@@ -457,8 +456,8 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, mapIndexStats.getNumberOfKeys());
-    assertEquals(50, mapIndexStats.getNumberOfValues());
-    assertEquals(300, mapIndexStats.getNumUpdates());
+    assertEquals(100, mapIndexStats.getNumberOfValues());
+    assertEquals(600, mapIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
@@ -466,14 +465,14 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, mapIndexStats.getNumberOfKeys());
-    assertEquals(50, mapIndexStats.getNumberOfValues());
-    assertEquals(300, mapIndexStats.getNumUpdates());
+    assertEquals(100, mapIndexStats.getNumberOfValues());
+    assertEquals(600, mapIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(400, mapIndexStats.getNumUpdates());
+    assertEquals(800, mapIndexStats.getNumUpdates());
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(0, mapIndexStats.getNumberOfKeys());
@@ -667,8 +666,8 @@ public class IndexStatisticsJUnitTest {
     IndexStatistics mapIndexStats = keyIndex3.getStatistics();
 
     assertEquals(100, mapIndexStats.getNumberOfKeys());
-    assertEquals(100, mapIndexStats.getNumberOfValues());
-    assertEquals(100, mapIndexStats.getNumUpdates());
+    assertEquals(200, mapIndexStats.getNumberOfValues());
+    assertEquals(200, mapIndexStats.getNumUpdates());
 
 
     Position.cnt = 0;
@@ -677,8 +676,8 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(100, mapIndexStats.getNumberOfKeys());
-    assertEquals(100, mapIndexStats.getNumberOfValues());
-    assertEquals(200, mapIndexStats.getNumUpdates());
+    assertEquals(200, mapIndexStats.getNumberOfValues());
+    assertEquals(400, mapIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -696,8 +695,8 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(50, mapIndexStats.getNumberOfKeys());
-    assertEquals(50, mapIndexStats.getNumberOfValues());
-    assertEquals(300, mapIndexStats.getNumUpdates());
+    assertEquals(100, mapIndexStats.getNumberOfValues());
+    assertEquals(600, mapIndexStats.getNumUpdates());
 
 
     for (int i = 0; i < 50; i++) {
@@ -705,14 +704,14 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(50, mapIndexStats.getNumberOfKeys());
-    assertEquals(50, mapIndexStats.getNumberOfValues());
-    assertEquals(300, mapIndexStats.getNumUpdates());
+    assertEquals(100, mapIndexStats.getNumberOfValues());
+    assertEquals(600, mapIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(400, mapIndexStats.getNumUpdates());
+    assertEquals(800, mapIndexStats.getNumUpdates());
 
     assertEquals(0, mapIndexStats.getNumberOfKeys());
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
@@ -15,9 +15,11 @@
 package org.apache.geode.cache.query.internal.index;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 
@@ -40,6 +42,7 @@ import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.cache.query.internal.IndexTrackingQueryObserver;
 import org.apache.geode.cache.query.internal.QueryObserverHolder;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
+import org.apache.geode.util.internal.UncheckedUtils;
 
 @Category({OQLIndexTest.class})
 public class MapRangeIndexMaintenanceJUnitTest {
@@ -47,7 +50,7 @@ public class MapRangeIndexMaintenanceJUnitTest {
   private static final String INDEX_NAME = "keyIndex1";
 
   private static QueryService qs;
-  private static Region region;
+  private static Region<Object, Object> region;
   private static Index keyIndex1;
 
   @Before
@@ -339,6 +342,303 @@ public class MapRangeIndexMaintenanceJUnitTest {
         .newQuery("select * from " + SEPARATOR + "portfolio p where p.positions['SUN'] = null")
         .execute();
     assertEquals(1, result.size());
+  }
+
+  @Test
+  public void testQueriesForValueInMapFieldWithoutIndex() throws Exception {
+    region =
+        CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
+    qs = CacheUtils.getQueryService();
+    testQueriesForValueInMapField(region, qs);
+  }
+
+  @Test
+  public void testQueriesForValueInMapFieldWithCompactMapIndexWithOneKey() throws Exception {
+    region =
+        CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
+    qs = CacheUtils.getQueryService();
+
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN']", SEPARATOR + "portfolio ");
+    assertThat(keyIndex1).isInstanceOf(CompactRangeIndex.class);
+    testQueriesForValueInMapField(region, qs);
+
+    long keys = ((CompactRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        ((CompactRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        ((CompactRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
+    long uses =
+        ((CompactRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes in region entries for the 'SUN' key:
+    // ("nothing", "more", null) + 1 for any entry that does not have
+    // a value for the "SUN" key (UNDEFINED)
+    assertThat(keys).isEqualTo(4);
+    // mapIndexKeys must be zero because the index used is a range index and not a map index
+    assertThat(mapIndexKeys).isEqualTo(0);
+    // The number of values must be equal to the number of region entries
+    assertThat(values).isEqualTo(7);
+    // The index must be used in every query
+    assertThat(uses).isEqualTo(4);
+  }
+
+  @Test
+  public void testQueriesForValueInMapFieldWithCompactMapIndexWithSeveralKeys() throws Exception {
+    region =
+        CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
+    qs = CacheUtils.getQueryService();
+
+    keyIndex1 =
+        qs.createIndex(INDEX_NAME, "positions['SUN', 'ERICSSON']", SEPARATOR + "portfolio ");
+    assertThat(keyIndex1).isInstanceOf(CompactMapRangeIndex.class);
+    testQueriesForValueInMapField(region, qs);
+
+    long keys = ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
+    long uses =
+        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes for the 'SUN' key (null, "nothing", "more") + 1 (when
+    // the key is not present: undefined) plus
+    // the number of different values the positions map takes for the 'ERICSSON' key
+    // ("hey") + 1 (when the key is not present: undefined) for each entry in the region.
+    assertThat(keys).isEqualTo(6);
+    // The number of mapIndexKeys must be equal to the number of keys
+    // in the index that appear in region entries:
+    // 'SUN', 'ERICSSON'
+    assertThat(mapIndexKeys).isEqualTo(2);
+    // The number of values must be equal to the number of entries
+    // times the number of indexed keys in the map
+    assertThat(values).isEqualTo(14);
+    // The index must be used in all queries
+    assertThat(uses).isEqualTo(4);
+  }
+
+  @Test
+  public void testQueriesForValueInMapFieldWithCompactMapIndexWithStar() throws Exception {
+    region =
+        CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
+    qs = CacheUtils.getQueryService();
+
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", SEPARATOR + "portfolio ");
+    assertThat(keyIndex1).isInstanceOf(CompactMapRangeIndex.class);
+    testQueriesForValueInMapField(region, qs);
+
+    long keys = ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
+    long uses =
+        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes for each key
+    // for each entry in the region:
+    // "something", null, "nothing", "more", "empty", "hey", "tip"
+    assertThat(keys).isEqualTo(7);
+    // The number of mapIndexKeys must be equal to the number of different keys
+    // that appear in entries of the region:
+    // "IBM", "ERICSSON", "HP", "SUN", null
+    assertThat(mapIndexKeys).isEqualTo(5);
+    // The number of values must be equal to the number of values the
+    // positions map takes for each key
+    // for each entry in the region:
+    // "something", null, "nothing", "more", "empty", "hey", "more", "tip"
+    assertThat(values).isEqualTo(8);
+    // The index must not be used in queries with "!="
+    assertThat(uses).isEqualTo(2);
+  }
+
+  @Test
+  public void testQueriesForValueInMapFieldWithMapIndexWithOneKey() throws Exception {
+    IndexManager.TEST_RANGEINDEX_ONLY = true;
+    region =
+        CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
+    qs = CacheUtils.getQueryService();
+
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN']", SEPARATOR + "portfolio ");
+    assertThat(keyIndex1).isInstanceOf(RangeIndex.class);
+    testQueriesForValueInMapField(region, qs);
+
+    long keys = ((RangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        ((RangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        ((RangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
+    long uses =
+        ((RangeIndex) keyIndex1).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes in region entries for the 'SUN' key:
+    // ("nothing", "more") excluding null.
+    assertThat(keys).isEqualTo(2);
+    // mapIndexKeys must be zero because the index used is a range index and not a map index
+    assertThat(mapIndexKeys).isEqualTo(0);
+    // The number of values must be equal to the number of region entries
+    assertThat(values).isEqualTo(7);
+    // The index must be used in every query
+    assertThat(uses).isEqualTo(4);
+  }
+
+  @Test
+  public void testQueriesForValueInMapFieldWithMapIndexWithSeveralKeys() throws Exception {
+    IndexManager.TEST_RANGEINDEX_ONLY = true;
+    region =
+        CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
+    qs = CacheUtils.getQueryService();
+
+    keyIndex1 =
+        qs.createIndex(INDEX_NAME, "positions['SUN', 'ERICSSON']", SEPARATOR + "portfolio ");
+    assertThat(keyIndex1).isInstanceOf(MapRangeIndex.class);
+    testQueriesForValueInMapField(region, qs);
+
+    long keys = ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
+    long uses =
+        ((MapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes for the 'SUN' key ("nothing", "more") plus
+    // the number of different values the positions map takes for the 'ERICSSON' key
+    // ("hey") for each entry in the region (null values not counted).
+    assertThat(keys).isEqualTo(3);
+    // The number of mapIndexKeys must be equal to the number of keys
+    // in the index that appear in positions map of region entries:
+    // 'SUN', 'ERICSSON'
+    assertThat(mapIndexKeys).isEqualTo(2);
+    // The number of values must be equal to the number of
+    // entries times the number of keys in the index
+    assertThat(values).isEqualTo(14);
+    // The index must be used for all queries
+    assertThat(uses).isEqualTo(4);
+  }
+
+  @Test
+  public void testQueriesForValueInMapFieldWithMapIndexWithStar() throws Exception {
+    IndexManager.TEST_RANGEINDEX_ONLY = true;
+    region =
+        CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE).create("portfolio");
+    qs = CacheUtils.getQueryService();
+
+    keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", SEPARATOR + "portfolio ");
+    assertThat(keyIndex1).isInstanceOf(MapRangeIndex.class);
+    testQueriesForValueInMapField(region, qs);
+
+    long keys = ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
+    long uses =
+        ((MapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes for each key for each entry in the region:
+    // "something", null, "nothing", "more", "hey", "tip"
+    assertThat(keys).isEqualTo(6);
+    // The number of mapIndexKeys must be equal to the number of different keys
+    // that appear in entries of the region:
+    // "IBM", "ERICSSON", "HP", "SUN", "cannotBeNull"
+    assertThat(mapIndexKeys).isEqualTo(5);
+    // The number of values must be equal to the number of values the
+    // positions map takes for each key for each entry in the region:
+    // "something", null, "nothing", "more", "hey", "more", "tip"
+    assertThat(values).isEqualTo(8);
+    // The index must not be used in queries with "!="
+    assertThat(uses).isEqualTo(2);
+  }
+
+  public void testQueriesForValueInMapField(Region<Object, Object> region, QueryService qs)
+      throws Exception {
+
+    // Empty map
+    Portfolio p = new Portfolio(1, 1);
+    p.positions = new HashMap<>();
+    region.put(1, p);
+
+    // Map is null
+    Portfolio p2 = new Portfolio(2, 2);
+    p2.positions = null;
+    region.put(2, p2);
+
+    // Map with null value for "SUN" key
+    Portfolio p3 = new Portfolio(3, 3);
+    p3.positions = new HashMap<>();
+    p3.positions.put("IBM", "something");
+    p3.positions.put("SUN", null);
+    region.put(3, p3);
+
+    // Map with not null value for "SUN" key
+    Portfolio p4 = new Portfolio(4, 4);
+    p4.positions = new HashMap<>();
+    p4.positions.put("SUN", "nothing");
+    region.put(4, p4);
+
+    // Map with another value for the "SUN" key
+    Portfolio p5 = new Portfolio(5, 5);
+    p5.positions = new HashMap<>();
+    p5.positions.put("SUN", "more");
+    // null is not allowed as key
+    p5.positions.put("cannotBeNull", "empty");
+    region.put(5, p5);
+
+    // One more with map without the "SUN" key
+    Portfolio p6 = new Portfolio(6, 6);
+    p6.positions = new HashMap<>();
+    p6.positions.put("ERICSSON", "hey");
+    region.put(6, p6);
+
+    // Map with a repeated value for the "SUN" key
+    Portfolio p7 = new Portfolio(7, 7);
+    p7.positions = new HashMap<>();
+    p7.positions.put("SUN", "more");
+    p7.positions.put("HP", "tip");
+    region.put(7, p7);
+
+    String query;
+    query = "select * from " + SEPARATOR + "portfolio p where p.positions['SUN'] = null";
+    SelectResults<Object> result = UncheckedUtils.uncheckedCast(qs
+        .newQuery(query)
+        .execute());
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.contains(p3)).isTrue();
+
+    query = "select * from " + SEPARATOR + "portfolio p where p.positions['SUN'] != null";
+    result = UncheckedUtils.uncheckedCast(qs
+        .newQuery(query)
+        .execute());
+    assertThat(result.size()).isEqualTo(6);
+    assertThat(result.containsAll(Arrays.asList(p, p2, p4, p5, p6, p7))).isTrue();
+
+    query = "select * from " + SEPARATOR + "portfolio p where p.positions['SUN'] = 'nothing'";
+    result = UncheckedUtils.uncheckedCast(qs
+        .newQuery(query)
+        .execute());
+    assertThat(result.size()).isEqualTo(1);
+    assertThat(result.contains(p4)).isTrue();
+
+    query = "select * from " + SEPARATOR + "portfolio p where p.positions['SUN'] != 'nothing'";
+    result = UncheckedUtils.uncheckedCast(qs
+        .newQuery(query)
+        .execute());
+    assertThat(result.size()).isEqualTo(6);
+    assertThat(result.containsAll(Arrays.asList(p, p2, p3, p5, p6, p7))).isTrue();
+
+    query = "select * from " + SEPARATOR + "portfolio p";
+    result = UncheckedUtils.uncheckedCast(qs
+        .newQuery(query)
+        .execute());
+    assertThat(result.size()).isEqualTo(7);
+    assertThat(result.containsAll(Arrays.asList(p, p2, p3, p4, p5, p6, p7))).isTrue();
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
@@ -251,18 +251,18 @@ public class PRIndexStatisticsJUnitTest {
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 100; i++) {
       region.put(Integer.toString(i), new Portfolio(i, i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -273,32 +273,32 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
-    assertEquals(100 /* Execution time */, keyIndexStats.getTotalUses());
+    // Index should be used
+    assertEquals(100, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(600, keyIndexStats.getNumUpdates());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
 
@@ -326,8 +326,8 @@ public class PRIndexStatisticsJUnitTest {
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     Position.cnt = 0;
     for (int i = 0; i < 100; i++) {
@@ -336,8 +336,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -348,7 +348,6 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
     assertEquals(100 /* Execution time */, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
@@ -357,8 +356,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
@@ -366,15 +365,15 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(400, keyIndexStats.getNumUpdates());
+    assertEquals(800, keyIndexStats.getNumUpdates());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
 
@@ -562,9 +561,9 @@ public class PRIndexStatisticsJUnitTest {
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     Position.cnt = 0;
     for (int i = 0; i < 100; i++) {
@@ -572,9 +571,9 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -585,7 +584,6 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
     assertEquals((100 /* Execution time */), keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
@@ -593,24 +591,24 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(600, keyIndexStats.getNumUpdates());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
 
@@ -645,8 +643,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     Position.cnt = 0;
     for (int i = 0; i < 100; i++) {
@@ -655,8 +653,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -667,7 +665,6 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
     assertEquals(100 /* Execution time */, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
@@ -676,8 +673,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
@@ -685,8 +682,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
 
     for (int i = 50; i < 100; i++) {
@@ -694,7 +691,7 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(400, keyIndexStats.getNumUpdates());
+    assertEquals(800, keyIndexStats.getNumUpdates());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
 
     qs.removeIndex(keyIndex3);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledConstruction.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledConstruction.java
@@ -23,7 +23,6 @@ import org.apache.geode.cache.query.AmbiguousNameException;
 import org.apache.geode.cache.query.FunctionDomainException;
 import org.apache.geode.cache.query.NameResolutionException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
-import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.TypeMismatchException;
 import org.apache.geode.internal.Assert;
 
@@ -64,9 +63,6 @@ public class CompiledConstruction extends AbstractCompiledValue {
     for (Iterator itr = this.args.iterator(); itr.hasNext();) {
       CompiledValue cv = (CompiledValue) itr.next();
       Object eval = cv.evaluate(context);
-      if (eval == QueryService.UNDEFINED) {
-        return QueryService.UNDEFINED;
-      }
       newSet.add(eval);
     }
     return newSet;

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledIndexOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledIndexOperation.java
@@ -104,7 +104,10 @@ public class CompiledIndexOperation extends AbstractCompiledValue implements Map
     }
 
     if (rcvr instanceof Map) {
-      return ((Map) rcvr).get(index);
+      if (((Map<?, ?>) rcvr).containsKey(index)) {
+        return ((Map) rcvr).get(index);
+      }
+      return QueryService.UNDEFINED;
     }
     if ((rcvr instanceof List) || rcvr.getClass().isArray() || (rcvr instanceof String)) {
       if (!(index instanceof Integer)) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/ResultsCollectionPdxDeserializerWrapper.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/ResultsCollectionPdxDeserializerWrapper.java
@@ -217,5 +217,4 @@ public class ResultsCollectionPdxDeserializerWrapper implements SelectResults {
   public void setElementType(ObjectType elementType) {
     results.setElementType(elementType);
   }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractMapIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractMapIndex.java
@@ -328,44 +328,43 @@ public abstract class AbstractMapIndex extends AbstractIndex {
 
   @Override
   void addMapping(Object key, Object value, RegionEntry entry) throws IMQException {
-    if (key == QueryService.UNDEFINED || !(key instanceof Map)) {
-      return;
-    }
-    if (this.isAllKeys) {
-      Iterator<Map.Entry<?, ?>> entries = ((Map) key).entrySet().iterator();
-      while (entries.hasNext()) {
-        Map.Entry<?, ?> mapEntry = entries.next();
-        Object mapKey = mapEntry.getKey();
-        Object indexKey = mapEntry.getValue();
-        this.doIndexAddition(mapKey, indexKey, value, entry);
-      }
-    } else {
-      for (Object mapKey : mapKeys) {
-        Object indexKey = ((Map) key).get(mapKey);
-        if (indexKey != null) {
-          this.doIndexAddition(mapKey, indexKey, value, entry);
-        }
-      }
-    }
+    addOrSaveMapping(key, value, entry, true);
   }
 
   @Override
   void saveMapping(Object key, Object value, RegionEntry entry) throws IMQException {
-    if (key == QueryService.UNDEFINED || !(key instanceof Map)) {
+    addOrSaveMapping(key, value, entry, false);
+  }
+
+  void addOrSaveMapping(Object key, Object value, RegionEntry entry, boolean isAdd)
+      throws IMQException {
+    if (key == QueryService.UNDEFINED || (key != null && !(key instanceof Map))) {
       return;
     }
     if (this.isAllKeys) {
+      if (key == null) {
+        return;
+      }
       Iterator<Map.Entry<?, ?>> entries = ((Map) key).entrySet().iterator();
       while (entries.hasNext()) {
         Map.Entry<?, ?> mapEntry = entries.next();
         Object mapKey = mapEntry.getKey();
         Object indexKey = mapEntry.getValue();
-        this.saveIndexAddition(mapKey, indexKey, value, entry);
+        if (isAdd) {
+          this.doIndexAddition(mapKey, indexKey, value, entry);
+        } else {
+          this.saveIndexAddition(mapKey, indexKey, value, entry);
+        }
       }
     } else {
       for (Object mapKey : mapKeys) {
-        Object indexKey = ((Map) key).get(mapKey);
-        if (indexKey != null) {
+        Object indexKey = QueryService.UNDEFINED;
+        if (key != null && ((Map) key).containsKey(mapKey)) {
+          indexKey = ((Map) key).get(mapKey);
+        }
+        if (isAdd) {
+          this.doIndexAddition(mapKey, indexKey, value, entry);
+        } else {
           this.saveIndexAddition(mapKey, indexKey, value, entry);
         }
       }
@@ -427,4 +426,7 @@ public abstract class AbstractMapIndex extends AbstractIndex {
     return mapKeyToValueIndex.size() == 0 ? true : false;
   }
 
+  public boolean getIsAllKeys() {
+    return isAllKeys;
+  }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactMapRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactMapRangeIndex.java
@@ -98,10 +98,13 @@ public class CompactMapRangeIndex extends AbstractMapIndex {
 
   @Override
   void saveMapping(Object key, Object value, RegionEntry entry) throws IMQException {
-    if (key == QueryService.UNDEFINED || !(key instanceof Map)) {
+    if (key == QueryService.UNDEFINED || (key != null && !(key instanceof Map))) {
       return;
     }
     if (this.isAllKeys) {
+      if (key == null) {
+        return;
+      }
       Iterator<Map.Entry<?, ?>> entries = ((Map) key).entrySet().iterator();
       while (entries.hasNext()) {
         Map.Entry<?, ?> mapEntry = entries.next();
@@ -112,11 +115,11 @@ public class CompactMapRangeIndex extends AbstractMapIndex {
       removeOldMappings(((Map) key).keySet(), entry);
     } else {
       for (Object mapKey : mapKeys) {
-        Object indexKey = ((Map) key).get(mapKey);
-        if (indexKey != null) {
-          // Do not convert to IndexManager.NULL. We are only interested in specific keys
-          this.saveIndexAddition(mapKey, indexKey, value, entry);
+        Object indexKey = QueryService.UNDEFINED;
+        if (key != null && ((Map) key).containsKey(mapKey)) {
+          indexKey = ((Map) key).get(mapKey);
         }
+        this.saveIndexAddition(mapKey, indexKey, value, entry);
       }
     }
   }

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
@@ -183,14 +183,17 @@ public class Portfolio implements Serializable, DataSerializable {
 
   public String toString() {
     String out =
-        "Portfolio [ID=" + ID + " status=" + status + " type=" + type + " pkid=" + pkid + "\n ";
-    Iterator iter = positions.entrySet().iterator();
-    while (iter.hasNext()) {
-      Map.Entry entry = (Map.Entry) iter.next();
-      out += entry.getKey() + ":" + entry.getValue() + ", ";
+        "Portfolio [ID=" + ID + " status=" + status + " type=" + type + " pkid=" + pkid
+            + System.lineSeparator();
+    if (positions != null) {
+      Iterator iter = positions.entrySet().iterator();
+      while (iter.hasNext()) {
+        Map.Entry entry = (Map.Entry) iter.next();
+        out += entry.getKey() + ":" + entry.getValue() + ", ";
+      }
+      out += System.lineSeparator() + " P1:" + position1 + ", P2:" + position2;
     }
-    out += "\n P1:" + position1 + ", P2:" + position2;
-    return out + "\n]";
+    return out + System.lineSeparator() + "]";
   }
 
   /**


### PR DESCRIPTION
…d with != conditions except for * case

commit 16150cdeb0860ce0dadc35248a358140c6b92d33
Author: Alberto Gomez <alberto.gomez@est.tech>
Date:   Sat Mar 27 09:45:41 2021 +0100

    Allow map index to be used with != conditions except for * case

commit 8a8e629ef2d0228d83793834c4bc74a325800486
Author: Alberto Gomez <alberto.gomez@est.tech>
Date:   Wed Mar 31 10:30:19 2021 +0200

    GEODE-9004: Update some comments in test cases after review

commit 1784eac89c64b621910a039b03540f5dd39764a4
Author: Alberto Gomez <alberto.gomez@est.tech>
Date:   Tue Mar 30 18:03:30 2021 +0200

    GEODE-9004_1: Update after review. Fixed queries with non-compact indexes and added comments in test cases

commit d1fe48a261486c6ca956dec0f98197ab8f76062b
Author: Alberto Gomez <alberto.gomez@est.tech>
Date:   Mon Mar 29 17:18:15 2021 +0200

    GEODE-9004: Add comments to test cases and small update

commit 150e73ec6fb9340c41c799e315686e30d197c1dc
Author: Alberto Gomez <alberto.gomez@est.tech>
Date:   Fri Mar 26 12:53:45 2021 +0100

    GEODE-9004: Fix issues in queries targeting a Map field

    Queries in which map fields are involved
    in the condition, sometimes do not return the same entries
    if map indexes are used, compared to when map indexes
    are not used.

    Diferences were found when the condition on the
    map field was of type '!=' and also when the condition
    on the map field was comparing the value with null.

    Example1:
    Running a query with the following condition:
    positions['SUN'] = null

    in a region with the following entries:
    entry1.positions=null
    entry2.positions={'a'=>'b'}
    entry3.positions={'SUN'=>null}

    - will return entry1 and entry3 if there are no
      indexes defined.
    - will return no entries if the following index is defined:
      positions['SUN','c']
    - will return entry3 if the following index is defined:
      positions[*]

    Example2:
    Running a query with the following condition:
    positions['SUN'] != '3'

    in a region with the following entries:
    entry1.positions=null
    entry2.positions={'a'=>'b'}
    entry3.positions={'SUN'=>'4'}
    entry4.positions={'SUN'=>'3'}
    entry5.positions={'SUN'=>null}

    - will return all entries except for entry4 if:
      there are no indexes defined.
    - will return entry3 if the following index is defined:
      positions['SUN','c']
    - will return entry3 and entry5 if the following index is defined:
      positions[*]

    In order to have the same results for these
    queries no matter if indexes are used,
    the following changes have been made:
    - When running queries, the result of getting the
    value from a Map that does not contain the key used
    to access the value will be
    considered UNDEFINED instead of null.
    This will imply that queries where the condition is
    positions['SUN'] = null will not return entries
    that do not have the 'SUN' key in the positions Map.

    - Queries with map indexes will not be able to use
    the indexes if the query is of type '!=' against
    any of the indexed map fields.
    Example:
    for index positions['SUN', 'ERIC'] or
    positions[*]
    the following query will not use indexes:
    positions['SUN'] != '44'

    These changes must be documented accordingly
    in the corresponding indexes section.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
