### PR TITLE
GEODE-9155: Change frequency of passive expiration

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/resources/0001-configure-redis-tests.patch
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/resources/0001-configure-redis-tests.patch
@@ -162,17 +162,33 @@ index de24eabed..aeeb1da7f 100644
  
      test {PERSIST returns 0 against non existing or non volatile keys} {
          r set x foo
-@@ -154,39 +154,39 @@ start_server {tags {"expire"}} {
-         set size1 [r dbsize]
-         # Redis expires random keys ten times every second so we are
-         # fairly sure that all the three keys should be evicted after
+@@ -149,44 +149,44 @@ start_server {tags {"expire"}} {
+-    test {Redis should actively expire keys incrementally} {
+-        r flushdb
+-        r psetex key1 500 a
+-        r psetex key2 500 a
+-        r psetex key3 500 a
+-        set size1 [r dbsize]
+-        # Redis expires random keys ten times every second so we are
+-        # fairly sure that all the three keys should be evicted after
 -        # one second.
 -        after 1000
-+        # two seconds.
-+        after 2000
-         set size2 [r dbsize]
-         list $size1 $size2
-     } {3 0}
+-        set size2 [r dbsize]
+-        list $size1 $size2
+-    } {3 0}
++#    test {Redis should actively expire keys incrementally} {
++#        r flushdb
++#        r psetex key1 500 a
++#        r psetex key2 500 a
++#        r psetex key3 500 a
++#        set size1 [r dbsize]
++#        # Redis expires random keys ten times every second so we are
++#        # fairly sure that all the three keys should be evicted after
++#        # one second.
++#        after 1000
++#        set size2 [r dbsize]
++#        list $size1 $size2
++#    } {3 0}
  
 -    test {Redis should lazy expire keys} {
 -        r flushdb

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/GeodeServerRunTest.java
@@ -30,9 +30,10 @@ public class GeodeServerRunTest {
 
   @Test
   @Ignore("This is a no-op test to conveniently run redis api for geode server for local development/testing purposes")
-  public void runGeodeServer() {
+  public void runGeodeServer() throws InterruptedException {
     LogService.getLogger().warn("Server running on port: " + server.getPort());
     while (true) {
+      Thread.sleep(1000);
     }
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -31,6 +31,7 @@ import org.junit.Test;
 import redis.clients.jedis.BitOP;
 import redis.clients.jedis.Jedis;
 
+import org.apache.geode.redis.internal.PassiveExpirationManager;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.RedisPortSupplier;
 
@@ -169,7 +170,8 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisPortSupp
   public void testPassiveExpiration() {
     runCommandAndAssertNoStatUpdates("hash", (k) -> {
       jedis.expire(k, 1);
-      GeodeAwaitility.await().during(Duration.ofSeconds(3)).until(() -> true);
+      GeodeAwaitility.await().atMost(Duration.ofMinutes(PassiveExpirationManager.INTERVAL))
+          .until(() -> jedis.hkeys("hash").isEmpty());
     });
   }
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -170,8 +170,8 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisPortSupp
   public void testPassiveExpiration() {
     runCommandAndAssertNoStatUpdates("hash", (k) -> {
       jedis.expire(k, 1);
-      GeodeAwaitility.await().atMost(Duration.ofMinutes(PassiveExpirationManager.INTERVAL))
-          .until(() -> jedis.hkeys("hash").isEmpty());
+      GeodeAwaitility.await().atMost(Duration.ofMinutes(PassiveExpirationManager.INTERVAL * 2))
+          .until(() -> jedis.keys("hash").isEmpty());
     });
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/PassiveExpirationManager.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/PassiveExpirationManager.java
@@ -16,7 +16,7 @@
 
 package org.apache.geode.redis.internal;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.geode.logging.internal.executors.LoggingExecutors.newSingleThreadScheduledExecutor;
 
 import java.util.Map;
@@ -24,6 +24,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.EntryDestroyedException;
 import org.apache.geode.cache.Region;
@@ -42,15 +43,15 @@ public class PassiveExpirationManager {
   private final ScheduledExecutorService expirationExecutor;
   private final RedisStats redisStats;
 
+  @VisibleForTesting
+  public static final int INTERVAL = 3;
 
   public PassiveExpirationManager(Region<RedisKey, RedisData> dataRegion, RedisStats redisStats) {
     this.dataRegion = dataRegion;
     this.redisStats = redisStats;
     expirationExecutor = newSingleThreadScheduledExecutor("GemFireRedis-PassiveExpiration-");
-    int INTERVAL = 1;
     expirationExecutor.scheduleWithFixedDelay(() -> doDataExpiration(dataRegion), INTERVAL,
-        INTERVAL,
-        SECONDS);
+        INTERVAL, MINUTES);
   }
 
   public void stop() {


### PR DESCRIPTION
change the interval in the PassiveExpirationManager from 1 second to 3
minutes. this significantly reduces the CPU load of passive expiration.

this change requires that one redis test must be commented out in the
patch file.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
