### PR TITLE
GEODE-8977: include syncs in thread monitor stack

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/AbstractExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/AbstractExecutor.java
@@ -14,15 +14,18 @@
  */
 package org.apache.geode.internal.monitoring.executor;
 
+import static java.lang.Integer.min;
+
+import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
-import org.apache.geode.annotations.Immutable;
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.annotations.Immutable;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 public abstract class AbstractExecutor {
@@ -51,12 +54,21 @@ public abstract class AbstractExecutor {
     logger.warn(createThreadReport(stuckTime));
   }
 
+  private static ThreadInfo getThreadInfo(long threadId) {
+    ThreadInfo[] threadInfos =
+        ManagementFactory.getThreadMXBean().getThreadInfo(new long[] {threadId}, true, true);
+    if (threadInfos != null) {
+      return threadInfos[0];
+    } else {
+      return null;
+    }
+  }
+
   String createThreadReport(long stuckTime) {
 
     DateFormat dateFormat = new SimpleDateFormat("dd MMM yyyy HH:mm:ss zzz");
 
-    ThreadInfo thread =
-        ManagementFactory.getThreadMXBean().getThreadInfo(this.threadID, THREAD_DUMP_DEPTH);
+    ThreadInfo thread = getThreadInfo(threadID);
     boolean logThreadDetails = (thread != null);
 
     StringBuilder stringBuilder = new StringBuilder();
@@ -89,12 +101,11 @@ public abstract class AbstractExecutor {
         .append(lineSeparator);
 
     if (logThreadDetails) {
-      writeThreadStack(thread, "Thread stack:", stringBuilder);
+      writeThreadStack(thread, "Thread stack", stringBuilder);
     }
 
     if (logThreadDetails && thread.getLockOwnerName() != null) {
-      ThreadInfo lockOwnerThread = ManagementFactory.getThreadMXBean()
-          .getThreadInfo(thread.getLockOwnerId(), THREAD_DUMP_DEPTH);
+      ThreadInfo lockOwnerThread = getThreadInfo(thread.getLockOwnerId());
       if (lockOwnerThread != null) {
         writeThreadStack(lockOwnerThread, LOCK_OWNER_THREAD_STACK, stringBuilder);
       }
@@ -109,17 +120,38 @@ public abstract class AbstractExecutor {
   private static final String lineSeparator = System.lineSeparator();
 
   private void writeThreadStack(ThreadInfo thread, String header, StringBuilder strb) {
-    strb.append(header).append(lineSeparator);
+    strb.append(header).append(" for \"")
+        .append(thread.getThreadName())
+        .append("\" (0x").append(Long.toHexString(thread.getThreadId()))
+        .append("):").append(lineSeparator);
+    strb.append("java.lang.ThreadState: ").append(thread.getThreadState());
+    if (thread.isSuspended()) {
+      strb.append(" (suspended)");
+    }
+    if (thread.isInNative()) {
+      strb.append(" (in native)");
+    }
+    strb.append(lineSeparator);
     MonitorInfo[] lockedMonitors = thread.getLockedMonitors();
-    for (int i = 0; i < thread.getStackTrace().length; i++) {
+    for (int i = 0; i < min(thread.getStackTrace().length, THREAD_DUMP_DEPTH); i++) {
       String row = thread.getStackTrace()[i].toString();
       strb.append(INDENT).append("at ").append(row).append(lineSeparator);
       appendLockedMonitor(strb, i, lockedMonitors);
     }
+    strb.append("Locked ownable synchronizers:").append(lineSeparator);
+    LockInfo[] lockedSynchronizers = thread.getLockedSynchronizers();
+    if (lockedSynchronizers.length == 0) {
+      strb.append(INDENT).append("- None").append(lineSeparator);
+    } else {
+      for (LockInfo lockInfo : lockedSynchronizers) {
+        strb.append(INDENT).append("- ").append(lockInfo).append(lineSeparator);
+      }
+    }
   }
 
-  private void appendLockedMonitor(StringBuilder strb, int stackDepth, MonitorInfo[] lockedMonitors) {
-    for (MonitorInfo monitorInfo: lockedMonitors) {
+  private void appendLockedMonitor(StringBuilder strb, int stackDepth,
+      MonitorInfo[] lockedMonitors) {
+    for (MonitorInfo monitorInfo : lockedMonitors) {
       if (stackDepth == monitorInfo.getLockedStackDepth()) {
         strb.append(INDENT).append("  - locked " + monitorInfo).append(lineSeparator);
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/AbstractExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/AbstractExecutor.java
@@ -15,10 +15,12 @@
 package org.apache.geode.internal.monitoring.executor;
 
 import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
+import org.apache.geode.annotations.Immutable;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -101,12 +103,26 @@ public abstract class AbstractExecutor {
     return stringBuilder.toString();
   }
 
+  @Immutable
+  private static final String INDENT = "  ";
+  @Immutable
+  private static final String lineSeparator = System.lineSeparator();
+
   private void writeThreadStack(ThreadInfo thread, String header, StringBuilder strb) {
-    final String lineSeparator = System.lineSeparator();
     strb.append(header).append(lineSeparator);
+    MonitorInfo[] lockedMonitors = thread.getLockedMonitors();
     for (int i = 0; i < thread.getStackTrace().length; i++) {
       String row = thread.getStackTrace()[i].toString();
-      strb.append(row).append(lineSeparator);
+      strb.append(INDENT).append("at ").append(row).append(lineSeparator);
+      appendLockedMonitor(strb, i, lockedMonitors);
+    }
+  }
+
+  private void appendLockedMonitor(StringBuilder strb, int stackDepth, MonitorInfo[] lockedMonitors) {
+    for (MonitorInfo monitorInfo: lockedMonitors) {
+      if (stackDepth == monitorInfo.getLockedStackDepth()) {
+        strb.append(INDENT).append("  - locked " + monitorInfo).append(lineSeparator);
+      }
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/monitoring/executor/AbstractExecutorGroupJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/monitoring/executor/AbstractExecutorGroupJUnitTest.java
@@ -78,11 +78,11 @@ public class AbstractExecutorGroupJUnitTest {
       public void run() {
         blockedThreadWaiting[0] = true;
         synchronized (syncObject) {
-          try {
-            syncObject.wait(timeoutInMilliseconds);
-          } catch (InterruptedException e) {
-            return;
-          }
+//          try {
+//            syncObject.wait(timeoutInMilliseconds);
+//          } catch (InterruptedException e) {
+//            return;
+//          }
         }
       }
     };
@@ -90,6 +90,7 @@ public class AbstractExecutorGroupJUnitTest {
     await().until(() -> blockingThreadWaiting[0]);
     blockedThread.start();
     await().until(() -> blockedThreadWaiting[0]);
+    Thread.sleep(500);
     try {
       AbstractExecutor executor = new AbstractExecutor("testGroup", blockedThread.getId()) {
         @Override
@@ -99,6 +100,7 @@ public class AbstractExecutorGroupJUnitTest {
       };
       await().untilAsserted(() -> {
         String threadReport = executor.createThreadReport(60000);
+        System.out.println("DEBUG: " + threadReport);
         Assertions.assertThat(threadReport).contains(AbstractExecutor.LOCK_OWNER_THREAD_STACK);
       });
     } finally {

--- a/geode-core/src/test/java/org/apache/geode/internal/monitoring/executor/AbstractExecutorGroupJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/monitoring/executor/AbstractExecutorGroupJUnitTest.java
@@ -15,9 +15,9 @@
 package org.apache.geode.internal.monitoring.executor;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.geode.test.awaitility.GeodeAwaitility;
@@ -78,11 +78,6 @@ public class AbstractExecutorGroupJUnitTest {
       public void run() {
         blockedThreadWaiting[0] = true;
         synchronized (syncObject) {
-//          try {
-//            syncObject.wait(timeoutInMilliseconds);
-//          } catch (InterruptedException e) {
-//            return;
-//          }
         }
       }
     };
@@ -90,7 +85,6 @@ public class AbstractExecutorGroupJUnitTest {
     await().until(() -> blockingThreadWaiting[0]);
     blockedThread.start();
     await().until(() -> blockedThreadWaiting[0]);
-    Thread.sleep(500);
     try {
       AbstractExecutor executor = new AbstractExecutor("testGroup", blockedThread.getId()) {
         @Override
@@ -100,8 +94,11 @@ public class AbstractExecutorGroupJUnitTest {
       };
       await().untilAsserted(() -> {
         String threadReport = executor.createThreadReport(60000);
-        System.out.println("DEBUG: " + threadReport);
-        Assertions.assertThat(threadReport).contains(AbstractExecutor.LOCK_OWNER_THREAD_STACK);
+        assertThat(threadReport)
+            .contains(AbstractExecutor.LOCK_OWNER_THREAD_STACK + " for \"blocking thread\"");
+        assertThat(threadReport).contains("Waiting on <" + syncObject + ">");
+        assertThat(threadReport).contains("Owned By <blocking thread>");
+        assertThat(threadReport).contains("- locked " + syncObject);
       });
     } finally {
       blockingThread.interrupt();


### PR DESCRIPTION
The thread monitor report's stack frames now use "at " to look like a standard JVM stack dump.
If a frame holds a synchronization then it will be followed by a line that says " - locked " and shows the identity of the object synced on.
After the stack a section titled "Locked ownable synchronizers:" will show what locks the thread holds just like a standard JVM stack dump.
Also before the first frame the ThreadState is printed just like a JVM stack dump.
Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
