### PR TITLE
GEODE-9220: Switch hash integration tests to use JedisCluster

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -435,7 +435,7 @@
       <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers</artifactId>
-        <version>1.14.3</version>
+        <version>1.15.3</version>
       </dependency>
       <dependency>
         <groupId>pl.pragmatists</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -161,7 +161,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.springframework.hateoas', name: 'spring-hateoas', version: '1.3.0')
         api(group: 'org.springframework.ldap', name: 'spring-ldap-core', version: '2.3.2.RELEASE')
         api(group: 'org.springframework.shell', name: 'spring-shell', version: get('springshell.version'))
-        api(group: 'org.testcontainers', name: 'testcontainers', version: '1.14.3')
+        api(group: 'org.testcontainers', name: 'testcontainers', version: '1.15.3')
         api(group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.0')
         api(group: 'redis.clients', name: 'jedis', version: '3.5.2')
         api(group: 'io.lettuce', name: 'lettuce-core', version: '6.1.1.RELEASE')

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HScanNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HScanNativeRedisAcceptanceTest.java
@@ -16,16 +16,20 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import org.junit.ClassRule;
 
-import org.apache.geode.NativeRedisTestRule;
+import org.apache.geode.redis.NativeRedisClusterTestRule;
 
 public class HScanNativeRedisAcceptanceTest extends AbstractHScanIntegrationTest {
 
   @ClassRule
-  public static NativeRedisTestRule redis = new NativeRedisTestRule();
+  public static NativeRedisClusterTestRule redis = new NativeRedisClusterTestRule();
 
   @Override
   public int getPort() {
-    return redis.getPort();
+    return redis.getExposedPorts().get(0);
   }
 
+  @Override
+  public void flushAll() {
+    redis.flushAll();
+  }
 }

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HashesNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HashesNativeRedisAcceptanceTest.java
@@ -16,16 +16,21 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import org.junit.ClassRule;
 
-import org.apache.geode.NativeRedisTestRule;
+import org.apache.geode.redis.NativeRedisClusterTestRule;
 
 public class HashesNativeRedisAcceptanceTest extends AbstractHashesIntegrationTest {
 
   @ClassRule
-  public static NativeRedisTestRule redis = new NativeRedisTestRule();
+  public static NativeRedisClusterTestRule redis = new NativeRedisClusterTestRule();
 
   @Override
   public int getPort() {
-    return redis.getPort();
+    return redis.getExposedPorts().get(0);
+  }
+
+  @Override
+  public void flushAll() {
+    redis.flushAll();
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HincrByFloatNativeRedisAccetanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/hash/HincrByFloatNativeRedisAccetanceTest.java
@@ -17,16 +17,20 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import org.junit.ClassRule;
 
-import org.apache.geode.NativeRedisTestRule;
+import org.apache.geode.redis.NativeRedisClusterTestRule;
 
 public class HincrByFloatNativeRedisAccetanceTest extends AbstractHincrByFloatIntegrationTest {
 
   @ClassRule
-  public static NativeRedisTestRule redis = new NativeRedisTestRule();
+  public static NativeRedisClusterTestRule redis = new NativeRedisClusterTestRule();
 
   @Override
   public int getPort() {
-    return redis.getPort();
+    return redis.getExposedPorts().get(0);
   }
 
+  @Override
+  public void flushAll() {
+    redis.flushAll();
+  }
 }

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/resources/testcontainers.properties
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/resources/testcontainers.properties
@@ -1,0 +1,16 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+# agreements. See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the License. You may obtain a
+# copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+#
+
+transport.type=httpclient5

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
@@ -122,6 +122,7 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
         } finally {
           redisCluster.stop();
           proxies.forEach(RedisProxy::stop);
+          exposedPorts.clear();
         }
       }
     };

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
@@ -76,6 +76,10 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
           redisCluster.withExposedService("redis-node-" + i, REDIS_PORT);
         }
 
+        // This assumes docker-compose is installed locally. Removing this line will automatically
+        // pull a container containing docker-compose, but it will run slower (at least on MacOS).
+        redisCluster.withLocalCompose(true);
+
         redisCluster.start();
 
         int port = redisCluster.getServicePort("redis-node-0", REDIS_PORT);

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
@@ -125,4 +125,19 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
     return delegate.apply(containerStatement, description);
   }
 
+  public void flushAll() {
+    ClusterNodes nodes;
+    try (Jedis jedis = new Jedis("localhost", exposedPorts.get(0))) {
+      nodes = ClusterNodes.parseClusterNodes(jedis.clusterNodes());
+    }
+
+    for (ClusterNode node : nodes.getNodes()) {
+      if (!node.primary) {
+        continue;
+      }
+      try (Jedis jedis = new Jedis(node.ipAddress, (int) node.port)) {
+        jedis.flushAll();
+      }
+    }
+  }
 }

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/RedisIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/RedisIntegrationTest.java
@@ -13,9 +13,17 @@
  * the License.
  */
 
-package org.apache.geode.test.dunit.rules;
+package org.apache.geode.redis;
 
-public interface RedisPortSupplier {
+import redis.clients.jedis.Jedis;
+
+public interface RedisIntegrationTest {
 
   int getPort();
+
+  default void flushAll() {
+    try (Jedis jedis = new Jedis("localhost", getPort())) {
+      jedis.flushAll();
+    }
+  }
 }

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxy.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxy.java
@@ -50,7 +50,7 @@ public final class RedisProxy {
 
   public RedisProxy(int targetPort) {
     bossGroup = new NioEventLoopGroup(1);
-    workerGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("RedisProxy"));
+    workerGroup = new NioEventLoopGroup(2, new DefaultThreadFactory("RedisProxy"));
 
     ChannelFuture future = new ServerBootstrap().group(bossGroup, workerGroup)
         .channel(NioServerSocketChannel.class)

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxy.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxy.java
@@ -33,6 +33,7 @@ import io.netty.handler.codec.redis.RedisArrayAggregator;
 import io.netty.handler.codec.redis.RedisBulkStringAggregator;
 import io.netty.handler.codec.redis.RedisDecoder;
 import io.netty.handler.codec.redis.RedisEncoder;
+import io.netty.util.concurrent.DefaultThreadFactory;
 
 
 /**
@@ -49,7 +50,7 @@ public final class RedisProxy {
 
   public RedisProxy(int targetPort) {
     bossGroup = new NioEventLoopGroup(1);
-    workerGroup = new NioEventLoopGroup(1);
+    workerGroup = new NioEventLoopGroup(4, new DefaultThreadFactory("RedisProxy"));
 
     ChannelFuture future = new ServerBootstrap().group(bossGroup, workerGroup)
         .channel(NioServerSocketChannel.class)

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxy.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxy.java
@@ -50,7 +50,7 @@ public final class RedisProxy {
 
   public RedisProxy(int targetPort) {
     bossGroup = new NioEventLoopGroup(1);
-    workerGroup = new NioEventLoopGroup(4, new DefaultThreadFactory("RedisProxy"));
+    workerGroup = new NioEventLoopGroup(1, new DefaultThreadFactory("RedisProxy"));
 
     ChannelFuture future = new ServerBootstrap().group(bossGroup, workerGroup)
         .channel(NioServerSocketChannel.class)

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.proxy;
 
+import java.net.InetSocketAddress;
 import java.util.Map;
 
 import io.netty.bootstrap.Bootstrap;
@@ -85,6 +86,17 @@ public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
     outboundChannel = f.channel();
     f.addListener((ChannelFutureListener) future -> {
       if (future.isSuccess()) {
+        InetSocketAddress target = (InetSocketAddress) inboundChannel.localAddress();
+        for (Map.Entry<HostPort, HostPort> entry : mappings.entrySet()) {
+          HostPort exposed = entry.getValue();
+          if (target.getPort() == exposed.getPort()) {
+            logger.info("Established proxy connection {} -> {} -> {}",
+                inboundChannel.remoteAddress(),
+                inboundChannel.localAddress(),
+                entry.getKey());
+            break;
+          }
+        }
         // connection complete start to read first data
         inboundChannel.read();
       } else {

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
@@ -97,8 +97,7 @@ public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
             break;
           }
         }
-        // connection complete start to read first data
-        inboundChannel.read();
+        inboundChannel.config().setAutoRead(true);
       } else {
         logger.error("Failed to connect", future.cause());
         inboundChannel.close();
@@ -108,11 +107,11 @@ public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
 
   /**
    * Any redis commands which return an IP or port which needs to be translated into an external
-   * IP/port need to be added to this method and an appropriate {@link RedisResponseProcessor}
-   * needs to be implemented.
+   * IP/port need to be added to this method and an appropriate {@link RedisResponseProcessor} needs
+   * to be implemented.
    * <p/>
-   * Note that each inbound command has an explicit outbound processor associated. Commands that
-   * do not need any processing are simply handled by a {@link NoopRedisResponseProcessor}.
+   * Note that each inbound command has an explicit outbound processor associated. Commands that do
+   * not need any processing are simply handled by a {@link NoopRedisResponseProcessor}.
    */
   @Override
   public void channelRead(final ChannelHandlerContext ctx, Object msg) {

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyOutboundHandler.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyOutboundHandler.java
@@ -51,9 +51,7 @@ public class RedisProxyOutboundHandler extends ChannelInboundHandlerAdapter {
 
     inboundChannel.writeAndFlush(processor.process(msg, ctx.channel()))
         .addListener((ChannelFutureListener) future -> {
-          if (future.isSuccess()) {
-            inboundChannel.read();
-          } else {
+          if (!future.isSuccess()) {
             logger.error("Failed to return response on inboundChannel", future.cause());
             future.channel().close();
           }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/AbstractCommandPipeliningIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/AbstractCommandPipeliningIntegrationTest.java
@@ -30,10 +30,9 @@ import redis.clients.jedis.Pipeline;
 
 import org.apache.geode.redis.mocks.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
-public abstract class AbstractCommandPipeliningIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractCommandPipeliningIntegrationTest implements RedisIntegrationTest {
   private Jedis publisher;
   private Jedis subscriber;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
@@ -17,17 +17,31 @@ package org.apache.geode.redis;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.function.BiFunction;
+
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 
 public class RedisCommandArgumentsTestHelper {
   public static void assertExactNumberOfArgs(Jedis jedis, Protocol.Command command, int numArgs) {
+    assertExactNumberOfArgs0(jedis::sendCommand, command, numArgs);
+  }
+
+  public static void assertExactNumberOfArgs(JedisCluster jedis,
+      Protocol.Command command, int numArgs) {
+    assertExactNumberOfArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args), command,
+        numArgs);
+  }
+
+  private static void assertExactNumberOfArgs0(BiFunction<Protocol.Command, byte[][], Object> runMe,
+      Protocol.Command command, int numArgs) {
     final int MAX_NUM_ARGS = 5; // currently enough for all implemented commands
 
     for (int i = 0; i <= MAX_NUM_ARGS; i++) {
       if (i != numArgs) {
         byte[][] args = buildArgs(i);
-        assertThatThrownBy(() -> jedis.sendCommand(command, args))
+        assertThatThrownBy(() -> runMe.apply(command, args))
             .hasMessageContaining("ERR wrong number of arguments for '"
                 + command.toString().toLowerCase() + "' command");
       }
@@ -35,18 +49,40 @@ public class RedisCommandArgumentsTestHelper {
   }
 
   public static void assertAtLeastNArgs(Jedis jedis, Protocol.Command command, int minNumArgs) {
+    assertAtLeastNArgs0(jedis::sendCommand, command, minNumArgs);
+  }
+
+  public static void assertAtLeastNArgs(JedisCluster jedis, Protocol.Command command,
+      int minNumArgs) {
+    assertAtLeastNArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args), command,
+        minNumArgs);
+  }
+
+  private static void assertAtLeastNArgs0(BiFunction<Protocol.Command, byte[][], Object> runMe,
+      Protocol.Command command, int minNumArgs) {
     for (int i = 0; i < minNumArgs; i++) {
       byte[][] args = buildArgs(i);
-      assertThatThrownBy(() -> jedis.sendCommand(command, args))
+      assertThatThrownBy(() -> runMe.apply(command, args))
           .hasMessageContaining("ERR wrong number of arguments for '"
               + command.toString().toLowerCase() + "' command");
     }
   }
 
   public static void assertAtMostNArgs(Jedis jedis, Protocol.Command command, int maxNumArgs) {
+    assertAtMostNArgs0(jedis::sendCommand, command, maxNumArgs);
+  }
+
+  public static void assertAtMostNArgs(JedisCluster jedis, Protocol.Command command,
+      int maxNumArgs) {
+    assertAtMostNArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args), command,
+        maxNumArgs);
+  }
+
+  private static void assertAtMostNArgs0(BiFunction<Protocol.Command, byte[][], Object> runMe,
+      Protocol.Command command, int maxNumArgs) {
     for (int i = maxNumArgs + 1; i <= 5; i++) {
       byte[][] args = buildArgs(i);
-      assertThatThrownBy(() -> jedis.sendCommand(command, args))
+      assertThatThrownBy(() -> runMe.apply(command, args))
           .hasMessageContaining("ERR wrong number of arguments for '"
               + command.toString().toLowerCase() + "' command");
     }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractGlobPatternIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractGlobPatternIntegrationTest.java
@@ -22,10 +22,10 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractGlobPatternIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractGlobPatternIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
@@ -22,10 +22,10 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractUnknownIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractUnknownIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/cluster/AbstractClusterIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/cluster/AbstractClusterIntegrationTest.java
@@ -24,9 +24,9 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
+import org.apache.geode.redis.RedisIntegrationTest;
 
-public abstract class AbstractClusterIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractClusterIntegrationTest implements RedisIntegrationTest {
 
   private JedisCluster jedis;
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractEchoIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractEchoIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractEchoIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractEchoIntegrationTest implements RedisIntegrationTest {
 
   private static final int REDIS_CLIENT_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractPingIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractPingIntegrationTest.java
@@ -25,10 +25,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractPingIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractPingIntegrationTest implements RedisIntegrationTest {
 
   protected static final int REDIS_CLIENT_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractSelectIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractSelectIntegrationTest.java
@@ -25,10 +25,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSelectIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSelectIntegrationTest implements RedisIntegrationTest {
 
   private static final int REDIS_CLIENT_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -25,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -34,40 +35,35 @@ import java.util.stream.Collectors;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTest {
 
-  protected Jedis jedis;
-  private static Jedis jedis2;
-  private static Jedis jedis3;
+  protected JedisCluster jedis;
+  private static JedisCluster jedis2;
+  private static JedisCluster jedis3;
 
   private static final int REDIS_CLIENT_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
 
   @Before
   public void setUp() {
-    jedis = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
-    jedis2 = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
-    jedis3 = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
-  }
-
-  @After
-  public void flushAll() {
-    jedis.flushAll();
-    jedis2.flushAll();
-    jedis3.flushAll();
+    jedis = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
+    jedis2 = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
+    jedis3 = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
   }
 
   @After
   public void tearDown() {
+    flushAll();
     jedis.close();
     jedis2.close();
     jedis3.close();
@@ -84,7 +80,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
   public void givenMatchArgumentWithoutPatternOnExistingKey_returnsSyntaxError() {
     jedis.hset("key", "b", "1");
 
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "key", "0", "Match"))
+    assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.HSCAN, "key", "0", "Match"))
         .hasMessageContaining(ERROR_SYNTAX);
   }
 
@@ -93,7 +89,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
   public void givenMatchArgumentWithoutPatternOnNonExistentKey_returnsEmptyArray() {
 
     List<Object> result =
-        (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN, "key1", "0", "Match");
+        (List<Object>) jedis.sendCommand("key1", Protocol.Command.HSCAN, "key1", "0", "Match");
 
     assertThat((List<String>) result.get(1)).isEmpty();
   }
@@ -102,7 +98,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
   public void givenCountArgumentWithoutNumberOnExistingKey_returnsSyntaxError() {
     jedis.hset("a", "b", "1");
 
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "Count"))
+    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "Count"))
         .hasMessageContaining(ERROR_SYNTAX);
   }
 
@@ -110,7 +106,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
   @SuppressWarnings("unchecked")
   public void givenCountArgumentWithoutNumberOnNonExistentKey_returnsEmptyArray() {
     List<Object> result =
-        (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN, "b", "0", "Count");
+        (List<Object>) jedis.sendCommand("b", Protocol.Command.HSCAN, "b", "0", "Count");
 
     assertThat((List<String>) result.get(1)).isEmpty();
   }
@@ -118,55 +114,60 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
   @Test
   public void givenMatchOrCountKeywordNotSpecified_returnsSyntaxError() {
     jedis.hset("a", "b", "1");
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "a*", "1"))
+    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "a*", "1"))
         .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
   public void givenCount_whenCountParameterIsNotAnInteger_returnsNotIntegerError() {
     jedis.hset("a", "b", "1");
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "MATCH"))
-        .hasMessageContaining(ERROR_NOT_INTEGER);
+    assertThatThrownBy(
+        () -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "COUNT", "MATCH"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenMultipleCounts_whenAnyCountParameterIsNotAnInteger_returnsNotIntegerError() {
     jedis.hset("a", "b", "1");
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "3",
-        "COUNT", "sjlfs", "COUNT", "1"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+    assertThatThrownBy(
+        () -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "COUNT", "3",
+            "COUNT", "sjlfs", "COUNT", "1"))
+                .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenCount_whenCountParameterIsZero_returnsSyntaxError() {
     jedis.hset("a", "b", "1");
 
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "0"))
-        .hasMessageContaining(ERROR_SYNTAX);
+    assertThatThrownBy(
+        () -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "COUNT", "0"))
+            .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
   public void givenCount_whenCountParameterIsNegative_returnsSyntaxError() {
     jedis.hset("a", "b", "1");
 
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0", "COUNT", "-37"))
-        .hasMessageContaining(ERROR_SYNTAX);
+    assertThatThrownBy(
+        () -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "COUNT", "-37"))
+            .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
   public void givenMultipleCounts_whenAnyCountParameterIsLessThanOne_returnsSyntaxError() {
     jedis.hset("key", "b", "1");
 
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "key", "0", "COUNT", "3",
-        "COUNT", "0", "COUNT", "1"))
-            .hasMessageContaining(ERROR_SYNTAX);
+    assertThatThrownBy(
+        () -> jedis.sendCommand("key", Protocol.Command.HSCAN, "key", "0", "COUNT", "3",
+            "COUNT", "0", "COUNT", "1"))
+                .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
   public void givenKeyIsNotAHash_returnsWrongTypeError() {
     jedis.sadd("a", "1");
 
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "0"))
+    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0"))
         .hasMessageContaining(ERROR_WRONG_TYPE);
   }
 
@@ -174,21 +175,22 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
   public void givenKeyIsNotAHash_andCursorIsNotAnInteger_returnsCursorError() {
     jedis.sadd("a", "b");
 
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "sjfls"))
+    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "sjfls"))
         .hasMessageContaining(ERROR_CURSOR);
   }
 
   @Test
   public void givenNonexistentKey_andCursorIsNotAnInteger_returnsCursorError() {
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "notReal", "sjfls"))
-        .hasMessageContaining(ERROR_CURSOR);
+    assertThatThrownBy(
+        () -> jedis.sendCommand("notReal", Protocol.Command.HSCAN, "notReal", "sjfls"))
+            .hasMessageContaining(ERROR_CURSOR);
   }
 
   @Test
   public void givenExistentHashKey_andCursorIsNotAnInteger_returnsCursorError() {
     jedis.hset("a", "b", "1");
 
-    assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.HSCAN, "a", "sjfls"))
+    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "sjfls"))
         .hasMessageContaining(ERROR_CURSOR);
   }
 
@@ -230,7 +232,8 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
     scanParams.count(1);
     scanParams.match("\\p");
 
-    ScanResult<Map.Entry<String, String>> result = jedis.hscan("a", "0", scanParams);
+    ScanResult<Map.Entry<byte[], byte[]>> result =
+        jedis.hscan("a".getBytes(), "0".getBytes(), scanParams);
 
     assertThat(result.getResult()).isEmpty();
   }
@@ -278,7 +281,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
     String cursor = "0";
 
     do {
-      result = (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN,
+      result = (List<Object>) jedis.sendCommand("colors", Protocol.Command.HSCAN,
           "colors",
           cursor,
           "COUNT", "2",
@@ -301,12 +304,12 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
-    ScanResult<Map.Entry<String, String>> result;
-    List<Map.Entry<String, String>> allEntries = new ArrayList<>();
+    ScanResult<Map.Entry<byte[], byte[]>> result;
+    List<Map.Entry<byte[], byte[]>> allEntries = new ArrayList<>();
     String cursor = "0";
 
     do {
-      result = jedis.hscan("colors", cursor, scanParams);
+      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
@@ -316,20 +319,33 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
 
   @Test
   public void givenMatch_returnsAllMatchingEntries() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("12", "green");
-    entryMap.put("3", "grey");
-    jedis.hmset("colors", entryMap);
+    Map<byte[], byte[]> entryMap = new HashMap<>();
+    byte[] field3 = "3".getBytes();
+    entryMap.put("1".getBytes(), "yellow".getBytes());
+    entryMap.put("12".getBytes(), "green".getBytes());
+    entryMap.put(field3, "grey".getBytes());
+    jedis.hmset("colors".getBytes(), entryMap);
 
     ScanParams scanParams = new ScanParams();
     scanParams.match("1*");
 
-    ScanResult<Map.Entry<String, String>> result = jedis.hscan("colors", "0", scanParams);
+    ScanResult<Map.Entry<byte[], byte[]>> result =
+        jedis.hscan("colors".getBytes(), "0".getBytes(), scanParams);
 
-    entryMap.remove("3");
+    entryMap.remove(field3);
     assertThat(result.isCompleteIteration()).isTrue();
-    assertThat(new HashSet<>(result.getResult())).containsAll(entryMap.entrySet());
+    assertThat(new HashSet<>(result.getResult()))
+        .usingElementComparator(new MapEntryWithByteArraysComparator())
+        .containsExactlyInAnyOrderElementsOf(entryMap.entrySet());
+  }
+
+  private static class MapEntryWithByteArraysComparator
+      implements Comparator<Map.Entry<byte[], byte[]>> {
+    @Override
+    public int compare(Map.Entry<byte[], byte[]> o1, Map.Entry<byte[], byte[]> o2) {
+      return Arrays.equals(o1.getKey(), o2.getKey()) &&
+          Arrays.equals(o1.getValue(), o2.getValue()) ? 0 : 1;
+    }
   }
 
   @Test
@@ -342,8 +358,9 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
     jedis.hmset("colors", entryMap);
 
     List<Object> result =
-        (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN,
-            "colors", "0", "MATCH", "3*", "MATCH", "1*");
+        (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
+            "colors".getBytes(), "0".getBytes(), "MATCH".getBytes(), "3*".getBytes(),
+            "MATCH".getBytes(), "1*".getBytes());
 
     assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
     assertThat((List<Object>) result.get(1)).containsAll(
@@ -352,28 +369,30 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
 
   @Test
   public void givenMatchAndCount_returnsAllMatchingKeys() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("12", "green");
-    entryMap.put("3", "orange");
-    jedis.hmset("colors", entryMap);
+    Map<byte[], byte[]> entryMap = new HashMap<>();
+    byte[] field3 = "3".getBytes();
+    entryMap.put("1".getBytes(), "yellow".getBytes());
+    entryMap.put("12".getBytes(), "green".getBytes());
+    entryMap.put(field3, "orange".getBytes());
+    jedis.hmset("colors".getBytes(), entryMap);
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
     scanParams.match("1*");
-    ScanResult<Map.Entry<String, String>> result;
-    List<Map.Entry<String, String>> allEntries = new ArrayList<>();
+    ScanResult<Map.Entry<byte[], byte[]>> result;
+    List<Map.Entry<byte[], byte[]>> allEntries = new ArrayList<>();
     String cursor = "0";
 
     do {
-      result = jedis.hscan("colors", cursor, scanParams);
+      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    entryMap.remove("3");
+    entryMap.remove(field3);
 
     assertThat(new HashSet<>(allEntries))
+        .usingElementComparator(new MapEntryWithByteArraysComparator())
         .containsAll(entryMap.entrySet());
   }
 
@@ -391,8 +410,10 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
     String cursor = "0";
 
     do {
-      result = (List<Object>) jedis.sendCommand(Protocol.Command.HSCAN, "colors", cursor, "COUNT",
-          "37", "MATCH", "3*", "COUNT", "2", "COUNT", "1", "MATCH", "1*");
+      result = (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
+          "colors".getBytes(), cursor.getBytes(), "COUNT".getBytes(), "37".getBytes(),
+          "MATCH".getBytes(), "3*".getBytes(), "COUNT".getBytes(), "2".getBytes(),
+          "COUNT".getBytes(), "1".getBytes(), "MATCH".getBytes(), "1*".getBytes());
       allEntries.addAll((List<byte[]>) result.get(1));
       cursor = new String((byte[]) result.get(0));
     } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
@@ -431,7 +452,6 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
     data.put("field_2", "green");
     data.put("field_3", "grey");
     jedis.hmset("colors", data);
-
 
     ScanResult<Map.Entry<String, String>> result = jedis.hscan("colors", "5");
 
@@ -492,7 +512,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
 
   }
 
-  private void multipleHScanAndAssertOnContentOfResultSet(Jedis jedis,
+  private void multipleHScanAndAssertOnContentOfResultSet(JedisCluster jedis,
       final Map<String, String> initialHashData) {
 
     List<String> allEntries = new ArrayList<>();
@@ -510,7 +530,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisPortSupplier 
     assertThat(allEntries).containsAll(initialHashData.keySet());
   }
 
-  private void multipleHScanAndAssertOnSizeOfResultSet(Jedis jedis,
+  private void multipleHScanAndAssertOnSizeOfResultSet(JedisCluster jedis,
       final Map<String, String> initialHashData) {
     List<Map.Entry<String, String>> allEntries = new ArrayList<>();
     ScanResult<Map.Entry<String, String>> result;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -479,6 +479,9 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
           int fieldSuffix = i % SIZE_OF_INITIAL_HASH_DATA;
           jedis.hset(HASH_KEY, BASE_FIELD + fieldSuffix, "new_value_" + i);
         }).run();
+
+    jedis1.close();
+    jedis2.close();
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -48,8 +48,6 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
 public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTest {
 
   protected JedisCluster jedis;
-  private static JedisCluster jedis2;
-  private static JedisCluster jedis3;
 
   private static final int REDIS_CLIENT_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
@@ -57,16 +55,12 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   @Before
   public void setUp() {
     jedis = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
-    jedis2 = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
-    jedis3 = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
   }
 
   @After
   public void tearDown() {
     flushAll();
     jedis.close();
-    jedis2.close();
-    jedis3.close();
   }
 
   /********* Parameter Checks **************/
@@ -473,10 +467,10 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     new ConcurrentLoopingThreads(ITERATION_COUNT,
         (i) -> multipleHScanAndAssertOnSizeOfResultSet(jedis, INITIAL_HASH_DATA),
-        (i) -> multipleHScanAndAssertOnSizeOfResultSet(jedis2, INITIAL_HASH_DATA),
+        (i) -> multipleHScanAndAssertOnSizeOfResultSet(jedis, INITIAL_HASH_DATA),
         (i) -> {
           int fieldSuffix = i % SIZE_OF_INITIAL_HASH_DATA;
-          jedis3.hset(HASH_KEY, BASE_FIELD + fieldSuffix, "new_value_" + i);
+          jedis.hset(HASH_KEY, BASE_FIELD + fieldSuffix, "new_value_" + i);
         }).run();
   }
 
@@ -488,11 +482,11 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     new ConcurrentLoopingThreads(ITERATION_COUNT,
         (i) -> multipleHScanAndAssertOnContentOfResultSet(jedis, INITIAL_HASH_DATA),
-        (i) -> multipleHScanAndAssertOnContentOfResultSet(jedis2, INITIAL_HASH_DATA),
+        (i) -> multipleHScanAndAssertOnContentOfResultSet(jedis, INITIAL_HASH_DATA),
         (i) -> {
           String field = "new_" + BASE_FIELD + i;
-          jedis3.hset(HASH_KEY, field, "whatever");
-          jedis3.hdel(HASH_KEY, field);
+          jedis.hset(HASH_KEY, field, "whatever");
+          jedis.hdel(HASH_KEY, field);
         }).run();
 
   }
@@ -505,10 +499,10 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     new ConcurrentLoopingThreads(ITERATION_COUNT,
         (i) -> multipleHScanAndAssertOnContentOfResultSet(jedis, INITIAL_HASH_DATA),
-        (i) -> multipleHScanAndAssertOnContentOfResultSet(jedis2, INITIAL_HASH_DATA));
+        (i) -> multipleHScanAndAssertOnContentOfResultSet(jedis, INITIAL_HASH_DATA));
 
     INITIAL_HASH_DATA
-        .forEach((field, value) -> assertThat(jedis3.hget(HASH_KEY, field).equals(value)));
+        .forEach((field, value) -> assertThat(jedis.hget(HASH_KEY, field).equals(value)));
 
   }
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHincrByFloatIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHincrByFloatIntegrationTest.java
@@ -40,20 +40,17 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
 
   private JedisCluster jedis;
-  private JedisCluster jedis2;
   private static int ITERATION_COUNT = 4000;
 
   @Before
   public void setUp() {
     jedis = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
-    jedis2 = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
   }
 
   @After
   public void tearDown() {
     flushAll();
     jedis.close();
-    jedis2.close();
   }
 
   @Test
@@ -176,7 +173,7 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
 
     new ConcurrentLoopingThreads(ITERATION_COUNT,
         (i) -> jedis.hincrByFloat(key, field, 0.5),
-        (i) -> jedis2.hincrByFloat(key, field, 1.0)).run();
+        (i) -> jedis.hincrByFloat(key, field, 1.0)).run();
 
     String value = jedis.hget(key, field);
     assertThat(Float.valueOf(value)).isEqualTo(ITERATION_COUNT * 1.5f);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractMemoryOverheadIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractMemoryOverheadIntegrationTest.java
@@ -24,8 +24,8 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
 /**
  * Contains tests that measure the used memory of redis or radish and assert that the memory
@@ -35,7 +35,7 @@ import org.apache.geode.test.dunit.rules.RedisPortSupplier;
  * @see #measureAndCheckPerEntryOverhead(AddEntryFunction, Measurement) (IntToLongFunction,
  *      Measurement)
  */
-public abstract class AbstractMemoryOverheadIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractMemoryOverheadIntegrationTest implements RedisIntegrationTest {
 
   private static final int WARM_UP_ENTRY_COUNT = 1000;
   private static final int TOTAL_ENTRY_COUNT = 5000;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/HScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/HScanIntegrationTest.java
@@ -68,21 +68,21 @@ public class HScanIntegrationTest extends AbstractHScanIntegrationTest {
 
   @Test
   public void givenCount_shouldReturnExpectedNumberOfEntries() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("2", "green");
-    entryMap.put("3", "orange");
-    jedis.hmset("colors", entryMap);
+    Map<byte[], byte[]> entryMap = new HashMap<>();
+    entryMap.put("1".getBytes(), "yellow".getBytes());
+    entryMap.put("2".getBytes(), "green".getBytes());
+    entryMap.put("3".getBytes(), "orange".getBytes());
+    jedis.hmset("colors".getBytes(), entryMap);
 
     int COUNT_PARAM = 2;
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(COUNT_PARAM);
-    ScanResult<Map.Entry<String, String>> result;
+    ScanResult<Map.Entry<byte[], byte[]>> result;
 
     String cursor = "0";
 
-    result = jedis.hscan("colors", cursor, scanParams);
+    result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
 
     assertThat(result.getResult().size()).isEqualTo(COUNT_PARAM);
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractDelIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractDelIntegrationTest.java
@@ -27,10 +27,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractDelIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractDelIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractExistsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractExistsIntegrationTest.java
@@ -27,10 +27,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractExistsIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractExistsIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractExpireAtIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractExpireAtIntegrationTest.java
@@ -26,10 +26,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractExpireAtIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractExpireAtIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractExpireIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractExpireIntegrationTest.java
@@ -26,10 +26,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractExpireIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractExpireIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
@@ -27,10 +27,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractKeysIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractKeysIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractPExpireAtIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractPExpireAtIntegrationTest.java
@@ -25,10 +25,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractPExpireAtIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractPExpireAtIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractPTTLIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractPTTLIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractPTTLIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractPTTLIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractPersistIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractPersistIntegrationTest.java
@@ -27,10 +27,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.params.SetParams;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractPersistIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractPersistIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractPexpireIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractPexpireIntegrationTest.java
@@ -26,10 +26,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractPexpireIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractPexpireIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractRenameIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractRenameIntegrationTest.java
@@ -39,15 +39,15 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisDataException;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.StripedExecutor;
 import org.apache.geode.redis.internal.executor.SynchronizedStripedExecutor;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractRenameIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractRenameIntegrationTest implements RedisIntegrationTest {
   private Jedis jedis;
   private Jedis jedis2;
   private Jedis jedis3;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractScanIntegrationTest.java
@@ -33,10 +33,10 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractScanIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractScanIntegrationTest implements RedisIntegrationTest {
 
   protected Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractTTLIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractTTLIntegrationTest.java
@@ -27,10 +27,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractTTLIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractTTLIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractTypeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractTypeIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractTypeIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractTypeIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractUnlinkIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractUnlinkIntegrationTest.java
@@ -27,10 +27,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractUnlinkIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractUnlinkIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractLettucePubSubIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractLettucePubSubIntegrationTest.java
@@ -37,11 +37,11 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
-public abstract class AbstractLettucePubSubIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractLettucePubSubIntegrationTest implements RedisIntegrationTest {
 
   private static final String CHANNEL = "best-channel";
   private static final String PATTERN = "best-*";

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
@@ -44,13 +44,13 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.mocks.MockBinarySubscriber;
 import org.apache.geode.redis.mocks.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
-public abstract class AbstractPubSubIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationTest {
   private Jedis publisher;
   private Jedis subscriber;
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
@@ -29,12 +29,12 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.mocks.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
-public abstract class AbstractSubscriptionsIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSubscriptionsIntegrationTest implements RedisIntegrationTest {
 
   public static final int REDIS_CLIENT_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractDBSizeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractDBSizeIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractDBSizeIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractDBSizeIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractFlushAllIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractFlushAllIntegrationTest.java
@@ -26,10 +26,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractFlushAllIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractFlushAllIntegrationTest implements RedisIntegrationTest {
 
   protected Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractFlushDBIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractFlushDBIntegrationTest.java
@@ -25,10 +25,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractFlushDBIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractFlushDBIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.executor.server;
 
+import static org.apache.geode.redis.internal.PassiveExpirationManager.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
@@ -31,11 +32,11 @@ import org.junit.Test;
 import redis.clients.jedis.BitOP;
 import redis.clients.jedis.Jedis;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.PassiveExpirationManager;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractHitsMissesIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrationTest {
 
   private static final String HITS = "keyspace_hits";
   private static final String MISSES = "keyspace_misses";
@@ -170,7 +171,7 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisPortSupp
   public void testPassiveExpiration() {
     runCommandAndAssertNoStatUpdates("hash", (k) -> {
       jedis.expire(k, 1);
-      GeodeAwaitility.await().atMost(Duration.ofMinutes(PassiveExpirationManager.INTERVAL * 2))
+      GeodeAwaitility.await().atMost(Duration.ofMinutes(INTERVAL * 2))
           .until(() -> jedis.keys("hash").isEmpty());
     });
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.redis.internal.executor.server;
 
-import static org.apache.geode.redis.internal.PassiveExpirationManager.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
@@ -33,6 +32,7 @@ import redis.clients.jedis.BitOP;
 import redis.clients.jedis.Jedis;
 
 import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.redis.internal.PassiveExpirationManager;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrationTest {
@@ -170,7 +170,7 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   public void testPassiveExpiration() {
     runCommandAndAssertNoStatUpdates("hash", (k) -> {
       jedis.expire(k, 1);
-      GeodeAwaitility.await().atMost(Duration.ofMinutes(INTERVAL * 2))
+      GeodeAwaitility.await().atMost(Duration.ofMinutes(PassiveExpirationManager.INTERVAL * 2))
           .until(() -> jedis.keys("hash").isEmpty());
     });
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -33,7 +33,6 @@ import redis.clients.jedis.BitOP;
 import redis.clients.jedis.Jedis;
 
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.PassiveExpirationManager;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrationTest {

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractInfoIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractInfoIntegrationTest.java
@@ -34,10 +34,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractInfoIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractInfoIntegrationTest implements RedisIntegrationTest {
 
   private static final String KEYSPACE_START = "db0";
   private Jedis jedis;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractRedisInfoStatsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractRedisInfoStatsIntegrationTest.java
@@ -35,10 +35,10 @@ import redis.clients.jedis.Jedis;
 
 import org.apache.geode.internal.statistics.EnabledStatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisIntegrationTest {
 
   private static final int TIMEOUT = (int) GeodeAwaitility.getTimeout().toMillis();
   private static final String EXISTING_HASH_KEY = "Existing_Hash";

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
@@ -27,10 +27,10 @@ import redis.clients.jedis.Jedis;
 
 import org.apache.geode.internal.statistics.EnabledStatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractRedisMemoryStatsIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractRedisMemoryStatsIntegrationTest implements RedisIntegrationTest {
 
   private static final int TIMEOUT = (int) GeodeAwaitility.getTimeout().toMillis();
   private static final String EXISTING_HASH_KEY = "Existing_Hash";

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractShutDownIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractShutDownIntegrationTest.java
@@ -26,10 +26,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractShutDownIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractShutDownIntegrationTest implements RedisIntegrationTest {
 
   protected Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractSlowlogIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractSlowlogIntegrationTest.java
@@ -27,10 +27,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.Slowlog;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSlowlogIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSlowlogIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractTimeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractTimeIntegrationTest.java
@@ -27,10 +27,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractTimeIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractTimeIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSDiffIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSDiffIntegrationTest.java
@@ -29,10 +29,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSDiffIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTest {
   private Jedis jedis;
   private Jedis jedis2;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSInterIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSInterIntegrationTest.java
@@ -29,10 +29,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSInterIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSInterIntegrationTest implements RedisIntegrationTest {
   private Jedis jedis;
   private Jedis jedis2;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSIsMemberIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSIsMemberIntegrationTest.java
@@ -27,10 +27,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSIsMemberIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSIsMemberIntegrationTest implements RedisIntegrationTest {
   private Jedis jedis;
   private static final ThreePhraseGenerator generator = new ThreePhraseGenerator();
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSMoveIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSMoveIntegrationTest.java
@@ -31,11 +31,11 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSMoveIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTest {
   private Jedis jedis;
   private Jedis jedis2;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSPopIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSPopIntegrationTest.java
@@ -31,10 +31,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSPopIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTest {
   private Jedis jedis;
   private Jedis jedis2;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSRemIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSRemIntegrationTest.java
@@ -29,10 +29,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSRemIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSRemIntegrationTest implements RedisIntegrationTest {
   private Jedis jedis;
   private Jedis jedis2;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
@@ -33,10 +33,10 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.ScanParams;
 import redis.clients.jedis.ScanResult;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSScanIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTest {
   protected Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSUnionIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSUnionIntegrationTest.java
@@ -29,10 +29,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSUnionIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationTest {
   private Jedis jedis;
   private Jedis jedis2;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSetsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSetsIntegrationTest.java
@@ -36,10 +36,10 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSetsIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractAppendIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractAppendIntegrationTest.java
@@ -28,9 +28,9 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
+import org.apache.geode.redis.RedisIntegrationTest;
 
-public abstract class AbstractAppendIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractAppendIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractBitCountIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractBitCountIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractBitCountIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractBitCountIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractBitOpIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractBitOpIntegrationTest.java
@@ -28,9 +28,9 @@ import redis.clients.jedis.BitOP;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
+import org.apache.geode.redis.RedisIntegrationTest;
 
-public abstract class AbstractBitOpIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractBitOpIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractBitPosIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractBitPosIntegrationTest.java
@@ -25,10 +25,10 @@ import redis.clients.jedis.BitPosParams;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractBitPosIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractBitPosIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractDecrByIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractDecrByIntegrationTest.java
@@ -29,10 +29,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractDecrByIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractDecrIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractDecrIntegrationTest.java
@@ -24,10 +24,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractDecrIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractDecrIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetBitIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetBitIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractGetBitIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractGetBitIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetIntegrationTest.java
@@ -25,10 +25,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractGetIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractGetIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetRangeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetRangeIntegrationTest.java
@@ -30,10 +30,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractGetRangeIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractGetRangeIntegrationTest implements RedisIntegrationTest {
 
   private Random random = new Random();
   private Jedis jedis;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetSetIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractGetSetIntegrationTest.java
@@ -33,11 +33,11 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisDataException;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractGetSetIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractGetSetIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByFloatIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByFloatIntegrationTest.java
@@ -29,10 +29,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractIncrByFloatIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegrationTest {
 
   private static final int JEDIS_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByIntegrationTest.java
@@ -30,10 +30,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractIncrByIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractIncrByIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis1;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrIntegrationTest.java
@@ -27,10 +27,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractIncrIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractIncrIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractLettuceAppendIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractLettuceAppendIntegrationTest.java
@@ -25,10 +25,10 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
-public abstract class AbstractLettuceAppendIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractLettuceAppendIntegrationTest implements RedisIntegrationTest {
 
   protected RedisClient client;
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractMGetIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractMGetIntegrationTest.java
@@ -26,10 +26,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractMGetIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractMGetIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractMSetIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractMSetIntegrationTest.java
@@ -32,10 +32,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractMSetIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractMSetIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractMSetNXIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractMSetNXIntegrationTest.java
@@ -26,10 +26,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractMSetNXIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractMSetNXIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractPSetEXIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractPSetEXIntegrationTest.java
@@ -23,10 +23,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractPSetEXIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractPSetEXIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetBitIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetBitIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSetBitIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSetBitIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetEXIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetEXIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSetEXIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSetEXIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetIntegrationTest.java
@@ -36,11 +36,11 @@ import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.params.SetParams;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSetIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetNXIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetNXIntegrationTest.java
@@ -26,10 +26,10 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSetNXIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSetNXIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetRangeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetRangeIntegrationTest.java
@@ -24,10 +24,10 @@ import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractSetRangeIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractSetRangeIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis;
   private static final int REDIS_CLIENT_TIMEOUT =

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractStringIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractStringIntegrationTest.java
@@ -27,11 +27,11 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisDataException;
 
+import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
-public abstract class AbstractStringIntegrationTest implements RedisPortSupplier {
+public abstract class AbstractStringIntegrationTest implements RedisIntegrationTest {
 
   private Jedis jedis1;
   private Jedis jedis2;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -37,7 +37,6 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -386,11 +385,7 @@ public class RedisHash extends AbstractRedisData {
   @SuppressWarnings("unchecked")
   private List<ByteArrayWrapper> createKeySnapShot(UUID clientID) {
 
-    List<ByteArrayWrapper> keySnapShot =
-        hash.keySet()
-            .stream()
-            .map(key -> new ByteArrayWrapper(key.toBytes()))
-            .collect(Collectors.toList());
+    List<ByteArrayWrapper> keySnapShot = new ArrayList<>(hash.keySet());
 
     this.hScanSnapShots.put(clientID, keySnapShot);
     this.hScanSnapShotCreationTimes.put(clientID, currentTimeMillis());

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
@@ -41,6 +42,8 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
  * Implementation of the HScan command used to incrementally iterate over a collection of elements.
  */
 public class HScanExecutor extends AbstractScanExecutor {
+
+  private static final Logger logger = LogService.getLogger();
 
   @Override
   public RedisResponse executeCommand(Command command,
@@ -104,8 +107,7 @@ public class HScanExecutor extends AbstractScanExecutor {
     try {
       matchPattern = convertGlobToRegex(globPattern);
     } catch (PatternSyntaxException e) {
-
-      LogService.getLogger().warn(
+      logger.warn(
           "Could not compile the pattern: '{}' due to the following exception: '{}'. HSCAN will return an empty list.",
           globPattern, e.getMessage());
 


### PR DESCRIPTION
- This also renames `RedisPortSupplier` to `RedisIntegrationTest`. This
  interface now includes a `flushAll()` method to be implemented by tests
  that use NativeRedisClusterTestRule. This is necessary because `flushAll`
  is only applied to a single node in a cluster.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
