### PR TITLE
GEODE-9068: Follow-up to APIs compatible with Redis doc update 

### DIFF
--- a/geode-book/master_middleman/source/subnavs/geode-subnav.erb
+++ b/geode-book/master_middleman/source/subnavs/geode-subnav.erb
@@ -2215,7 +2215,7 @@ gfsh</a>
                                 <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/geode_apis_compatible_with_redis.html#supported-commands">Supported Redis Commands</a>
                             </li>
                             <li>
-                                <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/geode_apis_compatible_with_redis#advantages-over-redis">Advantages of <%=vars.product_name%> over Redis</a>
+                                <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/geode_apis_compatible_with_redis.html#advantages-over-redis">Advantages of <%=vars.product_name%> over Redis</a>
                             </li>
                             <li>
                                 <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/geode_apis_compatible_with_redis.html#expiration-accuracy">Expiration Accuracy</a>


### PR DESCRIPTION
Fixes one bad link in the user guide left-hand navigation panel.
Eliminates 537 warnings when generating the user guide.

