### PR TITLE
GEODE-9244: Improve the rsync_code_down CI script

### DIFF
--- a/ci/images/google-windows-geode-builder/packer.json
+++ b/ci/images/google-windows-geode-builder/packer.json
@@ -85,7 +85,7 @@
         "Move-Item \"C:\\Program Files\\BellSoft\\LibericaJDK-11*\" c:\\java11",
         "choco install -y liberica8jdk",
         "Move-Item \"C:\\Program Files\\BellSoft\\LibericaJDK-8*\" c:\\java8",
-        "choco install -y openssh --version 7.7.2.1 /SSHServerFeature",
+        "choco install openssh -params '/SSHServerFeature' -confirm",
         "refreshenv",
         "$OldPath = (Get-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Session Manager\\Environment' -Name PATH).Path",
         "$NewPath = $OldPath + ';' + 'c:\\Program Files\\Git\\bin' + ';' + 'c:\\tools\\cygwin\\bin'",

--- a/ci/scripts/rsync_code_down.sh
+++ b/ci/scripts/rsync_code_down.sh
@@ -44,20 +44,26 @@ OUTPUT_DIR=${BASE_DIR}/geode-results
 case $ARTIFACT_SLUG in
   windows*)
     JAVA_BUILD_PATH=C:/java8
-    EXEC_COMMAND="bash -c 'export JAVA_HOME=${JAVA_BUILD_PATH}; cd geode; ./gradlew --no-daemon combineReports'"
+    del=";"
     ;;
   *)
     # JAVA_BUILD_PATH=/usr/lib/jvm/java-${JAVA_BUILD_VERSION}-openjdk-amd64
     JAVA_BUILD_PATH=/usr/lib/jvm/bellsoft-java${JAVA_BUILD_VERSION}-amd64
-    EXEC_COMMAND="bash -c 'export JAVA_HOME=${JAVA_BUILD_PATH} && cd geode && ./gradlew --no-daemon combineReports'"
+    del="&&"
     ;;
 esac
 
-ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "${EXEC_COMMAND}"
+EXEC_COMMAND="bash -c 'export JAVA_HOME=${JAVA_BUILD_PATH} \
+  ${del} cd geode \
+  ${del} ./gradlew --no-daemon combineReports \
+  ${del} ./gradlew --stop \
+  ${del} cd .. \
+  ${del} rm -rf .gradle/caches .gradle/wrapper'"
 
-time rsync -e "ssh ${SSH_OPTIONS}" -ah geode@${INSTANCE_IP_ADDRESS}:geode ${OUTPUT_DIR}/ &
-time rsync -e "ssh ${SSH_OPTIONS}" -ah geode@${INSTANCE_IP_ADDRESS}:.gradle ${OUTPUT_DIR}/geode/.gradle_logs &
+time ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "${EXEC_COMMAND}"
 
-wait
+time ssh ${SSH_OPTIONS} "geode@${INSTANCE_IP_ADDRESS}" tar -czf - geode .gradle | tar -C "${OUTPUT_DIR}" -zxf -
+
+mv "${OUTPUT_DIR}/.gradle" "${OUTPUT_DIR}/geode/.gradle_logs"
 
 set +x


### PR DESCRIPTION
* DRY the commands per platform.
* Use tar-pipe over ssh, instead of bad windows rsync
* Delete some gradle cache files that are not part of this build

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
