### PR TITLE
Revert "GEODE-9104: Removed ESCAPE_NON_ASCII feature so non-ASCII cha…

### DIFF
--- a/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
+++ b/geode-web-api/src/integrationTest/java/org/apache/geode/rest/internal/web/controllers/RestAccessControllerTest.java
@@ -105,12 +105,6 @@ public class RestAccessControllerTest {
   private static final String ORDER_CAS_OLD_JSON = "order-cas-old.json";
   private static final String ORDER_CAS_NEW_JSON = "order-cas-new.json";
   private static final String ORDER_CAS_WRONG_OLD_JSON = "order-cas-wrong-old.json";
-  private static final String CUSTOMER_CONTAINING_CHINESE_JSON =
-      "customer-containing-chinese.json";
-  private static final String CUSTOMER_CONTAINING_CHINESE_QUERY_FULL_RESULT_JSON =
-      "customer-containing-chinese-query-full-result.json";
-  private static final String CUSTOMER_CONTAINING_CHINESE_QUERY_STRUCT_RESULT_JSON =
-      "customer-containing-chinese-query-struct-result.json";
 
   private static final String SLASH = "/";
   private static final String KEY_PREFIX = "/?+ @&./";
@@ -173,9 +167,6 @@ public class RestAccessControllerTest {
     loadResource(ORDER_CAS_OLD_JSON);
     loadResource(ORDER_CAS_NEW_JSON);
     loadResource(ORDER_CAS_WRONG_OLD_JSON);
-    loadResource(CUSTOMER_CONTAINING_CHINESE_JSON);
-    loadResource(CUSTOMER_CONTAINING_CHINESE_QUERY_FULL_RESULT_JSON);
-    loadResource(CUSTOMER_CONTAINING_CHINESE_QUERY_STRUCT_RESULT_JSON);
 
     RestAgent.createParameterizedQueryRegion();
 
@@ -1365,39 +1356,6 @@ public class RestAccessControllerTest {
         .andExpect(header().string("Resource-Count", "60"));
   }
 
-
-  @Test
-  @WithMockUser
-  public void putGetQueryCustomerContainingMandarin() throws Exception {
-    // Put customer containing mandarin
-    mockMvc.perform(put("/v1/customers/1")
-        .content(jsonResources.get(CUSTOMER_CONTAINING_CHINESE_JSON))
-        .with(POST_PROCESSOR))
-        .andExpect(status().isOk())
-        .andExpect(header().string("Location", BASE_URL + "/customers/1"));
-
-    // Get customer containing mandarin
-    mockMvc.perform(get("/v1/customers/1")
-        .with(POST_PROCESSOR))
-        .andExpect(status().isOk())
-        .andExpect(content().json(jsonResources.get(CUSTOMER_CONTAINING_CHINESE_JSON)));
-
-    // Query full customer containing mandarin
-    mockMvc.perform(
-        get("/v1/queries/adhoc?q=SELECT * FROM " + SEPARATOR + "customers WHERE customerId = 1")
-            .with(POST_PROCESSOR))
-        .andExpect(status().isOk())
-        .andExpect(
-            content().json(jsonResources.get(CUSTOMER_CONTAINING_CHINESE_QUERY_FULL_RESULT_JSON)));
-
-    // Query struct customer containing mandarin
-    mockMvc.perform(get("/v1/queries/adhoc?q=SELECT firstName, lastName FROM " + SEPARATOR
-        + "customers WHERE customerId = 1")
-            .with(POST_PROCESSOR))
-        .andExpect(status().isOk())
-        .andExpect(content()
-            .json(jsonResources.get(CUSTOMER_CONTAINING_CHINESE_QUERY_STRUCT_RESULT_JSON)));
-  }
 
   private void deleteAllQueries() throws Exception {
     MvcResult result = mockMvc.perform(get("/v1/queries")

--- a/geode-web-api/src/integrationTest/resources/org/apache/geode/rest/internal/web/controllers/customer-containing-chinese-query-full-result.json
+++ b/geode-web-api/src/integrationTest/resources/org/apache/geode/rest/internal/web/controllers/customer-containing-chinese-query-full-result.json
@@ -1,7 +1,0 @@
-[
-  {
-    "customerId": 1,
-    "firstName": "名",
-    "lastName": "姓"
-  }
-]

--- a/geode-web-api/src/integrationTest/resources/org/apache/geode/rest/internal/web/controllers/customer-containing-chinese-query-struct-result.json
+++ b/geode-web-api/src/integrationTest/resources/org/apache/geode/rest/internal/web/controllers/customer-containing-chinese-query-struct-result.json
@@ -1,6 +1,0 @@
-[
-  {
-    "firstName": "名",
-    "lastName": "姓"
-  }
-]

--- a/geode-web-api/src/integrationTest/resources/org/apache/geode/rest/internal/web/controllers/customer-containing-chinese.json
+++ b/geode-web-api/src/integrationTest/resources/org/apache/geode/rest/internal/web/controllers/customer-containing-chinese.json
@@ -1,5 +1,0 @@
-{
-  "customerId": 1,
-  "firstName": "名",
-  "lastName": "姓"
-}

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/util/JSONUtils.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/util/JSONUtils.java
@@ -24,6 +24,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonGenerator.Feature;
+import com.fasterxml.jackson.core.json.JsonWriteFeature;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.util.Assert;
@@ -52,6 +53,7 @@ public abstract class JSONUtils {
   }
 
   public static JsonGenerator enableDisableJSONGeneratorFeature(JsonGenerator generator) {
+    generator.enable(JsonWriteFeature.ESCAPE_NON_ASCII.mappedFeature());
     generator.disable(Feature.AUTO_CLOSE_TARGET);
     generator.setPrettyPrinter(new DefaultPrettyPrinter());
     return generator;


### PR DESCRIPTION
…racters are displayed"

This reverts commit b7299661375ed0926303f63484cb46dae1e12ffa.

The unit test fails on windows.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
