### PR TITLE
GEODE-9218: Remove TLSv1 and TLSv1.1 from tests.

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsWithSSLDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/controllers/RestAPIsWithSSLDUnitTest.java
@@ -340,22 +340,6 @@ public class RestAPIsWithSSLDUnitTest {
   }
 
   @Test
-  public void testSSLWithTLSv11Protocol() throws Exception {
-    Properties props = new Properties();
-    props.setProperty(SSL_KEYSTORE, findTrustedJKSWithSingleEntry().getCanonicalPath());
-    props.setProperty(SSL_TRUSTSTORE, findTrustedJKSWithSingleEntry().getCanonicalPath());
-    props.setProperty(SSL_KEYSTORE_PASSWORD, "password");
-    props.setProperty(SSL_TRUSTSTORE_PASSWORD, "password");
-    props.setProperty(SSL_KEYSTORE_TYPE, "JKS");
-    props.setProperty(SSL_PROTOCOLS, "TLSv1.1");
-    props.setProperty(SSL_CIPHERS, "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
-    props.setProperty(SSL_ENABLED_COMPONENTS, SecurableCommunicationChannel.WEB.getConstant());
-
-    startClusterWithSSL(props);
-    validateConnection(props);
-  }
-
-  @Test
   public void testSSLWithTLSv12Protocol() throws Exception {
     Properties props = new Properties();
     props.setProperty(SSL_KEYSTORE, findTrustedJKSWithSingleEntry().getCanonicalPath());
@@ -520,21 +504,6 @@ public class RestAPIsWithSSLDUnitTest {
         findTrustedJKSWithSingleEntry().getCanonicalPath());
     props.setProperty(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD, "password");
     props.setProperty(HTTP_SERVICE_SSL_PROTOCOLS, "TLS");
-
-    startClusterWithSSL(props);
-    validateConnection(props);
-  }
-
-  @SuppressWarnings("deprecation")
-  @Test
-  public void testSSLWithTLSv11ProtocolLegacy() throws Exception {
-    Properties props = new Properties();
-    props.setProperty(HTTP_SERVICE_SSL_ENABLED, "true");
-    props.setProperty(HTTP_SERVICE_SSL_KEYSTORE,
-        findTrustedJKSWithSingleEntry().getCanonicalPath());
-    props.setProperty(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD, "password");
-    props.setProperty(HTTP_SERVICE_SSL_PROTOCOLS, "TLSv1.1");
-    props.setProperty(HTTP_SERVICE_SSL_CIPHERS, "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
 
     startClusterWithSSL(props);
     validateConnection(props);

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityWithSSLTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestSecurityWithSSLTest.java
@@ -57,7 +57,7 @@ public class RestSecurityWithSSLTest {
       .withProperty(SSL_KEYSTORE_PASSWORD, "password").withProperty(SSL_KEYSTORE_TYPE, "JKS")
       .withProperty(SSL_TRUSTSTORE, KEYSTORE_FILE.getPath())
       .withProperty(SSL_TRUSTSTORE_PASSWORD, "password")
-      .withProperty(SSL_PROTOCOLS, "TLSv1.2,TLSv1.1").withAutoStart();
+      .withProperty(SSL_PROTOCOLS, "TLSv1.2").withAutoStart();
 
   @Test
   public void testRestSecurityWithSSL() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/LocatorDUnitTest.java
@@ -427,7 +427,7 @@ public class LocatorDUnitTest implements Serializable {
     properties.setProperty(SSL_KEYSTORE, getSingleKeyKeystore());
     properties.setProperty(SSL_KEYSTORE_PASSWORD, "password");
     properties.setProperty(SSL_KEYSTORE_TYPE, "JKS");
-    properties.setProperty(SSL_PROTOCOLS, "TLSv1,TLSv1.1,TLSv1.2");
+    properties.setProperty(SSL_PROTOCOLS, "TLSv1.2");
     properties.setProperty(SSL_TRUSTSTORE, getSingleKeyKeystore());
     properties.setProperty(SSL_TRUSTSTORE_PASSWORD, "password");
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/JMXMBeanDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/JMXMBeanDUnitTest.java
@@ -125,7 +125,7 @@ public class JMXMBeanDUnitTest implements Serializable {
     sslProperties.setProperty(SSL_TRUSTSTORE, singleKeystore);
     sslProperties.setProperty(SSL_ENABLED_COMPONENTS,
         SecurableCommunicationChannel.JMX.getConstant());
-    sslProperties.setProperty(SSL_PROTOCOLS, "TLSv1.2,TLSv1.1");
+    sslProperties.setProperty(SSL_PROTOCOLS, "TLSv1.2");
 
     sslPropertiesWithMultiKey = new Properties();
     sslPropertiesWithMultiKey.putAll(Maps.fromProperties(sslProperties));

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SSLUtilTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SSLUtilTest.java
@@ -76,11 +76,11 @@ public class SSLUtilTest {
 
   @Test
   public void getARealProtocolAfterProcessingAny() throws Exception {
-    final String[] algorithms = {"dream weaver", "any", "TLSv1.1"};
+    final String[] algorithms = {"dream weaver", "any", "TLSv1.2"};
     final String[] algorithmsForAny = new String[] {"sweet dreams (are made of this)"};
     final SSLContext sslContextInstance = SSLUtil.findSSLContextForProtocols(algorithms,
         algorithmsForAny);
-    assertThat(sslContextInstance.getProtocol().equalsIgnoreCase("TLSv1.1")).isTrue();
+    assertThat(sslContextInstance.getProtocol().equalsIgnoreCase("TLSv1.2")).isTrue();
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorFactoryJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/SocketCreatorFactoryJUnitTest.java
@@ -369,7 +369,7 @@ public class SocketCreatorFactoryJUnitTest {
     properties.setProperty(SSL_REQUIRE_AUTHENTICATION, "true");
     properties.setProperty(SSL_CIPHERS,
         "TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
-    properties.setProperty(SSL_PROTOCOLS, "TLSv1,TLSv1.1,TLSv1.2");
+    properties.setProperty(SSL_PROTOCOLS, "TLSv1.2");
     properties.setProperty(SSL_KEYSTORE, jks.getCanonicalPath());
     properties.setProperty(SSL_KEYSTORE_PASSWORD, "password");
     properties.setProperty(SSL_KEYSTORE_TYPE, "JKS");
@@ -399,7 +399,7 @@ public class SocketCreatorFactoryJUnitTest {
     properties.setProperty(SERVER_SSL_ENABLED, "true");
     properties.setProperty(SERVER_SSL_CIPHERS,
         "TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
-    properties.setProperty(SERVER_SSL_PROTOCOLS, "TLSv1,TLSv1.1,TLSv1.2");
+    properties.setProperty(SERVER_SSL_PROTOCOLS, "TLSv1.2");
     properties.setProperty(SERVER_SSL_KEYSTORE, jks.getCanonicalPath());
     properties.setProperty(SERVER_SSL_KEYSTORE_PASSWORD, "password");
     properties.setProperty(SERVER_SSL_KEYSTORE_TYPE, "JKS");
@@ -433,7 +433,7 @@ public class SocketCreatorFactoryJUnitTest {
     properties.setProperty(CLUSTER_SSL_ENABLED, "true");
     properties.setProperty(CLUSTER_SSL_CIPHERS,
         "TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
-    properties.setProperty(CLUSTER_SSL_PROTOCOLS, "TLSv1,TLSv1.1,TLSv1.2");
+    properties.setProperty(CLUSTER_SSL_PROTOCOLS, "TLSv1.2");
     properties.setProperty(CLUSTER_SSL_KEYSTORE, jks.getCanonicalPath());
     properties.setProperty(CLUSTER_SSL_KEYSTORE_PASSWORD, "password");
     properties.setProperty(CLUSTER_SSL_KEYSTORE_TYPE, "JKS");
@@ -467,7 +467,7 @@ public class SocketCreatorFactoryJUnitTest {
     properties.setProperty(JMX_MANAGER_SSL_ENABLED, "true");
     properties.setProperty(JMX_MANAGER_SSL_CIPHERS,
         "TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
-    properties.setProperty(JMX_MANAGER_SSL_PROTOCOLS, "TLSv1,TLSv1.1,TLSv1.2");
+    properties.setProperty(JMX_MANAGER_SSL_PROTOCOLS, "TLSv1.2");
     properties.setProperty(JMX_MANAGER_SSL_KEYSTORE, jks.getCanonicalPath());
     properties.setProperty(JMX_MANAGER_SSL_KEYSTORE_PASSWORD, "password");
     properties.setProperty(JMX_MANAGER_SSL_KEYSTORE_TYPE, "JKS");
@@ -501,7 +501,7 @@ public class SocketCreatorFactoryJUnitTest {
     properties.setProperty(GATEWAY_SSL_ENABLED, "true");
     properties.setProperty(GATEWAY_SSL_CIPHERS,
         "TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
-    properties.setProperty(GATEWAY_SSL_PROTOCOLS, "TLSv1,TLSv1.1,TLSv1.2");
+    properties.setProperty(GATEWAY_SSL_PROTOCOLS, "TLSv1.2");
     properties.setProperty(GATEWAY_SSL_KEYSTORE, jks.getCanonicalPath());
     properties.setProperty(GATEWAY_SSL_KEYSTORE_PASSWORD, "password");
     properties.setProperty(GATEWAY_SSL_KEYSTORE_TYPE, "JKS");
@@ -535,7 +535,7 @@ public class SocketCreatorFactoryJUnitTest {
     properties.setProperty(HTTP_SERVICE_SSL_ENABLED, "true");
     properties.setProperty(HTTP_SERVICE_SSL_CIPHERS,
         "TLS_RSA_WITH_AES_256_CBC_SHA256,TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384,TLS_DHE_RSA_WITH_AES_256_CBC_SHA256,TLS_DHE_DSS_WITH_AES_256_CBC_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA");
-    properties.setProperty(HTTP_SERVICE_SSL_PROTOCOLS, "TLSv1,TLSv1.1,TLSv1.2");
+    properties.setProperty(HTTP_SERVICE_SSL_PROTOCOLS, "TLSv1.2");
     properties.setProperty(HTTP_SERVICE_SSL_KEYSTORE, jks.getCanonicalPath());
     properties.setProperty(HTTP_SERVICE_SSL_KEYSTORE_PASSWORD, "password");
     properties.setProperty(HTTP_SERVICE_SSL_KEYSTORE_TYPE, "JKS");


### PR DESCRIPTION
Recent versions of JDK11 and 8 have disabled TLSv1 and TLSv1.1 by default.
We shouldn't be using these protocols so we shouldn't be testing them anymore either.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
