### PR TITLE
GEODE-8191: update flaky test

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/ResourceInstance.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/ResourceInstance.java
@@ -33,11 +33,13 @@ public class ResourceInstance {
   private long[] previousStatValues = null;
   private long[] latestStatValues = null;
   private int[] updatedStats = null;
+  private boolean statValuesNotified;
 
   public ResourceInstance(int id, Statistics statistics, ResourceType type) {
     this.id = id;
     this.statistics = statistics;
     this.type = type;
+    this.statValuesNotified = false;
   }
 
   public int getId() {
@@ -50,6 +52,14 @@ public class ResourceInstance {
 
   public ResourceType getResourceType() {
     return this.type;
+  }
+
+  public boolean getStatValuesNotified() {
+    return this.statValuesNotified;
+  }
+
+  public void setStatValuesNotified(boolean notified) {
+    this.statValuesNotified = notified;
   }
 
   public Number getStatValue(StatisticDescriptor sd) {

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/SampleCollector.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/SampleCollector.java
@@ -274,7 +274,9 @@ public class SampleCollector {
     }
 
     for (ResourceInstance ri : updatedResources) {
-      ri.setPreviousStatValues(ri.getLatestStatValues());
+      if (ri.getStatValuesNotified()) {
+        ri.setPreviousStatValues(ri.getLatestStatValues());
+      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatArchiveWriter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatArchiveWriter.java
@@ -508,6 +508,9 @@ public class StatArchiveWriter implements StatArchiveFormat, SampleHandler {
       }
       writeTimeStamp(nanosTimeStamp);
       for (ResourceInstance ri : resourceInstances) {
+        if (!ri.getStatValuesNotified()) {
+          ri.setStatValuesNotified(true);
+        }
         writeSample(ri);
       }
       writeResourceInst(ILLEGAL_RESOURCE_INST_ID);

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/StatArchiveWriter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/StatArchiveWriter.java
@@ -508,9 +508,7 @@ public class StatArchiveWriter implements StatArchiveFormat, SampleHandler {
       }
       writeTimeStamp(nanosTimeStamp);
       for (ResourceInstance ri : resourceInstances) {
-        if (!ri.getStatValuesNotified()) {
-          ri.setStatValuesNotified(true);
-        }
+        ri.setStatValuesNotified(true);
         writeSample(ri);
       }
       writeResourceInst(ILLEGAL_RESOURCE_INST_ID);

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/ValueMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/ValueMonitor.java
@@ -98,6 +98,9 @@ public class ValueMonitor extends StatisticsMonitor {
         if (this.statistics.contains(resource.getStatistics())) {
           ResourceType resourceType = resource.getResourceType();
           StatisticDescriptor[] sds = resourceType.getStatisticDescriptors();
+          if (!resource.getStatValuesNotified()) {
+            resource.setStatValuesNotified(true);
+          }
           int[] updatedStats = resource.getUpdatedStats();
           for (int i = 0; i < updatedStats.length; i++) {
             int idx = updatedStats[i];

--- a/geode-core/src/main/java/org/apache/geode/internal/statistics/ValueMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/statistics/ValueMonitor.java
@@ -98,9 +98,7 @@ public class ValueMonitor extends StatisticsMonitor {
         if (this.statistics.contains(resource.getStatistics())) {
           ResourceType resourceType = resource.getResourceType();
           StatisticDescriptor[] sds = resourceType.getStatisticDescriptors();
-          if (!resource.getStatValuesNotified()) {
-            resource.setStatValuesNotified(true);
-          }
+          resource.setStatValuesNotified(true);
           int[] updatedStats = resource.getUpdatedStats();
           for (int i = 0; i < updatedStats.length; i++) {
             int idx = updatedStats[i];

--- a/geode-core/src/test/java/org/apache/geode/internal/statistics/SampleCollectorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/statistics/SampleCollectorTest.java
@@ -210,7 +210,7 @@ public class SampleCollectorTest {
     ResourceInstance resourceInstance = allocatedResourceInstanceInfo.getResourceInstance();
     assertNotNull(resourceInstance);
     assertEquals(0, resourceInstance.getId());
-    assertEquals(0, resourceInstance.getUpdatedStats().length);
+    assertEquals(1, resourceInstance.getUpdatedStats().length);
     assertEquals(1, resourceInstance.getLatestStatValues().length); // TODO: is this correct?
     Statistics statistics = resourceInstance.getStatistics();
     assertNotNull(statistics);


### PR DESCRIPTION
It seems that in some cases, creation of buckets of colocated region can take some time to finish. Until it is finished, recovery threads are updating statistics, but since ValueMonitor is not notified to monitor PartitionedRegionStats (this will happen when creation of region is finished), this info is not propagated. When finally creation of region is finished, SampleCollector will interpret stats as old info, and will not propagate it. 

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [*] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [*] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [*] Is your initial contribution a single, squashed commit?

- [*] Does `gradlew build` run cleanly?

- [*] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
