### PR TITLE
GEODE-9231: increase pipeline quotas and add Distributed and StressNew for JDK8 to PR pipeline

### DIFF
--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -23,7 +23,7 @@ groups:
   jobs:
   - {{ build_test.name }}
 {%- for test in tests %}
-  {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" %}
+  {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" or test.name == "StressNew" or test.name == "Distributed" %}
   - {{test.name}}Test{{java_test_version.name}}
   {%- endfor %}
 {%- endfor %}
@@ -275,7 +275,7 @@ jobs:
 
 
 {% for test in tests %}
-  {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" %}
+  {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("JDK8") or test.name == "Unit" or test.name == "StressNew" or test.name == "Distributed" %}
 - name: {{test.name}}Test{{java_test_version.name}}
   public: true
   plan:

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -23,17 +23,17 @@ benchmarks:
   - title: '_base'
     flag: ''
     options: ''
-    max_in_flight: 4
+    max_in_flight: 5
     timeout: 24h
   - title: '_with_ssl'
     flag: '-PwithSsl -PtestJVM=/usr/lib/jvm/bellsoft-java11-amd64'
     options: '--tests=*GetBenchmark --tests=*PutBenchmark'
-    max_in_flight: 1
+    max_in_flight: 2
     timeout: 8h
   - title: '_with_security_manager'
     flag: '-PwithSecurityManager'
     options: '--tests=Partitioned*'
-    max_in_flight: 2
+    max_in_flight: 3
     timeout: 12h
 
 build_test:
@@ -44,7 +44,7 @@ build_test:
   DUNIT_PARALLEL_FORKS: '4'
   EXECUTE_TEST_TIMEOUT: 20m
   GRADLE_TASK: build
-  MAX_IN_FLIGHT: 2
+  MAX_IN_FLIGHT: 1
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   PLATFORM: linux
@@ -116,13 +116,13 @@ tests:
   RAM: '8'
   name: Acceptance
 - ARTIFACT_SLUG: distributedtestfiles
-  CALL_STACK_TIMEOUT: '9900'
+  CALL_STACK_TIMEOUT: '11700'
   CPUS: '96'
   DISK: '200GB'
   DUNIT_PARALLEL_FORKS: '24'
-  EXECUTE_TEST_TIMEOUT: 3h00m
+  EXECUTE_TEST_TIMEOUT: 3h30m
   GRADLE_TASK: distributedTest
-  MAX_IN_FLIGHT: 3
+  MAX_IN_FLIGHT: 6
   PARALLEL_DUNIT: 'true'
   PLATFORM: linux
   RAM: '250'
@@ -168,7 +168,7 @@ tests:
 - ARTIFACT_SLUG: stressnewtestfiles
   CALL_STACK_TIMEOUT: '20700'
   CPUS: '96'
-  DISK: '200GB'
+  DISK: '300GB'
   DUNIT_PARALLEL_FORKS: '24'
   EXECUTE_TEST_TIMEOUT: 10h
   GRADLE_TASK: repeatTest


### PR DESCRIPTION
recently a number of tests have been added that seem to be flaky on JDK8 only.  Since the PR pipeline only tests on JDK11, these were not being caught.  Adding back JDK8 testing at the PR stage should help. 