### PR TITLE
GEODE-9128: Remove host name look-up from JGAddress (#6298)

### DIFF
--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGAddress.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGAddress.java
@@ -91,9 +91,9 @@ public class JGAddress extends UUID {
     StringBuilder sb = new StringBuilder();
 
     if (ip_addr == null)
-      sb.append("<null>");
+      sb.append("<no address>");
     else {
-      sb.append(ip_addr.getHostName());
+      sb.append(ip_addr);
     }
     if (vmViewId >= 0) {
       sb.append("<v").append(vmViewId).append('>');

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/JGroupsMessenger.java
@@ -335,7 +335,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     try {
       Object oldDSMembershipInfo = services.getConfig().getOldMembershipInfo();
       if (oldDSMembershipInfo != null) {
-        logger.debug("Reusing JGroups channel from previous system", properties);
+        if (logger.isDebugEnabled()) {
+          logger.debug("Reusing JGroups channel from previous system", properties);
+        }
         MembershipInformationImpl oldInfo = (MembershipInformationImpl) oldDSMembershipInfo;
         myChannel = oldInfo.getChannel();
         queuedMessagesFromReconnect = oldInfo.getQueuedMessages();
@@ -360,7 +362,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
         }
         reconnecting = true;
       } else {
-        logger.debug("JGroups configuration: {}", properties);
+        if (logger.isDebugEnabled()) {
+          logger.debug("JGroups configuration: {}", properties);
+        }
 
         checkForIPv6();
         InputStream is = new ByteArrayInputStream(properties.getBytes("UTF-8"));
@@ -412,7 +416,10 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
   private void checkForIPv6() throws Exception {
     boolean preferIpV6Addr = Boolean.getBoolean("java.net.preferIPv6Addresses");
     if (!preferIpV6Addr) {
-      logger.debug("forcing JGroups to think IPv4 is being used so it will choose an IPv4 address");
+      if (logger.isDebugEnabled()) {
+        logger
+            .debug("forcing JGroups to think IPv4 is being used so it will choose an IPv4 address");
+      }
       Field m = org.jgroups.util.Util.class.getDeclaredField("ip_stack_type");
       m.setAccessible(true);
       m.set(null, org.jgroups.util.StackType.IPv4);
@@ -461,7 +468,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     List<JGAddress> mbrs = v.getMembers().stream().map(JGAddress::new).collect(Collectors.toList());
     ViewId vid = new ViewId(new JGAddress(v.getCoordinator()), v.getViewId());
     View jgv = new View(vid, new ArrayList<>(mbrs));
-    logger.trace("installing view into JGroups stack: {}", jgv);
+    if (logger.isTraceEnabled()) {
+      logger.trace("installing view into JGroups stack: {}", jgv);
+    }
     this.myChannel.down(new Event(Event.VIEW_CHANGE, jgv));
 
     addressesWithIoExceptionsProcessed.clear();
@@ -700,7 +709,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
 
     if (logger.isDebugEnabled() && reliably) {
       String recips = useMcast ? "multicast" : destinations.toString();
-      logger.debug("sending via JGroups: [{}] recipients: {}", msg, recips);
+      if (logger.isDebugEnabled()) {
+        logger.debug("sending via JGroups: [{}] recipients: {}", msg, recips);
+      }
     }
 
     JGAddress local = this.jgAddress;
@@ -725,10 +736,14 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
           jmsg.setFlag(org.jgroups.Message.Flag.NO_RELIABILITY);
         }
         theStats.incSentBytes(jmsg.getLength());
-        logger.trace("Sending JGroups message: {}", jmsg);
+        if (logger.isTraceEnabled()) {
+          logger.trace("Sending JGroups message: {}", jmsg);
+        }
         myChannel.send(jmsg);
       } catch (Exception e) {
-        logger.debug("caught unexpected exception", e);
+        if (logger.isDebugEnabled()) {
+          logger.debug("caught unexpected exception", e);
+        }
         Throwable cause = e.getCause();
         if (cause instanceof MemberDisconnectedException) {
           problem = (Exception) cause;
@@ -815,7 +830,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
           }
           tmp.setDest(to);
           tmp.setSrc(this.jgAddress);
-          logger.trace("Unicasting to {}", to);
+          if (logger.isTraceEnabled()) {
+            logger.trace("Unicasting to {}", to);
+          }
           myChannel.send(tmp);
         } catch (Exception e) {
           problem = e;
@@ -852,7 +869,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     if (newView != null && newView != oldView) {
       for (ID d : destinations) {
         if (!newView.contains(d)) {
-          logger.debug("messenger: member has left the view: {}  view is now {}", d, newView);
+          if (logger.isDebugEnabled()) {
+            logger.debug("messenger: member has left the view: {}  view is now {}", d, newView);
+          }
           failedRecipients.add(d);
         }
       }
@@ -1018,7 +1037,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
     if (messageLength == 0) {
       // jgroups messages with no payload are used for protocol interchange, such
       // as STABLE_GOSSIP
-      logger.trace("message length is zero - ignoring");
+      if (logger.isTraceEnabled()) {
+        logger.trace("message length is zero - ignoring");
+      }
       return null;
     }
 
@@ -1209,7 +1230,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
           try {
             Digest digest = new Digest();
             digest.readFrom(dis);
-            logger.trace("installing JGroups message digest {} from {}", digest, m);
+            if (logger.isTraceEnabled()) {
+              logger.trace("installing JGroups message digest {} from {}", digest, m);
+            }
             this.myChannel.getProtocolStack().getTopProtocol()
                 .down(new Event(Event.MERGE_DIGEST, digest));
             jrsp.setMessengerData(null);
@@ -1411,7 +1434,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
   @Override
   public void setPublicKey(byte[] publickey, ID mbr) {
     if (encrypt != null) {
-      logger.debug("Setting PK for member " + mbr);
+      if (logger.isDebugEnabled()) {
+        logger.debug("Setting PK for member " + mbr);
+      }
       encrypt.setPublicKey(publickey, mbr);
     }
   }
@@ -1419,7 +1444,9 @@ public class JGroupsMessenger<ID extends MemberIdentifier> implements Messenger<
   @Override
   public void setClusterSecretKey(byte[] clusterSecretKey) {
     if (encrypt != null) {
-      logger.debug("Setting cluster key");
+      if (logger.isDebugEnabled()) {
+        logger.debug("Setting cluster key");
+      }
       encrypt.setClusterKey(clusterSecretKey);
     }
   }


### PR DESCRIPTION
(note: the branch for this is misnamed.  It should be feature/GEODE-9128-backport)

toString() was including the host name of the address, which is overkill
for the limited use of JGAddress.  Logging the InetAddress is sufficient to identify
a member.

JGroupsMessenger's logging that included this class wasn't checking the
log level before invoking logDebug() and other methods.  I've added
that.

(cherry picked from commit 8e1c7cdbab0fe806de14355af4dae938f8ddedda)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
