### PR TITLE
GEODE-9204: thread hung waiting for response

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/BadCacheLoaderDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/BadCacheLoaderDUnitTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.distributed.internal;
+
+import java.io.NotSerializableException;
+import java.io.Serializable;
+import java.util.Properties;
+
+import org.assertj.core.api.Assertions;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.InternalGemFireException;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.test.dunit.SerializableRunnableIF;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+
+public class BadCacheLoaderDUnitTest implements Serializable {
+  public static final String TEST_REGION = "testRegion";
+  public static final String TEST_KEY = "testKey";
+  public static final String TEST_VALUE = "testValue";
+
+  static class NotSerializableTestException extends RuntimeException {
+    Object unserializableField = new Object();
+  }
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule(2);
+
+  CacheRule cacheRule = CacheRule.builder().build();
+
+  /**
+   * Ensure that a cache loader throwing an exception that is not serializable is handled
+   * correctly
+   */
+  @Test
+  public void testNonSerializableObjectReturnedByCacheLoader() throws Exception {
+    final VM cacheLoaderVM = VM.getVM(0);
+    final VM fetchingVM = VM.getVM(1);
+
+    final Properties properties = new Properties();
+    properties.put(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER,
+        NotSerializableTestException.class.getName());
+
+    cacheLoaderVM.invoke("create a region with a bad cache loader",
+        createRegionWithBadCacheLoader(properties));
+
+    Assertions.assertThatThrownBy(() -> fetchingVM.invoke("fetch something from the cache",
+        fetchValueCausingCacheLoad(properties)))
+        .hasCauseInstanceOf(InternalGemFireException.class)
+        .hasRootCauseInstanceOf(NotSerializableException.class)
+        .hasRootCauseMessage("java.lang.Object");
+  }
+
+  @NotNull
+  private SerializableRunnableIF fetchValueCausingCacheLoad(Properties properties) {
+    return () -> {
+      final Cache cache = cacheRule.getOrCreateCache(properties);
+      final Region<String, Object> testRegion =
+          cache.<String, Object>createRegionFactory(RegionShortcut.PARTITION)
+              .setCacheLoader(helper -> new Object())
+              .create(TEST_REGION);
+      testRegion.getAttributesMutator().setCacheLoader(helper -> "should not be invoked");
+      testRegion.get(TEST_KEY);
+    };
+  }
+
+  @NotNull
+  private SerializableRunnableIF createRegionWithBadCacheLoader(Properties properties) {
+    return () -> {
+      final Cache cache = cacheRule.getOrCreateCache(properties);
+      final Region<String, Object> testRegion =
+          cache.<String, Object>createRegionFactory(RegionShortcut.PARTITION)
+              .setCacheLoader(helper -> {
+                throw new NotSerializableTestException();
+              })
+              .create(TEST_REGION);
+      testRegion.put(TEST_KEY, TEST_VALUE);
+      testRegion.destroy(TEST_KEY);
+    };
+  }
+}

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -175,8 +175,8 @@ fromData,52
 toData,48
 
 org/apache/geode/distributed/internal/ReplyMessage,2
-fromData,102
-toData,133
+fromData,136
+toData,170
 
 org/apache/geode/distributed/internal/SerialAckedMessage,2
 fromData,28

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -175,8 +175,8 @@ fromData,52
 toData,48
 
 org/apache/geode/distributed/internal/ReplyMessage,2
-fromData,136
-toData,170
+fromData,152
+toData,178
 
 org/apache/geode/distributed/internal/SerialAckedMessage,2
 fromData,28

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyMessage.java
@@ -23,7 +23,6 @@ import java.io.NotSerializableException;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
-import org.apache.geode.DataSerializer;
 import org.apache.geode.InvalidDeltaException;
 import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyMessage.java
@@ -297,7 +297,7 @@ public class ReplyMessage extends HighPriorityDistributionMessage {
     }
     if (this.returnValueIsException || this.returnValue != null) {
       try {
-        DataSerializer.writeObject(this.returnValue, out);
+        context.getSerializer().writeObject(this.returnValue, out);
       } catch (NotSerializableException e) {
         // When this happens data has already been written to the output stream for the
         // non-serializable object. The recipient will get a java.io.WriteAbortedException when
@@ -319,10 +319,10 @@ public class ReplyMessage extends HighPriorityDistributionMessage {
     }
     try {
       if (testFlag(status, EXCEPTION_FLAG)) {
-        this.returnValue = DataSerializer.readObject(in);
+        this.returnValue = context.getDeserializer().readObject(in);
         this.returnValueIsException = true;
       } else if (testFlag(status, OBJECT_FLAG)) {
-        this.returnValue = DataSerializer.readObject(in);
+        this.returnValue = context.getDeserializer().readObject(in);
         this.returnValueIsException = (returnValue instanceof ReplyException);
       }
     } catch (IOException e) {

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/ReplyMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/ReplyMessageTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.WriteAbortedException;
+
+import org.junit.Test;
+
+import org.apache.geode.internal.HeapDataOutputStream;
+import org.apache.geode.internal.InternalDataSerializer;
+
+public class ReplyMessageTest {
+  @Test
+  public void replyMessageCanSerializeWithNonSerializableValue() throws Exception {
+    final ReplyMessage replyMessage = new ReplyMessage();
+    replyMessage.setReturnValue(new Object());
+    final HeapDataOutputStream heapDataOutputStream = new HeapDataOutputStream(1000);
+    InternalDataSerializer.getDSFIDSerializer().invokeToData(replyMessage, heapDataOutputStream);
+    final byte[] bytes = heapDataOutputStream.toByteArray();
+    final DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(bytes));
+    final ReplyMessage newReplyMessage = new ReplyMessage();
+    InternalDataSerializer.getDSFIDSerializer().invokeFromData(newReplyMessage, dataInputStream);
+    assertThat(newReplyMessage.getException()).hasCauseInstanceOf(
+        WriteAbortedException.class);
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PutPutReplyMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PutPutReplyMessageJUnitTest.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.internal.cache.partitioned;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -26,7 +24,6 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.EntryEventImpl.OldValueImporter;
 import org.apache.geode.internal.cache.OldValueImporterTestBase;
 import org.apache.geode.internal.cache.partitioned.PutMessage.PutReplyMessage;
-import org.apache.geode.internal.serialization.DeserializationContext;
 
 public class PutPutReplyMessageJUnitTest extends OldValueImporterTestBase {
 
@@ -48,7 +45,8 @@ public class PutPutReplyMessageJUnitTest extends OldValueImporterTestBase {
   @Override
   protected void fromData(OldValueImporter ovi, byte[] bytes)
       throws IOException, ClassNotFoundException {
-    ((PutReplyMessage) ovi).fromData(new DataInputStream(new ByteArrayInputStream(bytes)), mock(
-        DeserializationContext.class));
+    final DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(bytes));
+    ((PutReplyMessage) ovi).fromData(dataInputStream,
+        InternalDataSerializer.createDeserializationContext(dataInputStream));
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tx/RemotePutReplyMessageJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tx/RemotePutReplyMessageJUnitTest.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.internal.cache.tx;
 
-import static org.mockito.Mockito.mock;
-
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -26,7 +24,6 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.EntryEventImpl.OldValueImporter;
 import org.apache.geode.internal.cache.OldValueImporterTestBase;
 import org.apache.geode.internal.cache.tx.RemotePutMessage.PutReplyMessage;
-import org.apache.geode.internal.serialization.DeserializationContext;
 
 public class RemotePutReplyMessageJUnitTest extends OldValueImporterTestBase {
 
@@ -48,7 +45,8 @@ public class RemotePutReplyMessageJUnitTest extends OldValueImporterTestBase {
   @Override
   protected void fromData(OldValueImporter ovi, byte[] bytes)
       throws IOException, ClassNotFoundException {
-    ((PutReplyMessage) ovi).fromData(new DataInputStream(new ByteArrayInputStream(bytes)), mock(
-        DeserializationContext.class));
+    final DataInputStream dataInputStream = new DataInputStream(new ByteArrayInputStream(bytes));
+    ((PutReplyMessage) ovi).fromData(dataInputStream,
+        InternalDataSerializer.createDeserializationContext(dataInputStream));
   }
 }


### PR DESCRIPTION
A not serializable exception can cause a ServerConnection thread to get stuck
waiting for a reply from another member.  This is caused by ReplyMessage
not handling a non-serializable "returnValue".

The fix is to catch and log the exception in the sending node and then
handle the problem in the receiving node.

I would have liked to serialize the "returnValue" field into a separate buffer
so as not to transmit a partial serialization of the object but that would require
an extra buffer copy for every ReplyMessage sent, and we send a lot of them.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
