### PR TITLE
GEODE-4709: Add list gateways output sample in UG

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/list.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/list.html.md.erb
@@ -116,8 +116,8 @@ gfsh>list clients
 
 ClientList
 
-            Client Name / ID              | Server Name / ID
------------------------------------------ | -----------------------------------------------------
+          Client Name / ID           | Server Name / ID
+------------------------------------ | -----------------------------------------------------
 192.0.2.0(4987:loner):58922:7b3398cf | member=server2,port=53508;  member=server1,port=56806
 192.0.2.0(5065:loner):39906:a6f598cf | member=server2,port=53508;  member=server1,port=56806
 ```
@@ -190,8 +190,8 @@ list disk-stores
 ``` pre
 gfsh> list disk-stores
 
-   Member Name   |                   Member Id                   | Disk Store Name |            Disk Store ID
-  -------------- | --------------------------------------------- | --------------- | ------------------------------------
+   Member Name   |                   Member Id               | Disk Store Name |            Disk Store ID
+  -------------- | ------------------------------------------| --------------- | ------------------------------------
   consumerServer | 192.0.2.0(consumerServer:13825)<v5>:3545  | consumerData    | 4029af26-fd82-4997-bd6c-33382cdbb5e9
   consumerServer | 192.0.2.0(consumerServer:13825)<v5>:3545  | observerData    | 7e0316ad-963c-49b0-9b01-8f59b8d9e29e
   producerServer | 192.0.2.0(producerServer:13826)<v3>:53764 | producerData    | 4670e4eb-1c50-4465-b418-08ede3d5dbed
@@ -292,7 +292,7 @@ gfsh> list functions --matches=reconcile.*
 **Sample Output:**
 
 ``` pre
-list functions
+gfsh> list functions
 
    Member   |          Function
   --------- | --------------------------
@@ -300,20 +300,20 @@ list functions
   camelot   | reconcileWeeklyExpenses
   excalibur | loadDataFromExternalSource
   excalibur | reconcileDailyExpenses
-
+```
 
 Example of 'list function' with a "matches" filter:
-
+``` pre
 gfsh> list functions --matches=reconcile.*
 
    Member   |        Function
   --------- | -----------------------
   camelot   | reconcileWeeklyExpenses
   excalibur | reconcileDailyExpenses
-
+```
 
 Example of 'list functions' when no functions are found in <%=vars.product_name%> :
-
+``` pre
 gfsh> list functions
 No Functions Found.
 ```
@@ -348,6 +348,32 @@ list gateways --senders-only
 list gateways --receivers-only
 ```
 
+**Sample Output:**
+
+``` pre
+
+gfsh>list gateways
+
+GatewaySender Section
+
+GatewaySender Id |              Member               | Remote Cluster Id |  Type    | Status  | Queued Events | Receiver Location
+---------------- | --------------------------------- |  ---------------- | -------- | ------- | ------------- | -----------------
+ln               | boglesbymac(ny-1:88641)<v2>:33491 | 2                 | Parallel | Running | 0             | boglesbymac:5037
+ln               | boglesbymac(ny-2:88705)<v3>:29329 | 2                 | Parallel | Running | 0             | boglesbymac:5064
+ln               | boglesbymac(ny-3:88715)<v4>:36808 | 2                 | Parallel | Running | 0             | boglesbymac:5132
+ln               | boglesbymac(ny-4:88724)<v5>:52993 | 2                 | Parallel | Running | 0             | boglesbymac:5324
+
+GatewayReceiver Section
+
+         Member                   | Port | Sender Count | Sender's Connected
+--------------------------------- | ---- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------
+boglesbymac(ny-1:88641)<v2>:33491 | 5057 | 9            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675","boglesbymac(ln-2:88662)<v3>:12796"]
+boglesbymac(ny-2:88705)<v3>:29329 | 5082 | 4            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
+boglesbymac(ny-3:88715)<v4>:36808 | 5371 | 4            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
+boglesbymac(ny-4:88724)<v5>:52993 | 5247 | 3            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
+
+```
+
 ## <a id="topic_B3B51B6DEA484EE086C4F657EC9831F2" class="no-quick-link"></a>list indexes
 
 Display the list of indexes created for all members.
@@ -379,14 +405,15 @@ list indexes --with-stats
 
 ``` pre
 gfsh>list indexes
-Member Name    |                   Member ID                   | Region Path |   Name   | Type  | Indexed Expression | From Clause
--------------- | --------------------------------------------- | ----------- | -------- | ----- | ------------------ | -----------
+Member Name    |                   Member ID               | Region Path |   Name   | Type  | Indexed Expression | From Clause
+-------------- | ----------------------------------------- | ----------- | -------- | ----- | ------------------ | -----------
 consumerServer | 192.0.2.0(consumerServer:13873):6317      | /consumers  | cidIdx   | KEY   | id                 | /consumers
 consumerServer | 192.0.2.0(consumerServer:13873):6317      | /consumers  | cnameIdx | RANGE | name               | /consumers
 producerServer | 192.0.2.0(producerServer:13874):19198     | /producers  | pidIdx   | RANGE | id                 | /producers
+```
 
 Example of 'list indexes' with stats printed:
-
+``` pre
 gfsh>list indexes --with-stats
 
 Member Name  | Member ID | Region Path |   Name   | Type  | Indexed Expression | From Clause | Uses | Updates | Update Time | Keys | Values

--- a/geode-docs/tools_modules/gfsh/command-pages/list.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/list.html.md.erb
@@ -29,7 +29,7 @@ List existing <%=vars.product_name%> resources such as deployed applications, di
 
 -   **[list clients](#topic_ts1_qb1_dk)**
 
-    Displays a list of connected clients.
+    Display a list of connected clients.
 
 -   **[list deployed](#topic_59DF60DE71AD4097B281749425254BFF)**
 
@@ -49,7 +49,7 @@ List existing <%=vars.product_name%> resources such as deployed applications, di
 
 -   **[list gateways](#topic_B1D89671C7B74074899C7D52F15849ED)**
 
-    Displays the gateway senders and receivers for a member or members.
+    Display the gateway senders and receivers for a member or members.
 
 -   **[list indexes](#topic_B3B51B6DEA484EE086C4F657EC9831F2)**
 
@@ -91,9 +91,7 @@ list async-event-queues
 
 ## <a id="topic_ts1_qb1_dk" class="no-quick-link"></a>list clients
 
-Displays a list of connected clients.
-
-Displays a list of connected clients and the servers they are connected to.
+Display a list of connected clients and the servers to which they connect.
 
 **Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
 
@@ -167,9 +165,9 @@ No JAR Files Found
 
 ## <a id="topic_BC14AD57EA304FB3845766898D01BD04" class="no-quick-link"></a>list disk-stores
 
-List all available disk stores across the <%=vars.product_name%> cluster
+List all available disk stores across the <%=vars.product_name%> cluster.
 
-The command also lists the configured disk directories and any Regions, Cache Servers, Gateways, PDX Serialization and Async Event Queues using Disk Stores to either overflow and/or persist information to disk. Use the `describe                         disk-store` command to see the details for a particular Disk Store.
+The command also lists the configured disk directories and any Regions, Cache Servers, Gateways, PDX Serialization and Async Event Queues using Disk Stores to either overflow and/or persist information to disk. Use the `describe disk-store` command to see the details for a particular Disk Store.
 
 **Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
 
@@ -200,9 +198,7 @@ gfsh> list disk-stores
 **Error Messages:**
 
 ``` pre
-gfsh> list disk-stores
 No Disk Stores Found
-
 ```
 
 ## <a id="topic_66016A698C334F4EBA19B99F51B0204B" class="no-quick-link"></a>list durable-cqs
@@ -249,8 +245,6 @@ server4 | cq3
 **Error Messages:**
 
 ``` pre
-gfsh>list durable-cqs --durable-client-id=client1
-
 Unable to list durable-cqs for durable-client-id : "client1" due to following reasons.
 
 No client found with client-id : client1
@@ -277,7 +271,7 @@ list functions [--matches=value] [--groups=value(,value)*]
 
 | Name                                             | Description                                                                                                                                                                                     |
 |--------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <span class="keyword parmname">\\-\\-matches </span> | Pattern that the function ID must match in order to be included. Uses Java pattern matching rules, not UNIX. For example, to match any character any number of times use ".\*" instead of "\*". |
+| <span class="keyword parmname">\\-\\-matches </span> | Pattern that the function ID must match in order to be included. Uses Java pattern matching rules, not UNIX. For example, to match any character any number of times use ".\*" rather than "\*". |
 | <span class="keyword parmname">\\-\\-groups</span>    | Group(s) of members for which functions will be displayed. Use a comma separated list for multiple groups.                                                                                      |
 | <span class="keyword parmname">&#8209;&#8209;members </span>  | Name or ID of the member(s) for which functions will be displayed. Use a comma separated list for multiple members.                                                                             |
 
@@ -285,8 +279,8 @@ list functions [--matches=value] [--groups=value(,value)*]
 **Example Commands:**
 
 ``` pre
-gfsh> list functions
-gfsh> list functions --matches=reconcile.*
+list functions
+list functions --matches=reconcile.*
 ```
 
 **Sample Output:**
@@ -302,7 +296,8 @@ gfsh> list functions
   excalibur | reconcileDailyExpenses
 ```
 
-Example of 'list function' with a "matches" filter:
+Example of `list functions` with a "matches" filter:
+
 ``` pre
 gfsh> list functions --matches=reconcile.*
 
@@ -312,15 +307,15 @@ gfsh> list functions --matches=reconcile.*
   excalibur | reconcileDailyExpenses
 ```
 
-Example of 'list functions' when no functions are found in <%=vars.product_name%> :
+**Error Messages:**
+
 ``` pre
-gfsh> list functions
-No Functions Found.
+No Functions Found
 ```
 
 ## <a id="topic_B1D89671C7B74074899C7D52F15849ED" class="no-quick-link"></a>list gateways
 
-Displays the gateway senders and receivers for a member or members.
+Display the gateway senders and receivers for a member or members.
 
 **Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
 
@@ -336,8 +331,8 @@ list gateways [--members=value(,value)*] [--groups=value(,value)*] [--senders-on
 |------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | <span class="keyword parmname">&#8209;&#8209;members</span> | Member(s) whose gateways senders and receiver display.                                                                         |
 | <span class="keyword parmname">\\-\\-groups</span>  | Group(s) of members for which Gateway Senders and Receivers will be displayed. Use a comma separated list for multiple groups. |
-| \\-\\-senders-only                                  | List only gateway senders. This parameter cannot be used together with `--receivers-only`                                                                                                     |
-| \\-\\-receivers-only                                | List only gateway receivers. This parameter cannot be used together with `--senders-only`.                                                                                                   |
+| \\-\\-senders\\-only                                  | List only gateway senders. This parameter cannot be used together with `--receivers-only`                                                                                                     |
+| \\-\\-receivers\\-only                                | List only gateway receivers. This parameter cannot be used together with `--senders-only`.                                                                                                   |
 
 
 **Example Commands:**
@@ -356,21 +351,21 @@ gfsh>list gateways
 
 GatewaySender Section
 
-GatewaySender Id |              Member               | Remote Cluster Id |  Type    | Status  | Queued Events | Receiver Location
----------------- | --------------------------------- |  ---------------- | -------- | ------- | ------------- | -----------------
-ln               | boglesbymac(ny-1:88641)<v2>:33491 | 2                 | Parallel | Running | 0             | boglesbymac:5037
-ln               | boglesbymac(ny-2:88705)<v3>:29329 | 2                 | Parallel | Running | 0             | boglesbymac:5064
-ln               | boglesbymac(ny-3:88715)<v4>:36808 | 2                 | Parallel | Running | 0             | boglesbymac:5132
-ln               | boglesbymac(ny-4:88724)<v5>:52993 | 2                 | Parallel | Running | 0             | boglesbymac:5324
+GatewaySender Id |              Member         | Remote Cluster Id |  Type    | Status  | Queued Events | Receiver Location
+---------------- | --------------------------- | ----------------- | -------- | ------- | ------------- | -----------------
+ln               | mymac(ny-1:88641)<v2>:33491 | 2                 | Parallel | Running | 0             | mymac:5037
+ln               | mymac(ny-2:88705)<v3>:29329 | 2                 | Parallel | Running | 0             | mymac:5064
+ln               | mymac(ny-3:88715)<v4>:36808 | 2                 | Parallel | Running | 0             | mymac:5132
+ln               | mymac(ny-4:88724)<v5>:52993 | 2                 | Parallel | Running | 0             | mymac:5324
 
 GatewayReceiver Section
 
-         Member                   | Port | Sender Count | Sender's Connected
---------------------------------- | ---- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------
-boglesbymac(ny-1:88641)<v2>:33491 | 5057 | 9            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675","boglesbymac(ln-2:88662)<v3>:12796"]
-boglesbymac(ny-2:88705)<v3>:29329 | 5082 | 4            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
-boglesbymac(ny-3:88715)<v4>:36808 | 5371 | 4            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
-boglesbymac(ny-4:88724)<v5>:52993 | 5247 | 3            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
+         Member             | Port | Sender Count | Senders Connected
+--------------------------- | ---- | ------------ | -----------------------------------------------------------------------------------------------------------------------
+mymac(ny-1:88641)<v2>:33491 | 5057 | 9            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-3:88672)<v4>:43675","mymac(ln-2:88662)<v3>:12796"]
+mymac(ny-2:88705)<v3>:29329 | 5082 | 4            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-3:88672)<v4>:43675"]
+mymac(ny-3:88715)<v4>:36808 | 5371 | 4            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-3:88672)<v4>:43675"]
+mymac(ny-4:88724)<v5>:52993 | 5247 | 3            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-3:88672)<v4>:43675"]
 
 ```
 
@@ -397,7 +392,6 @@ list indexes [--with-stats(=value)?]
 
 ``` pre
 list indexes
-
 list indexes --with-stats
 ```
 
@@ -413,6 +407,7 @@ producerServer | 192.0.2.0(producerServer:13874):19198     | /producers  | pidId
 ```
 
 Example of 'list indexes' with stats printed:
+
 ``` pre
 gfsh>list indexes --with-stats
 
@@ -425,10 +420,7 @@ ps...        | 192...    | /producers  | pidIdx   | RANGE | id                 |
 
 **Error Messages:**
 
-Example of output when no indexes are found in <%=vars.product_name%>:
-
 ``` pre
-gfsh> list indexes
 No Indexes Found
 ```
 
@@ -485,7 +477,7 @@ list lucene indexes [--with-stats(=value)]
 
 | Name                                               | Description                                            | Default Value |
 |----------------------------------------------------|--------------------------------------------------------|---------------|
-| <span class="keyword parmname">\\-\\-with-stats</span> | Specifies whether statistics should also be displayed. | false if not specified, true if specified         |
+| <span class="keyword parmname">\\-\\-with\\-stats</span> | Specifies whether statistics should also be displayed. | false if not specified, true if specified         |
 
 
 **Example Commands:**

--- a/geode-docs/topologies_and_comm/multi_site_configuration/setting_up_a_multisite_system.html.md.erb
+++ b/geode-docs/topologies_and_comm/multi_site_configuration/setting_up_a_multisite_system.html.md.erb
@@ -310,81 +310,79 @@ As an example, assume the following scenario:
 
 You can then execute the following in gfsh to see the effects of rebalancing:
 
-    gfsh -e "connect --locator=localhost[10331]" -e "list gateways"
-    ...
-    (2) Executing - list gateways
+``` pre
+gfsh -e "connect --locator=localhost[10331]" -e "list gateways"
+...
+(2) Executing - list gateways
 
-    Gateways
+GatewaySender Section
 
-    GatewaySender
+GatewaySender Id |              Member               | Remote Cluster Id |   Type   | Status  | Queued Events | Receiver Location
+---------------- | --------------------------------- | ----------------- | -------- | ------- | ------------- | -----------------
+ln               | mymac(ny-1:88641)<v2>:33491       | 2                 | Parallel | Running | 0             | mymac:5037
+ln               | mymac(ny-2:88705)<v3>:29329       | 2                 | Parallel | Running | 0             | mymac:5064
+ln               | mymac(ny-3:88715)<v4>:36808       | 2                 | Parallel | Running | 0             | mymac:5132
+ln               | mymac(ny-4:88724)<v5>:52993       | 2                 | Parallel | Running | 0             | mymac:5324
 
-    GatewaySender Id |              Member               | Remote Cluster Id |   Type   | Status  | Queued Events | Receiver Location
-    ---------------- | --------------------------------- | ----------------- | -------- | ------- | ------------- | -----------------
-    ln               | boglesbymac(ny-1:88641)<v2>:33491 | 2                 | Parallel | Running | 0             | boglesbymac:5037
-    ln               | boglesbymac(ny-2:88705)<v3>:29329 | 2                 | Parallel | Running | 0             | boglesbymac:5064
-    ln               | boglesbymac(ny-3:88715)<v4>:36808 | 2                 | Parallel | Running | 0             | boglesbymac:5132
-    ln               | boglesbymac(ny-4:88724)<v5>:52993 | 2                 | Parallel | Running | 0             | boglesbymac:5324
+GatewayReceiver Section
 
-    GatewayReceiver
-
-                 Member               | Port | Sender Count | Sender's Connected
-    --------------------------------- | ---- | ------------ | --------------------------------------------------------------------------
-    boglesbymac(ny-1:88641)<v2>:33491 | 5057 | 24           | ["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-2:88662)<v3>:12796","boglesbymac(ln-3:88672)<v4>:43675"]
-    boglesbymac(ny-2:88705)<v3>:29329 | 5082 | 0            | []
-    boglesbymac(ny-3:88715)<v4>:36808 | 5371 | 0            | []
-    boglesbymac(ny-4:88724)<v5>:52993 | 5247 | 0            | []
-
+             Member               | Port | Sender Count | Senders Connected
+--------------------------------- | ---- | ------------ | --------------------------------------------------------------------------
+mymac(ny-1:88641)<v2>:33491       | 5057 | 24           | ["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-2:88662)<v3>:12796","mymac(ln-3:88672)<v4>:43675"]
+mymac(ny-2:88705)<v3>:29329       | 5082 | 0            | []
+mymac(ny-3:88715)<v4>:36808       | 5371 | 0            | []
+mymac(ny-4:88724)<v5>:52993       | 5247 | 0            | []
+```
 
 Execute the load-balance command:
+``` pre
+gfsh -e "connect --locator=localhost[10441]" -e "load-balance gateway-sender --id=ny"...
 
-    gfsh -e "connect --locator=localhost[10441]" -e "load-balance gateway-sender --id=ny"...
+(2) Executing - load-balance gateway-sender --id=ny
 
-    (2) Executing - load-balance gateway-sender --id=ny
-
-                 Member               | Result | Message
-    --------------------------------- | ------ |--------------------------------------------------------------------------
-    boglesbymac(ln-1:88651)<v2>:48277 | OK     | GatewaySender ny is rebalanced on member boglesbymac(ln-1:88651)<v2>:48277
-    boglesbymac(ln-4:88681)<v5>:42784 | OK     | GatewaySender ny is rebalanced on member boglesbymac(ln-4:88681)<v5>:42784
-    boglesbymac(ln-3:88672)<v4>:43675 | OK     | GatewaySender ny is rebalanced on member boglesbymac(ln-3:88672)<v4>:43675
-    boglesbymac(ln-2:88662)<v3>:12796 | OK     | GatewaySender ny is rebalanced on member boglesbymac(ln-2:88662)<v3>:12796
+             Member               | Result | Message
+--------------------------------- | ------ |--------------------------------------------------------------------------
+mymac(ln-1:88651)<v2>:48277       | OK     | GatewaySender ny is rebalanced on member mymac(ln-1:88651)<v2>:48277
+mymac(ln-4:88681)<v5>:42784       | OK     | GatewaySender ny is rebalanced on member mymac(ln-4:88681)<v5>:42784
+mymac(ln-3:88672)<v4>:43675       | OK     | GatewaySender ny is rebalanced on member mymac(ln-3:88672)<v4>:43675
+mymac(ln-2:88662)<v3>:12796       | OK     | GatewaySender ny is rebalanced on member mymac(ln-2:88662)<v3>:12796
+```
 
 Listing gateways in ny again shows the connections are spread much better among the receivers.
 
+``` pre
+gfsh -e "connect --locator=localhost[10331]" -e "list gateways"...
 
-    gfsh -e "connect --locator=localhost[10331]" -e "list gateways"...
+(2) Executing - list gateways
 
-    (2) Executing - list gateways
+GatewaySender Section
 
-    Gateways
+GatewaySender Id |              Member               | Remote Cluster Id |  Type    | Status  | Queued Events | Receiver Location
+---------------- | --------------------------------- |  ---------------- | -------- | ------- | ------------- | -----------------
+ln               | mymac(ny-1:88641)<v2>:33491       | 2                 | Parallel | Running | 0             | mymac:5037
+ln               | mymac(ny-2:88705)<v3>:29329       | 2                 | Parallel | Running | 0             | mymac:5064
+ln               | mymac(ny-3:88715)<v4>:36808       | 2                 | Parallel | Running | 0             | mymac:5132
+ln               | mymac(ny-4:88724)<v5>:52993       | 2                 | Parallel | Running | 0             | mymac:5324
 
-    GatewaySender
+GatewayReceiver Section
 
-    GatewaySender Id |              Member               | Remote Cluster Id |  Type    | Status  | Queued Events | Receiver Location
-    ---------------- | --------------------------------- |  ---------------- | -------- | ------- | ------------- | -----------------
-    ln               | boglesbymac(ny-1:88641)<v2>:33491 | 2                 | Parallel | Running | 0             | boglesbymac:5037
-    ln               | boglesbymac(ny-2:88705)<v3>:29329 | 2                 | Parallel | Running | 0             | boglesbymac:5064
-    ln               | boglesbymac(ny-3:88715)<v4>:36808 | 2                 | Parallel | Running | 0             | boglesbymac:5132
-    ln               | boglesbymac(ny-4:88724)<v5>:52993 | 2                 | Parallel | Running | 0             | boglesbymac:5324
-
-    GatewayReceiver
-
-             Member                   | Port | Sender Count | Sender's Connected
-    --------------------------------- | ---- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------
-    boglesbymac(ny-1:88641)<v2>:33491 | 5057 | 9            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675","boglesbymac(ln-2:88662)<v3>:12796"]
-    boglesbymac(ny-2:88705)<v3>:29329 | 5082 | 4            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
-    boglesbymac(ny-3:88715)<v4>:36808 | 5371 | 4            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
-    boglesbymac(ny-4:88724)<v5>:52993 | 5247 | 3            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-3:88672)<v4>:43675"]
-
+         Member                   | Port | Sender Count | Senders Connected
+--------------------------------- | ---- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------
+mymac(ny-1:88641)<v2>:33491       | 5057 | 9            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-3:88672)<v4>:43675","mymac(ln-2:88662)<v3>:12796"]
+mymac(ny-2:88705)<v3>:29329       | 5082 | 4            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-3:88672)<v4>:43675"]
+mymac(ny-3:88715)<v4>:36808       | 5371 | 4            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-3:88672)<v4>:43675"]
+mymac(ny-4:88724)<v5>:52993       | 5247 | 3            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-3:88672)<v4>:43675"]
+```
 
 Running the load balance command in site ln again produces even better balance.
 
 ``` pre
-         Member                   | Port | Sender Count | Sender's Connected
+         Member                   | Port | Sender Count | Senders Connected
 --------------------------------- | ---- | ------------ |-------------------------------------------------------------------------------------------------------------------------------------------------
-boglesbymac(ny-1:88641)<v2>:33491 | 5057 | 7            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-2:88662)<v3>:12796","boglesbymac(ln-3:88672)<v4>:43675"]
-boglesbymac(ny-2:88705)<v3>:29329 | 5082 | 3            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-3:88672)<v4>:43675","boglesbymac(ln-2:88662)<v3>:12796"]
-boglesbymac(ny-3:88715)<v4>:36808 | 5371 | 5            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-2:88662)<v3>:12796","boglesbymac(ln-3:88672)<v4>:43675"]
-boglesbymac(ny-4:88724)<v5>:52993 | 5247 | 6            |["boglesbymac(ln-1:88651)<v2>:48277","boglesbymac(ln-4:88681)<v5>:42784","boglesbymac(ln-2:88662)<v3>:12796","boglesbymac(ln-3:88672)<v4>:43675"]
+mymac(ny-1:88641)<v2>:33491       | 5057 | 7            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-2:88662)<v3>:12796","mymac(ln-3:88672)<v4>:43675"]
+mymac(ny-2:88705)<v3>:29329       | 5082 | 3            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-3:88672)<v4>:43675","mymac(ln-2:88662)<v3>:12796"]
+mymac(ny-3:88715)<v4>:36808       | 5371 | 5            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-2:88662)<v3>:12796","mymac(ln-3:88672)<v4>:43675"]
+mymac(ny-4:88724)<v5>:52993       | 5247 | 6            |["mymac(ln-1:88651)<v2>:48277","mymac(ln-4:88681)<v5>:42784","mymac(ln-2:88662)<v3>:12796","mymac(ln-3:88672)<v4>:43675"]
 ```
 
 ## <a id="setting_up_a_multisite_system_one_ipaddr" class="no-quick-link"></a>Configuring One IP Address and Port to Access All Gateway Receivers in a Site

--- a/geode-docs/topologies_and_comm/multi_site_configuration/setting_up_a_multisite_system.html.md.erb
+++ b/geode-docs/topologies_and_comm/multi_site_configuration/setting_up_a_multisite_system.html.md.erb
@@ -335,6 +335,7 @@ mymac(ny-4:88724)<v5>:52993       | 5247 | 0            | []
 ```
 
 Execute the load-balance command:
+
 ``` pre
 gfsh -e "connect --locator=localhost[10441]" -e "load-balance gateway-sender --id=ny"...
 


### PR DESCRIPTION
`list gateways` command had no output example in the documentation. This PR also fixes other formatting errors in the `list.html.md.erb` file