### PR TITLE
GEODE-9136: make RedisData implement Sizeable

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -92,4 +92,11 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
       service.setEnableUnsupported(enableUnsupported);
     });
   }
+
+  public Long getDataStoreBytesInUseForDataRegion(MemberVM vm) {
+    return vm.invoke(() -> {
+      GeodeRedisService service = ClusterStartupRule.getCache().getService(GeodeRedisService.class);
+      return service.getDataStoreBytesInUseForDataRegion();
+    });
+  }
 }

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -29,7 +29,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.internal.size.ReflectionObjectSizer;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
@@ -52,9 +51,6 @@ public class PartitionedRegionStatsUpdateTest {
   public static final String HASH_KEY = "hash key";
   public static final String LONG_APPEND_VALUE = String.valueOf(Integer.MAX_VALUE);
   public static final String FIELD = "field";
-  private static final int SET_SIZE = 1000;
-
-  private final ReflectionObjectSizer ros = ReflectionObjectSizer.getInstance();
 
   @BeforeClass
   public static void classSetup() {

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -337,7 +337,7 @@ public class PartitionedRegionStatsUpdateTest {
   }
 
   @Test
-  @Ignore
+  @Ignore("confirm that bucket size stats are being calculated correctly before enabling")
   public void should_showMembersAgreeUponUsedSetMemory_afterDeltaPropagation() {
     jedis1.sadd(SET_KEY, "other"); // two sadds are required to force
     jedis1.sadd(SET_KEY, "value"); // deserialization on both servers

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -381,7 +381,7 @@ public class PartitionedRegionStatsUpdateTest {
     assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
   }
 
-  /******* confirm our math is right *******/
+  /******* check DatastoreBytesInUse using reflection *******/
 
   @Test
   public void string_bytesInUse_shouldReflectActualSizeOfDataInRegion() {
@@ -495,6 +495,8 @@ public class PartitionedRegionStatsUpdateTest {
 
     assertThat(actual).isCloseTo(expected, offset);
   }
+
+  /******* helper methods *******/
 
   private List<String> makeMemberList(int setSize, String baseString) {
     List<String> members = new ArrayList<>();

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -103,16 +103,20 @@ public class PartitionedRegionStatsUpdateTest {
 
   @Test
   public void should_showDecreaseInDatastoreBytesInUse_givenStringValueDeleted() {
-    jedis1.set(STRING_KEY, "value");
-
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    jedis1.set(STRING_KEY, "value");
+
+    long intermediateDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+    assertThat(intermediateDataStoreBytesInUse).isGreaterThan(initialDataStoreBytesInUse);
 
     jedis1.del(STRING_KEY);
 
     long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
 
-    assertThat(finalDataStoreBytesInUse).isLessThan(initialDataStoreBytesInUse);
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
   }
 
   @Test
@@ -246,22 +250,6 @@ public class PartitionedRegionStatsUpdateTest {
   }
 
   @Test
-  public void should_ShowNoIncreaseInDatastoreBytesInUse_givenHashValueSizeDoesNotIncrease() {
-    jedis1.hset(HASH_KEY, FIELD, "value");
-
-    long initialDataStoreBytesInUse =
-        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
-
-    for (int i = 0; i < 1000; i++) {
-      jedis1.hsetnx(HASH_KEY, FIELD, LONG_APPEND_VALUE);
-    }
-
-    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
-
-    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
-  }
-
-  @Test
   public void should_showDecreaseInDatastoreBytesInUse_givenHashValueDeleted() {
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
@@ -331,7 +319,7 @@ public class PartitionedRegionStatsUpdateTest {
     assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
   }
 
-  // confirm that the other member agrees upon size
+  /******* confirm that the other member agrees upon size *******/
 
   @Test
   public void should_showMembersAgreeUponUsedHashMemory_afterDeltaPropagation() {
@@ -393,7 +381,7 @@ public class PartitionedRegionStatsUpdateTest {
     assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
   }
 
-  // confirm our math is right
+  /******* confirm our math is right *******/
 
   @Test
   public void string_bytesInUse_shouldReflectActualSizeOfDataInRegion() {

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -337,7 +337,6 @@ public class PartitionedRegionStatsUpdateTest {
   }
 
   @Test
-  @Ignore("confirm that bucket size stats are being calculated correctly before enabling")
   public void should_showMembersAgreeUponUsedSetMemory_afterDeltaPropagation() {
     jedis1.sadd(SET_KEY, "other"); // two sadds are required to force
     jedis1.sadd(SET_KEY, "value"); // deserialization on both servers
@@ -363,24 +362,26 @@ public class PartitionedRegionStatsUpdateTest {
   }
 
   @Test
-  @Ignore("confirm that bucket size stats are being calculated correctly before enabling")
+  @Ignore("find a way to force deserialization on both members before enabling")
   public void should_showMembersAgreeUponUsedStringMemory_afterDeltaPropagation() {
+    String value = "value";
+
     jedis1.set(STRING_KEY, "12345"); // two sets are required to force
-    jedis1.set(STRING_KEY, "value"); // deserialization on both servers
+    jedis1.set(STRING_KEY, value); // deserialization on both servers
     // otherwise primary/secondary can disagree on size, and which server is primary varies
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
 
     for (int i = 0; i < 10; i++) {
-      jedis1.append(STRING_KEY, "a");
+      jedis1.set(STRING_KEY, value);
     }
 
     assertThat(jedis1.exists(STRING_KEY)).isTrue();
     assertThat(jedis2.exists(STRING_KEY)).isTrue();
 
-    assertThat(jedis1.get(STRING_KEY)).isEqualTo("valueaaaaaaaaaa");
-    assertThat(jedis2.get(STRING_KEY)).isEqualTo("valueaaaaaaaaaa");
+    assertThat(jedis1.get(STRING_KEY)).isEqualTo(value);
+    assertThat(jedis2.get(STRING_KEY)).isEqualTo(value);
 
     long server1FinalDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -337,8 +337,9 @@ public class PartitionedRegionStatsUpdateTest {
   }
 
   @Test
+  @Ignore
   public void should_showMembersAgreeUponUsedSetMemory_afterDeltaPropagation() {
-    jedis1.sadd(SET_KEY, "initialValue"); // two sadds are required to force
+    jedis1.sadd(SET_KEY, "other"); // two sadds are required to force
     jedis1.sadd(SET_KEY, "value"); // deserialization on both servers
     // otherwise primary/secondary can disagree on size, and which server is primary varies
 

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -374,11 +374,7 @@ public class PartitionedRegionStatsUpdateTest {
   @Test
   public void should_showMembersAgreeUponUsedStringMemory_afterDeltaPropagation() {
     jedis1.set(STRING_KEY, "eulav"); // two sets are required to force
-    System.out.println("HERE server1:" + clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1));
-    System.out.println("HERE server2: " + clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2));
     jedis2.set(STRING_KEY, "value"); // deserialization on both servers
-    System.out.println("HERE server1:" + clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1));
-    System.out.println("HERE server2: " + clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2));
     // otherwise primary/secondary can disagree on size, and which server is primary varies
 
     long initialDataStoreBytesInUse =

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -268,7 +268,7 @@ public class PartitionedRegionStatsUpdateTest {
   @Test
   public void should_showNoIncreaseInDatastoreBytesInUse_givenHSetDoesNotIncreaseHashSize() {
     jedis2.hset(HASH_KEY, FIELD, "initialvalue"); // two hsets are required to force
-    jedis2.hset(HASH_KEY, FIELD, "value");        // deserialization on both servers
+    jedis2.hset(HASH_KEY, FIELD, "value"); // deserialization on both servers
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
@@ -321,7 +321,7 @@ public class PartitionedRegionStatsUpdateTest {
   @Test
   public void should_showMembersAgreeUponUsedHashMemory_afterDeltaPropagation() {
     jedis1.hset(HASH_KEY, FIELD, "initialvalue"); // two hsets are required to force
-    jedis1.hset(HASH_KEY, FIELD, "finalvalue");   // deserialization on both servers
+    jedis1.hset(HASH_KEY, FIELD, "finalvalue"); // deserialization on both servers
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
@@ -339,8 +339,8 @@ public class PartitionedRegionStatsUpdateTest {
 
   @Test
   public void should_showMembersAgreeUponUsedSetMemory_afterDeltaPropagation() {
-    jedis1.sadd(SET_KEY, "value");  // two sadds are required to force
-    jedis1.sadd(SET_KEY, "value");  // deserialization on both servers
+    jedis1.sadd(SET_KEY, "value"); // two sadds are required to force
+    jedis1.sadd(SET_KEY, "value"); // deserialization on both servers
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
@@ -358,8 +358,8 @@ public class PartitionedRegionStatsUpdateTest {
 
   @Test
   public void should_showMembersAgreeUponUsedStringMemory_afterDeltaPropagation() {
-    jedis1.set(STRING_KEY, "value");  // two sets are required to force
-    jedis1.set(STRING_KEY, "value");  // deserialization on both servers
+    jedis1.set(STRING_KEY, "value"); // two sets are required to force
+    jedis1.set(STRING_KEY, "value"); // deserialization on both servers
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -146,7 +146,7 @@ public class PartitionedRegionStatsUpdateTest {
   }
 
   @Test
-  public void should_showNoIncreaseInDatastoreBytesInUse_givenStringValueSizeDoesNotIncreases() {
+  public void should_showNoIncreaseInDatastoreBytesInUse_givenStringValueSizeDoesNotIncrease() {
     jedis1.set(STRING_KEY, "value");
 
     long initialDataStoreBytesInUse =
@@ -176,7 +176,7 @@ public class PartitionedRegionStatsUpdateTest {
   }
 
   @Test
-  public void should_showNoIncreaseInDatastoreBytesInUse_givenSetValueSizeDoesNotIncreases() {
+  public void should_showNoIncreaseInDatastoreBytesInUse_givenSetValueSizeDoesNotIncrease() {
     jedis1.sadd(SET_KEY, "value");
 
     long initialDataStoreBytesInUse =
@@ -199,6 +199,11 @@ public class PartitionedRegionStatsUpdateTest {
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
 
     jedis1.sadd(SET_KEY, "value");
+
+    long intermediateDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+    assertThat(intermediateDataStoreBytesInUse).isGreaterThan(initialDataStoreBytesInUse);
+
     jedis1.del(SET_KEY);
 
     long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
@@ -262,6 +267,11 @@ public class PartitionedRegionStatsUpdateTest {
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
 
     jedis1.hset(HASH_KEY, FIELD, "value");
+
+    long intermediateDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+    assertThat(intermediateDataStoreBytesInUse).isGreaterThan(initialDataStoreBytesInUse);
+
     jedis1.del(HASH_KEY);
 
     long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
@@ -273,6 +283,7 @@ public class PartitionedRegionStatsUpdateTest {
   public void should_showNoIncreaseInDatastoreBytesInUse_givenHSetDoesNotIncreaseHashSize() {
     jedis2.hset(HASH_KEY, FIELD, "initialvalue"); // two hsets are required to force
     jedis2.hset(HASH_KEY, FIELD, "value"); // deserialization on both servers
+    // otherwise primary/secondary can disagree on size, and which server is primary varies
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
@@ -326,6 +337,7 @@ public class PartitionedRegionStatsUpdateTest {
   public void should_showMembersAgreeUponUsedHashMemory_afterDeltaPropagation() {
     jedis1.hset(HASH_KEY, FIELD, "initialvalue"); // two hsets are required to force
     jedis1.hset(HASH_KEY, FIELD, "finalvalue"); // deserialization on both servers
+    // otherwise primary/secondary can disagree on size, and which server is primary varies
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
@@ -345,6 +357,7 @@ public class PartitionedRegionStatsUpdateTest {
   public void should_showMembersAgreeUponUsedSetMemory_afterDeltaPropagation() {
     jedis1.sadd(SET_KEY, "value"); // two sadds are required to force
     jedis1.sadd(SET_KEY, "value"); // deserialization on both servers
+    // otherwise primary/secondary can disagree on size, and which server is primary varies
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
@@ -364,6 +377,7 @@ public class PartitionedRegionStatsUpdateTest {
   public void should_showMembersAgreeUponUsedStringMemory_afterDeltaPropagation() {
     jedis1.set(STRING_KEY, "value"); // two sets are required to force
     jedis1.set(STRING_KEY, "value"); // deserialization on both servers
+    // otherwise primary/secondary can disagree on size, and which server is primary varies
 
     long initialDataStoreBytesInUse =
         clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -1,0 +1,446 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+
+package org.apache.geode.redis.internal.data;
+
+import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import org.assertj.core.data.Offset;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.internal.size.ReflectionObjectSizer;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+
+public class PartitionedRegionStatsUpdateTest {
+
+  @ClassRule
+  public static RedisClusterStartupRule clusterStartUpRule = new RedisClusterStartupRule(3);
+
+  private static MemberVM server1;
+  private static MemberVM server2;
+
+  private static Jedis jedis1;
+  private static Jedis jedis2;
+
+  private static final int JEDIS_TIMEOUT = Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+  private static final String LOCAL_HOST = "127.0.0.1";
+  public static final String STRING_KEY = "string key";
+  public static final String SET_KEY = "set key";
+  public static final String HASH_KEY = "hash key";
+  public static final String LONG_APPEND_VALUE = String.valueOf(Integer.MAX_VALUE);
+  public static final String FIELD = "field";
+
+  private ReflectionObjectSizer ros = ReflectionObjectSizer.getInstance();
+
+  @BeforeClass
+  public static void classSetup() {
+    Properties locatorProperties = new Properties();
+    locatorProperties.setProperty(MAX_WAIT_TIME_RECONNECT, "15000");
+
+    MemberVM locator = clusterStartUpRule.startLocatorVM(0, locatorProperties);
+    int locatorPort = locator.getPort();
+
+    server1 = clusterStartUpRule.startRedisVM(1, locatorPort);
+    int redisServerPort1 = clusterStartUpRule.getRedisPort(1);
+    jedis1 = new Jedis(LOCAL_HOST, redisServerPort1, JEDIS_TIMEOUT);
+
+    server2 = clusterStartUpRule.startRedisVM(2, locatorPort);
+    int redisServerPort2 = clusterStartUpRule.getRedisPort(1);
+    jedis2 = new Jedis(LOCAL_HOST, redisServerPort2, JEDIS_TIMEOUT);
+  }
+
+  @Before
+  public void setup() {
+    jedis1.flushAll();
+  }
+
+  @Test
+  public void should_showIncreaseInDatastoreBytesInUse_givenStringValueSizeIncreases() {
+    String LONG_APPEND_VALUE = String.valueOf(Integer.MAX_VALUE);
+    jedis1.set(STRING_KEY, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.append(STRING_KEY, LONG_APPEND_VALUE);
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isGreaterThan(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showDecreaseInDatastoreBytesInUse_givenStringValueDeleted() {
+    jedis1.set(STRING_KEY, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    jedis1.del(STRING_KEY);
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isLessThan(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showDecreaseInDatastoreBytesInUse_givenStringValueShortened() {
+    jedis1.set(STRING_KEY, "longer value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    jedis1.set(STRING_KEY, "value");
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isLessThan(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_resetMemoryUsage_givenFlushAllCommand() {
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(initialDataStoreBytesInUse).isEqualTo(0L);
+
+    jedis1.set(STRING_KEY, "value");
+
+    jedis1.flushAll();
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showNoIncreaseInDatastoreBytesInUse_givenStringValueSizeDoesNotIncreases() {
+    jedis1.set(STRING_KEY, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.set(STRING_KEY, "value");
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showIncreaseInDatastoreBytesInUse_givenSetValueSizeIncreases() {
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.sadd(SET_KEY, "value" + i);
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isGreaterThan(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showNoIncreaseInDatastoreBytesInUse_givenSetValueSizeDoesNotIncreases() {
+    jedis1.sadd(SET_KEY, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.sadd(SET_KEY, "value");
+    }
+
+    assertThat(jedis1.scard(SET_KEY)).isEqualTo(1);
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showDecreaseInDatastoreBytesInUse_givenSetValueDeleted() {
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    jedis1.sadd(SET_KEY, "value");
+    jedis1.del(SET_KEY);
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showDecreaseInDatastoreBytesInUse_givenSetValueSizeDecreases() {
+    for (int i = 0; i < 10; i++) {
+      jedis1.sadd(SET_KEY, "value" + i);
+    }
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 10; i++) {
+      jedis1.srem(SET_KEY, "value" + i);
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isLessThan(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showIncreaseInDatastoreBytesInUse_givenHashValueSizeIncreases() {
+    jedis1.hset(HASH_KEY, FIELD, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.hset(HASH_KEY, FIELD + i, LONG_APPEND_VALUE);
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isGreaterThan(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_ShowNoIncreaseInDatastoreBytesInUse_givenHashValueSizeDoesNotIncrease() {
+    jedis1.hset(HASH_KEY, FIELD, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.hsetnx(HASH_KEY, FIELD, LONG_APPEND_VALUE);
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showDecreaseInDatastoreBytesInUse_givenHashValueDeleted() {
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    jedis1.hset(HASH_KEY, FIELD, "value");
+    jedis1.del(HASH_KEY);
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showNoIncreaseInDatastoreBytesInUse_givenHSetDoesNotIncreaseHashSize() {
+    jedis2.hset(HASH_KEY, FIELD, "initialvalue"); // two hsets are required to force
+    jedis2.hset(HASH_KEY, FIELD, "value");        // deserialization on both servers
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
+
+    for (int i = 0; i < 10; i++) {
+      jedis2.hset(HASH_KEY, FIELD, "value");
+    }
+
+    assertThat(jedis2.hgetAll(HASH_KEY).size()).isEqualTo(1);
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showIncreaseInDatastoreBytesInUse_givenHSetNXIncreasesHashSize() {
+    jedis1.hset(HASH_KEY, FIELD, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.hsetnx(HASH_KEY, FIELD + i, "value");
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isGreaterThan(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showNoIncreaseInDatastoreBytesInUse_givenHSetNXDoesNotIncreaseHashSize() {
+    jedis1.hset(HASH_KEY, FIELD, "value");
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.hsetnx(HASH_KEY, FIELD, "value");
+    }
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  // confirm that the other member agrees upon size
+
+  @Test
+  public void should_showMembersAgreeUponUsedHashMemory_afterDeltaPropagation() {
+    jedis1.hset(HASH_KEY, FIELD, "initialvalue"); // two hsets are required to force
+    jedis1.hset(HASH_KEY, FIELD, "finalvalue");   // deserialization on both servers
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
+
+    for (int i = 0; i < 10; i++) {
+      jedis1.hset(HASH_KEY, FIELD, "finalvalue");
+    }
+
+    assertThat(jedis1.hgetAll(HASH_KEY).size()).isEqualTo(1);
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showMembersAgreeUponUsedSetMemory_afterDeltaPropagation() {
+    jedis1.sadd(SET_KEY, "value");  // two sadds are required to force
+    jedis1.sadd(SET_KEY, "value");  // deserialization on both servers
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
+
+    for (int i = 0; i < 10; i++) {
+      jedis1.sadd(SET_KEY, "value");
+    }
+
+    assertThat(jedis1.scard(SET_KEY)).isEqualTo(1);
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  @Test
+  public void should_showMembersAgreeUponUsedStringMemory_afterDeltaPropagation() {
+    jedis1.set(STRING_KEY, "value");  // two sets are required to force
+    jedis1.set(STRING_KEY, "value");  // deserialization on both servers
+
+    long initialDataStoreBytesInUse =
+        clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
+
+    for (int i = 0; i < 10; i++) {
+      jedis1.set(STRING_KEY, "value");
+    }
+
+    assertThat(jedis1.exists(STRING_KEY)).isTrue();
+
+    long finalDataStoreBytesInUse = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server2);
+
+    assertThat(finalDataStoreBytesInUse).isEqualTo(initialDataStoreBytesInUse);
+  }
+
+  // confirm our math is right
+
+  @Test
+  public void string_bytesInUse_shouldReflectActualSizeOfDataInRegion() {
+    String value = "value";
+
+    jedis1.set("key2", value);
+
+    Long regionOverhead = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+
+    jedis1.set(STRING_KEY, value);
+
+    for (int i = 0; i < 100; i++) {
+      jedis1.append(STRING_KEY, LONG_APPEND_VALUE);
+      value += LONG_APPEND_VALUE;
+    }
+
+    Long actual = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+    Long expected = ros.sizeof(value.getBytes()) + regionOverhead;
+    Offset<Long> offset = Offset.offset(Math.round(expected * 0.05));
+
+    assertThat(actual).isCloseTo(expected, offset);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void set_bytesInUse_shouldReflectActualSizeOfDataInRegion() {
+    String baseValue = "string";
+
+    Set values = new HashSet<ByteArrayWrapper>();
+    values.add(new ByteArrayWrapper(baseValue.getBytes()));
+    jedis1.sadd(SET_KEY, baseValue);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.sadd(SET_KEY, baseValue + i);
+      values.add(new ByteArrayWrapper((baseValue + i).getBytes()));
+    }
+
+    Long actual = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+    int expected = ros.sizeof(values);
+    Offset<Long> offset = Offset.offset(Math.round(expected * 0.05));
+
+    assertThat(actual).isCloseTo(expected, offset);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void hash_bytesInUse_shouldReflectActualSizeOfDataInRegion() {
+    String baseValue = "value";
+    String baseField = "field";
+
+    HashMap<ByteArrayWrapper, ByteArrayWrapper> values = new HashMap<>();
+    values.put(new ByteArrayWrapper(baseField.getBytes()),
+        new ByteArrayWrapper(baseValue.getBytes()));
+    jedis1.hset(HASH_KEY, baseField, baseValue);
+
+    for (int i = 0; i < 1000; i++) {
+      jedis1.hset(HASH_KEY, baseField + i, baseValue + i);
+      values.put(new ByteArrayWrapper((baseField + i).getBytes()),
+          new ByteArrayWrapper((baseValue + i).getBytes()));
+    }
+
+    Long actual = clusterStartUpRule.getDataStoreBytesInUseForDataRegion(server1);
+    int expected = ros.sizeof(values);
+    Offset<Long> offset = Offset.offset(Math.round(expected * 0.05));
+
+    assertThat(actual).isCloseTo(expected, offset);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -20,15 +20,8 @@ package org.apache.geode.redis.internal.data;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Properties;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import org.assertj.core.data.Offset;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -462,7 +462,7 @@ public class PartitionedRegionStatsUpdateTest {
         new ByteArrayWrapper(baseValue.getBytes()));
     jedis1.hset(HASH_KEY, baseField, baseValue);
 
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < 10_000; i++) {
       jedis1.hset(HASH_KEY, baseField + i, baseValue + i);
       values.put(new ByteArrayWrapper((baseField + i).getBytes()),
           new ByteArrayWrapper((baseValue + i).getBytes()));

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
@@ -56,7 +56,7 @@ public class MemoryOverheadIntegrationTest extends AbstractMemoryOverheadIntegra
     result.put(Measurement.STRING, 201);
     result.put(Measurement.SET, 386);
     result.put(Measurement.SET_ENTRY, 72);
-    result.put(Measurement.HASH, 554);
+    result.put(Measurement.HASH, 543);
     result.put(Measurement.HASH_ENTRY, 106);
 
     return result;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractAppendIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractAppendIntegrationTest.java
@@ -20,7 +20,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -105,6 +107,26 @@ public abstract class AbstractAppendIntegrationTest implements RedisPortSupplier
   }
 
   @Test
+  public void testAppend_actuallyIncreasesBucketSize() {
+    int listSize = 1000;
+    String key = "key";
+
+    Map<String, String> info = getInfo(jedis);
+    Long previousMemValue = Long.valueOf(info.get("used_memory"));
+
+    jedis.set(key, "initial");
+    for (int i = 0; i < listSize; i++) {
+      jedis.append(key, "morestuff");
+    }
+
+    info = getInfo(jedis);
+    Long finalMemValue = Long.valueOf(info.get("used_memory"));
+
+
+    assertThat(finalMemValue).isGreaterThan(previousMemValue);
+  }
+
+  @Test
   public void testAppend_withUTF16KeyAndValue() throws IOException {
     String test_utf16_string = "最𐐷𤭢";
     byte[] testBytes = test_utf16_string.getBytes(StandardCharsets.UTF_16);
@@ -130,5 +152,24 @@ public abstract class AbstractAppendIntegrationTest implements RedisPortSupplier
       strings.add(baseString + i);
     }
     return strings;
+  }
+
+  /**
+   * Convert the values returned by the INFO command into a basic param:value map.
+   */
+  static Map<String, String> getInfo(Jedis jedis) {
+    Map<String, String> results = new HashMap<>();
+    String rawInfo = jedis.info();
+
+    for (String line : rawInfo.split("\r\n")) {
+      int colonIndex = line.indexOf(":");
+      if (colonIndex > 0) {
+        String key = line.substring(0, colonIndex);
+        String value = line.substring(colonIndex + 1);
+        results.put(key, value);
+      }
+    }
+
+    return results;
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -11,16 +11,16 @@ fromData,8
 toData,8
 
 org/apache/geode/redis/internal/data/RedisHash,2
-toData,29
-fromData,29
+toData,26
+fromData,26
 
 org/apache/geode/redis/internal/data/RedisKey,2
 fromData,20
 toData,17
 
 org/apache/geode/redis/internal/data/RedisSet,2
-toData,29
-fromData,29
+toData,26
+fromData,26
 
 org/apache/geode/redis/internal/data/RedisString,2
 toData,26

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -11,16 +11,16 @@ fromData,8
 toData,8
 
 org/apache/geode/redis/internal/data/RedisHash,2
-toData,15
-fromData,15
+toData,29
+fromData,29
 
 org/apache/geode/redis/internal/data/RedisKey,2
 fromData,20
 toData,17
 
 org/apache/geode/redis/internal/data/RedisSet,2
-toData,15
-fromData,15
+toData,29
+fromData,29
 
 org/apache/geode/redis/internal/data/RedisString,2
 toData,26

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -23,6 +23,7 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
@@ -149,5 +150,12 @@ public class GeodeRedisServer {
       redisStats.close();
       shutdown = true;
     }
+  }
+
+  @VisibleForTesting
+  protected Long getDataStoreBytesInUseForDataRegion() {
+    PartitionedRegion dataRegion = (PartitionedRegion) this.getRegionProvider().getDataRegion();
+    long dataStoreBytesInUse = dataRegion.getPrStats().getDataStoreBytesInUse();
+    return dataStoreBytesInUse;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.ResourceEvent;
@@ -127,5 +128,10 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
 
   public void setEnableUnsupported(boolean unsupported) {
     redisServer.setAllowUnsupportedCommands(unsupported);
+  }
+
+  @VisibleForTesting
+  public Long getDataStoreBytesInUseForDataRegion() {
+    return redisServer.getDataStoreBytesInUseForDataRegion();
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -138,10 +138,7 @@ public abstract class AbstractRedisData implements RedisData {
       return false;
     }
     long now = System.currentTimeMillis();
-    if (now < expireTimestamp) {
-      return false;
-    }
-    return true;
+    return now >= expireTimestamp;
   }
 
   @Override
@@ -150,10 +147,7 @@ public abstract class AbstractRedisData implements RedisData {
     if (expireTimestamp == NO_EXPIRATION) {
       return false;
     }
-    if (now < expireTimestamp) {
-      return false;
-    }
-    return true;
+    return now >= expireTimestamp;
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisData.java
@@ -122,4 +122,9 @@ public class NullRedisData implements RedisData {
   public void fromDelta(DataInput in) throws InvalidDeltaException {
     throw new UnsupportedOperationException();
   }
+
+  @Override
+  public int getSizeInBytes() {
+    return 0;
+  }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
@@ -20,8 +20,9 @@ package org.apache.geode.redis.internal.data;
 import org.apache.geode.Delta;
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
+import org.apache.geode.internal.size.Sizeable;
 
-public interface RedisData extends Delta, DataSerializableFixedID {
+public interface RedisData extends Delta, DataSerializableFixedID, Sizeable {
 
 
   /**
@@ -56,5 +57,9 @@ public interface RedisData extends Delta, DataSerializableFixedID {
   String type();
 
   boolean rename(Region<RedisKey, RedisData> region, RedisKey oldKey, RedisKey newKey);
+
+  default boolean getForceRecalculateSize() {
+    return true;
+  }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -59,8 +59,13 @@ public class RedisHash extends AbstractRedisData {
   private ConcurrentHashMap<UUID, List<ByteArrayWrapper>> hScanSnapShots;
   private ConcurrentHashMap<UUID, Long> hScanSnapShotCreationTimes;
   private ScheduledExecutorService HSCANSnapshotExpirationExecutor = null;
+
+  // these values are empirically derived using ReflectionObjectSizer, which provides an exact size
+  // of the object. It can't be used directly because of its performance impact. These values cause
+  // the size we keep track of to converge to the actual size as it increases.
   private static final int PER_STRING_OVERHEAD = PER_OBJECT_OVERHEAD + 46;
   private static final int PER_HASH_OVERHEAD = PER_OBJECT_OVERHEAD + 116;
+
   private AtomicInteger hashSize = new AtomicInteger(PER_HASH_OVERHEAD);
 
   private static int defaultHscanSnapshotsExpireCheckFrequency =

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -185,8 +185,11 @@ public class RedisHash extends AbstractRedisData {
   }
 
   private synchronized ByteArrayWrapper hashRemove(ByteArrayWrapper field) {
-    hashSize.addAndGet(-(2 * PER_STRING_OVERHEAD + field.length() + hash.get(field).length()));
-    return hash.remove(field);
+    ByteArrayWrapper oldValue = hash.remove(field);
+    if (oldValue != null) {
+      hashSize.addAndGet(-(2 * PER_STRING_OVERHEAD + field.length() + oldValue.length()));
+    }
+    return oldValue;
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -361,12 +361,12 @@ public class RedisHash extends AbstractRedisData {
     }
   }
 
-  private Pair<Integer, List<ByteArrayWrapper>> getResultsPair(List<ByteArrayWrapper> keysSnapShot,
+  private Pair<Integer, List<Object>> getResultsPair(List<ByteArrayWrapper> keysSnapShot,
       int startCursor, int count, Pattern matchPattern) {
 
     int indexOfKeys = startCursor;
 
-    List<ByteArrayWrapper> resultList = new ArrayList<>();
+    List<Object> resultList = new ArrayList<>();
 
     for (int index = startCursor; index < keysSnapShot.size(); index++) {
       if ((index - startCursor) == count) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -60,14 +60,10 @@ public class RedisHash extends AbstractRedisData {
   private ConcurrentHashMap<UUID, Long> hScanSnapShotCreationTimes;
   private ScheduledExecutorService HSCANSnapshotExpirationExecutor = null;
 
-  // these values are empirically derived using ReflectionObjectSizer, which provides an exact size
-  // of the object. It can't be used directly because of its performance impact. These values cause
-  // the size we keep track of to converge to the actual size as the number of entries/instances
-  // increases.
-  private static final int PER_BYTE_ARRAY_WRAPPER_OVERHEAD = PER_OBJECT_OVERHEAD + 46;
-//  private static final int PER_HASH_OVERHEAD = PER_OBJECT_OVERHEAD + 324;
-
   private int myCalculatedSize;
+  private static int baseRedisHashOverhead;
+  private static int hashMapInternalValuePairOverhead;
+  private static int sizeOfOverheadOfFirstPair;
 
   private static int defaultHscanSnapshotsExpireCheckFrequency =
       Integer.getInteger("redis.hscan-snapshot-cleanup-interval", 30000);
@@ -81,7 +77,7 @@ public class RedisHash extends AbstractRedisData {
 
   @VisibleForTesting
   public RedisHash(List<ByteArrayWrapper> fieldsToSet, int hscanSnapShotExpirationCheckFrequency,
-                   int minimumLifeForHscanSnaphot) {
+      int minimumLifeForHscanSnaphot) {
     this();
     this.HSCAN_SNAPSHOTS_EXPIRE_CHECK_FREQUENCY_MILLISECONDS =
         hscanSnapShotExpirationCheckFrequency;
@@ -114,56 +110,33 @@ public class RedisHash extends AbstractRedisData {
     calibrate_memory_values();
   }
 
-  private static int baseRedisHashOverhead;
-
-  private static int hashMapInternalValuePairOverhead;
-  private static int sizeOfOverheadOfFirstPair;
-  private static int internalHashMapStorageOverhead;
-
-
   private void calibrate_memory_values() {
     ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
 
-    myCalculatedSize = reflectionObjectSizer.sizeof(this);
+    myCalculatedSize = baseRedisHashOverhead = reflectionObjectSizer.sizeof(this);
 
+    HashMap<ByteArrayWrapper, ByteArrayWrapper> tempHashmap = new HashMap<>();
 
-    HashMap<ByteArrayWrapper, ByteArrayWrapper> temp_hashmap = new HashMap<>();
+    int baseHashmapSize = reflectionObjectSizer.sizeof(tempHashmap);
 
-    int base_hashmap_size = reflectionObjectSizer.sizeof(temp_hashmap);
-
-    ByteArrayWrapper field1 = new ByteArrayWrapper("a".getBytes());
-    ByteArrayWrapper value1 = new ByteArrayWrapper("b".getBytes());
-    ByteArrayWrapper field2 = new ByteArrayWrapper("c".getBytes());
+    ByteArrayWrapper field1 = new ByteArrayWrapper("a".getBytes()); // this method breaks if you
+    ByteArrayWrapper value1 = new ByteArrayWrapper("b".getBytes()); // make these fields and values
+    ByteArrayWrapper field2 = new ByteArrayWrapper("c".getBytes()); // longer than one character
     ByteArrayWrapper value2 = new ByteArrayWrapper("d".getBytes());
 
-    temp_hashmap.put(field1, value1);
+    tempHashmap.put(field1, value1);
+    int oneEntryHashMapSize = reflectionObjectSizer.sizeof(tempHashmap);
 
-    int hashmapWithSinglePairSize = reflectionObjectSizer.sizeof(temp_hashmap);
-
-    int one_entry_hashmap_size = reflectionObjectSizer.sizeof(temp_hashmap);
-
-    temp_hashmap.put(field2, value2);
-
-    int two_entries_hashmap_size = reflectionObjectSizer.sizeof(temp_hashmap);
+    tempHashmap.put(field2, value2);
+    int twoEntriesHashMapSize = reflectionObjectSizer.sizeof(tempHashmap);
 
     int sizeOfDataForOneFieldValuePair = 2;
 
     hashMapInternalValuePairOverhead =
-        two_entries_hashmap_size - one_entry_hashmap_size - sizeOfDataForOneFieldValuePair;
+        twoEntriesHashMapSize - oneEntryHashMapSize - sizeOfDataForOneFieldValuePair;
 
-    sizeOfOverheadOfFirstPair = hashmapWithSinglePairSize - base_hashmap_size
+    sizeOfOverheadOfFirstPair = oneEntryHashMapSize - baseHashmapSize
         - hashMapInternalValuePairOverhead - sizeOfDataForOneFieldValuePair;
-
-    System.out.println("3 letters in byte array wrapper: "
-        + "" +reflectionObjectSizer.sizeof(new ByteArrayWrapper("abc".getBytes())));
-
-    System.out.println("byte array wrapper: "
-        + "" +reflectionObjectSizer.sizeof(new ByteArrayWrapper()));
-
-    //wrong!!! correct before use!!!
-//    internalHashMapStorageOverhead =
-//        two_entries_hashmap_size - (2 * hashMapInternalValuePairOverhead) - base_hashmap_size;
-
   }
 
 
@@ -227,43 +200,27 @@ public class RedisHash extends AbstractRedisData {
 
 
   private synchronized ByteArrayWrapper hashPut(ByteArrayWrapper field, ByteArrayWrapper value) {
-    if (this.hash.isEmpty()){
-      this.myCalculatedSize +=sizeOfOverheadOfFirstPair;
+    if (this.hash.isEmpty()) {
+      this.myCalculatedSize += sizeOfOverheadOfFirstPair;
     }
 
     ByteArrayWrapper oldvalue = hash.put(field, value);
 
     if (oldvalue == null) {
-      int fieldValuePairSize =
-          (int) (hashMapInternalValuePairOverhead + Math.ceil(field.length()/8) + Math.ceil(value.length()/8));
-
-      System.out.println("hashMapInternalValuePairOverhead: " + hashMapInternalValuePairOverhead);
-      System.out.println("field size length: " + field.length());
-      System.out.println("value size length : " + value.length());
-
-
-      System.out.println("adding to non-existing value using calculated weights: " + fieldValuePairSize);
-
-      this.myCalculatedSize += fieldValuePairSize;
-
+      calculateSizeOfNewFieldValuePair(field, value);
     } else {
-
-      int newValueSize = value.length() - oldvalue.length();
-
-      System.out.println("adding to existing value" + newValueSize);
-
-      this.myCalculatedSize += newValueSize;
+      this.myCalculatedSize += value.length() - oldvalue.length();
     }
 
     return oldvalue;
   }
 
   private synchronized ByteArrayWrapper hashPutIfAbsent(ByteArrayWrapper field,
-                                                        ByteArrayWrapper value) {
+      ByteArrayWrapper value) {
     ByteArrayWrapper oldvalue = hash.putIfAbsent(field, value);
 
     if (oldvalue == null) {
-      myCalculatedSize += 2 * hashMapInternalValuePairOverhead + field.length() + value.length();
+      calculateSizeOfNewFieldValuePair(field, value);
     }
     return oldvalue;
   }
@@ -273,6 +230,11 @@ public class RedisHash extends AbstractRedisData {
     if (oldValue != null) {
       myCalculatedSize -= hashMapInternalValuePairOverhead + field.length() + oldValue.length();
     }
+
+    if (myCalculatedSize <= baseRedisHashOverhead + sizeOfOverheadOfFirstPair) {
+      myCalculatedSize = baseRedisHashOverhead;
+    }
+
     return oldValue;
   }
 
@@ -295,7 +257,7 @@ public class RedisHash extends AbstractRedisData {
   }
 
   public int hset(Region<RedisKey, RedisData> region, RedisKey key,
-                  List<ByteArrayWrapper> fieldsToSet, boolean nx) {
+      List<ByteArrayWrapper> fieldsToSet, boolean nx) {
     int fieldsAdded = 0;
     AddsDeltaInfo deltaInfo = null;
     Iterator<ByteArrayWrapper> iterator = fieldsToSet.iterator();
@@ -328,7 +290,7 @@ public class RedisHash extends AbstractRedisData {
   }
 
   public int hdel(Region<RedisKey, RedisData> region, RedisKey key,
-                  List<ByteArrayWrapper> fieldsToRemove) {
+      List<ByteArrayWrapper> fieldsToRemove) {
     int fieldsRemoved = 0;
     RemsDeltaInfo deltaInfo = null;
     for (ByteArrayWrapper fieldToRemove : fieldsToRemove) {
@@ -391,7 +353,7 @@ public class RedisHash extends AbstractRedisData {
   }
 
   public ImmutablePair<Integer, List<Object>> hscan(UUID clientID, Pattern matchPattern,
-                                                    int count, int startCursor) {
+      int count, int startCursor) {
 
     List<ByteArrayWrapper> keysToScan = getSnapShotOfKeySet(clientID);
 
@@ -423,9 +385,7 @@ public class RedisHash extends AbstractRedisData {
 
   @SuppressWarnings("unchecked")
   private Pair<Integer, List<Object>> getResultsPair(List<ByteArrayWrapper> keysSnapShot,
-                                                     int startCursor,
-                                                     int count,
-                                                     Pattern matchPattern) {
+      int startCursor, int count, Pattern matchPattern) {
 
     int indexOfKeys = startCursor;
 
@@ -460,9 +420,7 @@ public class RedisHash extends AbstractRedisData {
   }
 
   private int getCursorValueToReturn(int startCursor,
-                                     int numberOfIterationsCompleted,
-                                     List<ByteArrayWrapper> keySnapshot) {
-
+      int numberOfIterationsCompleted, List<ByteArrayWrapper> keySnapshot) {
     if (startCursor + numberOfIterationsCompleted >= keySnapshot.size()) {
       return 0;
     }
@@ -499,7 +457,7 @@ public class RedisHash extends AbstractRedisData {
   }
 
   public long hincrby(Region<RedisKey, RedisData> region, RedisKey key,
-                      ByteArrayWrapper field, long increment)
+      ByteArrayWrapper field, long increment)
       throws NumberFormatException, ArithmeticException {
     ByteArrayWrapper oldValue = hash.get(field);
     if (oldValue == null) {
@@ -535,7 +493,7 @@ public class RedisHash extends AbstractRedisData {
   }
 
   public BigDecimal hincrbyfloat(Region<RedisKey, RedisData> region, RedisKey key,
-                                 ByteArrayWrapper field, BigDecimal increment)
+      ByteArrayWrapper field, BigDecimal increment)
       throws NumberFormatException {
     ByteArrayWrapper oldValue = hash.get(field);
     if (oldValue == null) {
@@ -617,17 +575,13 @@ public class RedisHash extends AbstractRedisData {
   }
 
   @VisibleForTesting
-  protected static int getPerByteArrayWrapperOverhead() {
-    return PER_BYTE_ARRAY_WRAPPER_OVERHEAD;
-  }
-
-//  @VisibleForTesting
-//  protected static int getPerHashOverhead() {
-//    return PER_HASH_OVERHEAD;
-//  }
-
-  @VisibleForTesting
   protected HashMap<ByteArrayWrapper, ByteArrayWrapper> getHashMap() {
     return hash;
+  }
+
+  private void calculateSizeOfNewFieldValuePair(ByteArrayWrapper field, ByteArrayWrapper value) {
+    int diffBetweenFieldLengthAndValueLength = field.length() - value.length();
+    this.myCalculatedSize += hashMapInternalValuePairOverhead + Math.ceil(field.length() / 8.0)
+        + Math.ceil(value.length() / 8.0) + Math.ceil(diffBetweenFieldLengthAndValueLength / 8.0);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -48,7 +48,6 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.SerializationContext;
-import org.apache.geode.internal.size.ReflectionObjectSizer;
 import org.apache.geode.redis.internal.delta.AddsDeltaInfo;
 import org.apache.geode.redis.internal.delta.DeltaInfo;
 import org.apache.geode.redis.internal.delta.RemsDeltaInfo;
@@ -61,9 +60,9 @@ public class RedisHash extends AbstractRedisData {
   private ScheduledExecutorService HSCANSnapshotExpirationExecutor = null;
 
   private int myCalculatedSize;
-  private static int baseRedisHashOverhead;
-  private static int hashMapInternalValuePairOverhead;
-  private static int sizeOfOverheadOfFirstPair;
+  private static final int BASE_REDIS_HASH_OVERHEAD = 232;
+  protected static final int HASH_MAP_VALUE_PAIR_OVERHEAD = 96;
+  protected static final int SIZE_OF_OVERHEAD_OF_FIRST_PAIR = 96;
 
   private static int defaultHscanSnapshotsExpireCheckFrequency =
       Integer.getInteger("redis.hscan-snapshot-cleanup-interval", 30000);
@@ -107,45 +106,8 @@ public class RedisHash extends AbstractRedisData {
     this.MINIMUM_MILLISECONDS_FOR_HSCAN_SNAPSHOTS_TO_LIVE =
         this.defaultHscanSnapshotsMillisecondsToLive;
 
-    calibrate_memory_values();
+    this.myCalculatedSize = BASE_REDIS_HASH_OVERHEAD;
   }
-
-  private void calibrate_memory_values() {
-    ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
-
-    myCalculatedSize = baseRedisHashOverhead = reflectionObjectSizer.sizeof(this);
-    System.out.println("baseRedisHashOverhead: " + baseRedisHashOverhead);
-
-    HashMap<ByteArrayWrapper, ByteArrayWrapper> tempHashmap = new HashMap<>();
-
-    int emptyHashMapSize = reflectionObjectSizer.sizeof(tempHashmap);
-    System.out.println("emptyHashMapSize: " + emptyHashMapSize);
-
-    ByteArrayWrapper field1 = new ByteArrayWrapper("a".getBytes()); // this method breaks if you
-    ByteArrayWrapper value1 = new ByteArrayWrapper("b".getBytes()); // make these fields and values
-    ByteArrayWrapper field2 = new ByteArrayWrapper("c".getBytes()); // longer than one character
-    ByteArrayWrapper value2 = new ByteArrayWrapper("d".getBytes());
-
-    tempHashmap.put(field1, value1);
-    int oneEntryHashMapSize = reflectionObjectSizer.sizeof(tempHashmap);
-    System.out.println("oneEntryHashMapSize: " + oneEntryHashMapSize);
-
-    tempHashmap.put(field2, value2);
-    int twoEntriesHashMapSize = reflectionObjectSizer.sizeof(tempHashmap);
-    System.out.println("twoEntryHashMapSize: " + twoEntriesHashMapSize);
-
-    int sizeOfDataForOneFieldValuePair = 2;
-
-    hashMapInternalValuePairOverhead =
-        twoEntriesHashMapSize - oneEntryHashMapSize - sizeOfDataForOneFieldValuePair;
-    System.out.println("hashMapInternalValuePairOverhead: " + hashMapInternalValuePairOverhead);
-
-    sizeOfOverheadOfFirstPair = oneEntryHashMapSize - emptyHashMapSize
-        - hashMapInternalValuePairOverhead - sizeOfDataForOneFieldValuePair;
-    System.out.println("sizeOfOverheadOfFirstPair: " + sizeOfOverheadOfFirstPair);
-  }
-
-
 
   private void expireHScanSnapshots() {
     this.hScanSnapShotCreationTimes.entrySet().forEach(entry -> {
@@ -207,8 +169,7 @@ public class RedisHash extends AbstractRedisData {
 
   private synchronized ByteArrayWrapper hashPut(ByteArrayWrapper field, ByteArrayWrapper value) {
     if (this.hash.isEmpty()) {
-      this.myCalculatedSize += sizeOfOverheadOfFirstPair;
-      System.out.println("adding in sizeOfOverheadOfFirstPair: " + myCalculatedSize);
+      this.myCalculatedSize += SIZE_OF_OVERHEAD_OF_FIRST_PAIR;
     }
 
     ByteArrayWrapper oldvalue = hash.put(field, value);
@@ -216,11 +177,7 @@ public class RedisHash extends AbstractRedisData {
     if (oldvalue == null) {
       calculateSizeOfNewFieldValuePair(field, value);
     } else {
-      System.out.println("update path: pre-change calculated size: " + myCalculatedSize);
       this.myCalculatedSize += value.length() - oldvalue.length();
-      System.out.println("update path: post-change calculated size: " + myCalculatedSize);
-      System.out.println(
-          "update path: newValueSize: " + value.length() + " oldvalueSize: " + oldvalue.length());
     }
 
     return oldvalue;
@@ -236,14 +193,18 @@ public class RedisHash extends AbstractRedisData {
     return oldvalue;
   }
 
+  private void calculateSizeOfNewFieldValuePair(ByteArrayWrapper field, ByteArrayWrapper value) {
+    this.myCalculatedSize += HASH_MAP_VALUE_PAIR_OVERHEAD + field.length() + value.length();
+  }
+
   private synchronized ByteArrayWrapper hashRemove(ByteArrayWrapper field) {
     ByteArrayWrapper oldValue = hash.remove(field);
     if (oldValue != null) {
-      myCalculatedSize -= hashMapInternalValuePairOverhead + field.length() + oldValue.length();
+      myCalculatedSize -= HASH_MAP_VALUE_PAIR_OVERHEAD + field.length() + oldValue.length();
     }
 
-    if (myCalculatedSize <= baseRedisHashOverhead + sizeOfOverheadOfFirstPair) {
-      myCalculatedSize = baseRedisHashOverhead;
+    if (hash.size() == 0) {
+      myCalculatedSize = BASE_REDIS_HASH_OVERHEAD;
     }
 
     return oldValue;
@@ -297,6 +258,7 @@ public class RedisHash extends AbstractRedisData {
       }
     }
     storeChanges(region, key, deltaInfo);
+
     return fieldsAdded;
   }
 
@@ -583,19 +545,5 @@ public class RedisHash extends AbstractRedisData {
   @Override
   public int getSizeInBytes() {
     return myCalculatedSize;
-  }
-
-  @VisibleForTesting
-  protected HashMap<ByteArrayWrapper, ByteArrayWrapper> getHashMap() {
-    return hash;
-  }
-
-  private void calculateSizeOfNewFieldValuePair(ByteArrayWrapper field, ByteArrayWrapper value) {
-    int diffBetweenFieldLengthAndValueLength = Math.abs(field.length() - value.length());
-    System.out.println("diff: " + diffBetweenFieldLengthAndValueLength
-        + " pre-final calculated size: " + this.myCalculatedSize);
-    this.myCalculatedSize += hashMapInternalValuePairOverhead + field.length() + value.length()
-        - diffBetweenFieldLengthAndValueLength;
-    System.out.println("final myCalculatedSize: " + this.myCalculatedSize);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -59,8 +59,14 @@ public class RedisHash extends AbstractRedisData {
   private ConcurrentHashMap<UUID, Long> hScanSnapShotCreationTimes;
   private ScheduledExecutorService HSCANSnapshotExpirationExecutor = null;
 
-  private int myCalculatedSize;
-  private static final int BASE_REDIS_HASH_OVERHEAD = 232;
+  private int sizeInBytes;
+
+  // the following constants were calculated using reflection and math. you can find the tests for
+  // these values in RedisHashTest, which show the way these numbers were calculated. the constants
+  // have the advantage of saving us a lot of computation that would happen every time a new key was
+  // added. if our internal implementation changes, these values may be incorrect. the tests will
+  // catch this change. an increase in overhead should be carefully considered.
+  protected static final int BASE_REDIS_HASH_OVERHEAD = 232;
   protected static final int HASH_MAP_VALUE_PAIR_OVERHEAD = 96;
   protected static final int SIZE_OF_OVERHEAD_OF_FIRST_PAIR = 96;
 
@@ -78,9 +84,8 @@ public class RedisHash extends AbstractRedisData {
   public RedisHash(List<ByteArrayWrapper> fieldsToSet, int hscanSnapShotExpirationCheckFrequency,
       int minimumLifeForHscanSnaphot) {
     this();
-    this.HSCAN_SNAPSHOTS_EXPIRE_CHECK_FREQUENCY_MILLISECONDS =
-        hscanSnapShotExpirationCheckFrequency;
-    this.MINIMUM_MILLISECONDS_FOR_HSCAN_SNAPSHOTS_TO_LIVE = minimumLifeForHscanSnaphot;
+    HSCAN_SNAPSHOTS_EXPIRE_CHECK_FREQUENCY_MILLISECONDS = hscanSnapShotExpirationCheckFrequency;
+    MINIMUM_MILLISECONDS_FOR_HSCAN_SNAPSHOTS_TO_LIVE = minimumLifeForHscanSnaphot;
 
     Iterator<ByteArrayWrapper> iterator = fieldsToSet.iterator();
     while (iterator.hasNext()) {
@@ -96,21 +101,19 @@ public class RedisHash extends AbstractRedisData {
 
   // for serialization
   public RedisHash() {
-    this.hash = new HashMap<>();
-    this.hScanSnapShots = new ConcurrentHashMap<>();
-    this.hScanSnapShotCreationTimes = new ConcurrentHashMap<>();
+    hash = new HashMap<>();
+    hScanSnapShots = new ConcurrentHashMap<>();
+    hScanSnapShotCreationTimes = new ConcurrentHashMap<>();
 
-    this.HSCAN_SNAPSHOTS_EXPIRE_CHECK_FREQUENCY_MILLISECONDS =
-        this.defaultHscanSnapshotsExpireCheckFrequency;
+    HSCAN_SNAPSHOTS_EXPIRE_CHECK_FREQUENCY_MILLISECONDS = defaultHscanSnapshotsExpireCheckFrequency;
 
-    this.MINIMUM_MILLISECONDS_FOR_HSCAN_SNAPSHOTS_TO_LIVE =
-        this.defaultHscanSnapshotsMillisecondsToLive;
+    MINIMUM_MILLISECONDS_FOR_HSCAN_SNAPSHOTS_TO_LIVE = defaultHscanSnapshotsMillisecondsToLive;
 
-    this.myCalculatedSize = BASE_REDIS_HASH_OVERHEAD;
+    sizeInBytes = BASE_REDIS_HASH_OVERHEAD;
   }
 
   private void expireHScanSnapshots() {
-    this.hScanSnapShotCreationTimes.entrySet().forEach(entry -> {
+    hScanSnapShotCreationTimes.entrySet().forEach(entry -> {
       Long creationTime = entry.getValue();
       long millisecondsSinceCreation = currentTimeMillis() - creationTime;
 
@@ -123,22 +126,22 @@ public class RedisHash extends AbstractRedisData {
 
   @VisibleForTesting
   public ConcurrentHashMap<UUID, List<ByteArrayWrapper>> getHscanSnapShots() {
-    return this.hScanSnapShots;
+    return hScanSnapShots;
   }
 
   private void startHscanSnapshotScheduledRemoval() {
-    final int DELAY = this.HSCAN_SNAPSHOTS_EXPIRE_CHECK_FREQUENCY_MILLISECONDS;
+    final int DELAY = HSCAN_SNAPSHOTS_EXPIRE_CHECK_FREQUENCY_MILLISECONDS;
 
-    this.HSCANSnapshotExpirationExecutor =
+    HSCANSnapshotExpirationExecutor =
         newSingleThreadScheduledExecutor("GemFireRedis-HSCANSnapshotRemoval-");
 
-    this.HSCANSnapshotExpirationExecutor.scheduleWithFixedDelay(
+    HSCANSnapshotExpirationExecutor.scheduleWithFixedDelay(
         this::expireHScanSnapshots, DELAY, DELAY, MILLISECONDS);
   }
 
   private void shutDownHscanSnapshotScheduledRemoval() {
-    this.HSCANSnapshotExpirationExecutor.shutdown();
-    this.HSCANSnapshotExpirationExecutor = null;
+    HSCANSnapshotExpirationExecutor.shutdown();
+    HSCANSnapshotExpirationExecutor = null;
   }
 
   /**
@@ -150,7 +153,7 @@ public class RedisHash extends AbstractRedisData {
   public synchronized void toData(DataOutput out, SerializationContext context) throws IOException {
     super.toData(out, context);
     DataSerializer.writeHashMap(hash, out);
-    DataSerializer.writeInteger(myCalculatedSize, out);
+    DataSerializer.writeInteger(sizeInBytes, out);
   }
 
   @Override
@@ -158,7 +161,7 @@ public class RedisHash extends AbstractRedisData {
       throws IOException, ClassNotFoundException {
     super.fromData(in, context);
     hash = DataSerializer.readHashMap(in);
-    myCalculatedSize = DataSerializer.readInteger(in);
+    sizeInBytes = DataSerializer.readInteger(in);
   }
 
   @Override
@@ -168,16 +171,16 @@ public class RedisHash extends AbstractRedisData {
 
 
   private synchronized ByteArrayWrapper hashPut(ByteArrayWrapper field, ByteArrayWrapper value) {
-    if (this.hash.isEmpty()) {
-      this.myCalculatedSize += SIZE_OF_OVERHEAD_OF_FIRST_PAIR;
+    if (hash.isEmpty()) {
+      sizeInBytes += SIZE_OF_OVERHEAD_OF_FIRST_PAIR;
     }
 
     ByteArrayWrapper oldvalue = hash.put(field, value);
 
     if (oldvalue == null) {
-      calculateSizeOfNewFieldValuePair(field, value);
+      sizeInBytes += calculateSizeOfNewFieldValuePair(field, value);
     } else {
-      this.myCalculatedSize += value.length() - oldvalue.length();
+      sizeInBytes += value.length() - oldvalue.length();
     }
 
     return oldvalue;
@@ -185,26 +188,30 @@ public class RedisHash extends AbstractRedisData {
 
   private synchronized ByteArrayWrapper hashPutIfAbsent(ByteArrayWrapper field,
       ByteArrayWrapper value) {
+    if (hash.isEmpty()) {
+      sizeInBytes += SIZE_OF_OVERHEAD_OF_FIRST_PAIR;
+    }
+
     ByteArrayWrapper oldvalue = hash.putIfAbsent(field, value);
 
     if (oldvalue == null) {
-      calculateSizeOfNewFieldValuePair(field, value);
+      sizeInBytes += calculateSizeOfNewFieldValuePair(field, value);
     }
     return oldvalue;
   }
 
-  private void calculateSizeOfNewFieldValuePair(ByteArrayWrapper field, ByteArrayWrapper value) {
-    this.myCalculatedSize += HASH_MAP_VALUE_PAIR_OVERHEAD + field.length() + value.length();
+  private int calculateSizeOfNewFieldValuePair(ByteArrayWrapper field, ByteArrayWrapper value) {
+    return HASH_MAP_VALUE_PAIR_OVERHEAD + field.length() + value.length();
   }
 
   private synchronized ByteArrayWrapper hashRemove(ByteArrayWrapper field) {
     ByteArrayWrapper oldValue = hash.remove(field);
     if (oldValue != null) {
-      myCalculatedSize -= HASH_MAP_VALUE_PAIR_OVERHEAD + field.length() + oldValue.length();
+      sizeInBytes -= calculateSizeOfNewFieldValuePair(field, oldValue);
     }
 
-    if (hash.size() == 0) {
-      myCalculatedSize = BASE_REDIS_HASH_OVERHEAD;
+    if (hash.isEmpty()) {
+      sizeInBytes = BASE_REDIS_HASH_OVERHEAD;
     }
 
     return oldValue;
@@ -348,10 +355,10 @@ public class RedisHash extends AbstractRedisData {
   }
 
   private void removeHSCANSnapshot(UUID clientID) {
-    this.hScanSnapShots.remove(clientID);
-    this.hScanSnapShotCreationTimes.remove(clientID);
+    hScanSnapShots.remove(clientID);
+    hScanSnapShotCreationTimes.remove(clientID);
 
-    if (this.hScanSnapShots.isEmpty()) {
+    if (hScanSnapShots.isEmpty()) {
       shutDownHscanSnapshotScheduledRemoval();
     }
   }
@@ -403,10 +410,10 @@ public class RedisHash extends AbstractRedisData {
 
   @SuppressWarnings("unchecked")
   private List<ByteArrayWrapper> getSnapShotOfKeySet(UUID clientID) {
-    List<ByteArrayWrapper> keySnapShot = this.hScanSnapShots.get(clientID);
+    List<ByteArrayWrapper> keySnapShot = hScanSnapShots.get(clientID);
 
     if (keySnapShot == null) {
-      if (this.hScanSnapShots.isEmpty()) {
+      if (hScanSnapShots.isEmpty()) {
         startHscanSnapshotScheduledRemoval();
       }
       keySnapShot = createKeySnapShot(clientID);
@@ -423,15 +430,14 @@ public class RedisHash extends AbstractRedisData {
             .map(key -> new ByteArrayWrapper(key.toBytes()))
             .collect(Collectors.toList());
 
-    this.hScanSnapShots.put(clientID, keySnapShot);
-    this.hScanSnapShotCreationTimes.put(clientID, currentTimeMillis());
+    hScanSnapShots.put(clientID, keySnapShot);
+    hScanSnapShotCreationTimes.put(clientID, currentTimeMillis());
 
     return keySnapShot;
   }
 
   public long hincrby(Region<RedisKey, RedisData> region, RedisKey key,
-      ByteArrayWrapper field, long increment)
-      throws NumberFormatException, ArithmeticException {
+      ByteArrayWrapper field, long increment) throws NumberFormatException, ArithmeticException {
     ByteArrayWrapper oldValue = hash.get(field);
     if (oldValue == null) {
       ByteArrayWrapper newValue = new ByteArrayWrapper(Coder.longToBytes(increment));
@@ -466,8 +472,7 @@ public class RedisHash extends AbstractRedisData {
   }
 
   public BigDecimal hincrbyfloat(Region<RedisKey, RedisData> region, RedisKey key,
-      ByteArrayWrapper field, BigDecimal increment)
-      throws NumberFormatException {
+      ByteArrayWrapper field, BigDecimal increment) throws NumberFormatException {
     ByteArrayWrapper oldValue = hash.get(field);
     if (oldValue == null) {
       ByteArrayWrapper newValue = new ByteArrayWrapper(Coder.bigDecimalToBytes(increment));
@@ -544,6 +549,6 @@ public class RedisHash extends AbstractRedisData {
 
   @Override
   public int getSizeInBytes() {
-    return myCalculatedSize;
+    return sizeInBytes;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -62,7 +62,7 @@ public class RedisHash extends AbstractRedisData {
   // these values are empirically derived using ReflectionObjectSizer, which provides an exact size
   // of the object. It can't be used directly because of its performance impact. These values cause
   // the size we keep track of to converge to the actual size as it increases.
-  private static final int PER_STRING_OVERHEAD = PER_OBJECT_OVERHEAD + 46;
+  private static final int PER_BYTE_ARRAY_WRAPPER_OVERHEAD = PER_OBJECT_OVERHEAD + 46;
   private static final int PER_HASH_OVERHEAD = PER_OBJECT_OVERHEAD + 116;
 
   private int hashSize = PER_HASH_OVERHEAD;
@@ -172,7 +172,7 @@ public class RedisHash extends AbstractRedisData {
   private synchronized ByteArrayWrapper hashPut(ByteArrayWrapper field, ByteArrayWrapper value) {
     ByteArrayWrapper oldvalue = hash.put(field, value);
     if (oldvalue == null) {
-      hashSize += 2 * PER_STRING_OVERHEAD + field.length() + value.length();
+      hashSize += 2 * PER_BYTE_ARRAY_WRAPPER_OVERHEAD + field.length() + value.length();
     } else {
       hashSize += value.length() - oldvalue.length();
     }
@@ -183,7 +183,7 @@ public class RedisHash extends AbstractRedisData {
       ByteArrayWrapper value) {
     ByteArrayWrapper oldvalue = hash.putIfAbsent(field, value);
     if (oldvalue == null) {
-      hashSize += 2 * PER_STRING_OVERHEAD + field.length() + value.length();
+      hashSize += 2 * PER_BYTE_ARRAY_WRAPPER_OVERHEAD + field.length() + value.length();
     }
     return oldvalue;
   }
@@ -191,7 +191,7 @@ public class RedisHash extends AbstractRedisData {
   private synchronized ByteArrayWrapper hashRemove(ByteArrayWrapper field) {
     ByteArrayWrapper oldValue = hash.remove(field);
     if (oldValue != null) {
-      hashSize -= 2 * PER_STRING_OVERHEAD + field.length() + oldValue.length();
+      hashSize -= 2 * PER_BYTE_ARRAY_WRAPPER_OVERHEAD + field.length() + oldValue.length();
     }
     return oldValue;
   }
@@ -537,8 +537,8 @@ public class RedisHash extends AbstractRedisData {
   }
 
   @VisibleForTesting
-  protected static int getPerStringOverhead() {
-    return PER_STRING_OVERHEAD;
+  protected static int getPerByteArrayWrapperOverhead() {
+    return PER_BYTE_ARRAY_WRAPPER_OVERHEAD;
   }
 
   @VisibleForTesting

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -55,8 +55,8 @@ import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisHash extends AbstractRedisData {
   private HashMap<ByteArrayWrapper, ByteArrayWrapper> hash;
-  private ConcurrentHashMap<UUID, List<ByteArrayWrapper>> hScanSnapShots;
-  private ConcurrentHashMap<UUID, Long> hScanSnapShotCreationTimes;
+  private final ConcurrentHashMap<UUID, List<ByteArrayWrapper>> hScanSnapShots;
+  private final ConcurrentHashMap<UUID, Long> hScanSnapShotCreationTimes;
   private ScheduledExecutorService HSCANSnapshotExpirationExecutor = null;
 
   private int sizeInBytes;
@@ -70,10 +70,10 @@ public class RedisHash extends AbstractRedisData {
   protected static final int HASH_MAP_VALUE_PAIR_OVERHEAD = 96;
   protected static final int SIZE_OF_OVERHEAD_OF_FIRST_PAIR = 96;
 
-  private static int defaultHscanSnapshotsExpireCheckFrequency =
+  private static final int defaultHscanSnapshotsExpireCheckFrequency =
       Integer.getInteger("redis.hscan-snapshot-cleanup-interval", 30000);
 
-  private static int defaultHscanSnapshotsMillisecondsToLive =
+  private static final int defaultHscanSnapshotsMillisecondsToLive =
       Integer.getInteger("redis.hscan-snapshot-expiry", 30000);
 
   private int HSCAN_SNAPSHOTS_EXPIRE_CHECK_FREQUENCY_MILLISECONDS;
@@ -113,12 +113,10 @@ public class RedisHash extends AbstractRedisData {
   }
 
   private void expireHScanSnapshots() {
-    hScanSnapShotCreationTimes.entrySet().forEach(entry -> {
-      Long creationTime = entry.getValue();
+    hScanSnapShotCreationTimes.forEach((client, creationTime) -> {
       long millisecondsSinceCreation = currentTimeMillis() - creationTime;
 
       if (millisecondsSinceCreation >= MINIMUM_MILLISECONDS_FOR_HSCAN_SNAPSHOTS_TO_LIVE) {
-        UUID client = entry.getKey();
         removeHSCANSnapshot(client);
       }
     });
@@ -363,8 +361,7 @@ public class RedisHash extends AbstractRedisData {
     }
   }
 
-  @SuppressWarnings("unchecked")
-  private Pair<Integer, List<Object>> getResultsPair(List<ByteArrayWrapper> keysSnapShot,
+  private Pair<Integer, List<ByteArrayWrapper>> getResultsPair(List<ByteArrayWrapper> keysSnapShot,
       int startCursor, int count, Pattern matchPattern) {
 
     int indexOfKeys = startCursor;
@@ -396,7 +393,7 @@ public class RedisHash extends AbstractRedisData {
 
     Integer numberOfIterationsCompleted = indexOfKeys - startCursor;
 
-    return new ImmutablePair(numberOfIterationsCompleted, resultList);
+    return new ImmutablePair<>(numberOfIterationsCompleted, resultList);
   }
 
   private int getCursorValueToReturn(int startCursor,
@@ -408,7 +405,6 @@ public class RedisHash extends AbstractRedisData {
     return (startCursor + numberOfIterationsCompleted);
   }
 
-  @SuppressWarnings("unchecked")
   private List<ByteArrayWrapper> getSnapShotOfKeySet(UUID clientID) {
     List<ByteArrayWrapper> keySnapShot = hScanSnapShots.get(clientID);
 
@@ -421,7 +417,6 @@ public class RedisHash extends AbstractRedisData {
     return keySnapShot;
   }
 
-  @SuppressWarnings("unchecked")
   private List<ByteArrayWrapper> createKeySnapShot(UUID clientID) {
 
     List<ByteArrayWrapper> keySnapShot =

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -101,7 +101,6 @@ public class RedisHash extends AbstractRedisData {
 
   // for serialization
   public RedisHash() {
-    calibrate_memory_values();
     this.hash = new HashMap<>();
     this.hScanSnapShots = new ConcurrentHashMap<>();
     this.hScanSnapShotCreationTimes = new ConcurrentHashMap<>();
@@ -111,21 +110,26 @@ public class RedisHash extends AbstractRedisData {
 
     this.MINIMUM_MILLISECONDS_FOR_HSCAN_SNAPSHOTS_TO_LIVE =
         this.defaultHscanSnapshotsMillisecondsToLive;
+
+    calibrate_memory_values();
   }
 
-
   private static int baseRedisHashOverhead;
-  private static int perFieldValuePairOverhead;
+
+  private static int hashMapInternalValuePairOverhead;
+  private static int sizeOfOverheadOfFirstPair;
   private static int internalHashMapStorageOverhead;
 
 
   private void calibrate_memory_values() {
     ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
 
-    baseRedisHashOverhead = reflectionObjectSizer.sizeof(this);// + 18;
+    myCalculatedSize = reflectionObjectSizer.sizeof(this);
+
+
     HashMap<ByteArrayWrapper, ByteArrayWrapper> temp_hashmap = new HashMap<>();
+
     int base_hashmap_size = reflectionObjectSizer.sizeof(temp_hashmap);
-    baseRedisHashOverhead += base_hashmap_size;
 
     ByteArrayWrapper field1 = new ByteArrayWrapper("a".getBytes());
     ByteArrayWrapper value1 = new ByteArrayWrapper("b".getBytes());
@@ -134,22 +138,34 @@ public class RedisHash extends AbstractRedisData {
 
     temp_hashmap.put(field1, value1);
 
+    int hashmapWithSinglePairSize = reflectionObjectSizer.sizeof(temp_hashmap);
+
     int one_entry_hashmap_size = reflectionObjectSizer.sizeof(temp_hashmap);
 
     temp_hashmap.put(field2, value2);
 
     int two_entries_hashmap_size = reflectionObjectSizer.sizeof(temp_hashmap);
 
-    int sizeOfData = 2;
+    int sizeOfDataForOneFieldValuePair = 2;
 
-    perFieldValuePairOverhead =
-        two_entries_hashmap_size - one_entry_hashmap_size - sizeOfData;
+    hashMapInternalValuePairOverhead =
+        two_entries_hashmap_size - one_entry_hashmap_size - sizeOfDataForOneFieldValuePair;
 
-    internalHashMapStorageOverhead =
-        two_entries_hashmap_size - (2 * perFieldValuePairOverhead) - base_hashmap_size;
+    sizeOfOverheadOfFirstPair = hashmapWithSinglePairSize - base_hashmap_size
+        - hashMapInternalValuePairOverhead - sizeOfDataForOneFieldValuePair;
 
-    myCalculatedSize = baseRedisHashOverhead;
+    System.out.println("3 letters in byte array wrapper: "
+        + "" +reflectionObjectSizer.sizeof(new ByteArrayWrapper("abc".getBytes())));
+
+    System.out.println("byte array wrapper: "
+        + "" +reflectionObjectSizer.sizeof(new ByteArrayWrapper()));
+
+    //wrong!!! correct before use!!!
+//    internalHashMapStorageOverhead =
+//        two_entries_hashmap_size - (2 * hashMapInternalValuePairOverhead) - base_hashmap_size;
+
   }
+
 
 
   private void expireHScanSnapshots() {
@@ -211,20 +227,34 @@ public class RedisHash extends AbstractRedisData {
 
 
   private synchronized ByteArrayWrapper hashPut(ByteArrayWrapper field, ByteArrayWrapper value) {
+    if (this.hash.isEmpty()){
+      this.myCalculatedSize +=sizeOfOverheadOfFirstPair;
+    }
+
     ByteArrayWrapper oldvalue = hash.put(field, value);
 
     if (oldvalue == null) {
-      int fieldOneSize =  perFieldValuePairOverhead + field.length() + value.length();
+      int fieldValuePairSize =
+          (int) (hashMapInternalValuePairOverhead + Math.ceil(field.length()/8) + Math.ceil(value.length()/8));
 
-      System.out.println("perFieldOverhead " + perFieldValuePairOverhead);
-      System.out.println("adding to non-existing value using calculated weights: " + fieldOneSize);
-      this.myCalculatedSize += fieldOneSize;
+      System.out.println("hashMapInternalValuePairOverhead: " + hashMapInternalValuePairOverhead);
+      System.out.println("field size length: " + field.length());
+      System.out.println("value size length : " + value.length());
+
+
+      System.out.println("adding to non-existing value using calculated weights: " + fieldValuePairSize);
+
+      this.myCalculatedSize += fieldValuePairSize;
 
     } else {
-      int myCalculatedSize = value.length() - oldvalue.length();
-      System.out.println("adding to existing value" + myCalculatedSize);
-      this.myCalculatedSize += myCalculatedSize;
+
+      int newValueSize = value.length() - oldvalue.length();
+
+      System.out.println("adding to existing value" + newValueSize);
+
+      this.myCalculatedSize += newValueSize;
     }
+
     return oldvalue;
   }
 
@@ -233,7 +263,7 @@ public class RedisHash extends AbstractRedisData {
     ByteArrayWrapper oldvalue = hash.putIfAbsent(field, value);
 
     if (oldvalue == null) {
-      myCalculatedSize += 2 * perFieldValuePairOverhead + field.length() + value.length();
+      myCalculatedSize += 2 * hashMapInternalValuePairOverhead + field.length() + value.length();
     }
     return oldvalue;
   }
@@ -241,7 +271,7 @@ public class RedisHash extends AbstractRedisData {
   private synchronized ByteArrayWrapper hashRemove(ByteArrayWrapper field) {
     ByteArrayWrapper oldValue = hash.remove(field);
     if (oldValue != null) {
-      myCalculatedSize -= perFieldValuePairOverhead + field.length() + oldValue.length();
+      myCalculatedSize -= hashMapInternalValuePairOverhead + field.length() + oldValue.length();
     }
     return oldValue;
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -61,9 +61,10 @@ public class RedisHash extends AbstractRedisData {
 
   // these values are empirically derived using ReflectionObjectSizer, which provides an exact size
   // of the object. It can't be used directly because of its performance impact. These values cause
-  // the size we keep track of to converge to the actual size as it increases.
+  // the size we keep track of to converge to the actual size as the number of entries/instances
+  // increases.
   private static final int PER_BYTE_ARRAY_WRAPPER_OVERHEAD = PER_OBJECT_OVERHEAD + 46;
-  private static final int PER_HASH_OVERHEAD = PER_OBJECT_OVERHEAD + 116;
+  private static final int PER_HASH_OVERHEAD = PER_OBJECT_OVERHEAD + 324;
 
   private int hashSize = PER_HASH_OVERHEAD;
 
@@ -544,5 +545,10 @@ public class RedisHash extends AbstractRedisData {
   @VisibleForTesting
   protected static int getPerHashOverhead() {
     return PER_HASH_OVERHEAD;
+  }
+
+  @VisibleForTesting
+  protected HashMap<ByteArrayWrapper, ByteArrayWrapper> getHashMap() {
+    return hash;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -268,11 +268,7 @@ public class RedisSet extends AbstractRedisData {
 
   private synchronized void membersRemoveAll(RemsDeltaInfo remsDeltaInfo) {
     ArrayList<ByteArrayWrapper> removes = remsDeltaInfo.getRemoves();
-    if (members.size() == removes.size()) {
-      sizeInBytes = BASE_REDIS_SET_OVERHEAD;
-    } else {
-      sizeInBytes -= removes.stream().mapToInt(a -> a.length() + PER_MEMBER_OVERHEAD).sum();
-    }
+    sizeInBytes -= removes.stream().mapToInt(a -> a.length() + PER_MEMBER_OVERHEAD).sum();
     members.removeAll(removes);
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -89,13 +89,6 @@ public class RedisSet extends AbstractRedisData {
     internalHashsetStorageOverhead =
         two_entries_hashset_size - (2 * perMemberOverhead) - base_hashset_size;
 
-    System.out.println("JVM version:" + System.getProperty("java.version"));
-    System.out.println("brs:" + baseRedissetOverhead
-        + " bhs:" + base_hashset_size
-        + " oes:" + one_entry_hashset_size
-        + " tes:" + two_entries_hashset_size
-        + " mo:" + perMemberOverhead
-        + " ihso: " + internalHashsetStorageOverhead);
     myCalculatedSize = baseRedissetOverhead;
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -52,7 +52,8 @@ public class RedisSet extends AbstractRedisData {
   // of the object. It can't be used directly because of its performance impact. These values cause
   // the size we keep track of to converge to the actual size as it increases.
   private static final int PER_MEMBER_OVERHEAD = PER_OBJECT_OVERHEAD + 70;
-  private static final int PER_SET_OVERHEAD = PER_OBJECT_OVERHEAD + 240;
+  private static final int PER_SET_OVERHEAD = PER_OBJECT_OVERHEAD + 104;
+  private static final int SET_CAPACITY_OVERHEAD_FACTOR = 0;
 
   private int setSize = PER_SET_OVERHEAD;
 
@@ -343,7 +344,7 @@ public class RedisSet extends AbstractRedisData {
 
   @Override
   public int getSizeInBytes() {
-    return setSize;
+    return setSize + (SET_CAPACITY_OVERHEAD_FACTOR * (members.size() >> 4));
   }
 
   @VisibleForTesting

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -263,9 +263,6 @@ public class RedisSet extends AbstractRedisData {
   private synchronized void membersAddAll(AddsDeltaInfo addsDeltaInfo) {
     ArrayList<ByteArrayWrapper> adds = addsDeltaInfo.getAdds();
     sizeInBytes += adds.stream().mapToInt(a -> a.length() + PER_MEMBER_OVERHEAD).sum();
-    if (members.isEmpty()) {
-      sizeInBytes += INTERNAL_HASH_SET_STORAGE_OVERHEAD;
-    }
     members.addAll(adds);
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -49,6 +49,9 @@ import org.apache.geode.redis.internal.delta.RemsDeltaInfo;
 public class RedisSet extends AbstractRedisData {
   private HashSet<ByteArrayWrapper> members;
 
+  // these values are empirically derived using ReflectionObjectSizer, which provides an exact size
+  // of the object. It can't be used directly because of its performance impact. These values cause
+  // the size we keep track of to converge to the actual size as it increases.
   private static final int PER_MEMBER_OVERHEAD = PER_OBJECT_OVERHEAD + 70;
   private static final int PER_SET_OVERHEAD = PER_OBJECT_OVERHEAD + 240;
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.geode.DataSerializer;
-import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.KnownVersion;
@@ -714,11 +713,6 @@ public class RedisString extends AbstractRedisData {
     } else if (options == null || !options.isKeepTTL()) {
       persistNoDelta();
     }
-  }
-
-  @VisibleForTesting
-  protected static int getBaseRedisStringOverhead() {
-    return BASE_REDIS_STRING_OVERHEAD;
   }
 
   ////// methods that modify the "value" field ////////////

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -39,6 +39,9 @@ public class RedisString extends AbstractRedisData {
 
   private ByteArrayWrapper value;
 
+  // this value is empirically derived using ReflectionObjectSizer, which provides an exact size
+  // of the object. It can't be used directly because of its performance impact. This value causes
+  // the size we keep track of to converge to the actual size as it increases.
   public static final int PER_STRING_OVERHEAD = 34;
 
   public RedisString(ByteArrayWrapper value) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.KnownVersion;
@@ -713,6 +714,11 @@ public class RedisString extends AbstractRedisData {
     } else if (options == null || !options.isKeepTTL()) {
       persistNoDelta();
     }
+  }
+
+  @VisibleForTesting
+  protected static int getPerStringOverhead() {
+    return PER_STRING_OVERHEAD;
   }
 
   ////// methods that modify the "value" field ////////////

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -43,7 +43,7 @@ public class RedisString extends AbstractRedisData {
   // this value is empirically derived using ReflectionObjectSizer, which provides an exact size
   // of the object. It can't be used directly because of its performance impact. This value causes
   // the size we keep track of to converge to the actual size as it increases.
-  public static final int PER_STRING_OVERHEAD = 74;
+  protected static final int BASE_REDIS_STRING_OVERHEAD = 64;
 
   public RedisString(ByteArrayWrapper value) {
     this.value = value;
@@ -717,8 +717,8 @@ public class RedisString extends AbstractRedisData {
   }
 
   @VisibleForTesting
-  protected static int getPerStringOverhead() {
-    return PER_STRING_OVERHEAD;
+  protected static int getBaseRedisStringOverhead() {
+    return BASE_REDIS_STRING_OVERHEAD;
   }
 
   ////// methods that modify the "value" field ////////////
@@ -742,6 +742,6 @@ public class RedisString extends AbstractRedisData {
 
   @Override
   public int getSizeInBytes() {
-    return PER_STRING_OVERHEAD + value.length();
+    return BASE_REDIS_STRING_OVERHEAD + value.length();
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -43,7 +43,7 @@ public class RedisString extends AbstractRedisData {
   // this value is empirically derived using ReflectionObjectSizer, which provides an exact size
   // of the object. It can't be used directly because of its performance impact. This value causes
   // the size we keep track of to converge to the actual size as it increases.
-  public static final int PER_STRING_OVERHEAD = 34;
+  public static final int PER_STRING_OVERHEAD = 74;
 
   public RedisString(ByteArrayWrapper value) {
     this.value = value;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -35,10 +35,11 @@ import org.apache.geode.redis.internal.executor.string.SetOptions;
 import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisString extends AbstractRedisData {
-
   private int appendSequence;
 
   private ByteArrayWrapper value;
+
+  public static final int PER_STRING_OVERHEAD = 34;
 
   public RedisString(ByteArrayWrapper value) {
     this.value = value;
@@ -728,5 +729,10 @@ public class RedisString extends AbstractRedisData {
   @Override
   public KnownVersion[] getSerializationVersions() {
     return null;
+  }
+
+  @Override
+  public int getSizeInBytes() {
+    return PER_STRING_OVERHEAD + value.length();
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.data;
 
 import static java.lang.Math.round;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.geode.redis.internal.data.RedisHash.BASE_REDIS_HASH_OVERHEAD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
 import static org.mockito.Mockito.mock;
@@ -263,8 +264,15 @@ public class RedisHashTest {
   /************* Hash Size *************/
   /******* constants *******/
   @Test
+  public void constantBaseRedisHashOverhead_shouldEqualCalculatedOverhead() {
+    ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
+    int baseRedisHashOverhead = reflectionObjectSizer.sizeof(new RedisHash());
+
+    assertThat(baseRedisHashOverhead).isEqualTo(BASE_REDIS_HASH_OVERHEAD);
+  }
+
+  @Test
   public void constantValuePairOverhead_shouldEqualCalculatedOverhead() {
-    RedisHash redisHash = new RedisHash();
     int sizeOfDataForOneFieldValuePair = 16; // initial byte[]s are 8 bytes each
 
     HashMap<ByteArrayWrapper, ByteArrayWrapper> tempHashmap = new HashMap<>();
@@ -316,7 +324,7 @@ public class RedisHashTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void should_calculateSize_equalToROSSize_ofIndividualInstanceWithSingleValue() {
+  public void should_calculateSize_closeToROSSize_ofIndividualInstanceWithSingleValue() {
     ArrayList<ByteArrayWrapper> data = new ArrayList<>();
     data.add(new ByteArrayWrapper("field".getBytes()));
     data.add(new ByteArrayWrapper("valuethatisverylonggggggggg".getBytes()));

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -258,6 +258,13 @@ public class RedisHashTest {
     });
   }
 
+  @Test
+  public void hashSizeOverhead_shouldNotBeChanged_withoutForethoughtAndTesting() {
+    assertThat(RedisHash.PER_OBJECT_OVERHEAD).isEqualTo(8);
+    assertThat(RedisHash.getPerStringOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 46);
+    assertThat(RedisHash.getPerHashOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 116);
+  }
+
   private RedisHash createRedisHash(int NumberOfFields) {
     ArrayList<ByteArrayWrapper> elements = createListOfDataElements(NumberOfFields);
     return new RedisHash(elements);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -261,7 +261,7 @@ public class RedisHashTest {
   @Test
   public void hashSizeOverhead_shouldNotBeChanged_withoutForethoughtAndTesting() {
     assertThat(RedisHash.PER_OBJECT_OVERHEAD).isEqualTo(8);
-    assertThat(RedisHash.getPerStringOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 46);
+    assertThat(RedisHash.getPerByteArrayWrapperOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 46);
     assertThat(RedisHash.getPerHashOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 116);
   }
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.assertj.core.data.Offset;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 
@@ -78,10 +79,25 @@ public class RedisHashTest {
 
   private RedisHash createRedisHash(String k1, String v1, String k2, String v2) {
     ArrayList<ByteArrayWrapper> elements = new ArrayList<>();
-    elements.add(createByteArrayWrapper(k1));
-    elements.add(createByteArrayWrapper(v1));
-    elements.add(createByteArrayWrapper(k2));
-    elements.add(createByteArrayWrapper(v2));
+
+    ByteArrayWrapper key1 = createByteArrayWrapper(k1);
+    ByteArrayWrapper value1 = createByteArrayWrapper(v1);
+    ByteArrayWrapper key2 = createByteArrayWrapper(k2);
+    ByteArrayWrapper value2 = createByteArrayWrapper(v2);
+
+    System.out.println( "size of pair in test using ros "
+        + (reflectionObjectSizer.sizeof(key1) + reflectionObjectSizer.sizeof(value1)));
+
+    System.out.println( "size of pair2 in test using ros "
+        + (reflectionObjectSizer.sizeof(key2) + reflectionObjectSizer.sizeof(value2)));
+
+
+    elements.add(key1);
+    elements.add(value1);
+
+    elements.add(key2);
+    elements.add(value2);
+
     return new RedisHash(elements);
   }
 
@@ -262,11 +278,12 @@ public class RedisHashTest {
   }
 
   @Test
+  @Ignore("removing per hash overhead")
   public void hashSizeOverhead_shouldNotBeChanged_withoutForethoughtAndTesting() {
     assertThat(RedisHash.PER_OBJECT_OVERHEAD).isEqualTo(8);
     assertThat(RedisHash.getPerByteArrayWrapperOverhead())
         .isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 46);
-    assertThat(RedisHash.getPerHashOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 324);
+//    assertThat(RedisHash.getPerHashOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 324);
   }
 
   @SuppressWarnings("unchecked")
@@ -278,7 +295,7 @@ public class RedisHashTest {
     Long actual = Long.valueOf(current.getSizeInBytes());
     Offset<Long> offset = Offset.offset(Math.round(expected * 0.05));
 
-    assertThat(actual).isCloseTo(expected, offset);
+    assertThat(actual).isCloseTo(expected, Offset.offset(0l));
   }
 
   @SuppressWarnings("unchecked")

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -62,7 +62,7 @@ public class RedisHashTest {
   public void confirmToDataIsSynchronized() throws NoSuchMethodException {
     assertThat(Modifier.isSynchronized(RedisHash.class
         .getMethod("toData", DataOutput.class, SerializationContext.class).getModifiers()))
-        .isTrue();
+            .isTrue();
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -265,10 +265,11 @@ public class RedisHashTest {
   /******* constants *******/
   @Test
   public void constantBaseRedisHashOverhead_shouldEqualCalculatedOverhead() {
-    ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
-    int baseRedisHashOverhead = reflectionObjectSizer.sizeof(new RedisHash());
+    RedisHash hash = new RedisHash();
+    int baseRedisHashOverhead = reflectionObjectSizer.sizeof(hash);
 
     assertThat(baseRedisHashOverhead).isEqualTo(BASE_REDIS_HASH_OVERHEAD);
+    assertThat(hash.getSizeInBytes()).isEqualTo(baseRedisHashOverhead);
   }
 
   @Test
@@ -312,15 +313,6 @@ public class RedisHashTest {
   }
 
   /******* constructor *******/
-  @Test
-  public void should_calculateSize_equalToROSSize_ofEmptyIndividualInstance() {
-    RedisHash redisHash = new RedisHash();
-
-    int expected = reflectionObjectSizer.sizeof(redisHash);
-    int actual = redisHash.getSizeInBytes();
-
-    assertThat(actual).isEqualTo(expected);
-  }
 
   @SuppressWarnings("unchecked")
   @Test

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -19,8 +19,10 @@ package org.apache.geode.redis.internal.data;
 import static java.lang.Math.round;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.geode.redis.internal.data.RedisHash.BASE_REDIS_HASH_OVERHEAD;
+import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -263,6 +265,10 @@ public class RedisHashTest {
 
   /************* Hash Size *************/
   /******* constants *******/
+  // these tests contain the math that was used to derive the constants in RedisHash. If these tests
+  // start failing, it is because the overhead of RedisHash has changed. If it has decreased, good
+  // job! You can change the constants in RedisHash to reflect that. If it has increased, carefully
+  // consider that increase before changing the constants.
   @Test
   public void constantBaseRedisHashOverhead_shouldEqualCalculatedOverhead() {
     RedisHash hash = new RedisHash();
@@ -314,7 +320,6 @@ public class RedisHashTest {
 
   /******* constructor *******/
 
-  @SuppressWarnings("unchecked")
   @Test
   public void should_calculateSize_closeToROSSize_ofIndividualInstanceWithSingleValue() {
     ArrayList<ByteArrayWrapper> data = new ArrayList<>();
@@ -331,7 +336,6 @@ public class RedisHashTest {
     assertThat(actual).isCloseTo(expected, offset);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void should_calculateSize_closeToROSSize_ofIndividualInstanceWithMultipleValues() {
     RedisHash redisHash =
@@ -345,7 +349,6 @@ public class RedisHashTest {
     assertThat(actual).isCloseTo(expected, offset);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void should_calculateSize_closeToROSSize_withManyEntries() {
     final String baseField = "longerbase";
@@ -390,7 +393,6 @@ public class RedisHashTest {
     assertThat(hash.getSizeInBytes()).isEqualTo(expectedRedisHash.getSizeInBytes());
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void hsetShould_calculateSizeDifference_whenUpdatingExistingEntry_newIsShorterThanOld() {
     final RedisKey key = new RedisKey("key".getBytes());
@@ -401,7 +403,6 @@ public class RedisHashTest {
     testThatSizeIsUpdatedWhenUpdatingValue(key, field, initialValue, finalValue);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void hsetShould_calculateSizeDifference_whenUpdatingExistingEntry_oldIsShorterThanNew() {
     final RedisKey key = new RedisKey("key".getBytes());
@@ -412,7 +413,6 @@ public class RedisHashTest {
     testThatSizeIsUpdatedWhenUpdatingValue(key, field, initialValue, finalValue);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void hsetShould_calculateSizeDifference_whenUpdatingExistingEntry_valuesAreSameLength() {
     final RedisKey key = new RedisKey("key".getBytes());
@@ -423,12 +423,11 @@ public class RedisHashTest {
     testThatSizeIsUpdatedWhenUpdatingValue(key, field, initialValue, finalValue);
   }
 
-  @SuppressWarnings("unchecked")
   public void testThatSizeIsUpdatedWhenUpdatingValue(final RedisKey key, final String field,
       final String initialValue, final String finalValue) {
-    final Region region = mock(Region.class);
+    final Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
-    when(region.put(Object.class, Object.class)).thenReturn(returnData);
+    when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
     List<ByteArrayWrapper> initialData = new ArrayList<>();
@@ -451,16 +450,15 @@ public class RedisHashTest {
   }
 
   /******* put if absent *******/
-  @SuppressWarnings("unchecked")
   @Test
   public void putIfAbsentShould_calculateSizeEqualToSizeCalculatedInConstructor_forMultipleUniqueEntries() {
     final RedisKey key = new RedisKey("key".getBytes());
     final String baseField = "field";
     final String baseValue = "value";
 
-    final Region region = mock(Region.class);
+    final Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
-    when(region.put(Object.class, Object.class)).thenReturn(returnData);
+    when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
     List<ByteArrayWrapper> data = new ArrayList<>();
@@ -476,16 +474,15 @@ public class RedisHashTest {
     assertThat(hash.getSizeInBytes()).isCloseTo(expectedRedisHash.getSizeInBytes(), offset);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void putIfAbsentShould_notChangeSize_whenSameDataIsSetTwice() {
     final RedisKey key = new RedisKey("key".getBytes());
     final String baseField = "field";
     final String baseValue = "value";
 
-    final Region region = mock(Region.class);
+    final Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
-    when(region.put(Object.class, Object.class)).thenReturn(returnData);
+    when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
     List<ByteArrayWrapper> data = new ArrayList<>();
@@ -503,7 +500,6 @@ public class RedisHashTest {
     assertThat(hash.getSizeInBytes()).isEqualTo(expectedSize);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void putIfAbsent_shouldNotChangeSize_whenPuttingToExistingFields() {
     final RedisKey key = new RedisKey("key".getBytes());
@@ -511,9 +507,9 @@ public class RedisHashTest {
     final String initialBaseValue = "value";
     final String finalBaseValue = "longerValue";
 
-    final Region region = mock(Region.class);
+    final Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
-    when(region.put(Object.class, Object.class)).thenReturn(returnData);
+    when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
     List<ByteArrayWrapper> initialData = new ArrayList<>();
@@ -538,15 +534,14 @@ public class RedisHashTest {
   }
 
   /******* remove *******/
-  @SuppressWarnings("unchecked")
   @Test
   public void sizeShouldDecrease_whenValueIsRemoved() {
     final RedisKey key = new RedisKey("key".getBytes());
     final String baseField = "field";
     final String baseValue = "value";
-    final Region region = mock(Region.class);
+    final Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
-    when(region.put(Object.class, Object.class)).thenReturn(returnData);
+    when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     List<ByteArrayWrapper> data = new ArrayList<>();
     List<ByteArrayWrapper> dataToRemove = new ArrayList<>();
@@ -566,20 +561,19 @@ public class RedisHashTest {
     redisHash.hdel(region, key, dataToRemove);
 
     int expectedSize = initialSize - RedisHash.HASH_MAP_VALUE_PAIR_OVERHEAD - field1.length();
-    Offset offset = Offset.offset((int) round(expectedSize * 0.05));
+    Offset<Integer> offset = Offset.offset((int) round(expectedSize * 0.05));
 
     assertThat(redisHash.getSizeInBytes()).isCloseTo(expectedSize, offset);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void dataStoreBytesInUse_shouldReturnToHashOverhead_whenAllFieldsAreRemoved() {
     final RedisKey key = new RedisKey("key".getBytes());
     final String baseField = "field";
     final String baseValue = "value";
-    final Region region = mock(Region.class);
+    final Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
-    when(region.put(Object.class, Object.class)).thenReturn(returnData);
+    when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
     final int baseRedisHashOverhead = hash.getSizeInBytes();

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -286,17 +286,58 @@ public class RedisHashTest {
 //    assertThat(RedisHash.getPerHashOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 324);
   }
 
+  @Test
+  public void should_calculateSize_closeToROSSize_ofEmptyIndividualInstance() {
+    RedisHash subject = new RedisHash();
+
+    int expected = reflectionObjectSizer.sizeof(subject);
+
+    Long actual = Long.valueOf(subject.getSizeInBytes());
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+
+  @Test
+  public void should_calculateSize_closeToROSSize_ofIndividualInstanceWithSingleValue() {
+
+    ArrayList<ByteArrayWrapper> data = new ArrayList<>();
+    ByteArrayWrapper field1 = new ByteArrayWrapper("fet333333".getBytes());
+    ByteArrayWrapper value1= new ByteArrayWrapper("vw58888888888".getBytes());
+    data.add(field1);
+    data.add(value1);
+//    data.add(new ByteArrayWrapper("g".getBytes()));
+//    data.add(new ByteArrayWrapper("w".getBytes()));
+
+    RedisHash subject = new RedisHash(data);
+
+    int expected = reflectionObjectSizer.sizeof(subject);
+
+
+    Long actual = Long.valueOf(subject.getSizeInBytes());
+
+    System.out.println("field1: "+ field1.length());
+    System.out.println("value1: "+ value1.length());
+    System.out.println("total length:" + (field1.length() + value1.length()));
+
+    System.out.println("difference: "+  (expected - actual) );
+
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
   @SuppressWarnings("unchecked")
   @Test
-  public void should_calculateSize_closeToROSSize_ofIndividualInstance() {
-    RedisHash current = createRedisHash("k1", "v1", "k2", "v2");
+  public void should_calculateSize_closeToROSSize_ofIndividualInstanceWithData() {
+    RedisHash subject = createRedisHash("k", "v", "z", "x");
 
-    int expected = reflectionObjectSizer.sizeof(current);
-    Long actual = Long.valueOf(current.getSizeInBytes());
+    int expected = reflectionObjectSizer.sizeof(subject);
+    Long actual = Long.valueOf(subject.getSizeInBytes());
     Offset<Long> offset = Offset.offset(Math.round(expected * 0.05));
 
     assertThat(actual).isCloseTo(expected, Offset.offset(0l));
   }
+
 
   @SuppressWarnings("unchecked")
   @Test

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -266,7 +266,7 @@ public class RedisHashTest {
     assertThat(RedisHash.PER_OBJECT_OVERHEAD).isEqualTo(8);
     assertThat(RedisHash.getPerByteArrayWrapperOverhead())
         .isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 46);
-    assertThat(RedisHash.getPerHashOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 116);
+    assertThat(RedisHash.getPerHashOverhead()).isEqualTo(RedisHash.PER_OBJECT_OVERHEAD + 324);
   }
 
   @SuppressWarnings("unchecked")

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -275,7 +275,7 @@ public class RedisSetTest {
           + (PER_MEMBER_OVERHEAD * (i + 1)) + currentDataSize;
       Offset<Long> offset = Offset.offset(Math.round(expected * percentTolerance));
 
-      assertThat(actual).as("i=" + i).isCloseTo(expected, offset);
+      assertThat(actual).isCloseTo(expected, offset);
     }
   }
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -165,4 +165,11 @@ public class RedisSetTest {
     o2.fromDelta(in);
     assertThat(o2).isEqualTo(o1);
   }
+
+  @Test
+  public void overheadConstants_shouldNotChange_withoutForethoughtAndTesting() {
+    assertThat(RedisSet.PER_OBJECT_OVERHEAD).isEqualTo(8);
+    assertThat(RedisSet.getPerSetOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 240);
+    assertThat(RedisSet.getPerMemberOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 70);
+  }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -29,7 +29,6 @@ import java.util.Random;
 
 import org.assertj.core.data.Offset;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.geode.DataSerializer;
@@ -169,14 +168,6 @@ public class RedisSetTest {
     assertThat(o2).isNotEqualTo(o1);
     o2.fromDelta(in);
     assertThat(o2).isEqualTo(o1);
-  }
-
-  @Test
-  @Ignore
-  public void overheadConstants_shouldNotChange_withoutForethoughtAndTesting() {
-    assertThat(RedisSet.PER_OBJECT_OVERHEAD).isEqualTo(8);
-    assertThat(RedisSet.getPerSetOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 104);
-    assertThat(RedisSet.getPerMemberOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 70);
   }
 
   @SuppressWarnings("unchecked")

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -230,51 +230,45 @@ public class RedisSetTest {
   /******** constants *******/
   @Test
   public void baseOverheadConstant_shouldMatchCalculatedValue() {
-    ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
     int baseRedisSetOverhead = reflectionObjectSizer.sizeof(new RedisSet()) + 18;
 
-    HashSet<ByteArrayWrapper> temp_hashset = new HashSet<>();
-    int base_hashset_size = reflectionObjectSizer.sizeof(temp_hashset);
-    baseRedisSetOverhead += base_hashset_size;
+    int baseHashSetSize = reflectionObjectSizer.sizeof(new HashSet<>());
+    baseRedisSetOverhead += baseHashSetSize;
 
     assertThat(baseRedisSetOverhead).isEqualTo(BASE_REDIS_SET_OVERHEAD);
   }
 
   @Test
   public void perMemberOverheadConstant_shouldMatchCalculatedValue() {
-    ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
-
-    HashSet<ByteArrayWrapper> temp_hashset = new HashSet<>();
+    HashSet<ByteArrayWrapper> tempHashSet = new HashSet<>();
     ByteArrayWrapper member1 = new ByteArrayWrapper("a".getBytes());
     ByteArrayWrapper member2 = new ByteArrayWrapper("b".getBytes());
-    temp_hashset.add(member1);
-    int one_entry_hashset_size = reflectionObjectSizer.sizeof(temp_hashset);
+    tempHashSet.add(member1);
+    int oneEntryHashSetSize = reflectionObjectSizer.sizeof(tempHashSet);
 
-    temp_hashset.add(member2);
-    int two_entries_hashset_size = reflectionObjectSizer.sizeof(temp_hashset);
+    tempHashSet.add(member2);
+    int twoEntriesHashSetSize = reflectionObjectSizer.sizeof(tempHashSet);
 
-    int perMemberOverhead = two_entries_hashset_size - one_entry_hashset_size + 5;
+    int perMemberOverhead = twoEntriesHashSetSize - oneEntryHashSetSize + 5;
 
     assertThat(perMemberOverhead).isEqualTo(PER_MEMBER_OVERHEAD);
   }
 
   @Test
   public void internalHashsetStorageOverheadConstant_shouldMatchCalculatedValue() {
-    ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
-
-    HashSet<ByteArrayWrapper> temp_hashset = new HashSet<>();
-    int base_hashset_size = reflectionObjectSizer.sizeof(temp_hashset);
+    HashSet<ByteArrayWrapper> tempHashSet = new HashSet<>();
+    int baseHashSetSize = reflectionObjectSizer.sizeof(tempHashSet);
 
     ByteArrayWrapper baw1 = new ByteArrayWrapper("a".getBytes());
     ByteArrayWrapper baw2 = new ByteArrayWrapper("b".getBytes());
 
-    temp_hashset.add(baw1);
-    temp_hashset.add(baw2);
+    tempHashSet.add(baw1);
+    tempHashSet.add(baw2);
 
-    int two_entries_hashset_size = reflectionObjectSizer.sizeof(temp_hashset);
+    int twoEntryHashSetSize = reflectionObjectSizer.sizeof(tempHashSet);
 
     int internalHashsetStorageOverhead =
-        two_entries_hashset_size - (2 * PER_MEMBER_OVERHEAD) - base_hashset_size;
+        twoEntryHashSetSize - (2 * PER_MEMBER_OVERHEAD) - baseHashSetSize;
 
     assertThat(internalHashsetStorageOverhead).isEqualTo(INTERNAL_HASH_SET_STORAGE_OVERHEAD);
   }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -25,7 +25,9 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Random;
 
+import org.assertj.core.data.Offset;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -36,8 +38,10 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.internal.size.ReflectionObjectSizer;
 
 public class RedisSetTest {
+  private final ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
 
   @BeforeClass
   public static void beforeClass() {
@@ -65,13 +69,13 @@ public class RedisSetTest {
     assertThat(Modifier
         .isSynchronized(RedisSet.class
             .getMethod("toData", DataOutput.class, SerializationContext.class).getModifiers()))
-                .isTrue();
+        .isTrue();
   }
 
   private RedisSet createRedisSet(int m1, int m2) {
     return new RedisSet(Arrays.asList(
-        new ByteArrayWrapper(new byte[] {(byte) m1}),
-        new ByteArrayWrapper(new byte[] {(byte) m2})));
+        new ByteArrayWrapper(new byte[]{(byte) m1}),
+        new ByteArrayWrapper(new byte[]{(byte) m2})));
   }
 
   @Test
@@ -114,7 +118,7 @@ public class RedisSetTest {
   public void sadd_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisSet o1 = createRedisSet(1, 2);
-    ByteArrayWrapper member3 = new ByteArrayWrapper(new byte[] {3});
+    ByteArrayWrapper member3 = new ByteArrayWrapper(new byte[]{3});
     ArrayList<ByteArrayWrapper> adds = new ArrayList<>();
     adds.add(member3);
     o1.sadd(adds, region, null);
@@ -134,7 +138,7 @@ public class RedisSetTest {
   public void srem_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisSet o1 = createRedisSet(1, 2);
-    ByteArrayWrapper member1 = new ByteArrayWrapper(new byte[] {1});
+    ByteArrayWrapper member1 = new ByteArrayWrapper(new byte[]{1});
     ArrayList<ByteArrayWrapper> removes = new ArrayList<>();
     removes.add(member1);
     o1.srem(removes, region, null);
@@ -172,4 +176,65 @@ public class RedisSetTest {
     assertThat(RedisSet.getPerSetOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 240);
     assertThat(RedisSet.getPerMemberOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 70);
   }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void should_calculateSize_closeToROSSize_ofIndividualInstances() {
+    for (int i = 0; i < 1024; i += 16) {
+      RedisSet set = createRedisSetOfSpecifiedSize(i);
+
+      int expected = reflectionObjectSizer.sizeof(set);
+      Long actual = Long.valueOf(set.getSizeInBytes());
+      System.out.println(i + ", " + actual);
+      Offset<Long> offset = Offset.offset(Math.round(expected * 0.06));
+
+      assertThat(actual).isCloseTo(expected, offset);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void should_calculateSize_closeToROSSize_withManyEntries() {
+    for (int i = 0; i < 16; i++) {
+      RedisSet set = createRedisSetWithMemberOfSpecifiedSize(i * 64);
+      int expected = reflectionObjectSizer.sizeof(set);
+      Long actual = Long.valueOf(set.getSizeInBytes()) + 82; // TODO: should not need '82'!!!!
+      System.out.println(i + ", " + actual);
+      Offset<Long> offset = Offset.offset(Math.round(expected * 0.06));
+
+      assertThat(actual).isCloseTo(expected, offset);
+    }
+  }
+
+  private RedisSet createRedisSetOfSpecifiedSize(int setSize) {
+    ArrayList<ByteArrayWrapper> arrayList = new ArrayList<>();
+    for (int i = 0; i < setSize; i++) {
+
+      arrayList.add(new ByteArrayWrapper(("a" + i).getBytes()));
+    }
+    return new RedisSet(arrayList);
+  }
+
+  private RedisSet createRedisSetWithMemberOfSpecifiedSize(int memberSize) {
+    ArrayList<ByteArrayWrapper> arrayList = new ArrayList<>();
+    arrayList.add(new ByteArrayWrapper(createMemberOfSpecifiedSize("a", memberSize).getBytes()));
+    return new RedisSet(arrayList);
+  }
+
+  private String createMemberOfSpecifiedSize(final String base, final int stringSize) {
+    Random random = new Random();
+    if (base.length() > stringSize) {
+      return base;
+    }
+    System.out.println("gonna loop to:" + stringSize);
+    StringBuffer sb = new StringBuffer(stringSize);
+    sb.append(base);
+    for (int i = base.length(); i < stringSize; i++) {
+      int randy = random.nextInt(10);
+      sb.append(randy);
+    }
+    String javaString = sb.toString();
+    return javaString;
+  }
+
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -29,6 +29,7 @@ import java.util.Random;
 
 import org.assertj.core.data.Offset;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import org.apache.geode.DataSerializer;
@@ -171,6 +172,7 @@ public class RedisSetTest {
   }
 
   @Test
+  @Ignore
   public void overheadConstants_shouldNotChange_withoutForethoughtAndTesting() {
     assertThat(RedisSet.PER_OBJECT_OVERHEAD).isEqualTo(8);
     assertThat(RedisSet.getPerSetOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 104);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -69,13 +69,13 @@ public class RedisSetTest {
     assertThat(Modifier
         .isSynchronized(RedisSet.class
             .getMethod("toData", DataOutput.class, SerializationContext.class).getModifiers()))
-        .isTrue();
+                .isTrue();
   }
 
   private RedisSet createRedisSet(int m1, int m2) {
     return new RedisSet(Arrays.asList(
-        new ByteArrayWrapper(new byte[]{(byte) m1}),
-        new ByteArrayWrapper(new byte[]{(byte) m2})));
+        new ByteArrayWrapper(new byte[] {(byte) m1}),
+        new ByteArrayWrapper(new byte[] {(byte) m2})));
   }
 
   @Test
@@ -118,7 +118,7 @@ public class RedisSetTest {
   public void sadd_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisSet o1 = createRedisSet(1, 2);
-    ByteArrayWrapper member3 = new ByteArrayWrapper(new byte[]{3});
+    ByteArrayWrapper member3 = new ByteArrayWrapper(new byte[] {3});
     ArrayList<ByteArrayWrapper> adds = new ArrayList<>();
     adds.add(member3);
     o1.sadd(adds, region, null);
@@ -138,7 +138,7 @@ public class RedisSetTest {
   public void srem_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisSet o1 = createRedisSet(1, 2);
-    ByteArrayWrapper member1 = new ByteArrayWrapper(new byte[]{1});
+    ByteArrayWrapper member1 = new ByteArrayWrapper(new byte[] {1});
     ArrayList<ByteArrayWrapper> removes = new ArrayList<>();
     removes.add(member1);
     o1.srem(removes, region, null);
@@ -179,13 +179,12 @@ public class RedisSetTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void should_calculateSize_closeToROSSize_ofIndividualInstances() {
+  public void should_calculateSize_closeToROS_withVaryingMemberCounts() {
     for (int i = 0; i < 1024; i += 16) {
       RedisSet set = createRedisSetOfSpecifiedSize(i);
 
       int expected = reflectionObjectSizer.sizeof(set);
       Long actual = Long.valueOf(set.getSizeInBytes());
-      System.out.println(i + ", " + actual);
       Offset<Long> offset = Offset.offset(Math.round(expected * 0.06));
 
       assertThat(actual).isCloseTo(expected, offset);
@@ -194,12 +193,11 @@ public class RedisSetTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void should_calculateSize_closeToROSSize_withManyEntries() {
+  public void should_calculateSize_closeToROS_withVaryingMemberSize() {
     for (int i = 0; i < 16; i++) {
       RedisSet set = createRedisSetWithMemberOfSpecifiedSize(i * 64);
       int expected = reflectionObjectSizer.sizeof(set);
-      Long actual = Long.valueOf(set.getSizeInBytes()) + 82; // TODO: should not need '82'!!!!
-      System.out.println(i + ", " + actual);
+      Long actual = Long.valueOf(set.getSizeInBytes());
       Offset<Long> offset = Offset.offset(Math.round(expected * 0.06));
 
       assertThat(actual).isCloseTo(expected, offset);
@@ -209,24 +207,26 @@ public class RedisSetTest {
   private RedisSet createRedisSetOfSpecifiedSize(int setSize) {
     ArrayList<ByteArrayWrapper> arrayList = new ArrayList<>();
     for (int i = 0; i < setSize; i++) {
-
-      arrayList.add(new ByteArrayWrapper(("a" + i).getBytes()));
+      arrayList.add(new ByteArrayWrapper(("abcdefgh" + i).getBytes()));
     }
     return new RedisSet(arrayList);
   }
 
   private RedisSet createRedisSetWithMemberOfSpecifiedSize(int memberSize) {
     ArrayList<ByteArrayWrapper> arrayList = new ArrayList<>();
-    arrayList.add(new ByteArrayWrapper(createMemberOfSpecifiedSize("a", memberSize).getBytes()));
+    ByteArrayWrapper member =
+        new ByteArrayWrapper(createMemberOfSpecifiedSize("a", memberSize).getBytes());
+    if (member.length() > 0) {
+      arrayList.add(member);
+    }
     return new RedisSet(arrayList);
   }
 
   private String createMemberOfSpecifiedSize(final String base, final int stringSize) {
     Random random = new Random();
     if (base.length() > stringSize) {
-      return base;
+      return "";
     }
-    System.out.println("gonna loop to:" + stringSize);
     StringBuffer sb = new StringBuffer(stringSize);
     sb.append(base);
     for (int i = base.length(); i < stringSize; i++) {

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -173,7 +173,7 @@ public class RedisSetTest {
   @Test
   public void overheadConstants_shouldNotChange_withoutForethoughtAndTesting() {
     assertThat(RedisSet.PER_OBJECT_OVERHEAD).isEqualTo(8);
-    assertThat(RedisSet.getPerSetOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 240);
+    assertThat(RedisSet.getPerSetOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 104);
     assertThat(RedisSet.getPerMemberOverhead()).isEqualTo(RedisSet.PER_OBJECT_OVERHEAD + 70);
   }
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
@@ -53,7 +53,7 @@ public class RedisStringTest {
 
   @Test
   public void constructorSetsValue() {
-    ByteArrayWrapper byteArrayWrapper = new ByteArrayWrapper(new byte[]{0, 1, 2});
+    ByteArrayWrapper byteArrayWrapper = new ByteArrayWrapper(new byte[] {0, 1, 2});
     RedisString string = new RedisString(byteArrayWrapper);
     ByteArrayWrapper returnedByteArrayWrapper = string.get();
     assertThat(returnedByteArrayWrapper).isNotNull();
@@ -63,20 +63,20 @@ public class RedisStringTest {
   @Test
   public void setSetsValue() {
     RedisString string = new RedisString();
-    string.set(new ByteArrayWrapper(new byte[]{0, 1, 2}));
+    string.set(new ByteArrayWrapper(new byte[] {0, 1, 2}));
     ByteArrayWrapper returnedByteArrayWrapper = string.get();
     assertThat(returnedByteArrayWrapper).isNotNull();
     assertThat(returnedByteArrayWrapper.value)
-        .isEqualTo(new ByteArrayWrapper(new byte[]{0, 1, 2}).value);
+        .isEqualTo(new ByteArrayWrapper(new byte[] {0, 1, 2}).value);
   }
 
   @Test
   public void getReturnsSetValue() {
-    RedisString string = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
+    RedisString string = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
     ByteArrayWrapper returnedByteArrayWrapper = string.get();
     assertThat(returnedByteArrayWrapper).isNotNull();
     assertThat(returnedByteArrayWrapper.value)
-        .isEqualTo(new ByteArrayWrapper(new byte[]{0, 1}).value);
+        .isEqualTo(new ByteArrayWrapper(new byte[] {0, 1}).value);
   }
 
   @Test
@@ -84,8 +84,8 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisString redisString = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
-    ByteArrayWrapper part2 = new ByteArrayWrapper(new byte[]{2, 3, 4, 5});
+    RedisString redisString = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
+    ByteArrayWrapper part2 = new ByteArrayWrapper(new byte[] {2, 3, 4, 5});
     int redisStringSize = redisString.strlen();
     int part2Size = part2.length();
     int appendedStringSize = redisString.append(part2, region, null);
@@ -97,25 +97,25 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
-    ByteArrayWrapper part2 = new ByteArrayWrapper(new byte[]{2, 3});
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
+    ByteArrayWrapper part2 = new ByteArrayWrapper(new byte[] {2, 3});
     o1.append(part2, region, null);
     assertThat(o1.hasDelta()).isTrue();
-    assertThat(o1.get()).isEqualTo(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
+    assertThat(o1.get()).isEqualTo(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
     HeapDataOutputStream out = new HeapDataOutputStream(100);
     o1.toDelta(out);
     assertThat(o1.hasDelta()).isFalse();
     ByteArrayDataInput in = new ByteArrayDataInput(out.toByteArray());
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
     assertThat(o2).isNotEqualTo(o1);
     o2.fromDelta(in);
-    assertThat(o2.get()).isEqualTo(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
+    assertThat(o2.get()).isEqualTo(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
     assertThat(o2).isEqualTo(o1);
   }
 
   @Test
   public void confirmSerializationIsStable() throws IOException, ClassNotFoundException {
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
     o1.setExpirationTimestampNoDelta(1000);
     HeapDataOutputStream outputStream = new HeapDataOutputStream(100);
     DataSerializer.writeObject(o1, outputStream);
@@ -129,7 +129,7 @@ public class RedisStringTest {
     assertThat(Modifier
         .isSynchronized(RedisString.class
             .getMethod("toData", DataOutput.class, SerializationContext.class).getModifiers()))
-        .isTrue();
+                .isTrue();
   }
 
   @Test
@@ -137,7 +137,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0', ' ', '1'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0', ' ', '1'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incr(region, byteArrayWrapper))
         .isInstanceOf(NumberFormatException.class);
@@ -150,7 +150,7 @@ public class RedisStringTest {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisKey byteArrayWrapper = new RedisKey(
         // max value for signed long
-        new byte[]{'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5',
+        new byte[] {'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5',
             '8', '0', '7'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incr(region, byteArrayWrapper))
@@ -162,7 +162,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.incr(region, byteArrayWrapper);
     assertThat(string.get().toString()).isEqualTo("11");
@@ -173,7 +173,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0', ' ', '1'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0', ' ', '1'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incrby(region, byteArrayWrapper, 2L))
         .isInstanceOf(NumberFormatException.class);
@@ -186,7 +186,7 @@ public class RedisStringTest {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisKey byteArrayWrapper = new RedisKey(
         // max value for signed long
-        new byte[]{'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5',
+        new byte[] {'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5',
             '8', '0', '7'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incrby(region, byteArrayWrapper, 2L))
@@ -198,7 +198,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.incrby(region, byteArrayWrapper, 2L);
     assertThat(string.get().toString()).isEqualTo("12");
@@ -209,7 +209,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0', ' ', '1'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0', ' ', '1'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incrbyfloat(region, byteArrayWrapper, new BigDecimal("1.1")))
         .isInstanceOf(NumberFormatException.class);
@@ -220,7 +220,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.incrbyfloat(region, byteArrayWrapper, new BigDecimal("2.20"));
     assertThat(string.get().toString()).isEqualTo("12.20");
@@ -231,7 +231,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{0});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {0});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.decr(region, byteArrayWrapper))
         .isInstanceOf(NumberFormatException.class);
@@ -243,7 +243,7 @@ public class RedisStringTest {
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisKey byteArrayWrapper = new RedisKey(
-        new byte[]{'-', '9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7',
+        new byte[] {'-', '9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7',
             '5',
             '8', '0', '8'});
     RedisString string = new RedisString(byteArrayWrapper);
@@ -256,7 +256,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.decr(region, byteArrayWrapper);
     assertThat(string.get().toString()).isEqualTo("9");
@@ -267,7 +267,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{1});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {1});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.decrby(region, byteArrayWrapper, 2))
         .isInstanceOf(NumberFormatException.class);
@@ -279,7 +279,7 @@ public class RedisStringTest {
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisKey byteArrayWrapper = new RedisKey(
-        new byte[]{'-', '9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7',
+        new byte[] {'-', '9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7',
             '5',
             '8', '0', '7'});
     RedisString string = new RedisString(byteArrayWrapper);
@@ -292,7 +292,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.decrby(region, byteArrayWrapper, 2);
     assertThat(string.get().toString()).isEqualTo("8");
@@ -300,39 +300,39 @@ public class RedisStringTest {
 
   @Test
   public void strlenReturnsStringLength() {
-    RedisString string = new RedisString(new ByteArrayWrapper(new byte[]{1, 2, 3, 4}));
+    RedisString string = new RedisString(new ByteArrayWrapper(new byte[] {1, 2, 3, 4}));
     assertThat(string.strlen()).isEqualTo(4);
   }
 
   @Test
   public void strlenReturnsLengthOfEmptyString() {
-    RedisString string = new RedisString(new ByteArrayWrapper(new byte[]{}));
+    RedisString string = new RedisString(new ByteArrayWrapper(new byte[] {}));
     assertThat(string.strlen()).isEqualTo(0);
   }
 
   @Test
   public void equals_returnsFalse_givenDifferentExpirationTimes() {
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
     o1.setExpirationTimestampNoDelta(1000);
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
     o2.setExpirationTimestampNoDelta(999);
     assertThat(o1).isNotEqualTo(o2);
   }
 
   @Test
   public void equals_returnsFalse_givenDifferentValueBytes() {
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
     o1.setExpirationTimestampNoDelta(1000);
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 2}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 2}));
     o2.setExpirationTimestampNoDelta(1000);
     assertThat(o1).isNotEqualTo(o2);
   }
 
   @Test
   public void equals_returnsTrue_givenEqualValueBytesAndExpiration() {
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
     o1.setExpirationTimestampNoDelta(1000);
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
     o2.setExpirationTimestampNoDelta(1000);
     assertThat(o1).isEqualTo(o2);
   }
@@ -342,14 +342,14 @@ public class RedisStringTest {
   @Test
   public void setExpirationTimestamp_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
     o1.setExpirationTimestamp(region, null, 999);
     assertThat(o1.hasDelta()).isTrue();
     HeapDataOutputStream out = new HeapDataOutputStream(100);
     o1.toDelta(out);
     assertThat(o1.hasDelta()).isFalse();
     ByteArrayDataInput in = new ByteArrayDataInput(out.toByteArray());
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
     assertThat(o2).isNotEqualTo(o1);
     o2.fromDelta(in);
     assertThat(o2).isEqualTo(o1);
@@ -365,7 +365,7 @@ public class RedisStringTest {
   @Test
   public void should_calculateSize_closeToROSSize_ofIndividualInstances() {
     String javaString;
-    for (int i = 0; i < 512; i+=8) {
+    for (int i = 0; i < 512; i += 8) {
       javaString = makeStringOfSpecifiedSize(i);
       RedisString string = new RedisString(new RedisKey(javaString.getBytes()));
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 
+import org.assertj.core.data.Offset;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -35,8 +36,10 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.internal.size.ReflectionObjectSizer;
 
 public class RedisStringTest {
+  private final ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
 
   @BeforeClass
   public static void beforeClass() {
@@ -50,7 +53,7 @@ public class RedisStringTest {
 
   @Test
   public void constructorSetsValue() {
-    ByteArrayWrapper byteArrayWrapper = new ByteArrayWrapper(new byte[] {0, 1, 2});
+    ByteArrayWrapper byteArrayWrapper = new ByteArrayWrapper(new byte[]{0, 1, 2});
     RedisString string = new RedisString(byteArrayWrapper);
     ByteArrayWrapper returnedByteArrayWrapper = string.get();
     assertThat(returnedByteArrayWrapper).isNotNull();
@@ -60,20 +63,20 @@ public class RedisStringTest {
   @Test
   public void setSetsValue() {
     RedisString string = new RedisString();
-    string.set(new ByteArrayWrapper(new byte[] {0, 1, 2}));
+    string.set(new ByteArrayWrapper(new byte[]{0, 1, 2}));
     ByteArrayWrapper returnedByteArrayWrapper = string.get();
     assertThat(returnedByteArrayWrapper).isNotNull();
     assertThat(returnedByteArrayWrapper.value)
-        .isEqualTo(new ByteArrayWrapper(new byte[] {0, 1, 2}).value);
+        .isEqualTo(new ByteArrayWrapper(new byte[]{0, 1, 2}).value);
   }
 
   @Test
   public void getReturnsSetValue() {
-    RedisString string = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
+    RedisString string = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
     ByteArrayWrapper returnedByteArrayWrapper = string.get();
     assertThat(returnedByteArrayWrapper).isNotNull();
     assertThat(returnedByteArrayWrapper.value)
-        .isEqualTo(new ByteArrayWrapper(new byte[] {0, 1}).value);
+        .isEqualTo(new ByteArrayWrapper(new byte[]{0, 1}).value);
   }
 
   @Test
@@ -81,8 +84,8 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisString redisString = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
-    ByteArrayWrapper part2 = new ByteArrayWrapper(new byte[] {2, 3, 4, 5});
+    RedisString redisString = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
+    ByteArrayWrapper part2 = new ByteArrayWrapper(new byte[]{2, 3, 4, 5});
     int redisStringSize = redisString.strlen();
     int part2Size = part2.length();
     int appendedStringSize = redisString.append(part2, region, null);
@@ -94,25 +97,25 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
-    ByteArrayWrapper part2 = new ByteArrayWrapper(new byte[] {2, 3});
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
+    ByteArrayWrapper part2 = new ByteArrayWrapper(new byte[]{2, 3});
     o1.append(part2, region, null);
     assertThat(o1.hasDelta()).isTrue();
-    assertThat(o1.get()).isEqualTo(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
+    assertThat(o1.get()).isEqualTo(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
     HeapDataOutputStream out = new HeapDataOutputStream(100);
     o1.toDelta(out);
     assertThat(o1.hasDelta()).isFalse();
     ByteArrayDataInput in = new ByteArrayDataInput(out.toByteArray());
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
     assertThat(o2).isNotEqualTo(o1);
     o2.fromDelta(in);
-    assertThat(o2.get()).isEqualTo(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
+    assertThat(o2.get()).isEqualTo(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
     assertThat(o2).isEqualTo(o1);
   }
 
   @Test
   public void confirmSerializationIsStable() throws IOException, ClassNotFoundException {
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
     o1.setExpirationTimestampNoDelta(1000);
     HeapDataOutputStream outputStream = new HeapDataOutputStream(100);
     DataSerializer.writeObject(o1, outputStream);
@@ -126,7 +129,7 @@ public class RedisStringTest {
     assertThat(Modifier
         .isSynchronized(RedisString.class
             .getMethod("toData", DataOutput.class, SerializationContext.class).getModifiers()))
-                .isTrue();
+        .isTrue();
   }
 
   @Test
@@ -134,7 +137,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0', ' ', '1'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0', ' ', '1'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incr(region, byteArrayWrapper))
         .isInstanceOf(NumberFormatException.class);
@@ -147,7 +150,7 @@ public class RedisStringTest {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisKey byteArrayWrapper = new RedisKey(
         // max value for signed long
-        new byte[] {'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5',
+        new byte[]{'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5',
             '8', '0', '7'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incr(region, byteArrayWrapper))
@@ -159,7 +162,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.incr(region, byteArrayWrapper);
     assertThat(string.get().toString()).isEqualTo("11");
@@ -170,7 +173,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0', ' ', '1'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0', ' ', '1'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incrby(region, byteArrayWrapper, 2L))
         .isInstanceOf(NumberFormatException.class);
@@ -183,7 +186,7 @@ public class RedisStringTest {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisKey byteArrayWrapper = new RedisKey(
         // max value for signed long
-        new byte[] {'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5',
+        new byte[]{'9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7', '5',
             '8', '0', '7'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incrby(region, byteArrayWrapper, 2L))
@@ -195,7 +198,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.incrby(region, byteArrayWrapper, 2L);
     assertThat(string.get().toString()).isEqualTo("12");
@@ -206,7 +209,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0', ' ', '1'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0', ' ', '1'});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.incrbyfloat(region, byteArrayWrapper, new BigDecimal("1.1")))
         .isInstanceOf(NumberFormatException.class);
@@ -217,7 +220,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.incrbyfloat(region, byteArrayWrapper, new BigDecimal("2.20"));
     assertThat(string.get().toString()).isEqualTo("12.20");
@@ -228,7 +231,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {0});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{0});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.decr(region, byteArrayWrapper))
         .isInstanceOf(NumberFormatException.class);
@@ -240,7 +243,7 @@ public class RedisStringTest {
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisKey byteArrayWrapper = new RedisKey(
-        new byte[] {'-', '9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7',
+        new byte[]{'-', '9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7',
             '5',
             '8', '0', '8'});
     RedisString string = new RedisString(byteArrayWrapper);
@@ -253,7 +256,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.decr(region, byteArrayWrapper);
     assertThat(string.get().toString()).isEqualTo("9");
@@ -264,7 +267,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {1});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{1});
     RedisString string = new RedisString(byteArrayWrapper);
     assertThatThrownBy(() -> string.decrby(region, byteArrayWrapper, 2))
         .isInstanceOf(NumberFormatException.class);
@@ -276,7 +279,7 @@ public class RedisStringTest {
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisKey byteArrayWrapper = new RedisKey(
-        new byte[] {'-', '9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7',
+        new byte[]{'-', '9', '2', '2', '3', '3', '7', '2', '0', '3', '6', '8', '5', '4', '7', '7',
             '5',
             '8', '0', '7'});
     RedisString string = new RedisString(byteArrayWrapper);
@@ -289,7 +292,7 @@ public class RedisStringTest {
     // allows unchecked cast of mock to Region<RedisKey, RedisData>
     @SuppressWarnings("unchecked")
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisKey byteArrayWrapper = new RedisKey(new byte[] {'1', '0'});
+    RedisKey byteArrayWrapper = new RedisKey(new byte[]{'1', '0'});
     RedisString string = new RedisString(byteArrayWrapper);
     string.decrby(region, byteArrayWrapper, 2);
     assertThat(string.get().toString()).isEqualTo("8");
@@ -297,39 +300,39 @@ public class RedisStringTest {
 
   @Test
   public void strlenReturnsStringLength() {
-    RedisString string = new RedisString(new ByteArrayWrapper(new byte[] {1, 2, 3, 4}));
+    RedisString string = new RedisString(new ByteArrayWrapper(new byte[]{1, 2, 3, 4}));
     assertThat(string.strlen()).isEqualTo(4);
   }
 
   @Test
   public void strlenReturnsLengthOfEmptyString() {
-    RedisString string = new RedisString(new ByteArrayWrapper(new byte[] {}));
+    RedisString string = new RedisString(new ByteArrayWrapper(new byte[]{}));
     assertThat(string.strlen()).isEqualTo(0);
   }
 
   @Test
   public void equals_returnsFalse_givenDifferentExpirationTimes() {
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
     o1.setExpirationTimestampNoDelta(1000);
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
     o2.setExpirationTimestampNoDelta(999);
     assertThat(o1).isNotEqualTo(o2);
   }
 
   @Test
   public void equals_returnsFalse_givenDifferentValueBytes() {
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
     o1.setExpirationTimestampNoDelta(1000);
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 2}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 2}));
     o2.setExpirationTimestampNoDelta(1000);
     assertThat(o1).isNotEqualTo(o2);
   }
 
   @Test
   public void equals_returnsTrue_givenEqualValueBytesAndExpiration() {
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
     o1.setExpirationTimestampNoDelta(1000);
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1, 2, 3}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1, 2, 3}));
     o2.setExpirationTimestampNoDelta(1000);
     assertThat(o1).isEqualTo(o2);
   }
@@ -339,14 +342,14 @@ public class RedisStringTest {
   @Test
   public void setExpirationTimestamp_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = mock(Region.class);
-    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
+    RedisString o1 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
     o1.setExpirationTimestamp(region, null, 999);
     assertThat(o1.hasDelta()).isTrue();
     HeapDataOutputStream out = new HeapDataOutputStream(100);
     o1.toDelta(out);
     assertThat(o1.hasDelta()).isFalse();
     ByteArrayDataInput in = new ByteArrayDataInput(out.toByteArray());
-    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[] {0, 1}));
+    RedisString o2 = new RedisString(new ByteArrayWrapper(new byte[]{0, 1}));
     assertThat(o2).isNotEqualTo(o1);
     o2.fromDelta(in);
     assertThat(o2).isEqualTo(o1);
@@ -356,5 +359,46 @@ public class RedisStringTest {
   public void overheadConstants_shouldNotChange_withoutForethoughtAndTesting() {
     assertThat(RedisString.PER_OBJECT_OVERHEAD).isEqualTo(8);
     assertThat(RedisString.getPerStringOverhead()).isEqualTo(RedisString.PER_STRING_OVERHEAD);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void should_calculateSize_closeToROSSize_ofIndividualInstances() {
+    String javaString;
+    for (int i = 0; i < 512; i+=8) {
+      javaString = makeStringOfSpecifiedSize(i);
+      RedisString string = new RedisString(new RedisKey(javaString.getBytes()));
+
+      int expected = reflectionObjectSizer.sizeof(string);
+      Long actual = Long.valueOf(string.getSizeInBytes());
+      Offset<Long> offset = Offset.offset(Math.round(expected * 0.05));
+
+      assertThat(actual).isCloseTo(expected, offset);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void should_calculateSize_closeToROSSize_ofLargeStrings() {
+    String javaString = makeStringOfSpecifiedSize(10_000);
+
+    RedisKey byteArrayWrapper = new RedisKey(javaString.getBytes());
+    RedisString string = new RedisString(byteArrayWrapper);
+
+    Long actual = Long.valueOf(string.getSizeInBytes());
+    int expected = reflectionObjectSizer.sizeof(string);
+    Offset<Long> offset = Offset.offset(Math.round(expected * 0.05));
+
+    assertThat(actual).isEqualTo(expected);
+    assertThat(actual).isCloseTo(expected, offset);
+  }
+
+  private String makeStringOfSpecifiedSize(final int stringSize) {
+    StringBuffer sb = new StringBuffer(stringSize);
+    for (int i = 0; i < stringSize; i++) {
+      sb.append("a");
+    }
+    String javaString = sb.toString();
+    return javaString;
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
@@ -389,7 +389,6 @@ public class RedisStringTest {
     int expected = reflectionObjectSizer.sizeof(string);
     Offset<Long> offset = Offset.offset(Math.round(expected * 0.05));
 
-    assertThat(actual).isEqualTo(expected);
     assertThat(actual).isCloseTo(expected, offset);
   }
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
@@ -359,7 +359,7 @@ public class RedisStringTest {
   /******* constructors *******/
   @SuppressWarnings("unchecked")
   @Test
-  public void should_calculateSize_closeToROSSize_ofLargeStrings() {
+  public void should_calculateSize_equalToROSSize_ofLargeStrings() {
     String javaString = makeStringOfSpecifiedSize(10_000);
     RedisString string = new RedisString(new ByteArrayWrapper(javaString.getBytes()));
 
@@ -371,7 +371,7 @@ public class RedisStringTest {
 
   @SuppressWarnings("unchecked")
   @Test
-  public void should_calculateSize_closeToROSSize_ofStringOfVariousSizes() {
+  public void should_calculateSize_equalToROSSize_ofStringOfVariousSizes() {
     String javaString;
     for (int i = 0; i < 512; i += 8) {
       javaString = makeStringOfSpecifiedSize(i);
@@ -428,8 +428,6 @@ public class RedisStringTest {
   /******* constants *******/
   @Test
   public void overheadConstants_shouldMatchCalculatedValue() {
-    assertThat(RedisString.PER_OBJECT_OVERHEAD).isEqualTo(8); // see todo in RedisString
-
     RedisString redisString = new RedisString(new ByteArrayWrapper("".getBytes()));
     int calculatedSize = reflectionObjectSizer.sizeof(redisString);
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
@@ -357,7 +357,6 @@ public class RedisStringTest {
 
   /************* Size in Bytes Tests *************/
   /******* constructors *******/
-  @SuppressWarnings("unchecked")
   @Test
   public void should_calculateSize_equalToROSSize_ofLargeStrings() {
     String javaString = makeStringOfSpecifiedSize(10_000);
@@ -369,7 +368,6 @@ public class RedisStringTest {
     assertThat(actual).isEqualTo(expected);
   }
 
-  @SuppressWarnings("unchecked")
   @Test
   public void should_calculateSize_equalToROSSize_ofStringOfVariousSizes() {
     String javaString;
@@ -426,6 +424,10 @@ public class RedisStringTest {
   }
 
   /******* constants *******/
+  // this test contains the math that was used to derive the constants in RedisString. If this test
+  // starts failing, it is because the overhead of RedisString has changed. If it has decreased,
+  // good job! You can change the constant in RedisString to reflect that. If it has increased,
+  // carefully consider that increase before changing the constant.
   @Test
   public void overheadConstants_shouldMatchCalculatedValue() {
     RedisString redisString = new RedisString(new ByteArrayWrapper("".getBytes()));

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
@@ -351,4 +351,10 @@ public class RedisStringTest {
     o2.fromDelta(in);
     assertThat(o2).isEqualTo(o1);
   }
+
+  @Test
+  public void overheadConstants_shouldNotChange_withoutForethoughtAndTesting() {
+    assertThat(RedisString.PER_OBJECT_OVERHEAD).isEqualTo(8);
+    assertThat(RedisString.getPerStringOverhead()).isEqualTo(RedisString.PER_STRING_OVERHEAD);
+  }
 }


### PR DESCRIPTION
- make RedisData implement Sizeable
- reimplement delta force recalculate size
- add tests for hash add/remove/edit wo size change
- add tests for string add/append/remove/edit wo size change
- add tests for set add/remove/edit wo size change
- add tests to verify our math is right
- keep track of the data size as part of RedisHash, RedisString,
  and RedisSet

Signed-off-by: Ray Ingles <ringles@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
