### PR TITLE
GEODE-9153: Fix alpine-tools docker image

### DIFF
--- a/ci/images/alpine-tools/Dockerfile
+++ b/ci/images/alpine-tools/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:latest as winrm-builder
+FROM bellsoft/liberica-openjdk-alpine:8 as winrm-builder
 RUN apk --no-cache add \
     git \
     go \
@@ -38,6 +38,7 @@ RUN apk --no-cache add \
       openssl \
       python3 \
       py3-pip \
+      py3-yaml \
       rsync \
       util-linux \
   && gcloud config set core/disable_usage_reporting true \


### PR DESCRIPTION
* Use same image for builder as deployment
* Add py3-yaml package so python doesn't try to build it.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
