### PR TITLE
GEODE-9172: Add Junit rule to start docker-based redis cluster

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/NativeRedisClusterTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/NativeRedisClusterTest.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.exceptions.JedisMovedDataException;
+
+import org.apache.geode.test.dunit.rules.ClusterNode;
+import org.apache.geode.test.dunit.rules.NativeRedisClusterTestRule;
+
+/**
+ * This class serves merely as an example of using the {@link NativeRedisClusterTestRule}.
+ * Eventually it can be deleted since we'll end up with more comprehensive tests for various
+ * {@code CLUSTER} commands.
+ */
+public class NativeRedisClusterTest {
+
+  @ClassRule
+  public static NativeRedisClusterTestRule cluster = new NativeRedisClusterTestRule();
+
+  @Test
+  public void testEachProxyReturnsExposedPorts() {
+    for (Integer port : cluster.getExposedPorts()) {
+      try (Jedis jedis = new Jedis("localhost", port)) {
+        List<ClusterNode> nodes =
+            NativeRedisClusterTestRule.parseClusterNodes(jedis.clusterNodes());
+        List<Integer> ports = nodes.stream().map(f -> f.port).collect(Collectors.toList());
+        assertThat(ports).containsExactlyInAnyOrderElementsOf(cluster.getExposedPorts());
+      }
+    }
+  }
+
+  @Test
+  public void testClusterAwareClient() {
+    try (JedisCluster jedis =
+        new JedisCluster(new HostAndPort("localhost", cluster.getExposedPorts().get(0)))) {
+      jedis.set("a", "0"); // slot 15495
+      jedis.set("b", "1"); // slot 3300
+      jedis.set("c", "2"); // slot 7365
+      jedis.set("d", "3"); // slot 11298
+      jedis.set("e", "4"); // slot 15363
+      jedis.set("f", "5"); // slot 3168
+      jedis.set("g", "6"); // slot 7233
+      jedis.set("h", "7"); // slot 11694
+      jedis.set("i", "8"); // slot 15759
+      jedis.set("j", "9"); // slot 3564
+    }
+  }
+
+  @Test
+  public void testMoved() {
+    try (Jedis jedis =
+        new Jedis("localhost", cluster.getExposedPorts().get(0), 100000)) {
+      assertThatThrownBy(() -> jedis.set("a", "A"))
+          .isInstanceOf(JedisMovedDataException.class)
+          .hasMessageContaining("127.0.0.1");
+    }
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/ClusterNodesResponseProcessor.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/ClusterNodesResponseProcessor.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import java.util.Map;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.handler.codec.redis.ErrorRedisMessage;
+import io.netty.handler.codec.redis.FullBulkStringRedisMessage;
+import io.netty.util.CharsetUtil;
+
+import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.redis.internal.netty.CoderException;
+
+public class ClusterNodesResponseProcessor implements RedisResponseProcessor {
+
+  private final Map<HostPort, HostPort> mappings;
+
+  public ClusterNodesResponseProcessor(Map<HostPort, HostPort> mappings) {
+    this.mappings = mappings;
+  }
+
+  @Override
+  public Object process(Object message, Channel channel) {
+    if (message instanceof ErrorRedisMessage) {
+      return message;
+    }
+
+    ByteBuf buf = ((FullBulkStringRedisMessage) message).content();
+    String input = buf.toString(CharsetUtil.UTF_8);
+
+    for (Map.Entry<HostPort, HostPort> entry : mappings.entrySet()) {
+      String findHostPort = entry.getKey().getHost() + ":" + entry.getKey().getPort();
+      String replaceHostPort = entry.getValue().getHost() + ":" + entry.getValue().getPort();
+
+      input = input.replace(findHostPort, replaceHostPort);
+    }
+
+    buf.release();
+
+    ByteBuf response;
+    try {
+      response = Coder.getBulkStringResponse(channel.alloc().buffer(), input);
+    } catch (CoderException e) {
+      throw new RuntimeException(e);
+    }
+
+    return response;
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/ClusterSlotsResponseProcessor.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/ClusterSlotsResponseProcessor.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.netty.channel.Channel;
+import io.netty.handler.codec.redis.ArrayRedisMessage;
+import io.netty.handler.codec.redis.ErrorRedisMessage;
+import io.netty.handler.codec.redis.FullBulkStringRedisMessage;
+import io.netty.handler.codec.redis.IntegerRedisMessage;
+import io.netty.handler.codec.redis.RedisMessage;
+import io.netty.handler.codec.redis.SimpleStringRedisMessage;
+import io.netty.util.CharsetUtil;
+import org.apache.commons.lang3.tuple.Pair;
+
+public class ClusterSlotsResponseProcessor implements RedisResponseProcessor {
+
+  private final Map<HostPort, HostPort> mappings;
+
+  public ClusterSlotsResponseProcessor(Map<HostPort, HostPort> mappings) {
+    this.mappings = mappings;
+  }
+
+  /**
+   * CLUSTER SLOTS looks something like this:
+   *
+   * <pre>
+   * 1) 1) (integer) 0
+   *    2) (integer) 5460
+   *    3) 1) "127.0.0.1"
+   *       2) (integer) 30001
+   *       3) "09dbe9720cda62f7865eabc5fd8857c5d2678366"
+   *    4) 1) "127.0.0.1"
+   *       2) (integer) 30004
+   *       3) "821d8ca00d7ccf931ed3ffc7e3db0599d2271abf"
+   * 2) 1) (integer) 5461
+   *    2) (integer) 10922
+   *    3) 1) "127.0.0.1"
+   *       2) (integer) 30002
+   *       3) "c9d93d9f2c0c524ff34cc11838c2003d8c29e013"
+   *    4) 1) "127.0.0.1"
+   *       2) (integer) 30005
+   *       3) "faadb3eb99009de4ab72ad6b6ed87634c7ee410f"
+   * </pre>
+   */
+  @Override
+  public Object process(Object message, Channel channel) {
+    if (message instanceof ErrorRedisMessage) {
+      return message;
+    }
+
+    ArrayRedisMessage input = (ArrayRedisMessage) message;
+    List<RedisMessage> response = new ArrayList<>();
+
+    for (RedisMessage entry : input.children()) {
+      List<RedisMessage> newInner = new ArrayList<>();
+      ArrayRedisMessage inner = (ArrayRedisMessage) entry;
+
+      // slot start
+      newInner.add(inner.children().get(0));
+      // slot end
+      newInner.add(inner.children().get(1));
+
+      for (int i = 2; i < inner.children().size(); i++) {
+        ArrayRedisMessage hostPortArray = (ArrayRedisMessage) inner.children().get(i);
+        String host = ((FullBulkStringRedisMessage) hostPortArray.children().get(0))
+            .content().toString(CharsetUtil.UTF_8);
+        Integer port = (int) ((IntegerRedisMessage) hostPortArray.children().get(1)).value();
+        Pair<String, Integer> newMapping = getMapping(host, port);
+
+        List<RedisMessage> newHostPortArray = new ArrayList<>();
+        newHostPortArray.add(new SimpleStringRedisMessage(newMapping.getLeft()));
+        newHostPortArray.add(new IntegerRedisMessage(newMapping.getRight()));
+        for (int j = 2; j < hostPortArray.children().size(); j++) {
+          newHostPortArray.add(hostPortArray.children().get(j));
+        }
+
+        newInner.add(new ArrayRedisMessage(newHostPortArray));
+      }
+
+      response.add(new ArrayRedisMessage(newInner));
+    }
+
+    return new ArrayRedisMessage(response);
+  }
+
+  private Pair<String, Integer> getMapping(String host, Integer port) {
+    for (Map.Entry<HostPort, HostPort> entry : mappings.entrySet()) {
+      HostPort from = entry.getKey();
+      if (from.getHost().equals(host) && from.getPort().equals(port)) {
+        return Pair.of(entry.getValue().getHost(), entry.getValue().getPort());
+      }
+    }
+
+    throw new IllegalArgumentException("Unable to map host and port " + host + ":" + port);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/HostPort.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/HostPort.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import java.util.Objects;
+
+public class HostPort {
+
+  private final String host;
+  private final Integer port;
+
+  public HostPort(String host, Integer port) {
+    this.host = host;
+    this.port = port;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public Integer getPort() {
+    return port;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof HostPort)) {
+      return false;
+    }
+    HostPort hostPort = (HostPort) o;
+    return Objects.equals(host, hostPort.host)
+        && Objects.equals(port, hostPort.port);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(host, port);
+  }
+
+  @Override
+  public String toString() {
+    return host + ":" + port;
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/MovedResponseHandler.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/MovedResponseHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import java.util.Map;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.handler.codec.redis.ErrorRedisMessage;
+
+public class MovedResponseHandler extends ChannelInboundHandlerAdapter {
+
+  private final Map<HostPort, HostPort> mappings;
+  private final Channel inboundChannel;
+
+  public MovedResponseHandler(Channel inboundChannel, Map<HostPort, HostPort> mappings) {
+    this.inboundChannel = inboundChannel;
+    this.mappings = mappings;
+  }
+
+  @Override
+  public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+    if (msg instanceof ErrorRedisMessage) {
+      String content = ((ErrorRedisMessage) msg).content();
+      if (content.startsWith("MOVED")) {
+        for (Map.Entry<HostPort, HostPort> entry : mappings.entrySet()) {
+          String hostPort = entry.getKey().getHost() + ":" + entry.getKey().getPort();
+          int index = content.indexOf(hostPort);
+          if (index >= 0) {
+            String newHostPort = entry.getValue().getHost() + ":" + entry.getValue().getPort();
+            String response = content.substring(0, index) + newHostPort;
+            inboundChannel.writeAndFlush(new ErrorRedisMessage(response));
+            return;
+          }
+        }
+
+        throw new IllegalStateException("Unmapped MOVED received: " + content);
+      }
+    }
+
+    // Hand off to next handler
+    ctx.fireChannelRead(msg);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/NoopRedisResponseProcessor.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/NoopRedisResponseProcessor.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import io.netty.channel.Channel;
+
+public class NoopRedisResponseProcessor implements RedisResponseProcessor {
+  public static final RedisResponseProcessor INSTANCE = new NoopRedisResponseProcessor();
+
+  private NoopRedisResponseProcessor() {}
+
+  @Override
+  public Object process(Object message, Channel channel) {
+    return message;
+  }
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxy.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxy.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import java.net.InetSocketAddress;
+import java.util.HashMap;
+import java.util.Map;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.redis.RedisArrayAggregator;
+import io.netty.handler.codec.redis.RedisBulkStringAggregator;
+import io.netty.handler.codec.redis.RedisDecoder;
+import io.netty.handler.codec.redis.RedisEncoder;
+
+
+/**
+ * This proxy handles mangling Redis responses in whatever way is necessary. In the case of
+ * creating a docker-based redis cluster, we need to translate internal addresses into external
+ * addresses - see {@link RedisProxyInboundHandler#channelRead(ChannelHandlerContext, Object)}.
+ */
+public final class RedisProxy {
+
+  private final EventLoopGroup bossGroup;
+  private final EventLoopGroup workerGroup;
+  private final int exposedPort;
+  private final Map<HostPort, HostPort> mappings = new HashMap<>();
+
+  public RedisProxy(int targetPort) {
+    bossGroup = new NioEventLoopGroup(1);
+    workerGroup = new NioEventLoopGroup(1);
+
+    ChannelFuture future = new ServerBootstrap().group(bossGroup, workerGroup)
+        .channel(NioServerSocketChannel.class)
+        .childHandler(new ChannelInitializer<SocketChannel>() {
+          @Override
+          protected void initChannel(SocketChannel ch) {
+            ChannelPipeline p = ch.pipeline();
+            p.addLast(new RedisEncoder());
+            p.addLast(new RedisDecoder());
+            p.addLast(new RedisBulkStringAggregator());
+            p.addLast(new RedisArrayAggregator());
+            p.addLast(new RedisProxyInboundHandler("127.0.0.1", targetPort, mappings));
+          }
+        })
+        .childOption(ChannelOption.AUTO_READ, false)
+        .bind(0);
+    future.awaitUninterruptibly();
+
+    exposedPort = ((InetSocketAddress) future.channel().localAddress()).getPort();
+  }
+
+  public int getExposedPort() {
+    return exposedPort;
+  }
+
+  public void configure(Map<HostPort, HostPort> mappings) {
+    this.mappings.putAll(mappings);
+  }
+
+  public void stop() {
+    bossGroup.shutdownGracefully();
+    workerGroup.shutdownGracefully();
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import java.util.Map;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.redis.ArrayRedisMessage;
+import io.netty.handler.codec.redis.FullBulkStringRedisMessage;
+import io.netty.handler.codec.redis.RedisArrayAggregator;
+import io.netty.handler.codec.redis.RedisBulkStringAggregator;
+import io.netty.handler.codec.redis.RedisDecoder;
+import io.netty.handler.codec.redis.RedisEncoder;
+import io.netty.util.CharsetUtil;
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
+
+public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
+
+  private static final Logger logger = LogService.getLogger();
+  private final String remoteHost;
+  private final int remotePort;
+  private final Map<HostPort, HostPort> mappings;
+  private Channel outboundChannel;
+  private RedisProxyOutboundHandler outboundHandler;
+  private final ClusterSlotsResponseProcessor slotsResponseProcessor;
+  private final ClusterNodesResponseProcessor nodesResponseProcessor;
+  private MovedResponseHandler movedResponseHandler;
+
+  public RedisProxyInboundHandler(String remoteHost, int remotePort,
+      Map<HostPort, HostPort> mappings) {
+    this.remoteHost = remoteHost;
+    this.remotePort = remotePort;
+    this.mappings = mappings;
+    this.slotsResponseProcessor = new ClusterSlotsResponseProcessor(mappings);
+    this.nodesResponseProcessor = new ClusterNodesResponseProcessor(mappings);
+  }
+
+  @Override
+  public void channelActive(ChannelHandlerContext ctx) {
+    Channel inboundChannel = ctx.channel();
+    outboundHandler = new RedisProxyOutboundHandler(inboundChannel);
+    movedResponseHandler = new MovedResponseHandler(inboundChannel, mappings);
+
+    // Start the connection attempt.
+    Bootstrap b = new Bootstrap();
+    b.group(inboundChannel.eventLoop())
+        .channel(ctx.channel().getClass())
+        .handler(new ChannelInitializer<SocketChannel>() {
+          @Override
+          protected void initChannel(SocketChannel ch) {
+            ChannelPipeline p = ch.pipeline();
+            p.addLast(new RedisEncoder());
+            p.addLast(new RedisDecoder());
+            p.addLast(new RedisBulkStringAggregator());
+            p.addLast(new RedisArrayAggregator());
+            p.addLast(movedResponseHandler);
+            p.addLast(outboundHandler);
+          }
+        });
+    ChannelFuture f = b.connect(remoteHost, remotePort);
+    outboundChannel = f.channel();
+    f.addListener((ChannelFutureListener) future -> {
+      if (future.isSuccess()) {
+        // connection complete start to read first data
+        inboundChannel.read();
+      } else {
+        logger.error("Failed to connect", future.cause());
+        inboundChannel.close();
+      }
+    });
+  }
+
+  /**
+   * Any redis commands which return an IP or port which needs to be translated into an external
+   * IP/port need to be added to this method and an appropriate {@link RedisResponseProcessor}
+   * needs to be implemented.
+   * <p/>
+   * Note that each inbound command has an explicit outbound processor associated. Commands that
+   * do not need any processing are simply handled by a {@link NoopRedisResponseProcessor}.
+   */
+  @Override
+  public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+    if (outboundChannel.isActive()) {
+      // Commands always consist of an array of bulk strings
+      ArrayRedisMessage rMessage = (ArrayRedisMessage) msg;
+      String command = getArg(rMessage, 0);
+
+      switch (command.toLowerCase()) {
+        case "cluster":
+          String sub = getArg(rMessage, 1);
+          if ("slots".equals(sub)) {
+            outboundHandler.addResponseProcessor(slotsResponseProcessor);
+          } else if ("nodes".equals(sub)) {
+            outboundHandler.addResponseProcessor(nodesResponseProcessor);
+          }
+          break;
+        default:
+          outboundHandler.addResponseProcessor(NoopRedisResponseProcessor.INSTANCE);
+      }
+
+      outboundChannel.writeAndFlush(msg)
+          .addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+              // was able to flush out data, start to read the next chunk
+              ctx.channel().read();
+            } else {
+              logger.error("Failed to write to outboundChannel", future.cause());
+              future.channel().close();
+            }
+          });
+    }
+  }
+
+  private String getArg(ArrayRedisMessage redisArray, int index) {
+    if (index >= redisArray.children().size()) {
+      return null;
+    }
+    return ((FullBulkStringRedisMessage) redisArray.children().get(index))
+        .content().toString(CharsetUtil.UTF_8).toLowerCase();
+  }
+
+  @Override
+  public void channelInactive(ChannelHandlerContext ctx) {
+    if (outboundChannel != null) {
+      closeOnFlush(outboundChannel);
+    }
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    if (!cause.getMessage().contains("Connection reset by peer")) {
+      logger.info(cause);
+    }
+    closeOnFlush(ctx.channel());
+  }
+
+  /**
+   * Closes the specified channel after all queued write requests are flushed.
+   */
+  static void closeOnFlush(Channel ch) {
+    if (ch.isActive()) {
+      ch.writeAndFlush(Unpooled.EMPTY_BUFFER).addListener(ChannelFutureListener.CLOSE);
+    }
+  }
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyOutboundHandler.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyOutboundHandler.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
+
+public class RedisProxyOutboundHandler extends ChannelInboundHandlerAdapter {
+
+  private static final Logger logger = LogService.getLogger();
+  private final Queue<RedisResponseProcessor> processors = new LinkedBlockingQueue<>();
+  private final Channel inboundChannel;
+
+  public RedisProxyOutboundHandler(Channel inboundChannel) {
+    this.inboundChannel = inboundChannel;
+  }
+
+  @Override
+  public void channelActive(ChannelHandlerContext ctx) {
+    ctx.read();
+  }
+
+  @Override
+  public void channelRead(final ChannelHandlerContext ctx, Object msg) {
+    RedisResponseProcessor processor = processors.poll();
+    if (processor == null) {
+      logger.warn("No processor queued - will use default noop processor");
+      processor = NoopRedisResponseProcessor.INSTANCE;
+    }
+
+    inboundChannel.writeAndFlush(processor.process(msg, ctx.channel()))
+        .addListener((ChannelFutureListener) future -> {
+          if (future.isSuccess()) {
+            inboundChannel.read();
+          } else {
+            logger.error("Failed to return response on inboundChannel", future.cause());
+            future.channel().close();
+          }
+        });
+  }
+
+  @Override
+  public void channelInactive(ChannelHandlerContext ctx) {
+    RedisProxyInboundHandler.closeOnFlush(inboundChannel);
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+    if (!cause.getMessage().contains("Connection reset by peer")) {
+      logger.info(cause);
+    }
+    RedisProxyInboundHandler.closeOnFlush(ctx.channel());
+  }
+
+  public void addResponseProcessor(RedisResponseProcessor processor) {
+    processors.add(processor);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisResponseProcessor.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisResponseProcessor.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.proxy;
+
+import io.netty.channel.Channel;
+
+public interface RedisResponseProcessor {
+
+  Object process(Object message, Channel channel);
+
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/ClusterNode.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/ClusterNode.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.test.dunit.rules;
+
+public class ClusterNode {
+  public final String guid;
+  public final String ipAddress;
+  public final int port;
+  public final boolean primary;
+  public final int slotStart;
+  public final int slotEnd;
+
+  public ClusterNode(String guid, String ipAddress, int port, boolean primary, int slotStart,
+      int slotEnd) {
+    this.guid = guid;
+    this.ipAddress = ipAddress;
+    this.port = port;
+    this.primary = primary;
+    this.slotStart = slotStart;
+    this.slotEnd = slotEnd;
+  }
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/NativeRedisClusterTestRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/NativeRedisClusterTestRule.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.test.dunit.rules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.Serializable;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.github.dockerjava.api.model.ContainerNetwork;
+import org.apache.logging.log4j.Logger;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.RuleChain;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+import org.testcontainers.containers.DockerComposeContainer;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.proxy.HostPort;
+import org.apache.geode.redis.internal.proxy.RedisProxy;
+import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
+
+public class NativeRedisClusterTestRule extends ExternalResource implements Serializable {
+
+  private static final Logger logger = LogService.getLogger();
+  private static final Pattern ipPortCportRE = Pattern.compile("([^:]*):([0-9]*)@([0-9]*)");
+  private static final String REDIS_COMPOSE_YML = "/redis-cluster-compose.yml";
+  private static final int NODE_COUNT = 6;
+
+  private DockerComposeContainer<?> redisCluster;
+  private final RuleChain delegate;
+  private final int REDIS_PORT = 6379;
+  private final List<Integer> exposedPorts = new ArrayList<>();
+
+  public NativeRedisClusterTestRule() {
+    delegate = RuleChain
+        // Docker compose does not work on windows in CI. Ignore this test on windows
+        // Using a RuleChain to make sure we ignore the test before the rule comes into play
+        .outerRule(new IgnoreOnWindowsRule());
+  }
+
+  public List<Integer> getExposedPorts() {
+    return exposedPorts;
+  }
+
+  @Override
+  public Statement apply(Statement base, Description description) {
+    Statement containerStatement = new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        URL composeYml = getClass().getResource(REDIS_COMPOSE_YML);
+        assertThat(composeYml).as("Cannot load resource " + REDIS_COMPOSE_YML)
+            .isNotNull();
+
+        redisCluster =
+            new DockerComposeContainer<>("acceptance", new File(composeYml.getFile()));
+        for (int i = 0; i < NODE_COUNT; i++) {
+          redisCluster.withExposedService("redis-node-" + i, REDIS_PORT);
+        }
+
+        redisCluster.start();
+
+        int port = redisCluster.getServicePort("redis-node-0", REDIS_PORT);
+        Jedis jedis = new Jedis("localhost", port);
+        List<ClusterNode> nodes = parseClusterNodes(jedis.clusterNodes());
+
+        assertThat(nodes.stream().mapToInt(x -> x.primary ? 1 : 0).sum())
+            .as("Incorrect primary node count")
+            .isEqualTo(3);
+
+        // Used when translating internal redis host:port to the external host:port which is
+        // ultimately what command results will return.
+        Map<HostPort, HostPort> translationMappings = new HashMap<>();
+        List<RedisProxy> proxies = new ArrayList<>();
+
+        for (int i = 0; i < NODE_COUNT; i++) {
+          Map<String, ContainerNetwork> networks =
+              redisCluster.getContainerByServiceName("redis-node-" + i + "_1").get()
+                  .getContainerInfo().getNetworkSettings().getNetworks();
+          ContainerNetwork network = networks.values().iterator().next();
+          String containerIp = network.getIpAddress();
+          int socatPort = redisCluster.getServicePort("redis-node-" + i, REDIS_PORT);
+
+          RedisProxy proxy = new RedisProxy(socatPort);
+          Integer exposedPort = proxy.getExposedPort();
+          exposedPorts.add(exposedPort);
+          translationMappings.put(new HostPort(containerIp, REDIS_PORT),
+              new HostPort("127.0.0.1", exposedPort));
+
+          proxies.add(proxy);
+        }
+
+        proxies.forEach(p -> p.configure(translationMappings));
+
+        logger.info("Started redis cluster with mapped ports: {}", translationMappings);
+        try {
+          base.evaluate(); // This will run the test.
+        } finally {
+          redisCluster.stop();
+          proxies.forEach(RedisProxy::stop);
+        }
+      }
+    };
+
+    return delegate.apply(containerStatement, description);
+  }
+
+  public static List<ClusterNode> parseClusterNodes(String rawInput) {
+    List<ClusterNode> nodes = new ArrayList<>();
+
+    for (String line : rawInput.split("\\n")) {
+      nodes.add(parseOneClusterNodeLine(line));
+    }
+
+    return nodes;
+  }
+
+  private static ClusterNode parseOneClusterNodeLine(String line) {
+    String[] parts = line.split(" ");
+
+    Matcher addressMatcher = ipPortCportRE.matcher(parts[1]);
+    if (!addressMatcher.matches()) {
+      throw new IllegalArgumentException("Unable to extract ip:port@cport from " + line);
+    }
+
+    boolean primary = parts[2].contains("master");
+
+    int slotStart = -1;
+    int slotEnd = -1;
+    if (primary) {
+      // Sometimes we see a 'primary' without slots which seems to imply it hasn't yet transitioned
+      // to being a 'replica'.
+      if (parts.length > 8) {
+        String[] startEnd = parts[8].split("-");
+        slotStart = Integer.parseInt(startEnd[0]);
+        if (startEnd.length > 1) {
+          slotEnd = Integer.parseInt(startEnd[1]);
+        } else {
+          slotEnd = slotStart;
+        }
+      } else {
+        primary = false;
+      }
+    }
+
+    return new ClusterNode(
+        parts[0],
+        addressMatcher.group(1),
+        Integer.parseInt(addressMatcher.group(2)),
+        primary,
+        slotStart,
+        slotEnd);
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/commonTest/resources/redis-cluster-compose.yml
+++ b/geode-apis-compatible-with-redis/src/commonTest/resources/redis-cluster-compose.yml
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+# agreements. See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the License. You may obtain a
+# copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+
+version: '2'
+services:
+  redis-node-0:
+    image: docker.io/bitnami/redis-cluster:5.0
+    environment:
+      - 'ALLOW_EMPTY_PASSWORD=yes'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-1:
+    image: docker.io/bitnami/redis-cluster:5.0
+    environment:
+      - 'ALLOW_EMPTY_PASSWORD=yes'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-2:
+    image: docker.io/bitnami/redis-cluster:5.0
+    environment:
+      - 'ALLOW_EMPTY_PASSWORD=yes'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-3:
+    image: docker.io/bitnami/redis-cluster:5.0
+    environment:
+      - 'ALLOW_EMPTY_PASSWORD=yes'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-4:
+    image: docker.io/bitnami/redis-cluster:5.0
+    environment:
+      - 'ALLOW_EMPTY_PASSWORD=yes'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-node-5:
+    image: docker.io/bitnami/redis-cluster:5.0
+    environment:
+      - 'ALLOW_EMPTY_PASSWORD=yes'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+
+  redis-cluster-init:
+    image: docker.io/bitnami/redis-cluster:5.0
+    depends_on:
+      - redis-node-0
+      - redis-node-1
+      - redis-node-2
+      - redis-node-3
+      - redis-node-4
+      - redis-node-5
+    environment:
+      - 'REDIS_CLUSTER_REPLICAS=1'
+      - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
+      - 'REDIS_CLUSTER_CREATOR=yes'

--- a/geode-apis-compatible-with-redis/src/commonTest/resources/redis-cluster-compose.yml
+++ b/geode-apis-compatible-with-redis/src/commonTest/resources/redis-cluster-compose.yml
@@ -62,3 +62,4 @@ services:
       - 'REDIS_CLUSTER_REPLICAS=1'
       - 'REDIS_NODES=redis-node-0 redis-node-1 redis-node-2 redis-node-3 redis-node-4 redis-node-5'
       - 'REDIS_CLUSTER_CREATOR=yes'
+      - 'ALLOW_EMPTY_PASSWORD=yes'


### PR DESCRIPTION
The fun part here is that some redis commands will respond with internal
IP addresses which need to be rewritten so that clients are able to make
use of them. Currently CLUSTER SLOTS and CLUSTER NODES are implemented
with this functionality.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
