### PR TITLE
GEODE-8977: improve thread monitor to log lock information

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/monitoring/ThreadsMonitoringIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/monitoring/ThreadsMonitoringIntegrationTest.java
@@ -34,7 +34,6 @@ import org.apache.geode.internal.monitoring.executor.AbstractExecutor;
  */
 public class ThreadsMonitoringIntegrationTest {
 
-  private Properties nonDefault;
   private InternalCache cache;
 
   @Before
@@ -52,7 +51,7 @@ public class ThreadsMonitoringIntegrationTest {
   }
 
   private void initInternalDistributedSystem() {
-    nonDefault = new Properties();
+    Properties nonDefault = new Properties();
     nonDefault.put(ConfigurationProperties.MCAST_PORT, "0");
     nonDefault.put(ConfigurationProperties.LOCATORS, "");
     nonDefault.put(ConfigurationProperties.THREAD_MONITOR_ENABLED, "true");
@@ -84,9 +83,9 @@ public class ThreadsMonitoringIntegrationTest {
         .describedAs("ThreadMonitor monitoring process map validation should still be false.")
         .isFalse();
 
-    AbstractExecutor abstractExecutorGroup =
+    AbstractExecutor abstractExecutor =
         impl.getMonitorMap().get(Thread.currentThread().getId());
-    abstractExecutorGroup.setStartTime(abstractExecutorGroup.getStartTime()
+    abstractExecutor.setStartTime(abstractExecutor.getStartTime()
         - cache.getInternalDistributedSystem().getConfig().getThreadMonitorTimeLimit() - 1);
 
     assertThat(impl.getThreadsMonitoringProcess().mapValidation())
@@ -96,20 +95,15 @@ public class ThreadsMonitoringIntegrationTest {
         .describedAs("ThreadMonitor monitoring process should identify one stuck thread.")
         .isEqualTo(1);
 
-    impl.getMonitorMap().put(abstractExecutorGroup.getThreadID() + 1, abstractExecutorGroup);
-    impl.getMonitorMap().put(abstractExecutorGroup.getThreadID() + 2, abstractExecutorGroup);
-    impl.getThreadsMonitoringProcess().mapValidation();
-
-    assertThat((impl.getThreadsMonitoringProcess().getResourceManagerStats().getNumThreadStuck()))
-        .describedAs("ThreadMonitor monitoring process should identify three stuck threads.")
-        .isEqualTo(3);
-
     threadMonitoring.endMonitor();
-    impl.getThreadsMonitoringProcess().mapValidation();
+
+    assertThat(impl.getThreadsMonitoringProcess().mapValidation())
+        .describedAs("ThreadMonitor monitoring process map validation should now be false.")
+        .isFalse();
 
     assertThat((impl.getThreadsMonitoringProcess().getResourceManagerStats().getNumThreadStuck()))
-        .describedAs("ThreadMonitor monitoring process should identify two stuck threads.")
-        .isEqualTo(2);
+        .describedAs("ThreadMonitor monitoring process should identify no stuck threads.")
+        .isEqualTo(0);
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoringProcess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/ThreadsMonitoringProcess.java
@@ -122,7 +122,7 @@ public class ThreadsMonitoringProcess extends TimerTask {
   @VisibleForTesting
   public static Map<Long, ThreadInfo> createThreadInfoMap(Set<Long> stuckThreadIds) {
     /*
-     * NOTE: at last some implementations of getThreadInfo(long[], boolean, boolean)
+     * NOTE: at least some implementations of getThreadInfo(long[], boolean, boolean)
      * will core dump if the long array contains a duplicate value.
      * That is why stuckThreadIds is a Set instead of a List.
      */
@@ -152,11 +152,15 @@ public class ThreadsMonitoringProcess extends TimerTask {
     }
   }
 
+  /**
+   * @param threadId identifies the thread that may have a lock owner
+   * @return the lock owner thread id or -1 if no lock owner
+   */
   private long getLockOwnerId(long threadId) {
     /*
      * NOTE: the following getThreadInfo call is much cheaper than the one made
      * in createThreadInfoMap because it does not figure out what locks are being
-     * help by the thread and also does not get the call stack.
+     * held by the thread and also does not get the call stack.
      * All we need from it is the lockOwnerId.
      */
     final ThreadInfo threadInfo = ManagementFactory.getThreadMXBean().getThreadInfo(threadId, 0);

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/AbstractExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/AbstractExecutor.java
@@ -14,13 +14,18 @@
  */
 package org.apache.geode.internal.monitoring.executor;
 
+import static java.lang.Integer.min;
+
+import java.lang.management.LockInfo;
 import java.lang.management.ManagementFactory;
+import java.lang.management.MonitorInfo;
 import java.lang.management.ThreadInfo;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.annotations.Immutable;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 public abstract class AbstractExecutor {
@@ -49,12 +54,21 @@ public abstract class AbstractExecutor {
     logger.warn(createThreadReport(stuckTime));
   }
 
+  private static ThreadInfo getThreadInfo(long threadId) {
+    ThreadInfo[] threadInfos =
+        ManagementFactory.getThreadMXBean().getThreadInfo(new long[] {threadId}, true, true);
+    if (threadInfos != null) {
+      return threadInfos[0];
+    } else {
+      return null;
+    }
+  }
+
   String createThreadReport(long stuckTime) {
 
     DateFormat dateFormat = new SimpleDateFormat("dd MMM yyyy HH:mm:ss zzz");
 
-    ThreadInfo thread =
-        ManagementFactory.getThreadMXBean().getThreadInfo(this.threadID, THREAD_DUMP_DEPTH);
+    ThreadInfo thread = getThreadInfo(threadID);
     boolean logThreadDetails = (thread != null);
 
     StringBuilder stringBuilder = new StringBuilder();
@@ -87,12 +101,11 @@ public abstract class AbstractExecutor {
         .append(lineSeparator);
 
     if (logThreadDetails) {
-      writeThreadStack(thread, "Thread stack:", stringBuilder);
+      writeThreadStack(thread, "Thread stack", stringBuilder);
     }
 
     if (logThreadDetails && thread.getLockOwnerName() != null) {
-      ThreadInfo lockOwnerThread = ManagementFactory.getThreadMXBean()
-          .getThreadInfo(thread.getLockOwnerId(), THREAD_DUMP_DEPTH);
+      ThreadInfo lockOwnerThread = getThreadInfo(thread.getLockOwnerId());
       if (lockOwnerThread != null) {
         writeThreadStack(lockOwnerThread, LOCK_OWNER_THREAD_STACK, stringBuilder);
       }
@@ -101,12 +114,47 @@ public abstract class AbstractExecutor {
     return stringBuilder.toString();
   }
 
+  @Immutable
+  private static final String INDENT = "  ";
+  @Immutable
+  private static final String lineSeparator = System.lineSeparator();
+
   private void writeThreadStack(ThreadInfo thread, String header, StringBuilder strb) {
-    final String lineSeparator = System.lineSeparator();
-    strb.append(header).append(lineSeparator);
-    for (int i = 0; i < thread.getStackTrace().length; i++) {
+    strb.append(header).append(" for \"")
+        .append(thread.getThreadName())
+        .append("\" (0x").append(Long.toHexString(thread.getThreadId()))
+        .append("):").append(lineSeparator);
+    strb.append("java.lang.ThreadState: ").append(thread.getThreadState());
+    if (thread.isSuspended()) {
+      strb.append(" (suspended)");
+    }
+    if (thread.isInNative()) {
+      strb.append(" (in native)");
+    }
+    strb.append(lineSeparator);
+    MonitorInfo[] lockedMonitors = thread.getLockedMonitors();
+    for (int i = 0; i < min(thread.getStackTrace().length, THREAD_DUMP_DEPTH); i++) {
       String row = thread.getStackTrace()[i].toString();
-      strb.append(row).append(lineSeparator);
+      strb.append(INDENT).append("at ").append(row).append(lineSeparator);
+      appendLockedMonitor(strb, i, lockedMonitors);
+    }
+    strb.append("Locked ownable synchronizers:").append(lineSeparator);
+    LockInfo[] lockedSynchronizers = thread.getLockedSynchronizers();
+    if (lockedSynchronizers.length == 0) {
+      strb.append(INDENT).append("- None").append(lineSeparator);
+    } else {
+      for (LockInfo lockInfo : lockedSynchronizers) {
+        strb.append(INDENT).append("- ").append(lockInfo).append(lineSeparator);
+      }
+    }
+  }
+
+  private void appendLockedMonitor(StringBuilder strb, int stackDepth,
+      MonitorInfo[] lockedMonitors) {
+    for (MonitorInfo monitorInfo : lockedMonitors) {
+      if (stackDepth == monitorInfo.getLockedStackDepth()) {
+        strb.append(INDENT).append("  - locked " + monitorInfo).append(lineSeparator);
+      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/SuspendableExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/monitoring/executor/SuspendableExecutor.java
@@ -29,6 +29,10 @@ public abstract class SuspendableExecutor extends AbstractExecutor {
   @Override
   public void resumeMonitoring() {
     setStartTime(0);
+    // The ThreadMonitoringProcess will set the
+    // startTime once it sees it set to 0.
+    // This prevents the monitored thread from
+    // constantly calling System.currentTimeMillis.
     suspended = false;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/monitoring/executor/AbstractExecutorGroupJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/monitoring/executor/AbstractExecutorGroupJUnitTest.java
@@ -19,10 +19,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.management.ThreadInfo;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Test;
 
@@ -100,7 +100,7 @@ public class AbstractExecutorGroupJUnitTest {
         }
       };
       await().untilAsserted(() -> {
-        List<Long> threadIds = new ArrayList<>();
+        Set<Long> threadIds = new HashSet<>();
         threadIds.add(blockedThread.getId());
         threadIds.add(blockingThread.getId());
         String threadReport = executor.createThreadReport(60000,


### PR DESCRIPTION
This fix looks the same as the previous fix for GEODE-8977 but it performs much better.
The expensive form of getThreadInfo (the one that requests lock info) is now called at
most once each time the thread monitor wakes up. Before it was called at least once for every
thread that was stuck. With a high number of stuck threads this could cause operations like the
membership heartbeat to timeout resulting in a forced disconnect.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
