### PR TITLE
GEODE-9161: Fix some more gradle 7 warnings

### DIFF
--- a/extensions/geode-modules-assembly/build.gradle
+++ b/extensions/geode-modules-assembly/build.gradle
@@ -42,7 +42,7 @@ jar.enabled = true
 def moduleBaseName = "Apache_Geode_Modules"
 
 def configureTcServerAssembly = {
-  baseName = moduleBaseName
+  archiveBaseName = moduleBaseName
   classifier = "tcServer"
 
   // All client-server files
@@ -124,7 +124,7 @@ def configureTcServerAssembly = {
 }
 
 def configureTcServer30Assembly = {
-  baseName = moduleBaseName
+  archiveBaseName = moduleBaseName
   classifier = "tcServer30"
 
   into('geode-cs-tomcat-8/conf') {
@@ -165,7 +165,7 @@ def configureTcServer30Assembly = {
 }
 
 tasks.register('distTomcat', Zip) {
-  baseName = moduleBaseName
+  archiveBaseName = moduleBaseName
   classifier = "Tomcat"
 
   // All client-server files
@@ -192,7 +192,7 @@ tasks.register('distTomcat', Zip) {
 }
 
 tasks.register('distAppServer', Zip) {
-  baseName = moduleBaseName
+  archiveBaseName = moduleBaseName
   classifier = "AppServer"
 
   into('lib') {

--- a/extensions/geode-modules-session/build.gradle
+++ b/extensions/geode-modules-session/build.gradle
@@ -69,7 +69,7 @@ jar {
   manifest {
     attributes 'Main-Class': 'org.apache.geode.modules.session.installer.Installer'
   }
-  baseName = 'geode-modules-session'
+  archiveBaseName = 'geode-modules-session'
 }
 
 sonarqube {

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -438,7 +438,7 @@ tasks.register('depsJar', Jar) {
     configureDepsJar
   }
   description 'Assembles the jar archive that defines the gemfire classpath.'
-  archiveName 'geode-dependencies.jar'
+  archiveFileName='geode-dependencies.jar'
   doFirst {
     manifest {
       attributes("Class-Path": configureDepsJar.outputs.files.singleFile.text)
@@ -451,7 +451,7 @@ tasks.register('gfshDepsJar', Jar) {
     configureGfshDepsJar
   }
   description 'Assembles the jar archive that defines the gfsh classpath.'
-  archiveName 'gfsh-dependencies.jar'
+  archiveFileName='gfsh-dependencies.jar'
   doFirst {
     manifest {
       attributes("Class-Path": configureGfshDepsJar.outputs.files.singleFile.text)
@@ -619,7 +619,7 @@ distributions {
  tasks.named('srcDistTar'),
 ]*.configure {
   compression Compression.GZIP
-  extension 'tgz'
+  archiveExtension='tgz'
   build.dependsOn(it)
 }
 // Make build final task to generate all test and product resources

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -130,13 +130,13 @@ task raJar(type: Jar, dependsOn: classes) {
     description 'Assembles the jar archive that contains the JCA classes'
     from sourceSets.jca.output
     exclude 'org/apache/geode/ra/**'
-    archiveName 'ra.jar'
+    archiveFileName='ra.jar'
 }
 
 task jcaJar(type: Jar, dependsOn: raJar) {
     description 'Assembles the jar archive that contains the JCA bundle'
-    baseName 'geode-jca'
-    extension 'rar'
+    archiveBaseName='geode-jca'
+    archiveExtension='rar'
     metaInf { from 'src/jca/ra.xml' }
     from raJar.archivePath
 }


### PR DESCRIPTION
- use non deprecated naming of variables

Authored-by: M. Oleske <michael@oleske.engineer>

There are two gradle warnings about property names that are deprecated that seem to keep breaking things in ways I don't understand.  They are

```console
The AbstractArchiveTask.version property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveVersion property instead. See https://docs.gradle.org/6.8.3/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:version for more details.
        at build_6euirgls21gn4lcb28jgunnoc$_run_closure6$_closure48$_closure50.doCall(/Users/pivotal/workspace/geode/extensions/geode-modules-assembly/build.gradle:209)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
which results in `:extensions:geode-modules-assembly` not being able to build with error
```console
Execution failed for task ':extensions:geode-modules-assembly:distAppServer'.
> Could not add file '/Users/myusername/workspace/geode/extensions/geode-modules-assembly/release/session/bin/modify_war' to ZIP '/Users/myusername/workspace/geode/extensions/geode-modules-assembly/build/distributions/Apache_Geode_Modules-1.15.0-build.0-AppServer.zip'.
```

and

```console
The Distribution.baseName property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the distributionBaseName property instead. See https://docs.gradle.org/6.8.3/dsl/org.gradle.api.distribution.Distribution.html#org.gradle.api.distribution.Distribution:baseName for more details.
        at build_9e3m0v64r7rkv7ru42644ed8w$_run_closure24.doCall(/Users/pivotal/workspace/geode/geode-assembly/build.gradle:640)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```
Which results in integration tests failing with a message about
```console
Expecting file:
  /Users/myusername/workspace/geode/geode-assembly/build/install/property 'distributionBaseName'
to exist.
java.lang.AssertionError: 
Expecting file:
  /Users/myusername/workspace/geode/geode-assembly/build/install/property 'distributionBaseName'
to exist.
```

If someone knows how to resolve those, then I believe the only warnings left are about not resolving configurations in a safe manner/non deprecated manner.  The box for allow edits to maintainers is check, so please feel free to push changes that might help those two errors above.  I need help on those since I'm stuck on them.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
