### PR TITLE
Revert "GEODE-9055: drop patch version in docs if 0"

### DIFF
--- a/dev-tools/release/create_support_branches.sh
+++ b/dev-tools/release/create_support_branches.sh
@@ -184,13 +184,13 @@ sed -e "s#/. NOTE: when adding a new version#private static final short GEODE_${
   -i.bak $VER
 
 #  directory: docs/guide/113
-#  product_version: '1.13.2'
+#  product_version: '1.13'
 #  product_version_nodot: '113'
 #  product_version_geode: '1.13'
 #  product_version_old_minor: '1.12'
 sed -E \
     -e "s#docs/guide/[0-9]+#docs/guide/${NEWVERSION_MM_NODOT}#" \
-    -e "s#product_version: '[0-9.]+'#product_version: '${NEWVERSION%.0}'#" \
+    -e "s#product_version: '[0-9.]+'#product_version: '${NEWVERSION_MM}'#" \
     -e "s#version_nodot: '[0-9]+'#version_nodot: '${NEWVERSION_MM_NODOT}'#" \
     -e "s#product_version_geode: '[0-9.]+'#product_version_geode: '${NEWVERSION_MM}'#" \
     -e "s#product_version_old_minor: '[0-9.]+'#product_version_old_minor: '${VERSION_MM}'#" \

--- a/dev-tools/release/set_versions.sh
+++ b/dev-tools/release/set_versions.sh
@@ -121,9 +121,9 @@ set +x
 #version = 1.13.0-build.0
 sed -e "s/^version =.*/version = ${VERSION}${BUILDSUFFIX}/" -i.bak gradle.properties
 
-#  product_version: '1.13.2'
+#  product_version: '1.13'
 sed -E \
-    -e "s#product_version: '[0-9.]+'#product_version: '${VERSION%.0}'#" \
+    -e "s#product_version: '[0-9.]+'#product_version: '${VERSION_MM}'#" \
     -i.bak geode-book/config.yml
 
 #git clone -b branch --depth 1 https://github.com/apache/geode.git geode


### PR DESCRIPTION
docs would prefer product version to just always be major.minor, not sometimes also patch