### PR TITLE
GEODE-9122: Avoid possible ConcurrentModificationException with group…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -461,7 +462,8 @@ public class SerialGatewaySenderQueue implements RegionQueue {
     // so no need to worry about off-heap refCount.
   }
 
-  private void peekEventsFromIncompleteTransactions(List<AsyncEvent<?, ?>> batch, long lastKey) {
+  @VisibleForTesting
+  void peekEventsFromIncompleteTransactions(List<AsyncEvent<?, ?>> batch, long lastKey) {
     if (!mustGroupTransactionEvents()) {
       return;
     }
@@ -473,7 +475,9 @@ public class SerialGatewaySenderQueue implements RegionQueue {
 
     int retries = 0;
     while (true) {
-      for (TransactionId transactionId : incompleteTransactionIdsInBatch) {
+      for (Iterator<TransactionId> iter = incompleteTransactionIdsInBatch.iterator(); iter
+          .hasNext();) {
+        TransactionId transactionId = iter.next();
         List<KeyAndEventPair> keyAndEventPairs =
             peekEventsWithTransactionId(transactionId, lastKey);
         if (keyAndEventPairs.size() > 0
@@ -490,7 +494,7 @@ public class SerialGatewaySenderQueue implements RegionQueue {
                   event.getKey(), event.isLastEventInTransaction(), batch.size());
             }
           }
-          incompleteTransactionIdsInBatch.remove(transactionId);
+          iter.remove();
         }
       }
       if (incompleteTransactionIdsInBatch.size() == 0 ||

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueueJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueueJUnitTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -457,6 +458,30 @@ public class ParallelGatewaySenderQueueJUnitTest {
   }
 
   @Test
+  public void peekEventsFromIncompleteTransactionsDoesNotThrowConcurrentModificationExceptionWhenCompletingTwoTransactions() {
+    mockGatewaySenderStats();
+    GatewaySenderEventImpl event1 = createGatewaySenderEventImpl(1, false);
+    GatewaySenderEventImpl event2 = createGatewaySenderEventImpl(2, false);
+    GatewaySenderEventImpl event3 = createGatewaySenderEventImpl(1, true);
+    GatewaySenderEventImpl event4 = createGatewaySenderEventImpl(2, true);
+
+    Queue backingList = new LinkedList();
+    backingList.add(event3);
+    backingList.add(event4);
+    BucketRegionQueue bucketRegionQueue = mockBucketRegionQueue(backingList);
+
+    TestableParallelGatewaySenderQueue queue = new TestableParallelGatewaySenderQueue(sender,
+        Collections.emptySet(), 0, 1, metaRegionFactory);
+    queue.setGroupTransactionEvents(true);
+    queue.setMockedAbstractBucketRegionQueue(bucketRegionQueue);
+
+    List<GatewaySenderEventImpl> batch = new ArrayList<>(Arrays.asList(event1, event2));
+    PartitionedRegion mockBucketRegion = mockPR("bucketRegion");
+    queue.peekEventsFromIncompleteTransactions(batch, mockBucketRegion);
+  }
+
+
+  @Test
   public void testCalculateTimeToSleepNegativeInputReturnsZero() {
     assertEquals(0L, ParallelGatewaySenderQueue.calculateTimeToSleep(-3));
   }
@@ -475,6 +500,7 @@ public class ParallelGatewaySenderQueueJUnitTest {
   public void testCalculateTimeToSleepInputSmallerThanOneThousand() {
     assertEquals(2L, ParallelGatewaySenderQueue.calculateTimeToSleep(40));
   }
+
 
   private GatewaySenderEventImpl createGatewaySenderEventImpl(int transactionId,
       boolean isLastEventInTransaction) {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -2744,10 +2744,9 @@ public class WANTestBase extends DistributedTestCase {
     assertNotNull(r);
 
     long keyOffset = offset * ((putsPerTransaction + (10 * transactions)) * 100);
-    long i = 0;
     long j = 0;
     CacheTransactionManager mgr = cache.getCacheTransactionManager();;
-    for (i = 0; i < transactions; i++) {
+    for (int i = 0; i < transactions; i++) {
       boolean done = false;
       do {
         try {


### PR DESCRIPTION
…-transaction-events=true

When group-transaction-events is set to true
if the SerialGatewaySenderQueue.peekEventsFromIncompleteTransactions
or ParallelGatewaySenderQueue.peekEventsFromIncompleteTransactions contain
more than one TransactionId, and one of them is removed,
the ConcurrentModificationException will occur.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
