### PR TITLE
GEODE-9161: Fix simple Gradle 7 warnings

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -28,7 +28,7 @@ repositories {
 }
 
 dependencies {
-  testRuntime('org.apache.geode:geode-junit:1.3.0') {
+  testRuntimeOnly('org.apache.geode:geode-junit:1.3.0') {
     exclude group: 'org.apache.logging.log4j'
   }
   implementation(gradleApi())

--- a/extensions/geode-modules-session/build.gradle
+++ b/extensions/geode-modules-session/build.gradle
@@ -24,11 +24,11 @@ evaluationDependsOn(":geode-core")
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':extensions:geode-modules-session-internal')) {
+  api(platform(project(':boms:geode-all-bom')))
+  api(project(':extensions:geode-modules-session-internal')) {
     exclude module: 'geode-modules'
   }
-  compile(project(':geode-core'))
+  api(project(':geode-core'))
   implementation(project(':geode-common'))
 
   integrationTestImplementation(project(':extensions:geode-modules'))

--- a/extensions/session-testing-war/build.gradle
+++ b/extensions/session-testing-war/build.gradle
@@ -22,11 +22,11 @@ apply plugin: 'war'
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   implementation('javax.servlet:javax.servlet-api')
   implementation(project(':geode-deployment:geode-deployment-legacy'))
 }
 
 war {
-    version = ''
+    archiveVersion = ''
 }

--- a/geode-apis-compatible-with-redis/build.gradle
+++ b/geode-apis-compatible-with-redis/build.gradle
@@ -29,7 +29,7 @@ facets {
 }
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   implementation(project(':geode-serialization'))
   implementation(project(':geode-logging'))
   implementation(project(':geode-core'))
@@ -57,7 +57,7 @@ dependencies {
   integrationTestImplementation('org.apache.logging.log4j:log4j-core')
   // This only exists for debugging PubSubNativeRedisAcceptanceTest
   integrationTestImplementation('org.buildobjects:jproc:2.5.1')
-  integrationTestRuntime(project(':geode-log4j'))
+  integrationTestRuntimeOnly(project(':geode-log4j'))
 
   acceptanceTestImplementation(sourceSets.integrationTest.output)
   acceptanceTestImplementation(sourceSets.distributedTest.output)
@@ -66,7 +66,7 @@ dependencies {
   acceptanceTestImplementation(project(':geode-junit'))
   acceptanceTestImplementation('redis.clients:jedis')
   acceptanceTestImplementation('org.testcontainers:testcontainers')
-  acceptanceTestRuntime(project(':geode-log4j'))
+  acceptanceTestRuntimeOnly(project(':geode-log4j'))
   acceptanceTestImplementation('org.springframework.boot:spring-boot-starter-web') {
     exclude module: 'spring-boot-starter-tomcat'
   }

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -637,7 +637,7 @@ tasks.named('srcDistTar').configure {
 
 tasks.withType(Test) {
   dependsOn installDist
-  environment 'GEODE_HOME', "$buildDir/install/${distributions.main.distributionBaseName}"
+  environment 'GEODE_HOME', "$buildDir/install/${distributions.main.baseName}"
 }
 
 

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -163,7 +163,7 @@ task downloadWebServers(type:Copy) {
 }
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   gfshDependencies(platform(project(':boms:geode-all-bom')))
 
   dependentProjectNames.each {
@@ -217,7 +217,7 @@ dependencies {
   integrationTestImplementation('javax.annotation:javax.annotation-api')
   integrationTestImplementation('javax.servlet:javax.servlet-api')
 
-  integrationTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+  integrationTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
   integrationTestRuntimeOnly('io.swagger:swagger-annotations')
   // these two modules are for testing only
@@ -302,7 +302,7 @@ dependencies {
   upgradeTestRuntimeOnly(project(':extensions:session-testing-war'))
   upgradeTestRuntimeOnly('org.codehaus.cargo:cargo-core-uberjar')
   upgradeTestRuntimeOnly('org.apache.httpcomponents:httpclient')
-  upgradeTestRuntime files({ downloadWebServers } )
+  upgradeTestRuntimeOnly files({ downloadWebServers } )
 
   //Web servers used for session module testing
   webServerTomcat6('apache:tomcat:' + DependencyConstraints.get('tomcat6.version') + '@zip')
@@ -494,7 +494,7 @@ tasks.register('docs', Javadoc) {
 
 distributions {
   src {
-    baseName = 'apache-geode'
+    distributionBaseName = 'apache-geode'
     contents {
       from rootProject.tasks.writeBuildInfo
       from (rootDir) {
@@ -534,7 +534,7 @@ distributions {
     }
   }
   named('main') {
-    baseName = 'apache-geode'
+    distributionBaseName = 'apache-geode'
     contents {
       duplicatesStrategy 'exclude'
       exclude '*.asc'
@@ -637,7 +637,7 @@ tasks.named('srcDistTar').configure {
 
 tasks.withType(Test) {
   dependsOn installDist
-  environment 'GEODE_HOME', "$buildDir/install/${distributions.main.baseName}"
+  environment 'GEODE_HOME', "$buildDir/install/${distributions.main.distributionBaseName}"
 }
 
 

--- a/geode-assembly/geode-assembly-test/build.gradle
+++ b/geode-assembly/geode-assembly-test/build.gradle
@@ -21,7 +21,7 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   compileOnly(project(':extensions:geode-modules-test'))
   compileOnly(project(':geode-core'))
   compileOnly(project(':geode-pulse'))

--- a/geode-concurrency-test/build.gradle
+++ b/geode-concurrency-test/build.gradle
@@ -21,7 +21,7 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 apply from: "${project.projectDir}/../gradle/warnings.gradle"
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   implementation('junit:junit')
   implementation('org.apache.logging.log4j:log4j-api')
   integrationTestImplementation('org.assertj:assertj-core')

--- a/geode-connectors/build.gradle
+++ b/geode-connectors/build.gradle
@@ -48,7 +48,7 @@ task downloadJdbcJars(type:Copy) {
 }
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
 
   implementation(project(':geode-logging'))
   implementation(project(':geode-serialization'))

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -325,7 +325,7 @@ dependencies {
     api(project(':geode-management'))
 
 
-    jcaCompile(sourceSets.main.output)
+    jcaImplementation(sourceSets.main.output)
 
     testImplementation(project(':geode-junit')) {
         exclude module: 'geode-core'
@@ -341,11 +341,11 @@ dependencies {
 
     testImplementation(files("${System.getProperty('java.home')}/../lib/tools.jar"))
 
-    testRuntime('commons-collections:commons-collections')
-    testRuntime('commons-configuration:commons-configuration')
-    testRuntime('commons-io:commons-io')
-    testRuntime('commons-validator:commons-validator')
-    testRuntime('com.pholser:junit-quickcheck-generators')
+    testRuntimeOnly('commons-collections:commons-collections')
+    testRuntimeOnly('commons-configuration:commons-configuration')
+    testRuntimeOnly('commons-io:commons-io')
+    testRuntimeOnly('commons-validator:commons-validator')
+    testRuntimeOnly('com.pholser:junit-quickcheck-generators')
 
     // Needed for JDK8, not JDK11, after nebula.facet v7.0.9
     integrationTestImplementation(files("${System.getProperty('java.home')}/../lib/tools.jar"))
@@ -359,7 +359,7 @@ dependencies {
     integrationTestImplementation('pl.pragmatists:JUnitParams')
     integrationTestImplementation('com.tngtech.archunit:archunit-junit4')
 
-    integrationTestRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+    integrationTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
     integrationTestRuntimeOnly('org.apache.derby:derby')
     integrationTestRuntimeOnly('xerces:xercesImpl')

--- a/geode-dunit/build.gradle
+++ b/geode-dunit/build.gradle
@@ -21,7 +21,7 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   implementation(project(':geode-logging'))
   implementation(project(':geode-serialization'))
   implementation(project(':geode-membership'))
@@ -32,7 +32,7 @@ dependencies {
     exclude module: 'geode-core'
   }
 
-  compile(project(':geode-junit')) {
+  api(project(':geode-junit')) {
     exclude module: 'geode-core'
   }
 

--- a/geode-http-service/build.gradle
+++ b/geode-http-service/build.gradle
@@ -21,7 +21,7 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 apply from: "${project.projectDir}/../gradle/warnings.gradle"
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   implementation(project(':geode-logging'))
 
   implementation('org.apache.logging.log4j:log4j-api')

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -21,7 +21,7 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
 
   testImplementation(project(':geode-common'))
   compileOnly(project(':geode-core'))
@@ -59,7 +59,7 @@ dependencies {
 
   testImplementation('pl.pragmatists:JUnitParams')
 
-  testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+  testRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
 }
 
 test {

--- a/geode-logging/build.gradle
+++ b/geode-logging/build.gradle
@@ -21,7 +21,7 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 apply from: "${project.projectDir}/../gradle/warnings.gradle"
 
 dependencies {
-    compile(platform(project(':boms:geode-all-bom')))
+    api(platform(project(':boms:geode-all-bom')))
 
     // Geode-common has annotations and other pieces used by geode-logging
     api(project(':geode-common'))
@@ -37,7 +37,7 @@ dependencies {
     testImplementation('junit:junit')
     testImplementation('org.assertj:assertj-core')
 
-    testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+    testRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
     integrationTestImplementation(project(':geode-junit')) {
         exclude module: 'geode-logging'

--- a/geode-lucene/geode-lucene-test/build.gradle
+++ b/geode-lucene/geode-lucene-test/build.gradle
@@ -21,11 +21,11 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   implementation('org.apache.lucene:lucene-core')
   implementation(project(':geode-logging'))
   implementation(project(':geode-serialization'))
-  compile(project(':geode-core'))
+  api(project(':geode-core'))
   compileOnly(project(':geode-lucene'))
 
   implementation('junit:junit')

--- a/geode-management/build.gradle
+++ b/geode-management/build.gradle
@@ -21,7 +21,7 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 apply from: "${project.projectDir}/../gradle/warnings.gradle"
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   implementation('org.apache.commons:commons-lang3')
   implementation('commons-io:commons-io')
   implementation('com.fasterxml.jackson.core:jackson-databind')

--- a/geode-membership/build.gradle
+++ b/geode-membership/build.gradle
@@ -20,7 +20,7 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 
 dependencies {
-    compile(platform(project(':boms:geode-all-bom')))
+    api(platform(project(':boms:geode-all-bom')))
 
     // Geode-common has annotations and other pieces used by geode-logging
     api(project(':geode-common'))
@@ -48,7 +48,7 @@ dependencies {
     testImplementation('org.assertj:assertj-core')
     testImplementation('com.tngtech.archunit:archunit-junit4')
 
-    testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+    testRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
 
     integrationTestImplementation(project(':geode-junit'))

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -26,7 +26,7 @@ apply from: "${project.projectDir}/../gradle/warnings.gradle"
 jar.enabled = true
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   compileOnly(platform(project(':boms:geode-all-bom')))
   providedCompile(platform(project(':boms:geode-all-bom')))
 

--- a/geode-pulse/geode-pulse-test/build.gradle
+++ b/geode-pulse/geode-pulse-test/build.gradle
@@ -19,7 +19,7 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 apply from: "${rootDir}/${scriptDir}/warnings.gradle"
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   implementation('org.awaitility:awaitility')
   implementation('junit:junit')
   implementation('org.eclipse.jetty:jetty-server')
@@ -30,10 +30,10 @@ dependencies {
     ext.optional = true
   }
 
-  compile(project(':geode-core'))
-  compile(project(':geode-membership'))
-  compile(project(':geode-http-service'))
-  compile(project(':geode-junit')) {
+  api(project(':geode-core'))
+  api(project(':geode-membership'))
+  api(project(':geode-http-service'))
+  api(project(':geode-junit')) {
     exclude module: 'geode-core'
   }
   compileOnly(project(':geode-pulse'))

--- a/geode-rebalancer/build.gradle
+++ b/geode-rebalancer/build.gradle
@@ -22,8 +22,8 @@ apply from: "${project.projectDir}/../gradle/warnings.gradle"
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
-  compile(project(':geode-core'))
+  api(platform(project(':boms:geode-all-bom')))
+  api(project(':geode-core'))
   implementation(project(':geode-serialization'))
   implementation(project(':geode-logging'))
   integrationTestImplementation(project(':geode-junit')) {

--- a/geode-serialization/build.gradle
+++ b/geode-serialization/build.gradle
@@ -43,7 +43,7 @@ dependencies {
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')
 
-  testRuntime(project(path: ':geode-old-versions', configuration: 'testOutput'))
+  testRuntimeOnly(project(path: ':geode-old-versions', configuration: 'testOutput'))
 
   integrationTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-serialization'

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -21,7 +21,7 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
   compileOnly(platform(project(':boms:geode-all-bom')))
 
 

--- a/geode-web-api/build.gradle
+++ b/geode-web-api/build.gradle
@@ -29,7 +29,7 @@ configurations {
 }
 
 dependencies {
-  compile(platform(project(':boms:geode-all-bom'))){
+  api(platform(project(':boms:geode-all-bom'))){
     exclude module: "jackson-annotations"
   }
 

--- a/geode-web-management/build.gradle
+++ b/geode-web-management/build.gradle
@@ -48,7 +48,7 @@ configurations {
   war {}
 }
 dependencies {
-  compile(platform(project(':boms:geode-all-bom'))) {
+  api(platform(project(':boms:geode-all-bom'))) {
     exclude module: "jackson-annotations"
   }
   compileOnly(project(':geode-logging'))

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -59,13 +59,13 @@ dependencies {
 
   integrationTestImplementation(project(':geode-dunit'));
 
-  integrationTestRuntimeOnly(files(war.destinationDir))
+  integrationTestRuntimeOnly(files(war.destinationDirectory))
 
   distributedTestImplementation(project(':geode-common'))
   distributedTestImplementation(project(':geode-dunit'))
   distributedTestImplementation('pl.pragmatists:JUnitParams')
 
-  distributedTestRuntimeOnly(files(war.destinationDir))
+  distributedTestRuntimeOnly(files(war.destinationDirectory))
 
   upgradeTestImplementation(project(':geode-dunit')) {
   }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -106,7 +106,7 @@ gradle.taskGraph.whenReady({ graph ->
         attributes.put("Manifest-Version", "1.0")
         attributes.put("Created-By", System.getProperty("user.name"))
         attributes.put("Title", rootProject.name)
-        attributes.put("Version", version)
+        attributes.put("Version", archiveVersion)
         attributes.put("Organization", productOrg)
         attributes.put("Class-Path", runtimeList.join(' '))
         attributes.put("Dependent-Modules", projectDependencies.collect({ "${it.name}-${it.version}" }).join(' '))
@@ -133,7 +133,7 @@ configurations {
 // be created as libs/foo-sources.jar instead of libs/extensions/foo-sources.jar for example.
 tasks.all { task ->
   if (task instanceof Jar) {
-    baseName = project.name
+    archiveBaseName = project.name
   }
 }
 

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -75,7 +75,7 @@ dependencies {
     transitive = false
   }
 
-  testRuntime('cglib:cglib:' + DependencyConstraints.get('cglib.version')) {
+  testRuntimeOnly('cglib:cglib:' + DependencyConstraints.get('cglib.version')) {
     exclude module: 'org.apache.ant'
   }
 }


### PR DESCRIPTION
- testRuntime to testRuntimeOnly
- some compile to api
- version to archiveVersion
- basename to distributionbasename

Authored-by: M. Oleske <michael@oleske.engineer>

This does not fix all Gradle 7 warnings, but figured a start was better than no start.  I have checked the "Allow edits and access to secrets by maintainers" box, so if there is something else you see that you want to fix, please collaborated and push to this branch.  You can do this without me needing to grant you access to my fork directly.  The other fixes require actual thought to fix instead of just not using the deprecated name.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
