### PR TITLE
force all upgradeTest and integrationTest tasks to depend on installDist

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -698,3 +698,12 @@ acceptanceTest {
 }
 
 apply from: Paths.get("${rootDir}", 'gradle', 'japicmp.gradle')
+
+def needyTestNames = ['upgradeTest', 'integrationTest']
+dependentProjectNames.each { depProj ->
+  needyTestNames.each { needyTest ->
+    project(depProj).tasks.named(needyTest).configure {
+      dependsOn(tasks.named('installDist'))
+    }
+  }
+}


### PR DESCRIPTION
Might fix issues we've seen on support/1.14 with classes not in classpath during execution. We'll run a few test iterations and see how this goes...

