### PR TITLE
GEODE-8996: Separated the gfsh rebalance test from other tests.

### DIFF
--- a/geode-gfsh/src/upgradeTest/java/org/apache/geode/management/GfshRebalanceCommandCompatibilityTest.java
+++ b/geode-gfsh/src/upgradeTest/java/org/apache/geode/management/GfshRebalanceCommandCompatibilityTest.java
@@ -12,10 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.management;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.List;
@@ -26,31 +23,29 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
+import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.BackwardCompatibilityTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
-import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 import org.apache.geode.test.version.TestVersion;
 import org.apache.geode.test.version.VersionManager;
 
 @Category({BackwardCompatibilityTest.class})
 @RunWith(Parameterized.class)
-@Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
-public class GfshCompatibilityTest {
+public class GfshRebalanceCommandCompatibilityTest {
   private final String oldVersion;
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<String> data() {
     List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
+    result.removeIf(s -> TestVersion.compare(s, "1.11.0") < 0);
     return result;
   }
 
-  public GfshCompatibilityTest(String oldVersion) {
+  public GfshRebalanceCommandCompatibilityTest(String oldVersion) {
     this.oldVersion = oldVersion;
   }
-
-  private MemberVM oldLocator;
 
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule();
@@ -59,30 +54,27 @@ public class GfshCompatibilityTest {
   public ClusterStartupRule cluster = new ClusterStartupRule();
 
   @Test
-  public void currentGfshConnectToOlderVersionsOfLocator() throws Exception {
-    oldLocator = cluster.startLocatorVM(0, oldVersion);
-    int locatorPort = oldLocator.getPort();
-    cluster.startServerVM(1, oldVersion,
-        s -> s.withConnectionToLocator(locatorPort));
-    // pre 1.10, it should not be able to connect
-    if (TestVersion.compare(oldVersion, "1.5.0") < 0) {
-      gfsh.connect(oldLocator.getPort(), GfshCommandRule.PortType.locator);
-      assertThat(gfsh.isConnected()).isFalse();
-      assertThat(gfsh.getGfshOutput()).contains("Cannot use a")
-          .contains("gfsh client to connect to this cluster.");
-    } else if (TestVersion.compare(oldVersion, "1.10.0") < 0) {
-      gfsh.connect(oldLocator.getPort(), GfshCommandRule.PortType.locator);
-      assertThat(gfsh.isConnected()).isFalse();
-      assertThat(gfsh.getGfshOutput()).contains("Cannot use a")
-          .contains("gfsh client to connect to a " + oldVersion + " cluster.");
-    }
-    // post 1.10 (including) should connect and be able to execute command
-    else {
-      gfsh.connectAndVerify(oldLocator);
-      assertThat(gfsh.getGfshOutput())
-          .contains("You are connected to a cluster of version: " + oldVersion);
-      gfsh.executeAndAssertThat("list members")
-          .statusIsSuccess();
-    }
+  public void whenCurrentVersionLocatorsExecuteRebalanceOnOldServersThenItMustSucceed()
+      throws Exception {
+    MemberVM locator1 = cluster.startLocatorVM(0, oldVersion);
+    int locatorPort1 = locator1.getPort();
+    MemberVM locator2 =
+        cluster.startLocatorVM(1, 0, oldVersion, x -> x.withConnectionToLocator(locatorPort1));
+    int locatorPort2 = locator2.getPort();
+    cluster
+        .startServerVM(2, oldVersion, s -> s.withRegion(RegionShortcut.PARTITION, "region")
+            .withConnectionToLocator(locatorPort1, locatorPort2));
+    cluster
+        .startServerVM(3, oldVersion, s -> s.withRegion(RegionShortcut.PARTITION, "region")
+            .withConnectionToLocator(locatorPort1, locatorPort2));
+    cluster.stop(0);
+    locator1 = cluster.startLocatorVM(0, x -> x.withConnectionToLocator(locatorPort2));
+    cluster.stop(1);
+    int locatorPort1_v2 = locator1.getPort();
+    cluster.startLocatorVM(1, x -> x.withConnectionToLocator(locatorPort1_v2));
+    gfsh.connectAndVerify(locator1);
+    gfsh.executeAndAssertThat("rebalance ")
+        .statusIsSuccess();
+
   }
 }


### PR DESCRIPTION
	* Support for gfsh rebalance compatibilty is from 1.11.0
	* Remaining connectivity tests should be run with all other versions.
	* In the previous commit for GEODE-8996, the existing tests missed certain versions.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
