### PR TITLE
GEODE-9223: Removing ByteArrayWrapper from hashes 

### DIFF
--- a/geode-apis-compatible-with-redis/build.gradle
+++ b/geode-apis-compatible-with-redis/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   implementation(project(':geode-core'))
   implementation(project(':geode-gfsh'))
   implementation(project(':geode-membership'))
+  implementation('it.unimi.dsi:fastutil')
   implementation('com.github.davidmoten:geo')
   implementation('io.netty:netty-all')
   implementation('org.apache.logging.log4j:log4j-api')

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
@@ -33,7 +33,6 @@ import org.springframework.web.client.RestTemplate;
 import org.apache.geode.internal.cache.BucketDump;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisHash;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -161,7 +160,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
       return 0;
     }
     ObjectInputStream inputStream;
-    byte[] bytes = redisHash.hget(new ByteArrayWrapper("maxInactiveInterval".getBytes())).toBytes();
+    byte[] bytes = redisHash.hget("maxInactiveInterval".getBytes());
     ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
     try {
       inputStream = new ObjectInputStream(byteStream);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
@@ -56,8 +56,8 @@ public class MemoryOverheadIntegrationTest extends AbstractMemoryOverheadIntegra
     result.put(Measurement.STRING, 201);
     result.put(Measurement.SET, 386);
     result.put(Measurement.SET_ENTRY, 72);
-    result.put(Measurement.HASH, 543);
-    result.put(Measurement.HASH_ENTRY, 106);
+    result.put(Measurement.HASH, 514);
+    result.put(Measurement.HASH_ENTRY, 50);
 
     return result;
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
@@ -56,7 +56,7 @@ public class MemoryOverheadIntegrationTest extends AbstractMemoryOverheadIntegra
     result.put(Measurement.STRING, 201);
     result.put(Measurement.SET, 386);
     result.put(Measurement.SET_ENTRY, 72);
-    result.put(Measurement.HASH, 514);
+    result.put(Measurement.HASH, 490);
     result.put(Measurement.HASH_ENTRY, 50);
 
     return result;

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -11,8 +11,8 @@ fromData,8
 toData,8
 
 org/apache/geode/redis/internal/data/RedisHash,2
-toData,90
-fromData,61
+toData,101
+fromData,72
 
 org/apache/geode/redis/internal/data/RedisKey,2
 fromData,20

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -11,8 +11,8 @@ fromData,8
 toData,8
 
 org/apache/geode/redis/internal/data/RedisHash,2
-toData,26
-fromData,26
+toData,90
+fromData,61
 
 org/apache/geode/redis/internal/data/RedisKey,2
 fromData,20

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -23,6 +23,8 @@ import org.apache.geode.management.ManagementException;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.cluster.RedisPartitionResolver;
+import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
+import org.apache.geode.redis.internal.executor.hash.RedisHashCommandsFunctionInvoker;
 
 public class RegionProvider {
   /**
@@ -42,6 +44,7 @@ public class RegionProvider {
 
   private final Region<RedisKey, RedisData> dataRegion;
   private final Region<String, Object> configRegion;
+  private final RedisHashCommandsFunctionInvoker hashCommands;
 
   public RegionProvider(InternalCache cache) {
     validateBucketCount(REDIS_REGION_BUCKETS);
@@ -62,6 +65,8 @@ public class RegionProvider {
         cache.createInternalRegionFactory(RegionShortcut.REPLICATE);
     redisConfigRegionFactory.setInternalRegion(true).setIsUsedForMetaRegion(true);
     configRegion = redisConfigRegionFactory.create(REDIS_CONFIG_REGION);
+
+    this.hashCommands = new RedisHashCommandsFunctionInvoker(dataRegion);
   }
 
   public Region<RedisKey, RedisData> getDataRegion() {
@@ -83,5 +88,9 @@ public class RegionProvider {
           "Could not start server compatible with Redis - System property '%s' must be <= %d",
           REDIS_REGION_BUCKETS_PARAM, REDIS_SLOTS));
     }
+  }
+
+  public RedisHashCommands getHashCommands() {
+    return hashCommands;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -200,7 +200,7 @@ public abstract class AbstractRedisData implements RedisData {
     }
   }
 
-  private ArrayList<ByteArrayWrapper> readArrayList(DataInput in) throws IOException {
+  private <T> ArrayList<T> readArrayList(DataInput in) throws IOException {
     try {
       return DataSerializer.readArrayList(in);
     } catch (ClassNotFoundException e) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisHash.java
@@ -37,26 +37,26 @@ public class NullRedisHash extends RedisHash {
 
   @Override
   public int hset(Region<RedisKey, RedisData> region, RedisKey key,
-      List<ByteArrayWrapper> fieldsToSet, boolean nx) {
+      List<byte[]> fieldsToSet, boolean nx) {
     region.put(key, new RedisHash(fieldsToSet));
     return fieldsToSet.size() / 2;
   }
 
   @Override
   public long hincrby(Region<RedisKey, RedisData> region, RedisKey key,
-      ByteArrayWrapper field, long increment)
+      byte[] field, long increment)
       throws NumberFormatException, ArithmeticException {
     region.put(key,
-        new RedisHash(Arrays.asList(field, new ByteArrayWrapper(Coder.longToBytes(increment)))));
+        new RedisHash(Arrays.asList(field, Coder.longToBytes(increment))));
     return increment;
   }
 
   @Override
   public BigDecimal hincrbyfloat(Region<RedisKey, RedisData> region, RedisKey key,
-      ByteArrayWrapper field, BigDecimal increment) throws NumberFormatException {
+      byte[] field, BigDecimal increment) throws NumberFormatException {
     region.put(key,
         new RedisHash(
-            Arrays.asList(field, new ByteArrayWrapper(Coder.bigDecimalToBytes(increment)))));
+            Arrays.asList(field, Coder.bigDecimalToBytes(increment))));
     return increment;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -69,7 +69,7 @@ public class RedisHash extends AbstractRedisData {
   // added. if our internal implementation changes, these values may be incorrect. the tests will
   // catch this change. an increase in overhead should be carefully considered.
   protected static final int BASE_REDIS_HASH_OVERHEAD = 336;
-  protected static final int HASH_MAP_VALUE_PAIR_OVERHEAD = 47;
+  protected static final int HASH_MAP_VALUE_PAIR_OVERHEAD = 48;
 
   private static final int defaultHscanSnapshotsExpireCheckFrequency =
       Integer.getInteger("redis.hscan-snapshot-cleanup-interval", 30000);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
@@ -39,31 +39,31 @@ public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunction
   }
 
   @Override
-  public int hset(RedisKey key, List<ByteArrayWrapper> fieldsToSet, boolean NX) {
+  public int hset(RedisKey key, List<byte[]> fieldsToSet, boolean NX) {
     return stripedExecute(key,
         () -> getRedisHash(key, false)
             .hset(getRegion(), key, fieldsToSet, NX));
   }
 
   @Override
-  public int hdel(RedisKey key, List<ByteArrayWrapper> fieldsToRemove) {
+  public int hdel(RedisKey key, List<byte[]> fieldsToRemove) {
     return stripedExecute(key,
         () -> getRedisHash(key, false)
             .hdel(getRegion(), key, fieldsToRemove));
   }
 
   @Override
-  public Collection<ByteArrayWrapper> hgetall(RedisKey key) {
+  public Collection<byte[]> hgetall(RedisKey key) {
     return stripedExecute(key, () -> getRedisHash(key, true).hgetall());
   }
 
   @Override
-  public int hexists(RedisKey key, ByteArrayWrapper field) {
+  public int hexists(RedisKey key, byte[] field) {
     return stripedExecute(key, () -> getRedisHash(key, true).hexists(field));
   }
 
   @Override
-  public ByteArrayWrapper hget(RedisKey key, ByteArrayWrapper field) {
+  public byte[] hget(RedisKey key, byte[] field) {
     return stripedExecute(key, () -> getRedisHash(key, true).hget(field));
   }
 
@@ -73,27 +73,27 @@ public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunction
   }
 
   @Override
-  public int hstrlen(RedisKey key, ByteArrayWrapper field) {
+  public int hstrlen(RedisKey key, byte[] field) {
     return stripedExecute(key, () -> getRedisHash(key, true).hstrlen(field));
   }
 
   @Override
-  public List<ByteArrayWrapper> hmget(RedisKey key, List<ByteArrayWrapper> fields) {
+  public List<byte[]> hmget(RedisKey key, List<byte[]> fields) {
     return stripedExecute(key, () -> getRedisHash(key, true).hmget(fields));
   }
 
   @Override
-  public Collection<ByteArrayWrapper> hvals(RedisKey key) {
+  public Collection<byte[]> hvals(RedisKey key) {
     return stripedExecute(key, () -> getRedisHash(key, true).hvals());
   }
 
   @Override
-  public Collection<ByteArrayWrapper> hkeys(RedisKey key) {
+  public Collection<byte[]> hkeys(RedisKey key) {
     return stripedExecute(key, () -> getRedisHash(key, true).hkeys());
   }
 
   @Override
-  public Pair<Integer, List<Object>> hscan(RedisKey key, Pattern matchPattern,
+  public Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern,
       int count, int cursor, UUID clientID) {
     return stripedExecute(key,
         () -> getRedisHash(key, true)
@@ -101,14 +101,14 @@ public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunction
   }
 
   @Override
-  public long hincrby(RedisKey key, ByteArrayWrapper field, long increment) {
+  public long hincrby(RedisKey key, byte[] field, long increment) {
     return stripedExecute(key,
         () -> getRedisHash(key, false)
             .hincrby(getRegion(), key, field, increment));
   }
 
   @Override
-  public BigDecimal hincrbyfloat(RedisKey key, ByteArrayWrapper field, BigDecimal increment) {
+  public BigDecimal hincrbyfloat(RedisKey key, byte[] field, BigDecimal increment) {
     return stripedExecute(key,
         () -> getRedisHash(key, false)
             .hincrbyfloat(getRegion(), key, field, increment));

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/AddsDeltaInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/AddsDeltaInfo.java
@@ -21,20 +21,19 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import org.apache.geode.DataSerializer;
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 
 public class AddsDeltaInfo implements DeltaInfo {
-  private final ArrayList<ByteArrayWrapper> deltas;
+  private final ArrayList<byte[]> deltas;
 
-  public AddsDeltaInfo() {
-    this(new ArrayList<>());
+  public AddsDeltaInfo(int size) {
+    this(new ArrayList<>(size));
   }
 
-  public AddsDeltaInfo(ArrayList<ByteArrayWrapper> deltas) {
+  public AddsDeltaInfo(ArrayList<byte[]> deltas) {
     this.deltas = deltas;
   }
 
-  public void add(ByteArrayWrapper delta) {
+  public void add(byte[] delta) {
     deltas.add(delta);
   }
 
@@ -43,7 +42,7 @@ public class AddsDeltaInfo implements DeltaInfo {
     DataSerializer.writeArrayList(deltas, out);
   }
 
-  public ArrayList<ByteArrayWrapper> getAdds() {
+  public ArrayList<byte[]> getAdds() {
     return deltas;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/RemsDeltaInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/RemsDeltaInfo.java
@@ -21,20 +21,19 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import org.apache.geode.DataSerializer;
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 
 public class RemsDeltaInfo implements DeltaInfo {
-  private final ArrayList<ByteArrayWrapper> deltas;
+  private final ArrayList<byte[]> deltas;
 
   public RemsDeltaInfo() {
     this(new ArrayList<>());
   }
 
-  public RemsDeltaInfo(ArrayList<ByteArrayWrapper> deltas) {
+  public RemsDeltaInfo(ArrayList<byte[]> deltas) {
     this.deltas = deltas;
   }
 
-  public void add(ByteArrayWrapper delta) {
+  public void add(byte[] delta) {
     deltas.add(delta);
   }
 
@@ -43,7 +42,7 @@ public class RemsDeltaInfo implements DeltaInfo {
     DataSerializer.writeArrayList(deltas, out);
   }
 
-  public ArrayList<ByteArrayWrapper> getRemoves() {
+  public ArrayList<byte[]> getRemoves() {
     return deltas;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/CommandFunction.java
@@ -225,32 +225,32 @@ public class CommandFunction extends SingleResultRedisFunction {
         return setCommands.sdiffstore(key, setKeys);
       }
       case HSET: {
-        List<ByteArrayWrapper> fieldsToSet = (List<ByteArrayWrapper>) args[1];
+        List<byte[]> fieldsToSet = (List<byte[]>) args[1];
         boolean NX = (boolean) args[2];
         return hashCommands.hset(key, fieldsToSet, NX);
       }
       case HDEL: {
-        List<ByteArrayWrapper> fieldsToRemove = (List<ByteArrayWrapper>) args[1];
+        List<byte[]> fieldsToRemove = (List<byte[]>) args[1];
         return hashCommands.hdel(key, fieldsToRemove);
       }
       case HGETALL:
         return hashCommands.hgetall(key);
       case HEXISTS: {
-        ByteArrayWrapper field = (ByteArrayWrapper) args[1];
+        byte[] field = (byte[]) args[1];
         return hashCommands.hexists(key, field);
       }
       case HGET: {
-        ByteArrayWrapper field = (ByteArrayWrapper) args[1];
+        byte[] field = (byte[]) args[1];
         return hashCommands.hget(key, field);
       }
       case HLEN:
         return hashCommands.hlen(key);
       case HSTRLEN: {
-        ByteArrayWrapper field = (ByteArrayWrapper) args[1];
+        byte[] field = (byte[]) args[1];
         return hashCommands.hstrlen(key, field);
       }
       case HMGET: {
-        List<ByteArrayWrapper> fields = (List<ByteArrayWrapper>) args[1];
+        List<byte[]> fields = (List<byte[]>) args[1];
         return hashCommands.hmget(key, fields);
       }
       case HVALS:
@@ -265,13 +265,12 @@ public class CommandFunction extends SingleResultRedisFunction {
         return hashCommands.hscan(key, pattern, count, cursor, clientID);
       }
       case HINCRBY: {
-        ByteArrayWrapper field = (ByteArrayWrapper) args[1];
-
+        byte[] field = (byte[]) args[1];
         long increment = (long) args[2];
         return hashCommands.hincrby(key, field, increment);
       }
       case HINCRBYFLOAT: {
-        ByteArrayWrapper field = (ByteArrayWrapper) args[1];
+        byte[] field = (byte[]) args[1];
         BigDecimal increment = (BigDecimal) args[2];
         return hashCommands.hincrbyfloat(key, field, increment);
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
@@ -133,7 +133,7 @@ public class RedisResponse {
     return new RedisResponse((buffer) -> Coder.getWrongTypeResponse(buffer, error));
   }
 
-  public static RedisResponse scan(BigInteger cursor, List<Object> scanResult) {
+  public static RedisResponse scan(BigInteger cursor, List<?> scanResult) {
     return new RedisResponse((buffer) -> Coder.getScanResponse(buffer, cursor, scanResult));
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HDelExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HDelExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.hash;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -45,11 +44,11 @@ public class HDelExecutor extends HashExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-    List<ByteArrayWrapper> commandElems = command.getProcessedCommandWrappers();
+    List<byte[]> commandElems = command.getProcessedCommand();
 
     RedisKey key = command.getKey();
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
-    ArrayList<ByteArrayWrapper> fieldsToDelete =
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
+    ArrayList<byte[]> fieldsToDelete =
         new ArrayList<>(commandElems.subList(2, commandElems.size()));
     int numDeleted = redisHashCommands.hdel(key, fieldsToDelete);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HExistsExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HExistsExecutor.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import java.util.List;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -45,10 +44,9 @@ public class HExistsExecutor extends HashExecutor {
       ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
 
-    byte[] byteField = commandElems.get(FIELD_INDEX);
-    ByteArrayWrapper field = new ByteArrayWrapper(byteField);
+    byte[] field = commandElems.get(FIELD_INDEX);
     RedisKey key = command.getKey();
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
 
     return RedisResponse.integer(redisHashCommands.hexists(key, field));
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import java.util.Collection;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -47,8 +46,8 @@ public class HGetAllExecutor extends HashExecutor {
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
     RedisKey key = command.getKey();
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
-    Collection<ByteArrayWrapper> fieldsAndValues = redisHashCommands.hgetall(key);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
+    Collection<byte[]> fieldsAndValues = redisHashCommands.hgetall(key);
 
     return RedisResponse.array(fieldsAndValues);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetExecutor.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import java.util.List;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -42,11 +41,10 @@ public class HGetExecutor extends HashExecutor {
       ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
 
-    byte[] byteField = commandElems.get(FIELD_INDEX);
-    ByteArrayWrapper field = new ByteArrayWrapper(byteField);
+    byte[] field = commandElems.get(FIELD_INDEX);
     RedisKey key = command.getKey();
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
-    ByteArrayWrapper valueWrapper = redisHashCommands.hget(key, field);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
+    byte[] valueWrapper = redisHashCommands.hget(key, field);
 
     if (valueWrapper != null) {
       return RedisResponse.bulkString(valueWrapper);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetExecutor.java
@@ -44,10 +44,10 @@ public class HGetExecutor extends HashExecutor {
     byte[] field = commandElems.get(FIELD_INDEX);
     RedisKey key = command.getKey();
     RedisHashCommands redisHashCommands = context.getRedisHashCommands();
-    byte[] valueWrapper = redisHashCommands.hget(key, field);
+    byte[] value = redisHashCommands.hget(key, field);
 
-    if (valueWrapper != null) {
-      return RedisResponse.bulkString(valueWrapper);
+    if (value != null) {
+      return RedisResponse.bulkString(value);
     } else {
       return RedisResponse.nil();
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HIncrByExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HIncrByExecutor.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import java.util.List;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Coder;
@@ -55,8 +54,7 @@ public class HIncrByExecutor extends HashExecutor {
       ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
     RedisKey key = command.getKey();
-    byte[] byteField = commandElems.get(FIELD_INDEX);
-    ByteArrayWrapper field = new ByteArrayWrapper(byteField);
+    byte[] field = commandElems.get(FIELD_INDEX);
 
     byte[] incrArray = commandElems.get(INCREMENT_INDEX);
     long increment;
@@ -66,7 +64,7 @@ public class HIncrByExecutor extends HashExecutor {
       return RedisResponse.error(ERROR_INCREMENT_NOT_USABLE);
     }
 
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
 
     long value = redisHashCommands.hincrby(key, field, increment);
     return RedisResponse.integer(value);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HIncrByFloatExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HIncrByFloatExecutor.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.string.IncrByFloatExecutor;
@@ -65,9 +64,8 @@ public class HIncrByFloatExecutor extends HashExecutor {
     }
 
     RedisKey key = command.getKey();
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
-    byte[] byteField = commandElems.get(FIELD_INDEX);
-    ByteArrayWrapper field = new ByteArrayWrapper(byteField);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
+    byte[] field = commandElems.get(FIELD_INDEX);
 
     BigDecimal value = redisHashCommands.hincrbyfloat(key, field, validated.getLeft());
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HKeysExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HKeysExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import java.util.Collection;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -47,8 +46,8 @@ public class HKeysExecutor extends HashExecutor {
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
     RedisKey key = command.getKey();
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
-    Collection<ByteArrayWrapper> keys = redisHashCommands.hkeys(key);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
+    Collection<byte[]> keys = redisHashCommands.hkeys(key);
     if (keys.isEmpty()) {
       return RedisResponse.emptyArray();
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HLenExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HLenExecutor.java
@@ -39,7 +39,7 @@ public class HLenExecutor extends HashExecutor {
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
     RedisKey key = command.getKey();
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
     int len = redisHashCommands.hlen(key);
 
     return RedisResponse.integer(len);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMGetExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMGetExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.hash;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -48,12 +47,12 @@ public class HMGetExecutor extends HashExecutor {
       ExecutionHandlerContext context) {
 
     RedisKey key = command.getKey();
-    List<ByteArrayWrapper> commandElements = command.getProcessedCommandWrappers();
-    ArrayList<ByteArrayWrapper> fields =
+    List<byte[]> commandElements = command.getProcessedCommand();
+    ArrayList<byte[]> fields =
         new ArrayList<>(commandElements.subList(2, commandElements.size()));
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
 
-    List<ByteArrayWrapper> values = redisHashCommands.hmget(key, fields);
+    List<byte[]> values = redisHashCommands.hmget(key, fields);
 
     return RedisResponse.array(values);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMSetExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMSetExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.hash;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -50,12 +49,11 @@ public class HMSetExecutor extends HashExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-    List<ByteArrayWrapper> commandElems = command.getProcessedCommandWrappers();
+    List<byte[]> commandElems = command.getProcessedCommand();
 
     RedisKey key = command.getKey();
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
-    ArrayList<ByteArrayWrapper> fieldsToSet =
-        new ArrayList<>(commandElems.subList(2, commandElems.size()));
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
+    List<byte[]> fieldsToSet = new ArrayList<>(commandElems.subList(2, commandElems.size()));
     redisHashCommands.hset(key, fieldsToSet, false);
 
     return RedisResponse.ok();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -116,7 +116,7 @@ public class HScanExecutor extends AbstractScanExecutor {
     RedisHashCommands redisHashCommands =
         new RedisHashCommandsFunctionInvoker(context.getRegionProvider().getDataRegion());
 
-    Pair<Integer, List<Object>> scanResult =
+    Pair<Integer, List<byte[]>> scanResult =
         redisHashCommands.hscan(key, matchPattern, count, cursor, CLIENT_ID);
 
     context.setHscanCursor(scanResult.getLeft());

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HSetExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HSetExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.hash;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -43,14 +42,13 @@ public class HSetExecutor extends HashExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-    List<ByteArrayWrapper> commandElems = command.getProcessedCommandWrappers();
+    List<byte[]> commandElems = command.getProcessedCommand();
 
     RedisKey key = command.getKey();
 
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
 
-    ArrayList<ByteArrayWrapper> fieldsToSet =
-        new ArrayList<>(commandElems.subList(2, commandElems.size()));
+    List<byte[]> fieldsToSet = new ArrayList<>(commandElems.subList(2, commandElems.size()));
     int fieldsAdded = redisHashCommands.hset(key, fieldsToSet, onlySetOnAbsent());
 
     return RedisResponse.integer(fieldsAdded);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HStrLenExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HStrLenExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import java.util.List;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -29,10 +28,9 @@ public class HStrLenExecutor extends HashExecutor {
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     RedisKey key = command.getKey();
     List<byte[]> commandElems = command.getProcessedCommand();
-    byte[] byteField = commandElems.get(FIELD_INDEX);
-    ByteArrayWrapper field = new ByteArrayWrapper(byteField);
+    byte[] field = commandElems.get(FIELD_INDEX);
 
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
     int len = redisHashCommands.hstrlen(key, field);
 
     return RedisResponse.integer(len);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HValsExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HValsExecutor.java
@@ -17,7 +17,6 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import java.util.Collection;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -54,8 +53,8 @@ public class HValsExecutor extends HashExecutor {
       ExecutionHandlerContext context) {
     RedisKey key = command.getKey();
 
-    RedisHashCommands redisHashCommands = createRedisHashCommands(context);
-    Collection<ByteArrayWrapper> values = redisHashCommands.hvals(key);
+    RedisHashCommands redisHashCommands = context.getRedisHashCommands();
+    Collection<byte[]> values = redisHashCommands.hvals(key);
 
     if (values.isEmpty()) {
       return RedisResponse.emptyArray();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HashExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HashExecutor.java
@@ -16,16 +16,11 @@ package org.apache.geode.redis.internal.executor.hash;
 
 
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 /**
  * Executor for handling HASH datatypes
  */
 public abstract class HashExecutor extends AbstractExecutor {
   static final int FIELD_INDEX = 2;
-
-  RedisHashCommands createRedisHashCommands(ExecutionHandlerContext context) {
-    return new RedisHashCommandsFunctionInvoker(context.getRegionProvider().getDataRegion());
-  }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
@@ -23,34 +23,33 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisKey;
 
 public interface RedisHashCommands {
-  int hset(RedisKey key, List<ByteArrayWrapper> fieldsToSet, boolean NX);
+  int hset(RedisKey key, List<byte[]> fieldsToSet, boolean NX);
 
-  int hdel(RedisKey key, List<ByteArrayWrapper> fieldsToRemove);
+  int hdel(RedisKey key, List<byte[]> fieldsToRemove);
 
-  Collection<ByteArrayWrapper> hgetall(RedisKey key);
+  Collection<byte[]> hgetall(RedisKey key);
 
-  int hexists(RedisKey key, ByteArrayWrapper field);
+  int hexists(RedisKey key, byte[] field);
 
-  ByteArrayWrapper hget(RedisKey key, ByteArrayWrapper field);
+  byte[] hget(RedisKey key, byte[] field);
 
   int hlen(RedisKey key);
 
-  int hstrlen(RedisKey key, ByteArrayWrapper field);
+  int hstrlen(RedisKey key, byte[] field);
 
-  List<ByteArrayWrapper> hmget(RedisKey key, List<ByteArrayWrapper> fields);
+  List<byte[]> hmget(RedisKey key, List<byte[]> fields);
 
-  Collection<ByteArrayWrapper> hvals(RedisKey key);
+  Collection<byte[]> hvals(RedisKey key);
 
-  Collection<ByteArrayWrapper> hkeys(RedisKey key);
+  Collection<byte[]> hkeys(RedisKey key);
 
-  Pair<Integer, List<Object>> hscan(RedisKey key, Pattern matchPattern, int count,
+  Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern, int count,
       int cursor, UUID clientID);
 
-  long hincrby(RedisKey key, ByteArrayWrapper field, long increment);
+  long hincrby(RedisKey key, byte[] field, long increment);
 
-  BigDecimal hincrbyfloat(RedisKey key, ByteArrayWrapper field, BigDecimal increment);
+  BigDecimal hincrbyfloat(RedisKey key, byte[] field, BigDecimal increment);
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommandsFunctionInvoker.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommandsFunctionInvoker.java
@@ -38,7 +38,6 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisCommandsFunctionInvoker;
@@ -56,27 +55,27 @@ public class RedisHashCommandsFunctionInvoker extends RedisCommandsFunctionInvok
   }
 
   @Override
-  public int hset(RedisKey key, List<ByteArrayWrapper> fieldsToSet, boolean NX) {
+  public int hset(RedisKey key, List<byte[]> fieldsToSet, boolean NX) {
     return invokeCommandFunction(key, HSET, fieldsToSet, NX);
   }
 
   @Override
-  public int hdel(RedisKey key, List<ByteArrayWrapper> fieldsToRemove) {
+  public int hdel(RedisKey key, List<byte[]> fieldsToRemove) {
     return invokeCommandFunction(key, HDEL, fieldsToRemove);
   }
 
   @Override
-  public Collection<ByteArrayWrapper> hgetall(RedisKey key) {
+  public Collection<byte[]> hgetall(RedisKey key) {
     return invokeCommandFunction(key, HGETALL);
   }
 
   @Override
-  public int hexists(RedisKey key, ByteArrayWrapper field) {
+  public int hexists(RedisKey key, byte[] field) {
     return invokeCommandFunction(key, HEXISTS, field);
   }
 
   @Override
-  public ByteArrayWrapper hget(RedisKey key, ByteArrayWrapper field) {
+  public byte[] hget(RedisKey key, byte[] field) {
     return invokeCommandFunction(key, HGET, field);
   }
 
@@ -86,39 +85,39 @@ public class RedisHashCommandsFunctionInvoker extends RedisCommandsFunctionInvok
   }
 
   @Override
-  public int hstrlen(RedisKey key, ByteArrayWrapper field) {
+  public int hstrlen(RedisKey key, byte[] field) {
     return invokeCommandFunction(key, HSTRLEN, field);
   }
 
   @Override
-  public List<ByteArrayWrapper> hmget(RedisKey key,
-      List<ByteArrayWrapper> fields) {
+  public List<byte[]> hmget(RedisKey key,
+      List<byte[]> fields) {
     return invokeCommandFunction(key, HMGET, fields);
   }
 
   @Override
-  public Collection<ByteArrayWrapper> hvals(RedisKey key) {
+  public Collection<byte[]> hvals(RedisKey key) {
     return invokeCommandFunction(key, HVALS);
   }
 
   @Override
-  public Collection<ByteArrayWrapper> hkeys(RedisKey key) {
+  public Collection<byte[]> hkeys(RedisKey key) {
     return invokeCommandFunction(key, HKEYS);
   }
 
   @Override
-  public Pair<Integer, List<Object>> hscan(RedisKey key, Pattern matchPattern,
+  public Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern,
       int count, int cursor, UUID clientID) {
     return invokeCommandFunction(key, HSCAN, matchPattern, count, cursor, clientID);
   }
 
   @Override
-  public long hincrby(RedisKey key, ByteArrayWrapper field, long increment) {
+  public long hincrby(RedisKey key, byte[] field, long increment) {
     return invokeCommandFunction(key, HINCRBY, field, increment);
   }
 
   @Override
-  public BigDecimal hincrbyfloat(RedisKey key, ByteArrayWrapper field, BigDecimal increment) {
+  public BigDecimal hincrbyfloat(RedisKey key, byte[] field, BigDecimal increment) {
     return invokeCommandFunction(key, HINCRBYFLOAT, field, increment);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -189,7 +189,7 @@ public class Coder {
   }
 
   public static ByteBuf getScanResponse(ByteBuf buffer, BigInteger cursor,
-      List<Object> scanResult) {
+      List<?> scanResult) {
     buffer.writeByte(ARRAY_ID);
     buffer.writeBytes(intToBytes(2));
     buffer.writeBytes(CRLFar);
@@ -204,21 +204,21 @@ public class Coder {
     buffer.writeBytes(CRLFar);
 
     for (Object nextObject : scanResult) {
+      byte[] bytes;
       if (nextObject instanceof String) {
         String next = (String) nextObject;
-        buffer.writeByte(BULK_STRING_ID);
-        buffer.writeBytes(intToBytes(next.length()));
-        buffer.writeBytes(CRLFar);
-        buffer.writeBytes(stringToBytes(next));
-        buffer.writeBytes(CRLFar);
+        bytes = stringToBytes(next);
       } else if (nextObject instanceof ByteArrayWrapper) {
-        byte[] next = ((ByteArrayWrapper) nextObject).toBytes();
-        buffer.writeByte(BULK_STRING_ID);
-        buffer.writeBytes(intToBytes(next.length));
-        buffer.writeBytes(CRLFar);
-        buffer.writeBytes(next);
-        buffer.writeBytes(CRLFar);
+        bytes = ((ByteArrayWrapper) nextObject).toBytes();
+      } else {
+        bytes = (byte[]) nextObject;
       }
+
+      buffer.writeByte(BULK_STRING_ID);
+      buffer.writeBytes(intToBytes(bytes.length));
+      buffer.writeBytes(CRLFar);
+      buffer.writeBytes(bytes);
+      buffer.writeBytes(CRLFar);
     }
     return buffer;
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -55,6 +55,7 @@ import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.executor.CommandFunction;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.UnknownExecutor;
+import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
 import org.apache.geode.redis.internal.pubsub.PubSub;
 import org.apache.geode.redis.internal.statistics.RedisStats;
 
@@ -140,7 +141,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     return channel.writeAndFlush(response.encode(byteBufAllocator), channel.newPromise())
         .addListener((ChannelFutureListener) f -> {
           response.afterWrite();
-          logResponse(response, channel.remoteAddress().toString(), f.cause());
+          logResponse(response, channel.remoteAddress(), f.cause());
         });
   }
 
@@ -344,7 +345,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     return response;
   }
 
-  private void logResponse(RedisResponse response, String extraMessage, Throwable cause) {
+  private void logResponse(RedisResponse response, Object extraMessage, Throwable cause) {
     if (logger.isDebugEnabled() && response != null) {
       ByteBuf buf = response.encode(new UnpooledByteBufAllocator(false));
       if (cause == null) {
@@ -477,5 +478,9 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     } catch (InterruptedException e) {
       logger.info("Event loop interrupted", e);
     }
+  }
+
+  public RedisHashCommands getRedisHashCommands() {
+    return regionProvider.getHashCommands();
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -30,11 +30,13 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 import org.assertj.core.data.Offset;
 import org.junit.BeforeClass;
@@ -57,9 +59,6 @@ public class RedisHashTest {
 
   @BeforeClass
   public static void beforeClass() {
-    InternalDataSerializer
-        .getDSFIDSerializer()
-        .registerDSFID(DataSerializableFixedID.REDIS_BYTE_ARRAY_WRAPPER, ByteArrayWrapper.class);
     InternalDataSerializer.getDSFIDSerializer().registerDSFID(
         DataSerializableFixedID.REDIS_HASH_ID,
         RedisHash.class);
@@ -83,7 +82,6 @@ public class RedisHashTest {
     assertThat(o2).isEqualTo(o1);
   }
 
-  /************* Equals *************/
   @Test
   public void equals_returnsFalse_givenDifferentExpirationTimes() {
     RedisHash o1 = createRedisHash("k1", "v1", "k2", "v2");
@@ -125,9 +123,9 @@ public class RedisHashTest {
   public void hset_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = Mockito.mock(Region.class);
     RedisHash o1 = createRedisHash("k1", "v1", "k2", "v2");
-    ByteArrayWrapper k3 = createByteArrayWrapper("k3");
-    ByteArrayWrapper v3 = createByteArrayWrapper("v3");
-    ArrayList<ByteArrayWrapper> adds = new ArrayList<>();
+    byte[] k3 = Coder.stringToBytes("k3");
+    byte[] v3 = Coder.stringToBytes("v3");
+    ArrayList<byte[]> adds = new ArrayList<>();
     adds.add(k3);
     adds.add(v3);
     o1.hset(region, null, adds, false);
@@ -147,8 +145,8 @@ public class RedisHashTest {
   public void hdel_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisHash o1 = createRedisHash("k1", "v1", "k2", "v2");
-    ByteArrayWrapper k1 = createByteArrayWrapper("k1");
-    ArrayList<ByteArrayWrapper> removes = new ArrayList<>();
+    byte[] k1 = Coder.stringToBytes("k1");
+    ArrayList<byte[]> removes = new ArrayList<>();
     removes.add(k1);
     o1.hdel(region, null, removes);
     assertThat(o1.hasDelta()).isTrue();
@@ -190,23 +188,23 @@ public class RedisHashTest {
   @Test
   public void hscanSnaphots_shouldContainSnapshot_givenHscanHasBeenCalled() {
 
-    final List<ByteArrayWrapper> FIELDS_AND_VALUES_FOR_HASH = createListOfDataElements(100);
+    final List<byte[]> FIELDS_AND_VALUES_FOR_HASH = createListOfDataElements(100);
     RedisHash subject = new RedisHash(FIELDS_AND_VALUES_FOR_HASH);
     UUID clientID = UUID.randomUUID();
 
     subject.hscan(clientID, null, 10, 0);
 
-    ConcurrentHashMap<UUID, List<ByteArrayWrapper>> hscanSnapShotMap = subject.getHscanSnapShots();
+    ConcurrentHashMap<UUID, List<byte[]>> hscanSnapShotMap = subject.getHscanSnapShots();
 
     assertThat(hscanSnapShotMap.containsKey(clientID)).isTrue();
 
-    List<ByteArrayWrapper> keyList = hscanSnapShotMap.get(clientID);
+    List<byte[]> keyList = hscanSnapShotMap.get(clientID);
     assertThat(keyList).isNotEmpty();
 
     FIELDS_AND_VALUES_FOR_HASH.forEach((entry) -> {
-      if (entry.toString().contains("field")) {
+      if (Coder.bytesToString(entry).contains("field")) {
         assertThat(keyList).contains(entry);
-      } else if (entry.toString().contains("value")) {
+      } else if (Coder.bytesToString(entry).contains("value")) {
         assertThat(keyList).doesNotContain(entry);
       }
     });
@@ -216,23 +214,23 @@ public class RedisHashTest {
   @Test
   public void hscanSnaphots_shouldContainSnapshot_givenHscanHasBeenCalled_WithNonZeroCursor() {
 
-    final List<ByteArrayWrapper> FIELDS_AND_VALUES_FOR_HASH = createListOfDataElements(100);
+    final List<byte[]> FIELDS_AND_VALUES_FOR_HASH = createListOfDataElements(100);
     RedisHash subject = new RedisHash(FIELDS_AND_VALUES_FOR_HASH);
     UUID clientID = UUID.randomUUID();
 
     subject.hscan(clientID, null, 10, 10);
 
-    ConcurrentHashMap<UUID, List<ByteArrayWrapper>> hscanSnapShotMap = subject.getHscanSnapShots();
+    ConcurrentHashMap<UUID, List<byte[]>> hscanSnapShotMap = subject.getHscanSnapShots();
 
     assertThat(hscanSnapShotMap.containsKey(clientID)).isTrue();
 
-    List<ByteArrayWrapper> keyList = hscanSnapShotMap.get(clientID);
+    List<byte[]> keyList = hscanSnapShotMap.get(clientID);
     assertThat(keyList).isNotEmpty();
 
     FIELDS_AND_VALUES_FOR_HASH.forEach((entry) -> {
-      if (entry.toString().contains("field")) {
+      if (Coder.bytesToString(entry).contains("field")) {
         assertThat(keyList).contains(entry);
-      } else if (entry.toString().contains("value")) {
+      } else if (Coder.bytesToString(entry).contains("value")) {
         assertThat(keyList).doesNotContain(entry);
       }
     });
@@ -245,7 +243,7 @@ public class RedisHashTest {
 
     subject.hscan(client_ID, null, 10, 0);
 
-    ConcurrentHashMap<UUID, List<ByteArrayWrapper>> hscanSnapShotMap = subject.getHscanSnapShots();
+    ConcurrentHashMap<UUID, List<byte[]>> hscanSnapShotMap = subject.getHscanSnapShots();
     assertThat(hscanSnapShotMap).isEmpty();
   }
 
@@ -257,7 +255,7 @@ public class RedisHashTest {
     subject.hscan(client_ID, null, 1, 0);
 
     GeodeAwaitility.await().atMost(4, SECONDS).untilAsserted(() -> {
-      ConcurrentHashMap<UUID, List<ByteArrayWrapper>> hscanSnapShotMap =
+      ConcurrentHashMap<UUID, List<byte[]>> hscanSnapShotMap =
           subject.getHscanSnapShots();
       assertThat(hscanSnapShotMap).isEmpty();
     });
@@ -282,12 +280,12 @@ public class RedisHashTest {
   public void constantValuePairOverhead_shouldEqualCalculatedOverhead() {
     int sizeOfDataForOneFieldValuePair = 16; // initial byte[]s are 8 bytes each
 
-    HashMap<ByteArrayWrapper, ByteArrayWrapper> tempHashmap = new HashMap<>();
+    HashMap<byte[], byte[]> tempHashmap = new HashMap<>();
 
-    ByteArrayWrapper field1 = new ByteArrayWrapper("a".getBytes());
-    ByteArrayWrapper value1 = new ByteArrayWrapper("b".getBytes());
-    ByteArrayWrapper field2 = new ByteArrayWrapper("c".getBytes());
-    ByteArrayWrapper value2 = new ByteArrayWrapper("d".getBytes());
+    byte[] field1 = Coder.stringToBytes("a");
+    byte[] value1 = Coder.stringToBytes("b");
+    byte[] field2 = Coder.stringToBytes("c");
+    byte[] value2 = Coder.stringToBytes("d");
 
     tempHashmap.put(field1, value1);
     int oneEntryHashMapSize = reflectionObjectSizer.sizeof(tempHashmap);
@@ -303,11 +301,11 @@ public class RedisHashTest {
 
   @Test
   public void constantFirstPairOverhead_shouldEqual_calculatedOverhead() {
-    HashMap<ByteArrayWrapper, ByteArrayWrapper> tempHashmap = new HashMap<>();
+    HashMap<byte[], byte[]> tempHashmap = new HashMap<>();
     int emptyHashMapSize = reflectionObjectSizer.sizeof(tempHashmap);
 
-    ByteArrayWrapper field = new ByteArrayWrapper("a".getBytes());
-    ByteArrayWrapper value = new ByteArrayWrapper("b".getBytes());
+    byte[] field = Coder.stringToBytes("a");
+    byte[] value = Coder.stringToBytes("b");
 
     tempHashmap.put(field, value);
     int oneEntryHashMapSize = reflectionObjectSizer.sizeof(tempHashmap);
@@ -322,9 +320,9 @@ public class RedisHashTest {
 
   @Test
   public void should_calculateSize_closeToROSSize_ofIndividualInstanceWithSingleValue() {
-    ArrayList<ByteArrayWrapper> data = new ArrayList<>();
-    data.add(new ByteArrayWrapper("field".getBytes()));
-    data.add(new ByteArrayWrapper("valuethatisverylonggggggggg".getBytes()));
+    ArrayList<byte[]> data = new ArrayList<>();
+    data.add("field".getBytes());
+    data.add("valuethatisverylonggggggggg".getBytes());
 
     RedisHash redisHash = new RedisHash(data);
 
@@ -354,10 +352,10 @@ public class RedisHashTest {
     final String baseField = "longerbase";
     final String baseValue = "base";
 
-    ArrayList<ByteArrayWrapper> elements = new ArrayList<>();
+    ArrayList<byte[]> elements = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      elements.add(createByteArrayWrapper(baseField + i));
-      elements.add(createByteArrayWrapper(baseValue + i));
+      elements.add(Coder.stringToBytes(baseField + i));
+      elements.add(Coder.stringToBytes(baseValue + i));
     }
     RedisHash hash = new RedisHash(elements);
 
@@ -381,10 +379,10 @@ public class RedisHashTest {
     when(region.put(Object.class, Object.class)).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
-    List<ByteArrayWrapper> data = new ArrayList<>();
+    List<byte[]> data = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      data.add(new ByteArrayWrapper((baseField + i).getBytes()));
-      data.add(new ByteArrayWrapper((baseValue + i).getBytes()));
+      data.add(Coder.stringToBytes((baseField + i)));
+      data.add(Coder.stringToBytes((baseValue + i)));
     }
 
     hash.hset(region, key, data, false);
@@ -430,21 +428,21 @@ public class RedisHashTest {
     when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
-    List<ByteArrayWrapper> initialData = new ArrayList<>();
-    initialData.add(new ByteArrayWrapper(field.getBytes()));
-    initialData.add(new ByteArrayWrapper(initialValue.getBytes()));
+    List<byte[]> initialData = new ArrayList<>();
+    initialData.add(Coder.stringToBytes(field));
+    initialData.add(Coder.stringToBytes(initialValue));
 
     hash.hset(region, key, initialData, false);
     RedisHash expectedRedisHash = new RedisHash(new ArrayList<>(initialData));
 
-    List<ByteArrayWrapper> finalData = new ArrayList<>();
-    finalData.add(new ByteArrayWrapper(field.getBytes()));
-    finalData.add(new ByteArrayWrapper(finalValue.getBytes()));
+    List<byte[]> finalData = new ArrayList<>();
+    finalData.add(Coder.stringToBytes(field));
+    finalData.add(Coder.stringToBytes(finalValue));
 
     hash.hset(region, key, finalData, false);
 
     int expectedUpdatedRedisHashSize = expectedRedisHash.getSizeInBytes()
-        + (finalValue.getBytes().length - initialValue.getBytes().length);
+        + (Coder.stringToBytes(finalValue).length - Coder.stringToBytes(initialValue).length);
 
     assertThat(hash.getSizeInBytes()).isEqualTo(expectedUpdatedRedisHashSize);
   }
@@ -461,10 +459,10 @@ public class RedisHashTest {
     when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
-    List<ByteArrayWrapper> data = new ArrayList<>();
+    List<byte[]> data = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      data.add(new ByteArrayWrapper((baseField + i).getBytes()));
-      data.add(new ByteArrayWrapper((baseValue + i).getBytes()));
+      data.add(Coder.stringToBytes((baseField + i)));
+      data.add(Coder.stringToBytes((baseValue + i)));
     }
 
     hash.hset(region, key, data, true);
@@ -485,10 +483,10 @@ public class RedisHashTest {
     when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
-    List<ByteArrayWrapper> data = new ArrayList<>();
+    List<byte[]> data = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      data.add(new ByteArrayWrapper((baseField + i).getBytes()));
-      data.add(new ByteArrayWrapper((baseValue + i).getBytes()));
+      data.add(Coder.stringToBytes((baseField + i)));
+      data.add(Coder.stringToBytes((baseValue + i)));
     }
 
     hash.hset(region, key, data, true);
@@ -512,20 +510,20 @@ public class RedisHashTest {
     when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
     RedisHash hash = new RedisHash();
-    List<ByteArrayWrapper> initialData = new ArrayList<>();
+    List<byte[]> initialData = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      initialData.add(new ByteArrayWrapper((baseField + i).getBytes()));
-      initialData.add(new ByteArrayWrapper((initialBaseValue + i).getBytes()));
+      initialData.add(Coder.stringToBytes((baseField + i)));
+      initialData.add(Coder.stringToBytes((initialBaseValue + i)));
     }
 
     hash.hset(region, key, initialData, true);
 
     int expectedSize = hash.getSizeInBytes();
 
-    List<ByteArrayWrapper> finalData = new ArrayList<>();
+    List<byte[]> finalData = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      finalData.add(new ByteArrayWrapper((baseField + i).getBytes()));
-      finalData.add(new ByteArrayWrapper((finalBaseValue + i).getBytes()));
+      finalData.add(Coder.stringToBytes((baseField + i)));
+      finalData.add(Coder.stringToBytes((finalBaseValue + i)));
     }
 
     hash.hset(region, key, finalData, true);
@@ -543,12 +541,12 @@ public class RedisHashTest {
     final RedisData returnData = mock(RedisData.class);
     when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
 
-    List<ByteArrayWrapper> data = new ArrayList<>();
-    List<ByteArrayWrapper> dataToRemove = new ArrayList<>();
-    ByteArrayWrapper field1 = new ByteArrayWrapper((baseField + 1).getBytes());
-    ByteArrayWrapper value1 = new ByteArrayWrapper((baseValue + 1).getBytes());
-    ByteArrayWrapper field2 = new ByteArrayWrapper((baseField + 2).getBytes());
-    ByteArrayWrapper value2 = new ByteArrayWrapper((baseValue + 2).getBytes());
+    List<byte[]> data = new ArrayList<>();
+    List<byte[]> dataToRemove = new ArrayList<>();
+    byte[] field1 = Coder.stringToBytes((baseField + 1));
+    byte[] value1 = Coder.stringToBytes((baseValue + 1));
+    byte[] field2 = Coder.stringToBytes((baseField + 2));
+    byte[] value2 = Coder.stringToBytes((baseValue + 2));
     data.add(field1);
     data.add(value1);
     data.add(field2);
@@ -560,7 +558,7 @@ public class RedisHashTest {
 
     redisHash.hdel(region, key, dataToRemove);
 
-    int expectedSize = initialSize - RedisHash.HASH_MAP_VALUE_PAIR_OVERHEAD - field1.length();
+    int expectedSize = initialSize - RedisHash.HASH_MAP_VALUE_PAIR_OVERHEAD - field1.length;
     Offset<Integer> offset = Offset.offset((int) round(expectedSize * 0.05));
 
     assertThat(redisHash.getSizeInBytes()).isCloseTo(expectedSize, offset);
@@ -578,10 +576,10 @@ public class RedisHashTest {
     RedisHash hash = new RedisHash();
     final int baseRedisHashOverhead = hash.getSizeInBytes();
 
-    List<ByteArrayWrapper> data = new ArrayList<>();
+    List<byte[]> data = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
-      data.add(new ByteArrayWrapper((baseField + i).getBytes()));
-      data.add(new ByteArrayWrapper((baseValue + i).getBytes()));
+      data.add(Coder.stringToBytes((baseField + i)));
+      data.add(Coder.stringToBytes((baseValue + i)));
     }
 
     hash.hset(region, key, data, false);
@@ -589,8 +587,8 @@ public class RedisHashTest {
     assertThat(hash.getSizeInBytes()).isGreaterThan(0);
 
     for (int i = 0; i < 100; i++) {
-      List<ByteArrayWrapper> toRm = new ArrayList<>();
-      toRm.add(new ByteArrayWrapper((baseField + i).getBytes()));
+      List<byte[]> toRm = new ArrayList<>();
+      toRm.add(Coder.stringToBytes((baseField + i)));
       hash.hdel(region, key, toRm);
     }
 
@@ -600,42 +598,33 @@ public class RedisHashTest {
 
   /************* Helper Methods *************/
   private RedisHash createRedisHash(int NumberOfFields) {
-    ArrayList<ByteArrayWrapper> elements = createListOfDataElements(NumberOfFields);
+    ArrayList<byte[]> elements = createListOfDataElements(NumberOfFields);
     return new RedisHash(elements);
   }
 
-  private RedisHash createRedisHash(String k1, String v1, String k2, String v2) {
-    ArrayList<ByteArrayWrapper> elements = new ArrayList<>();
-
-    ByteArrayWrapper key1 = createByteArrayWrapper(k1);
-    ByteArrayWrapper value1 = createByteArrayWrapper(v1);
-    ByteArrayWrapper key2 = createByteArrayWrapper(k2);
-    ByteArrayWrapper value2 = createByteArrayWrapper(v2);
-
-    elements.add(key1);
-    elements.add(value1);
-
-    elements.add(key2);
-    elements.add(value2);
-
-    return new RedisHash(elements);
+  private RedisHash createRedisHash(String... keysAndValues) {
+    final List<byte[]> keysAndValuesList = Arrays
+        .stream(keysAndValues)
+        .map(Coder::stringToBytes)
+        .collect(Collectors.toList());
+    return new RedisHash(keysAndValuesList);
   }
 
-  private ArrayList<ByteArrayWrapper> createListOfDataElements(int NumberOfFields) {
-    ArrayList<ByteArrayWrapper> elements = new ArrayList<>();
+  private ArrayList<byte[]> createListOfDataElements(int NumberOfFields) {
+    ArrayList<byte[]> elements = new ArrayList<>();
     for (int i = 0; i < NumberOfFields; i++) {
-      elements.add(createByteArrayWrapper("field_" + i));
-      elements.add(createByteArrayWrapper("value_" + i));
+      elements.add(toBytes("field_" + i));
+      elements.add(toBytes("value_" + i));
     }
     return elements;
   }
 
   private RedisHash createRedisHashWithExpiration(int NumberOfFields, int hcanSnapshotExpiry) {
-    ArrayList<ByteArrayWrapper> elements = createListOfDataElements(NumberOfFields);
+    ArrayList<byte[]> elements = createListOfDataElements(NumberOfFields);
     return new RedisHash(elements, hcanSnapshotExpiry, hcanSnapshotExpiry);
   }
 
-  private ByteArrayWrapper createByteArrayWrapper(String str) {
-    return new ByteArrayWrapper(Coder.stringToBytes(str));
+  private byte[] toBytes(String str) {
+    return Coder.stringToBytes(str);
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/resources/expected-pom.xml
+++ b/geode-apis-compatible-with-redis/src/test/resources/expected-pom.xml
@@ -107,6 +107,17 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+      <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>spring-boot-starter-logging</artifactId>
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>com.github.davidmoten</groupId>
       <artifactId>geo</artifactId>
       <scope>runtime</scope>


### PR DESCRIPTION
No longer keeping ByteArrayWrapper classes in memory for RedisHashes or
creating ByteArrayWrapper classes when performing hash operations.

The main change to the RedisHash data structure was to switch from a
HashMap<ByteArrayWrapper, ByteArrayWrapper> to a
Object2ObjectOpenCustomHashMap<byte[], byte[]>. This saves ~50 bytes for each
field in the hash to not have the wrappers. Removing the extra allocations when
performing hash operations also helps performance.

Also removing a couple of extra unneeded allocations during logging and message
parsing. We should always create ArrayLists, etc. with a size if it is known so
those objects don't have to resize during parsing/deserialization.

Moving the hash commands executor to a shared object rather than allocating it
for each operation, which is extra GC pressure we don't need.

These changes BREAK compatibility with geode 1.14. The serialization format for
RedisHash, AddsDeltaInfo, and RemsDeltaInfo has changed to not write
ByteArrayWrapper classes on the wire.