### PR TITLE
GEODE-9197: don't stress deleted tests

### DIFF
--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -42,7 +42,7 @@ function changes_for_path() {
       echo "Could not determine merge base. Exiting..."
       exit 1
     fi
-    git diff --name-only ${mergeBase} -- $path
+    git diff --name-only --diff-filter=ACMR ${mergeBase} -- $path
   popd >> /dev/null
 }
 


### PR DESCRIPTION
a revert PR or a module refactoring are common scenarios where tests may appear as deleted, so StressNew shouldn't try to run them