### PR TITLE
GEODE-8996: Fixed rebalance gfsh and REST API in mixed version mode (…

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -290,7 +290,7 @@ dependencies {
     exclude module: 'geode-core'
   }
   upgradeTestCompile(project(':geode-assembly:geode-assembly-test'))
-
+  distributedTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
   upgradeTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
   upgradeTestRuntime(project(':extensions:session-testing-war'))
   upgradeTestRuntime('org.codehaus.cargo:cargo-core-uberjar')

--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPICompatibilityTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPICompatibilityTest.java
@@ -1,0 +1,194 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.geode.rest.internal.web.controllers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.management.operation.RebalanceOperation;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.BackwardCompatibilityTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.MemberStarterRule;
+import org.apache.geode.test.version.TestVersion;
+import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.util.internal.GeodeJsonMapper;
+
+@Category({BackwardCompatibilityTest.class})
+@RunWith(Parameterized.class)
+public class RestAPICompatibilityTest {
+  private final String oldVersion;
+  private static ObjectMapper mapper = GeodeJsonMapper.getMapper();
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<String> data() {
+    List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
+    result.removeIf(s -> TestVersion.compare(s, "1.11.0") < 0);
+    return result;
+  }
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  public RestAPICompatibilityTest(String oldVersion) throws JsonProcessingException {
+    this.oldVersion = oldVersion;
+    postRESTAPICalls = new HashMap<>();
+    // {REST endpoint,{Body, Successful Status Message, Introduced in version}}
+    postRESTAPICalls.put("/management/v1/operations/rebalances",
+        new String[] {mapper.writeValueAsString(new RebalanceOperation()), "Operation started",
+            "1.11.0"});
+  }
+
+  private static Map<String, String[]> postRESTAPICalls;
+
+
+  private static final String[][] getRESTAPICalls = {
+      // REST endpoint , status
+      {"/geode-mgmt/v1/management/commands?cmd=rebalance", "OK"}
+  };
+
+  @Test
+  public void restCommandExecutedOnLatestLocatorShouldBeBackwardsCompatible() throws Exception {
+    // Initialize all cluster members with old versions
+    MemberVM locator1 =
+        cluster.startLocatorVM(0, 0, oldVersion, MemberStarterRule::withHttpService);
+    int locatorPort1 = locator1.getPort();
+    MemberVM locator2 =
+        cluster.startLocatorVM(1, 0, oldVersion,
+            x -> x.withConnectionToLocator(locatorPort1).withHttpService());
+    int locatorPort2 = locator2.getPort();
+    cluster
+        .startServerVM(2, oldVersion, s -> s.withRegion(RegionShortcut.PARTITION, "region")
+            .withConnectionToLocator(locatorPort1, locatorPort2));
+    cluster
+        .startServerVM(3, oldVersion, s -> s.withRegion(RegionShortcut.PARTITION, "region")
+            .withConnectionToLocator(locatorPort1, locatorPort2));
+
+    // Roll locators to the current version
+    cluster.stop(0);
+    // gradle sets a property telling us where the build is located
+    final String buildDir = System.getProperty("geode.build.dir", System.getProperty("user.dir"));
+    locator1 = cluster.startLocatorVM(0, l -> l.withHttpService().withPort(locatorPort1)
+        .withConnectionToLocator(locatorPort2)
+        .withSystemProperty("geode.build.dir", buildDir));
+    cluster.stop(1);
+
+    cluster.startLocatorVM(1,
+        x -> x.withConnectionToLocator(locatorPort1).withHttpService().withPort(locatorPort2)
+            .withConnectionToLocator(locatorPort1)
+            .withSystemProperty("geode.build.dir", buildDir));
+
+    gfsh.connectAndVerify(locator1);
+    gfsh.execute("list members");
+    // Execute REST api calls to from the new locators to the old servers to ensure that backwards
+    // compatibility is maintained
+
+    executeAndValidatePOSTRESTCalls(locator1.getHttpPort());
+    executeAndValidateGETRESTCalls(locator1.getHttpPort());
+
+  }
+
+  void executeAndValidatePOSTRESTCalls(int locator) throws Exception {
+
+    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+      for (Map.Entry<String, String[]> entry : postRESTAPICalls.entrySet()) {
+        // Skip the test is the version is before the REST api was introduced.
+        if (TestVersion.compare(oldVersion, entry.getValue()[2]) < 0) {
+          continue;
+        }
+        HttpPost post =
+            new HttpPost("http://localhost:" + locator + entry.getKey());
+        post.addHeader("Content-Type", "application/json");
+        post.addHeader("Accept", "application/json");
+        StringEntity jsonStringEntity =
+            new StringEntity(entry.getValue()[0], ContentType.DEFAULT_TEXT);
+        post.setEntity(jsonStringEntity);
+        CloseableHttpResponse response = httpClient.execute(post);
+
+        HttpEntity entity = response.getEntity();
+        InputStream content = entity.getContent();
+
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(content))) {
+          String line;
+          StringBuilder sb = new StringBuilder();
+          while ((line = reader.readLine()) != null) {
+            sb.append(line);
+          }
+          JsonNode jsonObject = mapper.readTree(sb.toString());
+          String statusCode = jsonObject.findValue("statusCode").textValue();
+          assertThat(statusCode).satisfiesAnyOf(
+              value -> assertThat(value).isEqualTo("ACCEPTED"),
+              value -> assertThat(value).contains("OK"));
+          String statusMessage = jsonObject.findValue("statusMessage").textValue();
+          assertThat(statusMessage).contains(entry.getValue()[1]);
+        }
+      }
+    }
+  }
+
+  public static void executeAndValidateGETRESTCalls(int locator) throws Exception {
+
+    try (CloseableHttpClient httpclient = HttpClients.createDefault()) {
+      for (String[] commandExpectedResponsePair : getRESTAPICalls) {
+        HttpGet get =
+            new HttpGet("http://localhost:" + locator +
+                commandExpectedResponsePair[0]);
+        CloseableHttpResponse response = httpclient.execute(get);
+        HttpEntity entity = response.getEntity();
+        InputStream content = entity.getContent();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(content))) {
+          String line;
+          StringBuilder sb = new StringBuilder();
+          while ((line = reader.readLine()) != null) {
+            sb.append(line);
+          }
+          JsonNode jsonObject = mapper.readTree(sb.toString());
+          String statusCode = jsonObject.findValue("status").textValue();
+          assertThat(statusCode).contains(commandExpectedResponsePair[1]);
+        }
+      }
+    }
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CacheRealizationFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/CacheRealizationFunction.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.geode.management.internal.cli.functions;
+
+public class CacheRealizationFunction extends
+    org.apache.geode.management.internal.functions.CacheRealizationFunction {
+  private static final long serialVersionUID = 6209080805559452304L;
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RebalanceFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/cli/functions/RebalanceFunction.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.management.internal.cli.functions;
+
+public class RebalanceFunction extends
+    org.apache.geode.management.internal.functions.RebalanceFunction {
+  private static final long serialVersionUID = 1L;
+}

--- a/geode-core/src/main/java/org/apache/geode/management/internal/functions/CacheRealizationFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/functions/CacheRealizationFunction.java
@@ -50,7 +50,7 @@ public class CacheRealizationFunction implements InternalFunction<List> {
   private static final Logger logger = LogService.getLogger();
   @Immutable
   private static final Map<Class, ConfigurationRealizer> realizers = new HashMap<>();
-
+  private static final long serialVersionUID = -2695517414081975343L;
   static {
     realizers.put(Region.class, new RegionConfigRealizer());
     realizers.put(GatewayReceiver.class, new GatewayReceiverRealizer());

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -447,6 +447,8 @@ org/apache/geode/management/internal/beans/FileUploader$RemoteFile,false,filenam
 org/apache/geode/management/internal/beans/QueryDataFunction,true,1
 org/apache/geode/management/internal/beans/QueryDataFunction$LocalQueryFunction,true,1,id:java/lang/String,optimizeForWrite:boolean,regionName:java/lang/String,showMembers:boolean,this$0:org/apache/geode/management/internal/beans/QueryDataFunction
 org/apache/geode/management/internal/beans/stats/StatType,false
+org/apache/geode/management/internal/cli/functions/CacheRealizationFunction,true,6209080805559452304
+org/apache/geode/management/internal/cli/functions/RebalanceFunction,true,1
 org/apache/geode/management/internal/configuration/domain/SharedConfigurationStatus,false
 org/apache/geode/management/internal/configuration/functions/DownloadJarFunction,true,1
 org/apache/geode/management/internal/configuration/functions/GetClusterConfigurationFunction,false
@@ -457,7 +459,7 @@ org/apache/geode/management/internal/configuration/messages/ClusterManagementSer
 org/apache/geode/management/internal/exceptions/EntityExistsException,false
 org/apache/geode/management/internal/exceptions/EntityNotFoundException,false,statusOK:boolean
 org/apache/geode/management/internal/exceptions/NoMembersException,false
-org/apache/geode/management/internal/functions/CacheRealizationFunction,false
+org/apache/geode/management/internal/functions/CacheRealizationFunction,true,-2695517414081975343
 org/apache/geode/management/internal/functions/CliFunctionResult$StatusState,false
 org/apache/geode/management/internal/functions/GetMemberInformationFunction,true,1404642539058875565
 org/apache/geode/management/internal/functions/RebalanceFunction,true,1

--- a/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/api/LocatorClusterManagementServiceTest.java
@@ -171,7 +171,7 @@ public class LocatorClusterManagementServiceTest {
     functionResults.add(new RealizationResult().setMemberName("member1"));
     functionResults.add(
         new RealizationResult().setMemberName("member2").setSuccess(false).setMessage("failed"));
-    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any(), any());
+    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any());
 
     doReturn(Collections.singleton(mock(DistributedMember.class))).when(memberValidator)
         .findServers();
@@ -187,7 +187,7 @@ public class LocatorClusterManagementServiceTest {
     List<RealizationResult> functionResults = new ArrayList<>();
     functionResults.add(new RealizationResult().setMemberName("member1"));
     functionResults.add(new RealizationResult().setMemberName("member2"));
-    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any(), any());
+    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any());
 
     doReturn(Collections.singleton(mock(DistributedMember.class))).when(memberValidator)
         .findServers();
@@ -289,7 +289,7 @@ public class LocatorClusterManagementServiceTest {
     functionResults.add(new RealizationResult().setMemberName("member1"));
     functionResults.add(
         new RealizationResult().setMemberName("member2").setSuccess(false).setMessage("failed"));
-    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any(), any());
+    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any());
 
     doReturn(new String[] {"cluster"}).when(memberValidator).findGroupsWithThisElement(any(),
         any());
@@ -317,7 +317,7 @@ public class LocatorClusterManagementServiceTest {
     List<RealizationResult> functionResults = new ArrayList<>();
     functionResults.add(new RealizationResult().setMemberName("member1"));
     functionResults.add(new RealizationResult().setMemberName("member2"));
-    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any(), any());
+    doReturn(functionResults).when(service).executeAndGetFunctionResult(any(), any());
 
     doReturn(new String[] {"cluster"}).when(memberValidator).findGroupsWithThisElement(any(),
         any());

--- a/geode-gfsh/src/upgradeTest/java/org/apache/geode/management/GfshCompatibilityTest.java
+++ b/geode-gfsh/src/upgradeTest/java/org/apache/geode/management/GfshCompatibilityTest.java
@@ -43,7 +43,6 @@ public class GfshCompatibilityTest {
   @Parameterized.Parameters(name = "{0}")
   public static Collection<String> data() {
     List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
-    result.removeIf(s -> TestVersion.compare(s, "1.11.0") < 0);
     return result;
   }
 

--- a/geode-gfsh/src/upgradeTest/java/org/apache/geode/management/GfshRebalanceCompatibilityTest.java
+++ b/geode-gfsh/src/upgradeTest/java/org/apache/geode/management/GfshRebalanceCompatibilityTest.java
@@ -12,10 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.List;
@@ -26,6 +23,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.BackwardCompatibilityTest;
@@ -37,7 +35,8 @@ import org.apache.geode.test.version.VersionManager;
 @Category({BackwardCompatibilityTest.class})
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
-public class GfshCompatibilityTest {
+public class GfshRebalanceCompatibilityTest {
+
   private final String oldVersion;
 
   @Parameterized.Parameters(name = "{0}")
@@ -47,44 +46,39 @@ public class GfshCompatibilityTest {
     return result;
   }
 
-  public GfshCompatibilityTest(String oldVersion) {
-    this.oldVersion = oldVersion;
-  }
-
-  private MemberVM oldLocator;
-
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule();
 
   @Rule
   public ClusterStartupRule cluster = new ClusterStartupRule();
 
+  public GfshRebalanceCompatibilityTest(String oldVersion) {
+    this.oldVersion = oldVersion;
+  }
+
   @Test
-  public void currentGfshConnectToOlderVersionsOfLocator() throws Exception {
-    oldLocator = cluster.startLocatorVM(0, oldVersion);
-    int locatorPort = oldLocator.getPort();
-    cluster.startServerVM(1, oldVersion,
-        s -> s.withConnectionToLocator(locatorPort));
-    // pre 1.10, it should not be able to connect
-    if (TestVersion.compare(oldVersion, "1.5.0") < 0) {
-      gfsh.connect(oldLocator.getPort(), GfshCommandRule.PortType.locator);
-      assertThat(gfsh.isConnected()).isFalse();
-      assertThat(gfsh.getGfshOutput()).contains("Cannot use a")
-          .contains("gfsh client to connect to this cluster.");
-    } else if (TestVersion.compare(oldVersion, "1.10.0") < 0) {
-      gfsh.connect(oldLocator.getPort(), GfshCommandRule.PortType.locator);
-      assertThat(gfsh.isConnected()).isFalse();
-      assertThat(gfsh.getGfshOutput()).contains("Cannot use a")
-          .contains("gfsh client to connect to a " + oldVersion + " cluster.");
-    }
-    // post 1.10 (including) should connect and be able to execute command
-    else {
-      gfsh.connectAndVerify(oldLocator);
-      assertThat(gfsh.getGfshOutput())
-          .contains("You are connected to a cluster of version: " + oldVersion);
-      gfsh.executeAndAssertThat("list members")
-          .statusIsSuccess();
-    }
+  public void whenCurrentVersionLocatorsExecuteRebalanceOnOldServersThenItMustSucceed()
+      throws Exception {
+    MemberVM locator1 = cluster.startLocatorVM(0, oldVersion);
+    int locatorPort1 = locator1.getPort();
+    MemberVM locator2 =
+        cluster.startLocatorVM(1, 0, oldVersion, x -> x.withConnectionToLocator(locatorPort1));
+    int locatorPort2 = locator2.getPort();
+    cluster
+        .startServerVM(2, oldVersion, s -> s.withRegion(RegionShortcut.PARTITION, "region")
+            .withConnectionToLocator(locatorPort1, locatorPort2));
+    cluster
+        .startServerVM(3, oldVersion, s -> s.withRegion(RegionShortcut.PARTITION, "region")
+            .withConnectionToLocator(locatorPort1, locatorPort2));
+    cluster.stop(0);
+    locator1 = cluster.startLocatorVM(0, x -> x.withConnectionToLocator(locatorPort2));
+    cluster.stop(1);
+    int locatorPort1_v2 = locator1.getPort();
+    cluster.startLocatorVM(1, x -> x.withConnectionToLocator(locatorPort1_v2));
+    gfsh.connectAndVerify(locator1);
+    gfsh.executeAndAssertThat("rebalance ")
+        .statusIsSuccess();
+
   }
 
 }


### PR DESCRIPTION
…#6080)

   * Moved new child RebalanceFunction and CacheRealizationFunction to pre 1.12.0 locations.
   * While talking to pre-1.12.0 servers, the locators send the function from the old package.
   * While talking to 1.12.0 server, the new package function is used.
   * For RebalanceFunction and CacheRealizationFunction the serialVersionUID is set to the one created by 1.11.0 for old package location and serialVersionUID created by 1.12.0 for the latter.

(cherry picked from commit 3faf283c038880755a7356fe570a4f92a46826cd)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
