### PR TITLE
GEODE-5337: End-port is not exclusive when creating a gw receiver

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -423,13 +423,13 @@ if this option is specified and cluster configuration is enabled.
 <tr>
 <td><span class="keyword parmname">\-\-start-port</span></td>
 <td><p>Starting port number to use when specifying the range of possible port numbers this gateway receiver will use to connects to gateway senders in other sites. <%=vars.product_name%> chooses an unused port number in the specified port number range to start the receiver. If no port numbers in the range are available, an exception is thrown.</p>
-<p>The <code class="ph codeph">STARTPORT</code> value is inclusive while the <code class="ph codeph">ENDPORT</code> value is exclusive. For example, if you specify <code class="ph codeph">STARTPORT=&quot;50510&quot;</code> and <code class="ph codeph">ENDPORT=&quot;50520&quot;</code>, <%=vars.product_name%> chooses a port value from 50510 to 50519.</p></td>
+<p>The <code class="ph codeph">start-port</code> and <code class="ph codeph">end-port</code> values are inclusive. For example, if you specify <code class="ph codeph">start-port=&quot;50510&quot;</code> and <code class="ph codeph">end-port=&quot;50520&quot;</code>, <%=vars.product_name%> chooses a port value from 50510 to 50520.</p></td>
 <td>5000</td>
 </tr>
 <tr>
 <td><span class="keyword parmname">\-\-end-port</span></td>
 <td><p>Defines the upper bound port number to use when specifying the range of possible port numbers this gateway receiver will use to for connections from gateway senders in other sites. <%=vars.product_name%> chooses an unused port number in the specified port number range to start the receiver. If no port numbers in the range are available, an exception is thrown.</p>
-<p>The <code class="ph codeph">ENDPORT</code> value is exclusive while the <code class="ph codeph">STARTPORT</code> value is inclusive. For example, if you specify <code class="ph codeph">STARTPORT=&quot;50510&quot;</code> and <code class="ph codeph">ENDPORT=&quot;50520&quot;</code>, <%=vars.product_name%> chooses a port value from 50510 to 50519.</p></td>
+<p>The <code class="ph codeph">end-port</code> and <code class="ph codeph">start-port</code> values are inclusive. For example, if you specify <code class="ph codeph">start-port=&quot;50510&quot;</code> and <code class="ph codeph">end-port=&quot;50520&quot;</code>, <%=vars.product_name%> chooses a port value from 50510 to 50520.</p></td>
 <td>5500</td>
 </tr>
 <tr>


### PR DESCRIPTION
Documentation wrongly states that `end-port` value is not included on the port range in which gateway receivers will randomly select a port when they are created.