### PR TITLE
GEODE-9141: Hang while shutting down a cache server due to corrupted message

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/tcp/ConnectionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/tcp/ConnectionIntegrationTest.java
@@ -41,7 +41,6 @@ import org.mockito.junit.MockitoRule;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.net.SocketCloser;
 import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.junit.categories.MembershipTest;
@@ -91,9 +90,6 @@ public class ConnectionIntegrationTest {
 
     when(connectionTable.getConduit()).thenReturn(tcpConduit);
     when(tcpConduit.getSocketId()).thenReturn(new InetSocketAddress("localhost", 1234));
-    when(config.getEnableNetworkPartitionDetection()).thenReturn(false);
-    when(tcpConduit.getConfig()).thenReturn(config);
-    when(tcpConduit.getMemberId()).thenReturn(new InternalDistributedMember("localhost", 2345));
     when(connectionTable.getSocketCloser()).thenReturn(mock(SocketCloser.class));
 
     Connection connection = new Connection(connectionTable, socket);

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
@@ -296,17 +296,16 @@ public class BufferPool {
     throw new IllegalArgumentException("Unexpected buffer type " + type.toString());
   }
 
-
   /**
    * Releases a previously acquired buffer.
    */
   private void releaseBuffer(ByteBuffer buffer, boolean send) {
     if (buffer.isDirect()) {
-      buffer = getPoolableBuffer(buffer);
-      BBSoftReference bbRef = new BBSoftReference(buffer, send);
-      if (buffer.capacity() <= SMALL_BUFFER_SIZE) {
+      ByteBuffer poolableBuffer = getPoolableBuffer(buffer);
+      BBSoftReference bbRef = new BBSoftReference(poolableBuffer, send);
+      if (poolableBuffer.capacity() <= SMALL_BUFFER_SIZE) {
         bufferSmallQueue.offer(bbRef);
-      } else if (buffer.capacity() <= MEDIUM_BUFFER_SIZE) {
+      } else if (poolableBuffer.capacity() <= MEDIUM_BUFFER_SIZE) {
         bufferMiddleQueue.offer(bbRef);
       } else {
         bufferLargeQueue.offer(bbRef);


### PR DESCRIPTION
The corruption is occurring because another thread was using the same ByteBuffer to
perform a handshake on a new Connection and was still in
SocketChannel.read().  The thread initiating the handshake was
interrupted by CacheServer.close() and released the buffer prematurely,
allowing another thread to grab the still in-use buffer and serialize
a message into it.  The handshake thread's SocketChannel.read()
overwrites some of the content of the buffer before it is transmitted.

The fix is to include the input buffer as state that needs to be
protected by the stateLock and allow the handshake thread to retain
ownership of the buffer, releasing it in it's cleanup code.

I also deleted some very old checks for an IBM JRE that is no longer
required and was interfering with efforts to write a unit test.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
