### PR TITLE
GEODE-9199: Restructure String Dunit tests to work with compatible with Redis cluster mode

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsDUnitTest.java
@@ -25,11 +25,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.params.SetParams;
 
@@ -47,9 +49,7 @@ public class StringsDUnitTest {
   private static final int LIST_SIZE = 1000;
   private static final int NUM_ITERATIONS = 1000;
   private static final int JEDIS_TIMEOUT = Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
-  private static JedisCluster jedis1;
-  private static JedisCluster jedis2;
-  private static JedisCluster jedis3;
+  private static JedisCluster jedisCluster;
 
   private static Properties locatorProperties;
 
@@ -59,8 +59,7 @@ public class StringsDUnitTest {
   private static MemberVM server3;
 
   private static int redisServerPort1;
-  private static int redisServerPort2;
-  private static int redisServerPort3;
+
 
   @BeforeClass
   public static void classSetup() {
@@ -73,20 +72,18 @@ public class StringsDUnitTest {
     server3 = clusterStartUp.startRedisVM(3, locator.getPort());
 
     redisServerPort1 = clusterStartUp.getRedisPort(1);
-    redisServerPort2 = clusterStartUp.getRedisPort(2);
-    redisServerPort3 = clusterStartUp.getRedisPort(3);
 
-    jedis1 = new JedisCluster(new HostAndPort(LOCAL_HOST, redisServerPort1), JEDIS_TIMEOUT);
-    jedis2 = new JedisCluster(new HostAndPort(LOCAL_HOST, redisServerPort2), JEDIS_TIMEOUT);
-    jedis3 = new JedisCluster(new HostAndPort(LOCAL_HOST, redisServerPort3), JEDIS_TIMEOUT);
+    jedisCluster = new JedisCluster(new HostAndPort(LOCAL_HOST, redisServerPort1), JEDIS_TIMEOUT);
   }
 
+  @After
+  public void after(){
+    flushall();
+  }
 
   @AfterClass
   public static void tearDown() {
-    jedis1.close();
-    jedis2.close();
-    jedis3.close();
+    jedisCluster.close();
 
     server1.stop();
     server2.stop();
@@ -99,27 +96,26 @@ public class StringsDUnitTest {
     List<String> values = makeStringList(LIST_SIZE, "values1-");
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> jedis1.set(keys.get(i), values.get(i))).run();
+        (i) -> jedisCluster.set(keys.get(i), values.get(i))).run();
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> assertThat(jedis2.get(keys.get(i))).isEqualTo(values.get(i))).run();
+        (i) -> assertThat(jedisCluster.get(keys.get(i))).isEqualTo(values.get(i))).run();
   }
 
   @Test
   public void setnx_shouldOnlySucceedOnceForAParticularKey_givenMultipleClientsSettingSameKey() {
-    JedisCluster jedis1B =
-        new JedisCluster(new HostAndPort(LOCAL_HOST, redisServerPort1), JEDIS_TIMEOUT);
+
     List<String> keys = makeStringList(LIST_SIZE, "key1-");
     List<String> values = makeStringList(LIST_SIZE, "values1-");
     AtomicInteger successes1 = new AtomicInteger(0);
     AtomicInteger successes2 = new AtomicInteger(0);
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        makeSetNXConsumer(keys, values, successes1, jedis1),
-        makeSetNXConsumer(keys, values, successes2, jedis1B)).run();
+        makeSetNXConsumer(keys, values, successes1, jedisCluster),
+        makeSetNXConsumer(keys, values, successes2, jedisCluster)).run();
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> assertThat(jedis3.get(keys.get(i))).isEqualTo(values.get(i))).run();
+        (i) -> assertThat(jedisCluster.get(keys.get(i))).isEqualTo(values.get(i))).run();
 
     assertThat(successes1.get())
         .as("Apparently ConcurrentLoopingThread did not run")
@@ -141,12 +137,12 @@ public class StringsDUnitTest {
     AtomicLong successes2 = new AtomicLong(0);
 
     for (int i = 0; i < LIST_SIZE; i++) {
-      jedis1.set(keys.get(i), values.get(i));
+      jedisCluster.set(keys.get(i), values.get(i));
     }
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        makeSetXXConsumer(keys, values, successes1, jedis1),
-        makeSetXXConsumer(keys, values, successes2, jedis2)).run();
+        makeSetXXConsumer(keys, values, successes1, jedisCluster),
+        makeSetXXConsumer(keys, values, successes2, jedisCluster)).run();
 
     assertThat(successes2.get() + successes1.get()).isEqualTo(LIST_SIZE * 2);
   }
@@ -159,12 +155,12 @@ public class StringsDUnitTest {
     List<String> values2 = makeStringList(LIST_SIZE, "values2-");
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> jedis1.set(keys1.get(i), values1.get(i)),
-        (i) -> jedis2.set(keys2.get(i), values2.get(i))).run();
+        (i) -> jedisCluster.set(keys1.get(i), values1.get(i)),
+        (i) -> jedisCluster.set(keys2.get(i), values2.get(i))).run();
 
     for (int i = 0; i < LIST_SIZE; i++) {
-      assertThat(jedis3.get(keys1.get(i))).isEqualTo(values1.get(i));
-      assertThat(jedis3.get(keys2.get(i))).isEqualTo(values2.get(i));
+      assertThat(jedisCluster.get(keys1.get(i))).isEqualTo(values1.get(i));
+      assertThat(jedisCluster.get(keys2.get(i))).isEqualTo(values2.get(i));
     }
   }
 
@@ -174,35 +170,13 @@ public class StringsDUnitTest {
     List<String> values = makeStringList(LIST_SIZE, "values1-");
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> jedis1.set(keys.get(i), values.get(i)),
-        (i) -> jedis2.set(keys.get(i), values.get(i))).run();
+        (i) -> jedisCluster.set(keys.get(i), values.get(i)),
+        (i) -> jedisCluster.set(keys.get(i), values.get(i))).run();
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> assertThat(jedis3.get(keys.get(i))).isEqualTo(values.get(i))).run();
+        (i) -> assertThat(jedisCluster.get(keys.get(i))).isEqualTo(values.get(i))).run();
   }
 
-  @Test
-  public void set_shouldAllowTwoSetsOfClientsPerServerOperatingOnTheSameStringConcurrently() {
-    JedisCluster jedis1B =
-        new JedisCluster(new HostAndPort(LOCAL_HOST, redisServerPort1), JEDIS_TIMEOUT);
-    JedisCluster jedis2B =
-        new JedisCluster(new HostAndPort(LOCAL_HOST, redisServerPort2), JEDIS_TIMEOUT);
-
-    List<String> keys = makeStringList(LIST_SIZE, "keys-");
-    List<String> values = makeStringList(LIST_SIZE, "values-");
-
-    new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> jedis1.set(keys.get(i), values.get(i)),
-        (i) -> jedis1B.set(keys.get(i), values.get(i)),
-        (i) -> jedis2.set(keys.get(i), values.get(i)),
-        (i) -> jedis2B.set(keys.get(i), values.get(i))).run();
-
-    new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> assertThat(jedis3.get(keys.get(i))).isEqualTo(values.get(i))).run();
-
-    jedis1B.close();
-    jedis2B.close();
-  }
 
   @Test
   public void append_shouldAllowMultipleClientsToAppendDifferentValueToSameKeyConcurrently() {
@@ -211,12 +185,12 @@ public class StringsDUnitTest {
     List<String> values2 = makeStringList(LIST_SIZE, "values2-");
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> jedis1.append(keys.get(i), values1.get(i)),
-        (i) -> jedis2.append(keys.get(i), values2.get(i))).runInLockstep();
+        (i) -> jedisCluster.append(keys.get(i), values1.get(i)),
+        (i) -> jedisCluster.append(keys.get(i), values2.get(i))).runInLockstep();
 
     for (int i = 0; i < LIST_SIZE; i++) {
-      assertThat(jedis3.get(keys.get(i))).contains(values1.get(i));
-      assertThat(jedis3.get(keys.get(i))).contains(values2.get(i));
+      assertThat(jedisCluster.get(keys.get(i))).contains(values1.get(i));
+      assertThat(jedisCluster.get(keys.get(i))).contains(values2.get(i));
     }
   }
 
@@ -224,46 +198,48 @@ public class StringsDUnitTest {
   public void decr_shouldDecrementWhileDoingConcurrentDecr() {
     String key = "key";
     int initialValue = NUM_ITERATIONS * 2;
-    jedis1.set(key, String.valueOf(initialValue));
+    jedisCluster.set(key, String.valueOf(initialValue));
 
     new ConcurrentLoopingThreads(NUM_ITERATIONS,
-        (i) -> jedis1.decr(key),
-        (i) -> jedis2.decr(key))
+        (i) -> jedisCluster.decr(key),
+        (i) -> jedisCluster.decr(key))
             .run();
 
-    assertThat(jedis1.get(key)).isEqualTo("0");
+    assertThat(jedisCluster.get(key)).isEqualTo("0");
   }
 
   @Test
   public void decrby_shouldDecrementReliably_givenConcurrentThreadsPerformingDecrby() {
     String key = "key";
     int initialValue = NUM_ITERATIONS * 6;
-    jedis1.set(key, String.valueOf(initialValue));
+    jedisCluster.set(key, String.valueOf(initialValue));
 
     new ConcurrentLoopingThreads(NUM_ITERATIONS,
-        (i) -> jedis1.decrBy(key, 4),
-        (i) -> jedis2.decrBy(key, 2)).runInLockstep();
+        (i) -> jedisCluster.decrBy(key, 4),
+        (i) -> jedisCluster.decrBy(key, 2)).runInLockstep();
 
-    assertThat(jedis1.get(key)).isEqualTo("0");
+    assertThat(jedisCluster.get(key)).isEqualTo("0");
   }
 
   @Test
   public void strLen_returnsStringLengthWhileConcurrentlyUpdatingValues() {
     for (int i = 0; i < LIST_SIZE; i++) {
-      jedis1.set("key-" + i, "value-" + i);
+      jedisCluster.set("key-" + i, "value-" + i);
     }
 
     new ConcurrentLoopingThreads(LIST_SIZE,
-        (i) -> jedis1.set("key-" + i, "changedValue-" + i),
+        (i) -> jedisCluster.set("key-" + i, "changedValue-" + i),
         (i) -> {
-          long stringLength = jedis2.strlen("key-" + i);
-          assertThat(stringLength == ("changedValue-" + i).length()
-              || stringLength == ("value-" + i).length()).isTrue();
-        }).runInLockstep();
+          long stringLength = jedisCluster.strlen("key-" + i);
+          assertThat(
+              stringLength == ("changedValue-" + i).length()
+              || stringLength == ("value-" + i).length()
+          ).isTrue();
+    }).runInLockstep();
 
     for (int i = 0; i < LIST_SIZE; i++) {
       String key = "key-" + i;
-      String value = jedis1.get(key);
+      String value = jedisCluster.get(key);
       String expectedValue = "changedValue-" + i;
 
       assertThat(value.length()).isEqualTo(expectedValue.length());
@@ -271,6 +247,13 @@ public class StringsDUnitTest {
     }
   }
 
+
+  private void flushall(){
+    try (Jedis connection = jedisCluster.getConnectionFromSlot(0)) {
+      connection.flushAll();
+    }
+
+  }
 
   private List<String> makeStringList(int setSize, String baseString) {
     List<String> strings = new ArrayList<>();

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsDUnitTest.java
@@ -77,7 +77,7 @@ public class StringsDUnitTest {
   }
 
   @After
-  public void after(){
+  public void after() {
     flushall();
   }
 
@@ -233,9 +233,8 @@ public class StringsDUnitTest {
           long stringLength = jedisCluster.strlen("key-" + i);
           assertThat(
               stringLength == ("changedValue-" + i).length()
-              || stringLength == ("value-" + i).length()
-          ).isTrue();
-    }).runInLockstep();
+                  || stringLength == ("value-" + i).length()).isTrue();
+        }).runInLockstep();
 
     for (int i = 0; i < LIST_SIZE; i++) {
       String key = "key-" + i;
@@ -248,7 +247,7 @@ public class StringsDUnitTest {
   }
 
 
-  private void flushall(){
+  private void flushall() {
     try (Jedis connection = jedisCluster.getConnectionFromSlot(0)) {
       connection.flushAll();
     }


### PR DESCRIPTION


- change all Jedis clients to JedisCluster Clients
- change some tests to use ConcurrentLoopingThreads.runInLockStep where appropriate
- reword test names to reflect what is now being tested in cluster mode

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
