### PR TITLE
Revert "GEODE-8977: include syncs in thread monitor stack (#6248)"

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/monitoring/executor/AbstractExecutorGroupJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/monitoring/executor/AbstractExecutorGroupJUnitTest.java
@@ -15,9 +15,9 @@
 package org.apache.geode.internal.monitoring.executor;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import org.apache.geode.test.awaitility.GeodeAwaitility;
@@ -78,6 +78,11 @@ public class AbstractExecutorGroupJUnitTest {
       public void run() {
         blockedThreadWaiting[0] = true;
         synchronized (syncObject) {
+          try {
+            syncObject.wait(timeoutInMilliseconds);
+          } catch (InterruptedException e) {
+            return;
+          }
         }
       }
     };
@@ -94,11 +99,7 @@ public class AbstractExecutorGroupJUnitTest {
       };
       await().untilAsserted(() -> {
         String threadReport = executor.createThreadReport(60000);
-        assertThat(threadReport)
-            .contains(AbstractExecutor.LOCK_OWNER_THREAD_STACK + " for \"blocking thread\"");
-        assertThat(threadReport).contains("Waiting on <" + syncObject + ">");
-        assertThat(threadReport).contains("Owned By <blocking thread>");
-        assertThat(threadReport).contains("- locked " + syncObject);
+        Assertions.assertThat(threadReport).contains(AbstractExecutor.LOCK_OWNER_THREAD_STACK);
       });
     } finally {
       blockingThread.interrupt();


### PR DESCRIPTION
This reverts commit 903afb5332b06b10e7f53a1abe9c53775a94f39e.
This thread monitor improvement caused members to at times be forced out of the geode cluster because the new getThreadInfo call blocks all threads from running.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
