### PR TITLE
GEODE-9216 - User Guide: "gemfire.enableTcpKeepAlive" should be "gemf…

### DIFF
--- a/geode-docs/managing/logging/setting_up_logging.html.md.erb
+++ b/geode-docs/managing/logging/setting_up_logging.html.md.erb
@@ -65,7 +65,7 @@ Before you begin, make sure you understand [Basic Configuration and Programming]
     3.  Set the maximum size of a single log file in `log-file-size-limit`. If not set, the single, main log file is used. If set, the metadata file, the main log, and rolled child logs are used.
     4.  Set the maximum size of all log files in `log-disk-space-limit`. If non-zero, this limits the combined size of all inactive log files, deleting oldest files first to stay under the limit. A zero setting indicates no limit.
 
-4.  If you are using the `gfsh` command-line interface, `gfsh` can creates its own log file in the directory where you run the `gfsh` or `gfsh.bat` script. By default, gfsh does not generate log files for itself. To enable gfsh logs, set the following system property to the desired log level before starting gfsh:
+4.  If you are using the `gfsh` command-line interface, `gfsh` can create its own log file in the directory where you run the `gfsh` or `gfsh.bat` script. By default, gfsh does not generate log files for itself. To enable gfsh logs, set the following system property to the desired log level before starting gfsh:
 
     ``` pre
     export JAVA_ARGS=-Dgfsh.log-level=[severe|warning|info|config|fine|finer|finest]

--- a/geode-docs/managing/monitor_tune/socket_tcp_keepalive.html.md.erb
+++ b/geode-docs/managing/monitor_tune/socket_tcp_keepalive.html.md.erb
@@ -21,7 +21,7 @@ limitations under the License.
 
 <%=vars.product_name%> supports TCP KeepAlive to prevent socket connections from being timed out.
 
-The `gemfire.enableTcpKeepAlive` system property prevents connections that appear idle from being timed out (for example, by a firewall.) When configured to true, <%=vars.product_name%> enables the SO\_KEEPALIVE option for individual sockets. This operating system-level setting allows the socket to send verification checks (ACK requests) to remote systems in order to determine whether or not to keep the socket connection alive.
+The `gemfire.setTcpKeepAlive` system property prevents connections that appear idle from being timed out (for example, by a firewall.) When configured to true, <%=vars.product_name%> enables the SO\_KEEPALIVE option for individual sockets. This operating system-level setting allows the socket to send verification checks (ACK requests) to remote systems in order to determine whether or not to keep the socket connection alive.
 
 **Note:**
 The time intervals for sending the first ACK KeepAlive request, the subsequent ACK requests and the number of requests to send before closing the socket is configured on the operating system level.


### PR DESCRIPTION
…ire.setTcpKeepAlive"

Fixing the only occurrence in the document; also picking up another stray typo in the logging section.