### PR TITLE
GEODE-9224: Resolve doc discrepancy on region's entrysize description

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/DistributedRegionMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/DistributedRegionMXBean.java
@@ -290,8 +290,16 @@ public interface DistributedRegionMXBean {
   boolean isPersistentEnabled();
 
   /**
-   * Returns the aggregate entry size (in megabytes) of all entries. This will provide a correct
-   * value only if the eviction algorithm has been set to {@link EvictionAlgorithm#LRU_MEMORY}.
+   * Returns the aggregate entry size (in bytes) of all entries. 
+   * For replicated regions, provides a value only if the eviction algorithm
+   * is set to {@link EvictionAlgorithm#LRU_MEMORY}.
+   * The entry size in this distributed context represents the sum total of memory
+   * used for data in the region across all members, so the reported value may include
+   * redundancies.
+   *
+   * All partitioned regions can report entry size, but the value also includes
+   * redundant entries and also counts the size of all the secondary entries in 
+   * on the node.
    */
   long getEntrySize();
 

--- a/geode-core/src/main/java/org/apache/geode/management/DistributedRegionMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/DistributedRegionMXBean.java
@@ -290,7 +290,7 @@ public interface DistributedRegionMXBean {
   boolean isPersistentEnabled();
 
   /**
-   * Returns the aggregate entry size (in bytes) of all entries. 
+   * Returns the aggregate entry size (in bytes) of all entries.
    * For replicated regions, provides a value only if the eviction algorithm
    * is set to {@link EvictionAlgorithm#LRU_MEMORY}.
    * The entry size in this distributed context represents the sum total of memory

--- a/geode-core/src/main/java/org/apache/geode/management/DistributedRegionMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/DistributedRegionMXBean.java
@@ -298,8 +298,8 @@ public interface DistributedRegionMXBean {
    * redundancies.
    *
    * All partitioned regions can report entry size, but the value also includes
-   * redundant entries and also counts the size of all the secondary entries in 
-   * on the node.
+   * redundant entries and also counts the size of all the secondary entries in
+   * the node.
    */
   long getEntrySize();
 

--- a/geode-core/src/main/java/org/apache/geode/management/DistributedRegionMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/DistributedRegionMXBean.java
@@ -294,8 +294,8 @@ public interface DistributedRegionMXBean {
    * For replicated regions, provides a value only if the eviction algorithm
    * is set to {@link EvictionAlgorithm#LRU_MEMORY}.
    * The entry size in this distributed context represents the sum total of memory
-   * used for data in the region across all members, so the reported value may include
-   * redundancies.
+   * used for data in the region across all members, so the reported value will
+   * include any redundant copies.
    *
    * All partitioned regions can report entry size, but the value also includes
    * redundant entries and also counts the size of all the secondary entries in

--- a/geode-core/src/main/java/org/apache/geode/management/RegionMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/RegionMXBean.java
@@ -302,8 +302,8 @@ public interface RegionMXBean {
    * is set to {@link EvictionAlgorithm#LRU_MEMORY}.
    *
    * All partitioned regions can report entry size, but the value also includes
-   * redundant entries and also counts the size of all the secondary entries in 
-   * on the node.
+   * redundant entries and also counts the size of all the secondary entries in
+   * the node.
    */
   long getEntrySize();
 

--- a/geode-core/src/main/java/org/apache/geode/management/RegionMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/RegionMXBean.java
@@ -304,6 +304,8 @@ public interface RegionMXBean {
    * All partitioned regions can report entry size, but the value also includes
    * redundant entries and also counts the size of all the secondary entries in
    * the node.
+   *
+   * @return total entry size in bytes, -1 for replicated regions without LRU_MEMORY eviction
    */
   long getEntrySize();
 

--- a/geode-core/src/main/java/org/apache/geode/management/RegionMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/RegionMXBean.java
@@ -297,7 +297,7 @@ public interface RegionMXBean {
   long getDiskUsage();
 
   /**
-   * Returns the aggregate entry size (in bytes) of all entries. 
+   * Returns the aggregate entry size (in bytes) of all entries.
    * For replicated regions, provides a value only if the eviction algorithm
    * is set to {@link EvictionAlgorithm#LRU_MEMORY}.
    *

--- a/geode-core/src/main/java/org/apache/geode/management/RegionMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/RegionMXBean.java
@@ -297,12 +297,13 @@ public interface RegionMXBean {
   long getDiskUsage();
 
   /**
-   * Returns the aggregate entry size (in bytes) of all entries. This will provide a correct value
-   * only if the eviction algorithm has been set to {@link EvictionAlgorithm#LRU_MEMORY}.
+   * Returns the aggregate entry size (in bytes) of all entries. 
+   * For replicated regions, provides a value only if the eviction algorithm
+   * is set to {@link EvictionAlgorithm#LRU_MEMORY}.
    *
-   * For all partition regions it will show entry size in bytes. It will also include size of all
-   * the secondary entries in the data store. So while referring to size one should take redundancy
-   * into account
+   * All partitioned regions can report entry size, but the value also includes
+   * redundant entries and also counts the size of all the secondary entries in 
+   * on the node.
    */
   long getEntrySize();
 

--- a/geode-docs/tools_modules/pulse/pulse-views.html.md.erb
+++ b/geode-docs/tools_modules/pulse/pulse-views.html.md.erb
@@ -260,7 +260,7 @@ The following table describes the data elements displayed on the Member View scr
 <li><em>Name</em>. Region name.</li>
 <li><em>Type</em>. For example, REPLICATE, PARTITION.</li>
 <li><em>EntryCount</em>. Number of entries in the region.</li>
-<li><em>EntrySize</em>. The aggregate entry size (in bytes) of all entries. For replicated regions this field will only provide a value if the eviction algorithm has been set to EvictionAlgorithm#LRU_ MEMORY. All partition regions will have this value. However, the value includes redundant entries and will also count the size of all the secondary entries on the node.</li>
+<li><em>EntrySize</em>. The aggregate entry size (in bytes) of all entries. For replicated regions this field provides a value only if the eviction algorithm is set to EvictionAlgorithm#LRU_ MEMORY. All partition regions can report entry size, but note that the value includes redundant entries and also counts the size of all the secondary entries on the node.</li>
 </ul></td>
 </tr>
 <tr>
@@ -270,7 +270,7 @@ The following table describes the data elements displayed on the Member View scr
 <li><em>Name</em>. Region name.</li>
 <li><em>Type</em>. For example, REPLICATE, PARTITION.</li>
 <li><em>EntryCount</em>. Number of entries in the region.</li>
-<li><em>EntrySize</em>. The aggregate entry size (in bytes) of all entries. For replicated regions this field will only provide a value if the eviction algorithm has been set to EvictionAlgorithm#LRU_ MEMORY. All partition regions will have this value. However, the value includes redundant entries and will also count the size of all the secondary entries on the node.</li>
+<li><em>EntrySize</em>. The aggregate entry size (in bytes) of all entries. For replicated regions this field provides a value only if the eviction algorithm is set to EvictionAlgorithm#LRU_ MEMORY. All partition regions can report entry size, but note that the value includes redundant entries and also counts the size of all the secondary entries on the node.</li>
 <li><em>Scope</em>. Scope configured for the region.</li>
 <li><em>Disk Store Name</em>. Name of disk stores (if any) associated with the region.</li>
 <li><em>Disk Synchronous</em>. True if writes to disk are set to synchronous and false if not. This field reflects the configured disk-synchronous region attribute.</li>
@@ -370,7 +370,7 @@ The following table describes the data elements displayed on the Region View scr
 <ul>
 <li><em>Member Name</em>. The name of the <%=vars.product_name%> member hosting the region.</li>
 <li><em>EntryCount</em>. Number of entries for the region on that member.</li>
-<li><em>EntrySize</em>. The aggregate entry size (in bytes) of all entries on that member. For replicated regions this field will only provide a value if the eviction algorithm has been set to EvictionAlgorithm#LRU_ MEMORY. All partition regions will have this value. However, the value includes redundant entries and will also count the size of all the secondary entries on the node.</li>
+<li><em>EntrySize</em>. The aggregate entry size (in bytes) of all entries. For replicated regions this field provides a value only if the eviction algorithm is set to EvictionAlgorithm#LRU_ MEMORY. All partition regions can report entry size, but note that the value includes redundant entries and also counts the size of all the secondary entries on the node.</li>
 <li><em>Accessor</em>. Indicates whether the member is an accessor member.</li>
 <li><em>Reads/Writes</em>. Summary of reads and writes served from memory and from disk stores over the last 15 minutes.</li>
 </ul></td>


### PR DESCRIPTION
Descriptions of EntrySize for Pulse, RegionMXBean, and DistributedRegionMXBean are inconsistent in the user guide and the javadocs.
This PR reconciles those differences by modifying one user guide source and two sets of javadocs embedded in source code comments.
Note that the DistributedRegionMXBean description used to say the value was reported in megabytes, but now says bytes like the other two passages.