### PR TITLE
GEODE-9080: Add new stackdriver agent to Windows compute images

### DIFF
--- a/ci/images/google-windows-geode-builder/packer.json
+++ b/ci/images/google-windows-geode-builder/packer.json
@@ -108,6 +108,24 @@
     {
       "type": "powershell",
       "inline": [
+        "$ErrorActionPreference = \"Stop\"",
+        "Set-ExecutionPolicy Bypass -Scope Process -Force",
+        "(New-Object Net.WebClient).DownloadFile(\"https://repo.stackdriver.com/windows/StackdriverMonitoring-GCM-46.exe\", \"${env:UserProfile}\\StackdriverMonitoring-GCM-46.exe\")",
+        "Start-Process -FilePath \"${env:UserProfile}\\StackdriverMonitoring-GCM-46.exe\" -ArgumentList \"/S\"",
+        "while ($true) {",
+        "  try {",
+        "    Get-Service -Name StackdriverMonitoring",
+        "    break",
+        "  } catch {",
+        "    Write-Warning \"Wating on service StackdriverMonitoring\"",
+        "    Start-Sleep -s 10",
+        "  }",
+        "}"
+      ]
+    },
+    {
+      "type": "powershell",
+      "inline": [
 
         "write-output '>>>>>>>>>> Cloning geode repo <<<<<<<<<<'",
         "& 'c:\\Program Files\\Git\\bin\\git.exe' clone -b develop --depth 1 https://github.com/apache/geode.git geode",

--- a/ci/pipelines/meta/deploy_meta.sh
+++ b/ci/pipelines/meta/deploy_meta.sh
@@ -130,7 +130,6 @@ YML
     echo "Target ${FLY_TARGET} already exists."
   fi
 
-  FLY=${FLY:-$(which fly)}
 
   set -e
   if [[ ${UPSTREAM_FORK} != "apache" ]]; then


### PR DESCRIPTION
As a precursor to right-sizing our Windows instances, we need to know
their resource use. The jobs are not long-lived enough for the GCP
Recommendation system to tell us, so we need our own monitoring. Thus,
add stackdriver, so that we can see the data for memory and details
about CPU use.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
