### PR TITLE
GEODE-9069: Increasing the timeout in HGetDUnitTest

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HGetDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HGetDUnitTest.java
@@ -97,7 +97,7 @@ public class HGetDUnitTest {
           jedis1.hset(key, field, value);
           expectedMap.put(field, value);
         },
-        (i) -> GeodeAwaitility.await().atMost(Duration.ofSeconds(1)).untilAsserted(
+        (i) -> GeodeAwaitility.await().atMost(Duration.ofSeconds(60)).untilAsserted(
             () -> assertThat(jedis2.hget(key, "field-" + i)).isEqualTo("value-" + (i))))
                 .runInLockstep();
 


### PR DESCRIPTION
	* Similar to the previous commit for GEODE-9069, the timeout is increased for HGetDUnitTest

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
