### PR TITLE
fix CODEOWNERS rule that was intended to match dependencies only, not tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -201,6 +201,7 @@ geode-assembly/**/org/apache/geode/management/**                  @jdeppe-pivota
 geode-assembly/**/org/apache/geode/tools/pulse/**                 @jdeppe-pivotal @jinmeiliao
 geode-web-management/**                                           @jdeppe-pivotal @jinmeiliao
 geode-gfsh/**                                                     @jdeppe-pivotal @jinmeiliao @mhansonp @kirklund
+geode-assembly/**/bin/**                                          @jdeppe-pivotal @jinmeiliao @mhansonp @kirklund
 geode-pulse/**                                                    @jdeppe-pivotal @jinmeiliao @mhansonp
 geode-http-service/**                                             @jdeppe-pivotal @jinmeiliao
 geode-web/**                                                      @jdeppe-pivotal @jinmeiliao
@@ -224,6 +225,7 @@ geode-core/**/org/apache/geode/security/**                        @jdeppe-pivota
 geode-core/**/org/apache/geode/internal/security/**               @jdeppe-pivotal @jinmeiliao
 geode-core/**/org/apache/geode/cache/operations/**                @jdeppe-pivotal @jinmeiliao
 geode-core/**/org/apache/geode/internal/cache/operations/**       @jdeppe-pivotal @jinmeiliao
+geode-assembly/**/apache/geode/ssl/**                             @jdeppe-pivotal @jinmeiliao
 
 #-----------------------------------------------------------------
 # Logging
@@ -274,6 +276,7 @@ geode-junit/**                                                    @mhansonp @kir
 geode-junit/**/org/apache/geode/test/util/**                      @jdeppe-pivotal @onichols-pivotal
 geode-assembly/**/org/apache/geode/test/junit/**                  @jdeppe-pivotal @jinmeiliao
 geode-assembly/**/org/apache/geode/launchers/**                   @dschneider-pivotal @boglesby @kirklund @nabarunnag
+geode-assembly/**/resources/**                                    @boglesby @kirklund @nabarunnag @jdeppe-pivotal @jinmeiliao
 
 #-----------------------------------------------------------------
 # Redis API
@@ -297,6 +300,7 @@ geode-management/src/test/script/update-management-wiki.sh        @onichols-pivo
 static-analysis/**                                                @rhoughton-pivot @onichols-pivotal
 geode-old-versions/**                                             @onichols-pivotal @dickcav
 KEYS                                                              @onichols-pivotal @dickcav
+geode-assembly/**/org/apache/geode/**                             @rhoughton-pivot @onichols-pivotal @dickcav
 assembly_content.txt                                              @rhoughton-pivot @onichols-pivotal
 dependency_classpath.txt                                          @rhoughton-pivot @onichols-pivotal
 expected-pom.xml                                                  @rhoughton-pivot @onichols-pivotal

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -132,11 +132,13 @@ geode-core/**/org/apache/geode/cache/query/**                     @nabarunnag @D
 #-----------------------------------------------------------------
 extensions/**                                                     @sabbey37 @jdeppe-pivotal @BenjaminPerryRoss
 geode-core/**/org/apache/geode/internal/modules/util/**           @sabbey37 @jdeppe-pivotal @BenjaminPerryRoss
+geode-assembly/**/org/apache/geode/session/**                     @sabbey37 @jdeppe-pivotal @BenjaminPerryRoss
 
 #-----------------------------------------------------------------
 # DEV rest API
 #-----------------------------------------------------------------
 geode-web-api/**                                                  @jdeppe-pivotal @jinmeiliao
+geode-assembly/**/org/apache/geode/rest/**                        @jdeppe-pivotal @jinmeiliao
 
 #-----------------------------------------------------------------
 # Lucene integration
@@ -192,6 +194,7 @@ geode-core/**/org/apache/geode/internal/cache/wan/**              @gesterzhou @b
 # Management
 #-----------------------------------------------------------------
 geode-management/**                                               @jdeppe-pivotal @jinmeiliao
+geode-assembly/**/org/apache/geode/management/**                  @jdeppe-pivotal @jinmeiliao
 geode-web-management/**                                           @jdeppe-pivotal @jinmeiliao
 geode-gfsh/**                                                     @jdeppe-pivotal @jinmeiliao @mhansonp @kirklund
 geode-pulse/**                                                    @jdeppe-pivotal @jinmeiliao @mhansonp

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -50,14 +50,14 @@ geode-core/**/org/apache/geode/distributed/internal/*             @echobravopapa
 #-----------------------------------------------------------------
 geode-core/**/org/apache/geode/cache/client/**                    @echobravopapa @Bill @kirklund
 geode-core/**/org/apache/geode/cache/server/**                    @echobravopapa @Bill @kirklund
-geode-core/**/org/apache/geode/internal/cache/client/**           @Bill @echobravopapa
+geode-core/**/org/apache/geode/cache/client/internal/**           @Bill @echobravopapa
 geode-core/**/org/apache/geode/internal/cache/tier/**             @Bill @echobravopapa @agingade
 
 #-----------------------------------------------------------------
 # Client Queues
 #-----------------------------------------------------------------
 geode-core/**/org/apache/geode/internal/cache/ha/**               @agingade @boglesby @nabarunnag
-geode-core/**/org/apache/geode/internal/cache/tier/CacheClient*   @agingade @boglesby @nabarunnag
+geode-core/**/org/apache/geode/internal/cache/**/CacheClient*     @agingade @boglesby @nabarunnag
 
 #-----------------------------------------------------------------
 # Core Public API packages - Cache, Region, etc.
@@ -262,7 +262,7 @@ geode-core/**/org/apache/geode/internal/cache/control/**          @kirklund @Don
 geode-dunit/**                                                    @mhansonp @kirklund
 geode-junit/**                                                    @mhansonp @kirklund
 #geode-jmh/**
-geode-junit/**/org/apache/geode/test/util                         @jdeppe-pivotal @onichols-pivotal
+geode-junit/**/org/apache/geode/test/util/**                      @jdeppe-pivotal @onichols-pivotal
 
 #-----------------------------------------------------------------
 # Redis API

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -266,6 +266,7 @@ geode-dunit/**                                                    @mhansonp @kir
 geode-junit/**                                                    @mhansonp @kirklund
 #geode-jmh/**
 geode-junit/**/org/apache/geode/test/util/**                      @jdeppe-pivotal @onichols-pivotal
+geode-assembly/**/org/apache/geode/test/junit/**                  @jdeppe-pivotal @jinmeiliao
 
 #-----------------------------------------------------------------
 # Redis API

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -198,6 +198,7 @@ geode-assembly/**/apache/geode/cache/wan/**                       @gesterzhou @b
 #-----------------------------------------------------------------
 geode-management/**                                               @jdeppe-pivotal @jinmeiliao
 geode-assembly/**/org/apache/geode/management/**                  @jdeppe-pivotal @jinmeiliao
+geode-assembly/**/org/apache/geode/tools/pulse/**                 @jdeppe-pivotal @jinmeiliao
 geode-web-management/**                                           @jdeppe-pivotal @jinmeiliao
 geode-gfsh/**                                                     @jdeppe-pivotal @jinmeiliao @mhansonp @kirklund
 geode-pulse/**                                                    @jdeppe-pivotal @jinmeiliao @mhansonp
@@ -234,6 +235,7 @@ geode-core/**/org/apache/geode/internal/logging/**                @mhansonp @kir
 geode-core/**/org/apache/geode/i18n/**                            @agingade @kirklund
 geode-core/**/org/apache/geode/internal/i18n/**                   @agingade @kirklund
 geode-core/**/org/apache/geode/internal/io/**                     @agingade @kirklund
+geode-assembly/**/org/apache/geode/logging/**                     @agingade @kirklund
 
 #-----------------------------------------------------------------
 # Metrics & Statistics
@@ -241,6 +243,7 @@ geode-core/**/org/apache/geode/internal/io/**                     @agingade @kir
 geode-core/**/org/apache/geode/internal/statistics/**             @mhansonp @kirklund
 geode-core/**/org/apache/geode/internal/stats50/**                @mhansonp @kirklund
 geode-core/**/org/apache/geode/metrics/**                         @mhansonp @kirklund
+geode-assembly/**/org/apache/geode/metrics/**                     @mhansonp @kirklund
 
 #-----------------------------------------------------------------
 # Region Snapshots
@@ -270,7 +273,7 @@ geode-junit/**                                                    @mhansonp @kir
 #geode-jmh/**
 geode-junit/**/org/apache/geode/test/util/**                      @jdeppe-pivotal @onichols-pivotal
 geode-assembly/**/org/apache/geode/test/junit/**                  @jdeppe-pivotal @jinmeiliao
-geode-assembly/**/org/apache/geode/launchers                      @dschneider-pivotal @boglesby @kirklund @nabarunnag
+geode-assembly/**/org/apache/geode/launchers/**                   @dschneider-pivotal @boglesby @kirklund @nabarunnag
 
 #-----------------------------------------------------------------
 # Redis API

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -295,7 +295,7 @@ expected-pom.xml                                                  @rhoughton-piv
 #-----------------------------------------------------------------
 BUILDING.md                                                       @rhoughton-pivot @upthewaterspout
 CODE_OF_CONDUCT.md                                                @upthewaterspout @pivotal-amurmann @nonbinaryprogrammer
-LICENSE                                                           @onichols-pivotal @dickcav @metatype
-NOTICE                                                            @onichols-pivotal @dickcav @metatype
+LICENSE                                                           @onichols-pivotal @dickcav
+NOTICE                                                            @onichols-pivotal @dickcav
 /README.md                                                        @upthewaterspout @pivotal-amurmann
 #TESTING.md

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -175,6 +175,7 @@ geode-unsafe/**                                                   @nabarunnag @b
 geode-core/**/org/apache/geode/cache/persistence/**               @dschneider-pivotal @jchen21 @upthewaterspout @gesterzhou
 geode-core/**/org/apache/geode/internal/cache/persistence/**      @dschneider-pivotal @jchen21 @upthewaterspout @gesterzhou
 geode-core/**/org/apache/geode/internal/cache/backup/**           @dschneider-pivotal @agingade @jchen21 @upthewaterspout @gesterzhou
+geode-assembly/**/org/apache/geode/cache/persistence/**           @dschneider-pivotal @jchen21 @upthewaterspout @gesterzhou
 
 #-----------------------------------------------------------------
 # Region Version Vectors - used for sychronization on
@@ -189,6 +190,7 @@ geode-wan/**                                                      @gesterzhou @b
 geode-core/**/org/apache/geode/cache/asyncqueue/**                @gesterzhou @boglesby @nabarunnag
 geode-core/**/org/apache/geode/cache/wan/**                       @gesterzhou @boglesby @nabarunnag
 geode-core/**/org/apache/geode/internal/cache/wan/**              @gesterzhou @boglesby @nabarunnag
+geode-assembly/**/apache/geode/cache/wan/**                       @gesterzhou @boglesby @nabarunnag
 
 #-----------------------------------------------------------------
 # Management

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -286,7 +286,9 @@ geode-management/src/test/script/update-management-wiki.sh        @onichols-pivo
 static-analysis/**                                                @rhoughton-pivot @onichols-pivotal
 geode-old-versions/**                                             @onichols-pivotal @dickcav
 KEYS                                                              @onichols-pivotal @dickcav
-geode-assembly/**                                                 @rhoughton-pivot @onichols-pivotal
+assembly_content.txt                                              @rhoughton-pivot @onichols-pivotal
+dependency_classpath.txt                                          @rhoughton-pivot @onichols-pivotal
+expected-pom.xml                                                  @rhoughton-pivot @onichols-pivotal
 
 #-----------------------------------------------------------------
 # Documentation

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,7 +18,7 @@
 # CODEOWNERS and .asf.yml - ownerless so everyone "owns" it
 #-----------------------------------------------------------------
 #CODEOWNERS
-#.asf.yml
+#.asf.yaml
 
 #-----------------------------------------------------------------
 # Serialization

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,6 +52,7 @@ geode-core/**/org/apache/geode/cache/client/**                    @echobravopapa
 geode-core/**/org/apache/geode/cache/server/**                    @echobravopapa @Bill @kirklund
 geode-core/**/org/apache/geode/cache/client/internal/**           @Bill @echobravopapa
 geode-core/**/org/apache/geode/internal/cache/tier/**             @Bill @echobravopapa @agingade
+geode-assembly/**/apache/geode/client/sni/**                      @Bill @echobravopapa
 
 #-----------------------------------------------------------------
 # Client Queues
@@ -269,6 +270,7 @@ geode-junit/**                                                    @mhansonp @kir
 #geode-jmh/**
 geode-junit/**/org/apache/geode/test/util/**                      @jdeppe-pivotal @onichols-pivotal
 geode-assembly/**/org/apache/geode/test/junit/**                  @jdeppe-pivotal @jinmeiliao
+geode-assembly/**/org/apache/geode/launchers                      @dschneider-pivotal @boglesby @kirklund @nabarunnag
 
 #-----------------------------------------------------------------
 # Redis API

--- a/CODEWATCHERS
+++ b/CODEWATCHERS
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-# This file follows the same format as CODEOWNERS, but adds you as 
+# This file follows the same format as CODEOWNERS, but adds you as
 # an optional reviewer rather than a required code owner reviewer.
 
 
@@ -30,10 +30,12 @@ CODEWATCHERS                                                      @onichols-pivo
 #-----------------------------------------------------------------
 # Documentation
 #-----------------------------------------------------------------
-geode-book/**                                                     @karensmolermiller @davebarnes97
-geode-docs/**                                                     @karensmolermiller @davebarnes97
+geode-book/**                                                     @davebarnes97
+geode-docs/**                                                     @davebarnes97
 geode-book/config.yml                                             @onichols-pivotal
 geode-book/redirects.rb                                           @onichols-pivotal
+LICENSE                                                           @metatype
+NOTICE                                                            @metatype
 
 
 #-----------------------------------------------------------------

--- a/CODEWATCHERS
+++ b/CODEWATCHERS
@@ -24,7 +24,7 @@
 #-----------------------------------------------------------------
 CODEOWNERS                                                        @onichols-pivotal @rhoughton-pivot
 CODEWATCHERS                                                      @onichols-pivotal @rhoughton-pivot
-.asf.yml                                                          @onichols-pivotal @rhoughton-pivot
+.asf.yaml                                                         @onichols-pivotal @rhoughton-pivot
 
 
 #-----------------------------------------------------------------

--- a/CODEWATCHERS
+++ b/CODEWATCHERS
@@ -43,7 +43,6 @@ NOTICE                                                            @metatype
 #-----------------------------------------------------------------
 geode-core/**/org/apache/geode/cache/client/**                    @albertogpz
 geode-core/**/org/apache/geode/cache/server/**                    @albertogpz
-geode-core/**/org/apache/geode/internal/cache/client/**           @albertogpz
 geode-core/**/org/apache/geode/internal/cache/tier/**             @albertogpz
 
 


### PR DESCRIPTION
After fixing the overly-broad rule, I added each specific area left unowned to the appropriate existing code area