### PR TITLE
GEODE-9004: Align results of queries with and without map indexes

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
@@ -57,7 +57,7 @@ public class CompactRangeIndexJUnitTest {
 
   @Before
   public void setUp() {
-    System.setProperty("index_elemarray_threshold", "3");
+    IndexManager.INDEX_ELEMARRAY_THRESHOLD_FOR_TESTING = 3;
     utils = new QueryTestUtils();
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, "0");
@@ -68,7 +68,6 @@ public class CompactRangeIndexJUnitTest {
 
   @Test
   public void testCompactRangeIndex() throws Exception {
-    System.setProperty("index_elemarray_threshold", "3");
     index = utils.createIndex("type", "\"type\"", SEPARATOR + "exampleRegion");
     putValues(9);
     isUsingIndexElemArray("type1");
@@ -289,7 +288,6 @@ public class CompactRangeIndexJUnitTest {
       assertEquals("incorrect number of entries in collection", 3, count);
     } finally {
       DefaultQuery.testHook = null;
-      System.setProperty("index_elemarray_threshold", "100");
     }
   }
 
@@ -629,6 +627,7 @@ public class CompactRangeIndexJUnitTest {
 
   @After
   public void tearDown() throws Exception {
+    IndexManager.INDEX_ELEMARRAY_THRESHOLD_FOR_TESTING = -1;
     utils.closeCache();
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/CompactRangeIndexJUnitTest.java
@@ -477,7 +477,7 @@ public class CompactRangeIndexJUnitTest {
     p4.positions.put("SUN", null);
     region.put("KEY-" + 4, p4);
 
-    // execute query and check result size
+    // execute query for null value and check result size
     QueryService qs = utils.getCache().getQueryService();
     SelectResults<Object> results = UncheckedUtils.uncheckedCast(qs
         .newQuery(
@@ -486,6 +486,15 @@ public class CompactRangeIndexJUnitTest {
     assertThat(results.size()).isEqualTo(2);
     assertThat(results.contains(p2)).isTrue();
     assertThat(results.contains(p4)).isTrue();
+
+    // execute query for not null value and check result size
+    results = UncheckedUtils.uncheckedCast(qs
+        .newQuery(
+            "Select * from " + SEPARATOR + "exampleRegion r where r.positions['SUN'] != null")
+        .execute());
+    assertThat(results.size()).isEqualTo(2);
+    assertThat(results.contains(p1)).isTrue();
+    assertThat(results.contains(p3)).isTrue();
   }
 
   private void putValues(int num) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexMaintenanceJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexMaintenanceJUnitTest.java
@@ -686,7 +686,7 @@ public class IndexMaintenanceJUnitTest {
     // Test index maintenance
     // addition of new Portfolio object
     Map<Object, AbstractIndex> indxMap = mri.getRangeIndexHolderForTesting();
-    assertEquals(indxMap.size(), 3);
+    assertEquals(indxMap.size(), 4);
     for (int j = 1; j <= 3; ++j) {
       assertTrue(indxMap.containsKey("key" + j));
       RangeIndex rng = (RangeIndex) indxMap.get("key" + j);
@@ -717,7 +717,7 @@ public class IndexMaintenanceJUnitTest {
       mkid.maap.put("key" + j, "val" + j);
     }
     testRgn.put(ID, mkid);
-    assertEquals(indxMap.size(), 3);
+    assertEquals(indxMap.size(), 4);
     for (int j = 1; j <= 3; ++j) {
       assertTrue(indxMap.containsKey("key" + j));
       RangeIndex rng = (RangeIndex) indxMap.get("key" + j);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
@@ -345,7 +345,7 @@ public class IndexStatisticsJUnitTest {
     IndexStatistics keyIndexStats = keyIndex3.getStatistics();
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(102, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
     assertEquals(200, keyIndexStats.getNumberOfValues());
     assertEquals(200, keyIndexStats.getNumUpdates());
 
@@ -354,7 +354,7 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(102, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
     assertEquals(200, keyIndexStats.getNumberOfValues());
     assertEquals(400, keyIndexStats.getNumUpdates());
 
@@ -376,7 +376,7 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(52, keyIndexStats.getNumberOfKeys());
+    assertEquals(50, keyIndexStats.getNumberOfKeys());
     assertEquals(100, keyIndexStats.getNumberOfValues());
     assertEquals(500, keyIndexStats.getNumUpdates());
 
@@ -385,7 +385,7 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(52, keyIndexStats.getNumberOfKeys());
+    assertEquals(50, keyIndexStats.getNumberOfKeys());
     assertEquals(100, keyIndexStats.getNumberOfValues());
     assertEquals(500, keyIndexStats.getNumUpdates());
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
@@ -345,19 +345,18 @@ public class IndexStatisticsJUnitTest {
     IndexStatistics keyIndexStats = keyIndex3.getStatistics();
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(102, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 100; i++) {
       region.put(Integer.toString(i), new Portfolio(i, i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(102, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -377,24 +376,24 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(52, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(52, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
@@ -424,8 +423,8 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, mapIndexStats.getNumberOfKeys());
-    assertEquals(100, mapIndexStats.getNumberOfValues());
-    assertEquals(100, mapIndexStats.getNumUpdates());
+    assertEquals(200, mapIndexStats.getNumberOfValues());
+    assertEquals(200, mapIndexStats.getNumUpdates());
 
 
     Position.cnt = 0;
@@ -435,8 +434,8 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, mapIndexStats.getNumberOfKeys());
-    assertEquals(100, mapIndexStats.getNumberOfValues());
-    assertEquals(200, mapIndexStats.getNumUpdates());
+    assertEquals(200, mapIndexStats.getNumberOfValues());
+    assertEquals(400, mapIndexStats.getNumUpdates());
     String queryStr =
         "select * from " + SEPARATOR
             + "portfolio where positions['DELL'] != NULL OR positions['YHOO'] != NULL";
@@ -457,8 +456,8 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, mapIndexStats.getNumberOfKeys());
-    assertEquals(50, mapIndexStats.getNumberOfValues());
-    assertEquals(300, mapIndexStats.getNumUpdates());
+    assertEquals(100, mapIndexStats.getNumberOfValues());
+    assertEquals(600, mapIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
@@ -466,14 +465,14 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, mapIndexStats.getNumberOfKeys());
-    assertEquals(50, mapIndexStats.getNumberOfValues());
-    assertEquals(300, mapIndexStats.getNumUpdates());
+    assertEquals(100, mapIndexStats.getNumberOfValues());
+    assertEquals(600, mapIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(400, mapIndexStats.getNumUpdates());
+    assertEquals(800, mapIndexStats.getNumUpdates());
 
     assertEquals(2, mapIndexStats.getNumberOfMapIndexKeys());
     assertEquals(0, mapIndexStats.getNumberOfKeys());
@@ -667,8 +666,8 @@ public class IndexStatisticsJUnitTest {
     IndexStatistics mapIndexStats = keyIndex3.getStatistics();
 
     assertEquals(100, mapIndexStats.getNumberOfKeys());
-    assertEquals(100, mapIndexStats.getNumberOfValues());
-    assertEquals(100, mapIndexStats.getNumUpdates());
+    assertEquals(200, mapIndexStats.getNumberOfValues());
+    assertEquals(200, mapIndexStats.getNumUpdates());
 
 
     Position.cnt = 0;
@@ -677,8 +676,8 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(100, mapIndexStats.getNumberOfKeys());
-    assertEquals(100, mapIndexStats.getNumberOfValues());
-    assertEquals(200, mapIndexStats.getNumUpdates());
+    assertEquals(200, mapIndexStats.getNumberOfValues());
+    assertEquals(400, mapIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -696,8 +695,8 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(50, mapIndexStats.getNumberOfKeys());
-    assertEquals(50, mapIndexStats.getNumberOfValues());
-    assertEquals(300, mapIndexStats.getNumUpdates());
+    assertEquals(100, mapIndexStats.getNumberOfValues());
+    assertEquals(600, mapIndexStats.getNumUpdates());
 
 
     for (int i = 0; i < 50; i++) {
@@ -705,14 +704,14 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(50, mapIndexStats.getNumberOfKeys());
-    assertEquals(50, mapIndexStats.getNumberOfValues());
-    assertEquals(300, mapIndexStats.getNumUpdates());
+    assertEquals(100, mapIndexStats.getNumberOfValues());
+    assertEquals(600, mapIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(400, mapIndexStats.getNumUpdates());
+    assertEquals(800, mapIndexStats.getNumUpdates());
 
     assertEquals(0, mapIndexStats.getNumberOfKeys());
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 
@@ -359,27 +358,11 @@ public class MapRangeIndexMaintenanceJUnitTest {
     qs = CacheUtils.getQueryService();
 
     keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN']", SEPARATOR + "portfolio ");
-    assertThat(keyIndex1).isInstanceOf(CompactRangeIndex.class);
+
+    Class<CompactRangeIndex> indexType = CompactRangeIndex.class;
+    assertThat(keyIndex1).isInstanceOf(indexType);
     testQueriesForValueInMapField(region, qs);
-
-    long keys = ((CompactRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
-    long mapIndexKeys =
-        ((CompactRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
-    long values =
-        ((CompactRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
-    long uses =
-        ((CompactRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
-
-    // The number of keys must be equal to the number of different values the
-    // positions map takes in region entries for the 'SUN' key:
-    // ("nothing", "more"). null or UNDEFINED not included
-    assertThat(keys).isEqualTo(2);
-    // mapIndexKeys must be zero because the index used is a range index and not a map index
-    assertThat(mapIndexKeys).isEqualTo(0);
-    // The number of values must be equal to the number of region entries
-    assertThat(values).isEqualTo(7);
-    // The index must be used in every query
-    assertThat(uses).isEqualTo(4);
+    verifyStatsForQueriesForValueInMapFieldWithAnyRangeIndexWithOneKey(indexType);
   }
 
   @Test
@@ -390,31 +373,11 @@ public class MapRangeIndexMaintenanceJUnitTest {
 
     keyIndex1 =
         qs.createIndex(INDEX_NAME, "positions['SUN', 'ERICSSON']", SEPARATOR + "portfolio ");
-    assertThat(keyIndex1).isInstanceOf(CompactMapRangeIndex.class);
+
+    Class<CompactMapRangeIndex> indexType = CompactMapRangeIndex.class;
+    assertThat(keyIndex1).isInstanceOf(indexType);
     testQueriesForValueInMapField(region, qs);
-
-    long keys = ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
-    long mapIndexKeys =
-        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
-    long values =
-        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
-    long uses =
-        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
-
-    // The number of keys must be equal to the number of different values the
-    // positions map takes for the 'SUN' key ("nothing", "more") plus
-    // the number of different values the positions map takes for the 'ERICSSON' key
-    // ("hey"). null or UNDEFINED not included.
-    assertThat(keys).isEqualTo(3);
-    // The number of mapIndexKeys must be equal to the number of keys
-    // in the index that appear in region entries:
-    // 'SUN', 'ERICSSON'
-    assertThat(mapIndexKeys).isEqualTo(2);
-    // The number of values must be equal to the number of entries
-    // times the number of indexed keys in the map
-    assertThat(values).isEqualTo(14);
-    // The index must be used in all queries
-    assertThat(uses).isEqualTo(4);
+    verifyStatsForQueriesForValueInMapFieldWithAnyMapIndexWithSeveralKeys(indexType);
   }
 
   @Test
@@ -424,33 +387,11 @@ public class MapRangeIndexMaintenanceJUnitTest {
     qs = CacheUtils.getQueryService();
 
     keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", SEPARATOR + "portfolio ");
-    assertThat(keyIndex1).isInstanceOf(CompactMapRangeIndex.class);
+
+    Class<CompactMapRangeIndex> indexType = CompactMapRangeIndex.class;
+    assertThat(keyIndex1).isInstanceOf(indexType);
     testQueriesForValueInMapField(region, qs);
-
-    long keys = ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
-    long mapIndexKeys =
-        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
-    long values =
-        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
-    long uses =
-        ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
-
-    // The number of keys must be equal to the number of different values the
-    // positions map takes for each key
-    // for each entry in the region (null not included):
-    // "something", "nothing", "more", "empty", "hey", "tip"
-    assertThat(keys).isEqualTo(6);
-    // The number of mapIndexKeys must be equal to the number of different keys
-    // that appear in entries of the region:
-    // "IBM", "ERICSSON", "HP", "SUN", null
-    assertThat(mapIndexKeys).isEqualTo(5);
-    // The number of values must be equal to the number of values the
-    // positions map takes for each key
-    // for each entry in the region:
-    // "something", null, "nothing", "more", "empty", "hey", "more", "tip"
-    assertThat(values).isEqualTo(8);
-    // The index must not be used in queries with "!=" or when comparing with null
-    assertThat(uses).isEqualTo(1);
+    verifyStatsForQueriesForValueInMapFieldWithAnyMapIndexWithStar(indexType);
   }
 
   @Test
@@ -461,27 +402,11 @@ public class MapRangeIndexMaintenanceJUnitTest {
     qs = CacheUtils.getQueryService();
 
     keyIndex1 = qs.createIndex(INDEX_NAME, "positions['SUN']", SEPARATOR + "portfolio ");
-    assertThat(keyIndex1).isInstanceOf(RangeIndex.class);
+
+    Class<RangeIndex> indexType = RangeIndex.class;
+    assertThat(keyIndex1).isInstanceOf(indexType);
     testQueriesForValueInMapField(region, qs);
-
-    long keys = ((RangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
-    long mapIndexKeys =
-        ((RangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
-    long values =
-        ((RangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
-    long uses =
-        ((RangeIndex) keyIndex1).internalIndexStats.getTotalUses();
-
-    // The number of keys must be equal to the number of different values the
-    // positions map takes in region entries for the 'SUN' key:
-    // ("nothing", "more") excluding null.
-    assertThat(keys).isEqualTo(2);
-    // mapIndexKeys must be zero because the index used is a range index and not a map index
-    assertThat(mapIndexKeys).isEqualTo(0);
-    // The number of values must be equal to the number of region entries
-    assertThat(values).isEqualTo(7);
-    // The index must be used in every query
-    assertThat(uses).isEqualTo(4);
+    verifyStatsForQueriesForValueInMapFieldWithAnyRangeIndexWithOneKey(indexType);
   }
 
   @Test
@@ -493,31 +418,11 @@ public class MapRangeIndexMaintenanceJUnitTest {
 
     keyIndex1 =
         qs.createIndex(INDEX_NAME, "positions['SUN', 'ERICSSON']", SEPARATOR + "portfolio ");
-    assertThat(keyIndex1).isInstanceOf(MapRangeIndex.class);
+
+    Class<MapRangeIndex> indexType = MapRangeIndex.class;
+    assertThat(keyIndex1).isInstanceOf(indexType);
     testQueriesForValueInMapField(region, qs);
-
-    long keys = ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
-    long mapIndexKeys =
-        ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
-    long values =
-        ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
-    long uses =
-        ((MapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
-
-    // The number of keys must be equal to the number of different values the
-    // positions map takes for the 'SUN' key ("nothing", "more") plus
-    // the number of different values the positions map takes for the 'ERICSSON' key
-    // ("hey") for each entry in the region (null values not counted).
-    assertThat(keys).isEqualTo(3);
-    // The number of mapIndexKeys must be equal to the number of keys
-    // in the index that appear in the positions map of region entries:
-    // 'SUN', 'ERICSSON'
-    assertThat(mapIndexKeys).isEqualTo(2);
-    // The number of values must be equal to the number of
-    // entries times the number of keys in the index
-    assertThat(values).isEqualTo(14);
-    // The index must be used for all queries
-    assertThat(uses).isEqualTo(4);
+    verifyStatsForQueriesForValueInMapFieldWithAnyMapIndexWithSeveralKeys(indexType);
   }
 
   @Test
@@ -528,31 +433,11 @@ public class MapRangeIndexMaintenanceJUnitTest {
     qs = CacheUtils.getQueryService();
 
     keyIndex1 = qs.createIndex(INDEX_NAME, "positions[*]", SEPARATOR + "portfolio ");
-    assertThat(keyIndex1).isInstanceOf(MapRangeIndex.class);
+
+    Class<MapRangeIndex> indexType = MapRangeIndex.class;
+    assertThat(keyIndex1).isInstanceOf(indexType);
     testQueriesForValueInMapField(region, qs);
-
-    long keys = ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfKeys();
-    long mapIndexKeys =
-        ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfMapIndexKeys();
-    long values =
-        ((MapRangeIndex) keyIndex1).internalIndexStats.getNumberOfValues();
-    long uses =
-        ((MapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
-
-    // The number of keys must be equal to the number of different values the
-    // positions map takes for each key for each entry in the region:
-    // "something", null, "nothing", "more", "hey", "tip"
-    assertThat(keys).isEqualTo(6);
-    // The number of mapIndexKeys must be equal to the number of different keys
-    // that appear in entries of the region:
-    // "IBM", "ERICSSON", "HP", "SUN", "cannotBeNull"
-    assertThat(mapIndexKeys).isEqualTo(5);
-    // The number of values must be equal to the number of values the
-    // positions map takes for each key for each entry in the region:
-    // "something", null, "nothing", "more", "hey", "more", "tip"
-    assertThat(values).isEqualTo(8);
-    // The index must not be used in queries with "!=" or when comparing with null
-    assertThat(uses).isEqualTo(1);
+    verifyStatsForQueriesForValueInMapFieldWithAnyMapIndexWithStar(indexType);
   }
 
   public void testQueriesForValueInMapField(Region<Object, Object> region, QueryService qs)
@@ -607,36 +492,106 @@ public class MapRangeIndexMaintenanceJUnitTest {
     SelectResults<Object> result = UncheckedUtils.uncheckedCast(qs
         .newQuery(query)
         .execute());
-    assertThat(result.size()).isEqualTo(3);
-    assertThat(result.containsAll(Arrays.asList(p1, p3, p6))).isTrue();
+    assertThat(result).containsExactlyInAnyOrder(p1, p3, p6);
 
     query = "select * from " + SEPARATOR + "portfolio p where p.positions['SUN'] != null";
     result = UncheckedUtils.uncheckedCast(qs
         .newQuery(query)
         .execute());
-    assertThat(result.size()).isEqualTo(4);
-    assertThat(result.containsAll(Arrays.asList(p2, p4, p5, p7))).isTrue();
+    assertThat(result).containsExactlyInAnyOrder(p2, p4, p5, p7);
 
     query = "select * from " + SEPARATOR + "portfolio p where p.positions['SUN'] = 'nothing'";
     result = UncheckedUtils.uncheckedCast(qs
         .newQuery(query)
         .execute());
-    assertThat(result.size()).isEqualTo(1);
-    assertThat(result.contains(p4)).isTrue();
+    assertThat(result).containsExactly(p4);
 
     query = "select * from " + SEPARATOR + "portfolio p where p.positions['SUN'] != 'nothing'";
     result = UncheckedUtils.uncheckedCast(qs
         .newQuery(query)
         .execute());
-    assertThat(result.size()).isEqualTo(6);
-    assertThat(result.containsAll(Arrays.asList(p1, p2, p3, p5, p6, p7))).isTrue();
+    assertThat(result).containsExactlyInAnyOrder(p1, p2, p3, p5, p6, p7);
 
     query = "select * from " + SEPARATOR + "portfolio p";
     result = UncheckedUtils.uncheckedCast(qs
         .newQuery(query)
         .execute());
-    assertThat(result.size()).isEqualTo(7);
-    assertThat(result.containsAll(Arrays.asList(p1, p2, p3, p4, p5, p6, p7))).isTrue();
+    assertThat(result).containsExactlyInAnyOrder(p1, p2, p3, p4, p5, p6, p7);
+  }
+
+  private <T extends AbstractIndex> void verifyStatsForQueriesForValueInMapFieldWithAnyRangeIndexWithOneKey(
+      Class<T> indexType) {
+    long keys = (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfValues();
+    long uses =
+        (indexType.cast(keyIndex1)).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes in region entries for the 'SUN' key:
+    // ("nothing", "more"). null or UNDEFINED not included.
+    assertThat(keys).isEqualTo(2);
+    // mapIndexKeys must be zero because the index used is a range index and not a map index.
+    assertThat(mapIndexKeys).isEqualTo(0);
+    // The number of values must be equal to the number of region entries.
+    assertThat(values).isEqualTo(region.keySet().size());
+    // The index must be used in all the queries that have positions['SUN'] in the filter.
+    assertThat(uses).isEqualTo(4);
+  }
+
+  private <T extends AbstractMapIndex> void verifyStatsForQueriesForValueInMapFieldWithAnyMapIndexWithSeveralKeys(
+      Class<T> indexType) {
+    long keys = (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfValues();
+    long uses =
+        (indexType.cast(keyIndex1)).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes for the 'SUN' key ("nothing", "more") plus
+    // the number of different values the positions map takes for the 'ERICSSON' key
+    // ("hey"). null or UNDEFINED not included.
+    assertThat(keys).isEqualTo(3);
+    // The number of mapIndexKeys must be equal to the number of keys
+    // in the index that appear in region entries:
+    // 'SUN', 'ERICSSON'
+    assertThat(mapIndexKeys).isEqualTo(2);
+    // The number of values must be equal to the number of entries
+    // in the region times the number of indexed keys in the map: 'SUN', 'ERICSSON'.
+    assertThat(values).isEqualTo(region.keySet().size() * 2L);
+    // The index must be used in all the queries that have positions['SUN'] in the filter.
+    assertThat(uses).isEqualTo(4);
+  }
+
+  private <T extends AbstractMapIndex> void verifyStatsForQueriesForValueInMapFieldWithAnyMapIndexWithStar(
+      Class<T> indexType) {
+    long keys = (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfKeys();
+    long mapIndexKeys =
+        (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfMapIndexKeys();
+    long values =
+        (indexType.cast(keyIndex1)).internalIndexStats.getNumberOfValues();
+    long uses =
+        (indexType.cast(keyIndex1)).internalIndexStats.getTotalUses();
+
+    // The number of keys must be equal to the number of different values the
+    // positions map takes for each key for each entry in the region (null not included):
+    // "something", "nothing", "more", "empty", "hey", "tip"
+    assertThat(keys).isEqualTo(6);
+    // The number of mapIndexKeys must be equal to the number of different keys
+    // that appear in entries of the region:
+    // "IBM", "ERICSSON", "HP", "SUN", "cannotBeNull".
+    assertThat(mapIndexKeys).isEqualTo(5);
+    // The number of values must be equal to the number of values the
+    // positions map takes for each key for each entry in the region:
+    // "something", null, "nothing", "more", "empty", "hey", "more", "tip".
+    assertThat(values).isEqualTo(8);
+    // The index must be used in all the queries that have positions['SUN'] in the filter
+    // except for those using "!=" to compare with it or when comparing it with null.
+    assertThat(uses).isEqualTo(1);
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/MapRangeIndexMaintenanceJUnitTest.java
@@ -372,9 +372,8 @@ public class MapRangeIndexMaintenanceJUnitTest {
 
     // The number of keys must be equal to the number of different values the
     // positions map takes in region entries for the 'SUN' key:
-    // ("nothing", "more", null) + 1 for any entry that does not have
-    // a value for the "SUN" key (UNDEFINED)
-    assertThat(keys).isEqualTo(4);
+    // ("nothing", "more"). null or UNDEFINED not included
+    assertThat(keys).isEqualTo(2);
     // mapIndexKeys must be zero because the index used is a range index and not a map index
     assertThat(mapIndexKeys).isEqualTo(0);
     // The number of values must be equal to the number of region entries
@@ -403,14 +402,10 @@ public class MapRangeIndexMaintenanceJUnitTest {
         ((CompactMapRangeIndex) keyIndex1).internalIndexStats.getTotalUses();
 
     // The number of keys must be equal to the number of different values the
-    // positions map takes for the 'SUN' key ("nothing", "more") + 1 (if there
-    // are entries where positions is null) + 1 (if there are entries where
-    // the "SUN" key is not present or the mapped value is null) plus
+    // positions map takes for the 'SUN' key ("nothing", "more") plus
     // the number of different values the positions map takes for the 'ERICSSON' key
-    // ("hey") + 1 (if there are entries where positions is null) + 1
-    // (if there are entries where the "ERICSSON" key is not present or the mapped
-    // value is null)
-    assertThat(keys).isEqualTo(7);
+    // ("hey"). null or UNDEFINED not included.
+    assertThat(keys).isEqualTo(3);
     // The number of mapIndexKeys must be equal to the number of keys
     // in the index that appear in region entries:
     // 'SUN', 'ERICSSON'
@@ -442,9 +437,9 @@ public class MapRangeIndexMaintenanceJUnitTest {
 
     // The number of keys must be equal to the number of different values the
     // positions map takes for each key
-    // for each entry in the region:
-    // "something", null, "nothing", "more", "empty", "hey", "tip"
-    assertThat(keys).isEqualTo(7);
+    // for each entry in the region (null not included):
+    // "something", "nothing", "more", "empty", "hey", "tip"
+    assertThat(keys).isEqualTo(6);
     // The number of mapIndexKeys must be equal to the number of different keys
     // that appear in entries of the region:
     // "IBM", "ERICSSON", "HP", "SUN", null

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
@@ -251,7 +251,7 @@ public class PRIndexStatisticsJUnitTest {
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
     assertEquals(200, keyIndexStats.getNumberOfValues());
     assertEquals(200, keyIndexStats.getNumUpdates());
 
@@ -260,7 +260,7 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
     assertEquals(200, keyIndexStats.getNumberOfValues());
     assertEquals(400, keyIndexStats.getNumUpdates());
 
@@ -281,7 +281,7 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(50, keyIndexStats.getNumberOfKeys());
     assertEquals(100, keyIndexStats.getNumberOfValues());
     assertEquals(500, keyIndexStats.getNumUpdates());
 
@@ -290,7 +290,7 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(50, keyIndexStats.getNumberOfKeys());
     assertEquals(100, keyIndexStats.getNumberOfValues());
     assertEquals(500, keyIndexStats.getNumUpdates());
 
@@ -562,7 +562,7 @@ public class PRIndexStatisticsJUnitTest {
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
     assertEquals(200, keyIndexStats.getNumberOfValues());
     assertEquals(200, keyIndexStats.getNumUpdates());
 
@@ -572,7 +572,7 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
     assertEquals(200, keyIndexStats.getNumberOfValues());
     assertEquals(400, keyIndexStats.getNumUpdates());
 
@@ -593,7 +593,7 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(50, keyIndexStats.getNumberOfKeys());
     assertEquals(100, keyIndexStats.getNumberOfValues());
     assertEquals(500, keyIndexStats.getNumUpdates());
 
@@ -602,7 +602,7 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(50, keyIndexStats.getNumberOfKeys());
     assertEquals(100, keyIndexStats.getNumberOfValues());
     assertEquals(500, keyIndexStats.getNumUpdates());
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
@@ -251,18 +251,18 @@ public class PRIndexStatisticsJUnitTest {
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 100; i++) {
       region.put(Integer.toString(i), new Portfolio(i, i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -273,32 +273,32 @@ public class PRIndexStatisticsJUnitTest {
       query.execute();
     }
 
-    // Both RangeIndex should be used
-    assertEquals(100 /* Execution time */, keyIndexStats.getTotalUses());
+    // Index should be used
+    assertEquals(100, keyIndexStats.getTotalUses());
 
     for (int i = 0; i < 50; i++) {
       region.invalidate(Integer.toString(i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(600, keyIndexStats.getNumUpdates());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
 
@@ -326,8 +326,8 @@ public class PRIndexStatisticsJUnitTest {
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     Position.cnt = 0;
     for (int i = 0; i < 100; i++) {
@@ -336,8 +336,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -357,8 +357,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
@@ -366,15 +366,15 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(400, keyIndexStats.getNumUpdates());
+    assertEquals(800, keyIndexStats.getNumUpdates());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
 
@@ -562,9 +562,9 @@ public class PRIndexStatisticsJUnitTest {
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     Position.cnt = 0;
     for (int i = 0; i < 100; i++) {
@@ -572,9 +572,9 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfKeys());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -593,24 +593,24 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(250, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfKeys());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(500, keyIndexStats.getNumUpdates());
 
     for (int i = 50; i < 100; i++) {
       region.destroy(Integer.toString(i));
     }
 
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(600, keyIndexStats.getNumUpdates());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
 
@@ -645,8 +645,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(100, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(200, keyIndexStats.getNumUpdates());
 
     Position.cnt = 0;
     for (int i = 0; i < 100; i++) {
@@ -655,8 +655,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
-    assertEquals(100, keyIndexStats.getNumberOfValues());
-    assertEquals(200, keyIndexStats.getNumUpdates());
+    assertEquals(200, keyIndexStats.getNumberOfValues());
+    assertEquals(400, keyIndexStats.getNumUpdates());
 
     String queryStr =
         "select * from " + SEPARATOR
@@ -676,8 +676,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
     for (int i = 0; i < 50; i++) {
       region.destroy(Integer.toString(i));
@@ -685,8 +685,8 @@ public class PRIndexStatisticsJUnitTest {
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(50, keyIndexStats.getNumberOfKeys());
-    assertEquals(50, keyIndexStats.getNumberOfValues());
-    assertEquals(300, keyIndexStats.getNumUpdates());
+    assertEquals(100, keyIndexStats.getNumberOfValues());
+    assertEquals(600, keyIndexStats.getNumUpdates());
 
 
     for (int i = 50; i < 100; i++) {
@@ -694,7 +694,7 @@ public class PRIndexStatisticsJUnitTest {
     }
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
-    assertEquals(400, keyIndexStats.getNumUpdates());
+    assertEquals(800, keyIndexStats.getNumUpdates());
     assertEquals(0, keyIndexStats.getNumberOfKeys());
 
     qs.removeIndex(keyIndex3);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/CompiledComparison.java
@@ -22,6 +22,7 @@ import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.AmbiguousNameException;
 import org.apache.geode.cache.query.FunctionDomainException;
+import org.apache.geode.cache.query.Index;
 import org.apache.geode.cache.query.IndexType;
 import org.apache.geode.cache.query.NameResolutionException;
 import org.apache.geode.cache.query.QueryInvocationTargetException;
@@ -29,9 +30,12 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.query.Struct;
 import org.apache.geode.cache.query.TypeMismatchException;
+import org.apache.geode.cache.query.internal.index.AbstractIndex;
+import org.apache.geode.cache.query.internal.index.AbstractMapIndex;
 import org.apache.geode.cache.query.internal.index.IndexData;
 import org.apache.geode.cache.query.internal.index.IndexProtocol;
 import org.apache.geode.cache.query.internal.index.IndexUtils;
+import org.apache.geode.cache.query.internal.index.PartitionedIndex;
 import org.apache.geode.cache.query.internal.parse.OQLLexerTokenTypes;
 import org.apache.geode.cache.query.internal.types.StructTypeImpl;
 import org.apache.geode.cache.query.internal.types.TypeUtils;
@@ -642,13 +646,36 @@ public class CompiledComparison extends AbstractCompiledValue
     } else {
       CompiledValue path = pAndK._path;
       CompiledValue indexKey = pAndK._key;
-      IndexData indexData = null;
+      IndexData indexData;
       // CompiledLike should not use HashIndex and PrimarKey Index.
       if (this instanceof CompiledLike) {
         indexData =
             QueryUtils.getAvailableIndexIfAny(path, context, OQLLexerTokenTypes.LITERAL_like);
       } else {
         indexData = QueryUtils.getAvailableIndexIfAny(path, context, this._operator);
+      }
+
+      // Do not use indexes when map index with allkeys and != condition or when comparing with null
+      try {
+        if (indexData != null
+            && indexData.getIndex() instanceof AbstractMapIndex
+            && ((AbstractMapIndex) indexData.getIndex()).getIsAllKeys()
+            && (this._operator == TOK_NE ||
+                (this._right != null && (this._right instanceof CompiledLiteral)
+                    && this._right.evaluate(context) == null)
+                ||
+                (this._left != null && (this._left instanceof CompiledLiteral)
+                    && this._left.evaluate(context) == null))) {
+          Index prIndex = ((AbstractIndex) indexData.getIndex()).getPRIndex();
+          if (prIndex != null) {
+            ((PartitionedIndex) prIndex).releaseIndexReadLockForRemove();
+          } else {
+            ((AbstractIndex) indexData.getIndex()).releaseIndexReadLockForRemove();
+          }
+          return null;
+        }
+      } catch (Exception e) {
+        // Ignore. Should not throw with a CompiledLiteral.evaluate.
       }
 
       IndexProtocol index = null;

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractMapIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractMapIndex.java
@@ -16,7 +16,6 @@ package org.apache.geode.cache.query.internal.index;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -353,9 +352,7 @@ public abstract class AbstractMapIndex extends AbstractIndex {
       if (key == null) {
         return;
       }
-      Iterator<Map.Entry<?, ?>> entries = ((Map) key).entrySet().iterator();
-      while (entries.hasNext()) {
-        Map.Entry<?, ?> mapEntry = entries.next();
+      for (Map.Entry<?, ?> mapEntry : ((Map<?, ?>) key).entrySet()) {
         Object mapKey = mapEntry.getKey();
         Object indexKey = mapEntry.getValue();
         if (isAdd) {
@@ -370,7 +367,7 @@ public abstract class AbstractMapIndex extends AbstractIndex {
         if (key == null) {
           indexKey = QueryService.UNDEFINED;
         } else {
-          indexKey = ((Map) key).get(mapKey);
+          indexKey = ((Map<?, ?>) key).get(mapKey);
         }
         if (isAdd) {
           this.doIndexAddition(mapKey, indexKey, value, entry);

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactMapRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactMapRangeIndex.java
@@ -109,9 +109,7 @@ public class CompactMapRangeIndex extends AbstractMapIndex {
       if (key == null) {
         return;
       }
-      Iterator<Map.Entry<?, ?>> entries = ((Map) key).entrySet().iterator();
-      while (entries.hasNext()) {
-        Map.Entry<?, ?> mapEntry = entries.next();
+      for (Map.Entry<?, ?> mapEntry : ((Map<?, ?>) key).entrySet()) {
         Object mapKey = mapEntry.getKey();
         Object indexKey = mapEntry.getValue();
         this.saveIndexAddition(mapKey, indexKey, value, entry);
@@ -123,7 +121,7 @@ public class CompactMapRangeIndex extends AbstractMapIndex {
         if (key == null) {
           indexKey = QueryService.UNDEFINED;
         } else {
-          indexKey = ((Map) key).get(mapKey);
+          indexKey = ((Map<?, ?>) key).get(mapKey);
         }
         this.saveIndexAddition(mapKey, indexKey, value, entry);
       }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactMapRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactMapRangeIndex.java
@@ -98,10 +98,17 @@ public class CompactMapRangeIndex extends AbstractMapIndex {
 
   @Override
   void saveMapping(Object key, Object value, RegionEntry entry) throws IMQException {
-    if (key == QueryService.UNDEFINED || !(key instanceof Map)) {
+    if (key == QueryService.UNDEFINED || (key != null && !(key instanceof Map))) {
       return;
     }
     if (this.isAllKeys) {
+      // If the key is null or it has no elements then we cannot associate it
+      // to any index key (it would apply to all). That is why
+      // this type of index does not support !=
+      // queries or queries comparing with null.
+      if (key == null) {
+        return;
+      }
       Iterator<Map.Entry<?, ?>> entries = ((Map) key).entrySet().iterator();
       while (entries.hasNext()) {
         Map.Entry<?, ?> mapEntry = entries.next();
@@ -112,11 +119,13 @@ public class CompactMapRangeIndex extends AbstractMapIndex {
       removeOldMappings(((Map) key).keySet(), entry);
     } else {
       for (Object mapKey : mapKeys) {
-        Object indexKey = ((Map) key).get(mapKey);
-        if (indexKey != null) {
-          // Do not convert to IndexManager.NULL. We are only interested in specific keys
-          this.saveIndexAddition(mapKey, indexKey, value, entry);
+        Object indexKey;
+        if (key == null) {
+          indexKey = QueryService.UNDEFINED;
+        } else {
+          indexKey = ((Map) key).get(mapKey);
         }
+        this.saveIndexAddition(mapKey, indexKey, value, entry);
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexManager.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexManager.java
@@ -142,6 +142,9 @@ public class IndexManager {
   public static final String INDEX_ELEMARRAY_SIZE_PROP = "index_elemarray_size";
   public static final int INDEX_ELEMARRAY_THRESHOLD =
       Integer.parseInt(System.getProperty(INDEX_ELEMARRAY_THRESHOLD_PROP, "100"));
+  @MutableForTesting
+  public static int INDEX_ELEMARRAY_THRESHOLD_FOR_TESTING = -1;
+
   public static final int INDEX_ELEMARRAY_SIZE =
       Integer.parseInt(System.getProperty(INDEX_ELEMARRAY_SIZE_PROP, "5"));
   @MakeNotStatic

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -186,7 +186,11 @@ public class MemoryIndexStore implements IndexStore {
         } else {
           IndexElemArray elemArray = (IndexElemArray) regionEntries;
           synchronized (elemArray) {
-            if (elemArray.size() >= IndexManager.INDEX_ELEMARRAY_THRESHOLD) {
+            int threshold = IndexManager.INDEX_ELEMARRAY_THRESHOLD;
+            if (IndexManager.INDEX_ELEMARRAY_THRESHOLD_FOR_TESTING > 0) {
+              threshold = IndexManager.INDEX_ELEMARRAY_THRESHOLD_FOR_TESTING;
+            }
+            if (elemArray.size() >= threshold) {
               IndexConcurrentHashSet set =
                   new IndexConcurrentHashSet(IndexManager.INDEX_ELEMARRAY_THRESHOLD + 20, 0.75f, 1);
               // Replace first so that we are sure that the set is placed in

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -147,7 +147,9 @@ public class MemoryIndexStore implements IndexStore {
           retry = true;
           continue;
         } else if (regionEntries == null) {
-          internalIndexStats.incNumKeys(1);
+          if (indexKey != IndexManager.NULL && indexKey != QueryService.UNDEFINED) {
+            internalIndexStats.incNumKeys(1);
+          }
           numIndexKeys.incrementAndGet();
         } else if (regionEntries instanceof RegionEntry) {
           IndexElemArray elemArray = new IndexElemArray();
@@ -323,8 +325,10 @@ public class MemoryIndexStore implements IndexStore {
             found = regionEntries == entry;
             if (found) {
               if (this.valueToEntriesMap.remove(newKey, regionEntries)) {
+                if (newKey != IndexManager.NULL && newKey != QueryService.UNDEFINED) {
+                  internalIndexStats.incNumKeys(-1);
+                }
                 numIndexKeys.decrementAndGet();
-                internalIndexStats.incNumKeys(-1);
               } else {
                 // is another thread has since done an add and shifted us into a collection
                 retry = true;
@@ -360,8 +364,10 @@ public class MemoryIndexStore implements IndexStore {
               synchronized (entries) {
                 if (entries.isEmpty()) {
                   if (valueToEntriesMap.remove(newKey, entries)) {
+                    if (newKey != IndexManager.NULL && newKey != QueryService.UNDEFINED) {
+                      internalIndexStats.incNumKeys(-1);
+                    }
                     numIndexKeys.decrementAndGet();
-                    internalIndexStats.incNumKeys(-1);
                   }
                 }
               }

--- a/geode-docs/developing/query_index/creating_map_indexes.html.md.erb
+++ b/geode-docs/developing/query_index/creating_map_indexes.html.md.erb
@@ -60,5 +60,5 @@ You can still query against Map or HashMap fields without querying against a map
 
 **Note:**
 Map indexes on all keys (when `*` is specified) are not used in queries where the map field is compared with `null` or when it is compared using `!=`, e.g. `p.positions['company1'] = null` or `p.positions['company1'] != '3'`.
-These types of queries will be executed without making use of the index which could make them slower.
+These types of queries will be executed without making use of the index, which could make them slower.
 

--- a/geode-docs/developing/query_index/creating_map_indexes.html.md.erb
+++ b/geode-docs/developing/query_index/creating_map_indexes.html.md.erb
@@ -58,4 +58,7 @@ In order to create or query a map index, you must use the bracket notation to li
 **Note:**
 You can still query against Map or HashMap fields without querying against a map index. For example, you can always create a regular range query on a single key in any Map or HashMap field. However, note that subsequent query lookups will be limited to a single key.
 
+**Note:**
+Map indexes on all keys (when `*` is specified) are not used in queries where the map field is compared with `null` or when it is compared using `!=`, e.g. `p.positions['company1'] = null` or `p.positions['company1'] != '3'`.
+These types of queries will be executed without making use of the index which could make them slower.
 

--- a/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/query/data/Portfolio.java
@@ -183,14 +183,17 @@ public class Portfolio implements Serializable, DataSerializable {
 
   public String toString() {
     String out =
-        "Portfolio [ID=" + ID + " status=" + status + " type=" + type + " pkid=" + pkid + "\n ";
-    Iterator iter = positions.entrySet().iterator();
-    while (iter.hasNext()) {
-      Map.Entry entry = (Map.Entry) iter.next();
-      out += entry.getKey() + ":" + entry.getValue() + ", ";
+        "Portfolio [ID=" + ID + " status=" + status + " type=" + type + " pkid=" + pkid
+            + System.lineSeparator();
+    if (positions != null) {
+      Iterator iter = positions.entrySet().iterator();
+      while (iter.hasNext()) {
+        Map.Entry entry = (Map.Entry) iter.next();
+        out += entry.getKey() + ":" + entry.getValue() + ", ";
+      }
+      out += System.lineSeparator() + " P1:" + position1 + ", P2:" + position2;
     }
-    out += "\n P1:" + position1 + ", P2:" + position2;
-    return out + "\n]";
+    return out + System.lineSeparator() + "]";
   }
 
   /**


### PR DESCRIPTION
Queries in which map fields are involved
in the condition, sometimes do not return the same entries
if map indexes are used, compared to when map indexes
are not used.

Differences were found when the condition on the
map field was of type '!=' and also when the condition
on the map field was comparing the value with null.

Example1:
Running a query with the following condition:
positions['SUN'] = null

in a region with the following entries:
entry1.positions=null
entry2.positions={'a'=>'b'}
entry3.positions={'SUN'=>null}

- will return entry1 and entry3 if there are no
  indexes defined.
- will return no entries if the following index is defined:
  positions['SUN','c']
- will return entry3 if the following index is defined:
  positions[*]

Example2:
Running a query with the following condition:
positions['SUN'] != '3'

in a region with the following entries:
entry1.positions=null
entry2.positions={'a'=>'b'}
entry3.positions={'SUN'=>'4'}
entry4.positions={'SUN'=>'3'}
entry5.positions={'SUN'=>null}

- will return all entries except for entry4 if:
  there are no indexes defined.
- will return entry3 if the following index is defined:
  positions['SUN','c']
- will return entry3 and entry5 if the following index is defined:
  positions[*]

In order to have the same results for these
queries no matter if indexes are used,
the following changes have been made:

- When using compact map indexes or map indexes
an index entry will be created for every entry
added to the region even if the entry does not
contain the indexed map (the map is null) or
it does not contain any of the indexed keys.
The above will not apply to indexes of type
"allkeys" (e.g. positions[*]).

- As a consequence of the statement above
about indexes of type "allkeys", when the index
configured is of "allkeys" type and the query
is of type "!=" (e.g. positions['SUN'] != "3"
or the query is comparing against a null value
(e.g. positions['SUN'] = null) the index will
not be used.
This is a limitation of this solution
as allowing the index to be used in this case
would require bigger and more complex changes that
have not been considered in this solution.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
