### PR TITLE
GEODE-9161: Use not deperacted property in gradle build

### DIFF
--- a/extensions/geode-modules-assembly/build.gradle
+++ b/extensions/geode-modules-assembly/build.gradle
@@ -206,7 +206,7 @@ tasks.register('distAppServer', Zip) {
     from('release/session/bin/') {
       include 'modify_war'
 
-      filter(ReplaceTokens, tokens:['GEODE_VERSION': version])
+      filter(ReplaceTokens, tokens:['GEODE_VERSION': archiveVersion.get()])
       filter(ReplaceTokens, tokens:['SLF4J_VERSION': DependencyConstraints.get('slf4j-api.version')])
       filter(ReplaceTokens, tokens:['LOG4J_VERSION': DependencyConstraints.get('log4j.version')])
       filter(ReplaceTokens, tokens:['FASTUTIL_VERSION': DependencyConstraints.get('fastutil.version')])

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -638,7 +638,7 @@ tasks.named('srcDistTar').configure {
 
 tasks.withType(Test) {
   dependsOn installDist
-  environment 'GEODE_HOME', "$buildDir/install/${distributions.main.baseName}"
+  environment 'GEODE_HOME', "$buildDir/install/${distributions.main.distributionBaseName.get()}"
 }
 
 


### PR DESCRIPTION
- remember friends that if you switch from string to property, you need
a `.get()`

Authored-by: M. Oleske <michael@oleske.engineer>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
