### PR TITLE
DRAFT: Add New (Optional) Non-Differential Quorum Algorithm

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -382,7 +382,6 @@ public interface ConfigurationProperties {
    * <U>Default</U>: "false"
    */
   String DISABLE_AUTO_RECONNECT = "disable-auto-reconnect";
-  String QUORUM_ABSOLUTE_LOCATOR_COUNT = "quorum-absolute-locator-count";
   /**
    * The static String definition of the <i>"disable-tcp"</i> property <a name="disable-tcp"/a>
    * <p>
@@ -1922,6 +1921,7 @@ public interface ConfigurationProperties {
    * <U>Since</U>: Geode 1.0
    */
   String OFF_HEAP_MEMORY_SIZE = "off-heap-memory-size";
+  String QUORUM_ABSOLUTE_LOCATOR_COUNT = MembershipConfig.QUORUM_ABSOLUTE_LOCATOR_COUNT;
   /**
    * The static String definition of the <i>"compatible-with-redis-bind-address"</i> property <a
    * name="compatible-with-redis-bind-address"/a>

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -382,6 +382,7 @@ public interface ConfigurationProperties {
    * <U>Default</U>: "false"
    */
   String DISABLE_AUTO_RECONNECT = "disable-auto-reconnect";
+  String QUORUM_ABSOLUTE_LOCATOR_COUNT = "quorum-absolute-locator-count";
   /**
    * The static String definition of the <i>"disable-tcp"</i> property <a name="disable-tcp"/a>
    * <p>

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
@@ -111,6 +111,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.MEMCACHED_POR
 import static org.apache.geode.distributed.ConfigurationProperties.MEMCACHED_PROTOCOL;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.OFF_HEAP_MEMORY_SIZE;
+import static org.apache.geode.distributed.ConfigurationProperties.QUORUM_ABSOLUTE_LOCATOR_COUNT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PASSWORD;
@@ -1312,6 +1313,8 @@ public abstract class AbstractDistributionConfig extends AbstractConfig
         "The protocol that GemFireMemcachedServer understands. Default is ASCII. Values may be ASCII or BINARY");
     m.put(MEMCACHED_BIND_ADDRESS,
         "The address the GemFireMemcachedServer will listen on for remote connections. Default is \"\" which causes the GemFireMemcachedServer to listen on the host's default address. This property is ignored if memcached-port is \"0\".");
+    m.put(QUORUM_ABSOLUTE_LOCATOR_COUNT,
+        "When set to an integer value greater than 0, specifies the minimum number of locators required for quorum.");
     m.put(REDIS_BIND_ADDRESS,
         "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, localhost is requested from the operating system.");
     m.put(REDIS_ENABLED,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -4086,12 +4086,6 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   @ConfigAttributeGetter(name = DISABLE_AUTO_RECONNECT)
   boolean getDisableAutoReconnect();
 
-  int DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT =
-      MembershipConfig.DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT;
-
-  @ConfigAttributeGetter(name = QUORUM_ABSOLUTE_LOCATOR_COUNT)
-  int getQuorumAbsoluteLocatorCount();
-
   /**
    * Sets the value of {@link ConfigurationProperties#DISABLE_AUTO_RECONNECT}
    *
@@ -4100,8 +4094,16 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   @ConfigAttributeSetter(name = DISABLE_AUTO_RECONNECT)
   void setDisableAutoReconnect(boolean value);
 
+  @ConfigAttributeGetter(name = QUORUM_ABSOLUTE_LOCATOR_COUNT)
+  int getQuorumAbsoluteLocatorCount();
+
   @ConfigAttributeSetter(name = QUORUM_ABSOLUTE_LOCATOR_COUNT)
   void setQuorumAbsoluteLocatorCount(int quorumAbsoluteLocatorCount);
+
+  @ConfigAttribute(type = Integer.class, min = 1)
+  String QUORUM_ABSOLUTE_LOCATOR_COUNT_NAME = QUORUM_ABSOLUTE_LOCATOR_COUNT;
+  int DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT =
+      MembershipConfig.DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT;
 
   /**
    * @deprecated Geode 1.0 use {@link #getClusterSSLProperties()}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -111,6 +111,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.MEMCACHED_POR
 import static org.apache.geode.distributed.ConfigurationProperties.MEMCACHED_PROTOCOL;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.distributed.ConfigurationProperties.OFF_HEAP_MEMORY_SIZE;
+import static org.apache.geode.distributed.ConfigurationProperties.QUORUM_ABSOLUTE_LOCATOR_COUNT;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.REDIS_PASSWORD;
@@ -4085,6 +4086,12 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   @ConfigAttributeGetter(name = DISABLE_AUTO_RECONNECT)
   boolean getDisableAutoReconnect();
 
+  int DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT =
+      MembershipConfig.DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT;
+
+  @ConfigAttributeGetter(name = QUORUM_ABSOLUTE_LOCATOR_COUNT)
+  int getQuorumAbsoluteLocatorCount();
+
   /**
    * Sets the value of {@link ConfigurationProperties#DISABLE_AUTO_RECONNECT}
    *
@@ -4092,6 +4099,9 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    */
   @ConfigAttributeSetter(name = DISABLE_AUTO_RECONNECT)
   void setDisableAutoReconnect(boolean value);
+
+  @ConfigAttributeSetter(name = QUORUM_ABSOLUTE_LOCATOR_COUNT)
+  void setQuorumAbsoluteLocatorCount(int quorumAbsoluteLocatorCount);
 
   /**
    * @deprecated Geode 1.0 use {@link #getClusterSSLProperties()}

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -4100,7 +4100,7 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   @ConfigAttributeSetter(name = QUORUM_ABSOLUTE_LOCATOR_COUNT)
   void setQuorumAbsoluteLocatorCount(int quorumAbsoluteLocatorCount);
 
-  @ConfigAttribute(type = Integer.class, min = 1)
+  @ConfigAttribute(type = Integer.class, min = 0)
   String QUORUM_ABSOLUTE_LOCATOR_COUNT_NAME = QUORUM_ABSOLUTE_LOCATOR_COUNT;
   int DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT =
       MembershipConfig.DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT;

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -2462,13 +2462,13 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public int getQuorumAbsoluteLocatorCount() {
-    return quorumAbsoluteLocatorCount;
+  public void setDisableAutoReconnect(boolean value) {
+    disableAutoReconnect = value;
   }
 
   @Override
-  public void setDisableAutoReconnect(boolean value) {
-    disableAutoReconnect = value;
+  public int getQuorumAbsoluteLocatorCount() {
+    return quorumAbsoluteLocatorCount;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -394,6 +394,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    */
   private boolean disableAutoReconnect = DEFAULT_DISABLE_AUTO_RECONNECT;
 
+  private int quorumAbsoluteLocatorCount = DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT;
+
   /**
    * The security log file
    */
@@ -744,6 +746,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
 
     enableNetworkPartitionDetection = other.getEnableNetworkPartitionDetection();
     disableAutoReconnect = other.getDisableAutoReconnect();
+
+    quorumAbsoluteLocatorCount = other.getQuorumAbsoluteLocatorCount();
 
     securityClientAuthInit = other.getSecurityClientAuthInit();
     securityClientAuthenticator = other.getSecurityClientAuthenticator();
@@ -2458,8 +2462,18 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
+  public int getQuorumAbsoluteLocatorCount() {
+    return quorumAbsoluteLocatorCount;
+  }
+
+  @Override
   public void setDisableAutoReconnect(boolean value) {
     disableAutoReconnect = value;
+  }
+
+  @Override
+  public void setQuorumAbsoluteLocatorCount(final int quorumAbsoluteLocatorCount) {
+    this.quorumAbsoluteLocatorCount = quorumAbsoluteLocatorCount;
   }
 
   @Override
@@ -3243,6 +3257,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(securityLogLevel, that.securityLogLevel)
         .append(enableNetworkPartitionDetection, that.enableNetworkPartitionDetection)
         .append(disableAutoReconnect, that.disableAutoReconnect)
+        .append(quorumAbsoluteLocatorCount, that.quorumAbsoluteLocatorCount)
         .append(securityPeerMembershipTimeout, that.securityPeerMembershipTimeout)
         .append(removeUnresponsiveClient, that.removeUnresponsiveClient)
         .append(deltaPropagation, that.deltaPropagation)
@@ -3394,6 +3409,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(securityPeerAuthenticator).append(securityClientAccessor)
         .append(securityClientAccessorPP).append(securityLogLevel)
         .append(enableNetworkPartitionDetection).append(disableAutoReconnect)
+        .append(quorumAbsoluteLocatorCount)
         .append(securityLogFile).append(securityPeerMembershipTimeout).append(security)
         .append(userDefinedProps).append(removeUnresponsiveClient).append(deltaPropagation)
         .append(props).append(distributedSystemId).append(remoteLocators).append(enforceUniqueHost)

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -104,7 +104,7 @@ public class DistributionConfigJUnitTest {
   @Test
   public void testGetAttributeNames() {
     String[] attNames = AbstractDistributionConfig._getAttNames();
-    assertThat(attNames.length).isEqualTo(169);
+    assertThat(attNames.length).isEqualTo(170);
 
     List boolList = new ArrayList();
     List intList = new ArrayList();
@@ -139,7 +139,7 @@ public class DistributionConfigJUnitTest {
     // TODO - This makes no sense. One has no idea what the correct expected number of attributes
     // are.
     assertEquals(36, boolList.size());
-    assertEquals(35, intList.size());
+    assertEquals(36, intList.size());
     assertEquals(88, stringList.size());
     assertEquals(5, fileList.size());
     assertEquals(5, otherList.size());

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -181,9 +181,9 @@ public class GMSJoinLeaveJUnitTest {
     locatorClient = mock(TcpClient.class);
 
     if (useTestGMSJoinLeave) {
-      gmsJoinLeave = new GMSJoinLeaveTest(locatorClient);
+      gmsJoinLeave = new GMSJoinLeaveTest(locatorClient, 0);
     } else {
-      gmsJoinLeave = new GMSJoinLeave(locatorClient);
+      gmsJoinLeave = new GMSJoinLeave(locatorClient, 0);
     }
     gmsJoinLeave.init(services);
     gmsJoinLeave.start();
@@ -1514,7 +1514,7 @@ public class GMSJoinLeaveJUnitTest {
   @Test
   public void testPauseIfThereIsNoCoordinator() throws InterruptedException {
     locatorClient = mock(TcpClient.class);
-    gmsJoinLeave = new GMSJoinLeave(locatorClient);
+    gmsJoinLeave = new GMSJoinLeave(locatorClient, 0);
     assertThat(gmsJoinLeave.pauseIfThereIsNoCoordinator(-1, GMSJoinLeave.JOIN_RETRY_SLEEP))
         .isFalse();
     assertThat(gmsJoinLeave.pauseIfThereIsNoCoordinator(1, GMSJoinLeave.JOIN_RETRY_SLEEP)).isTrue();
@@ -1565,8 +1565,8 @@ public class GMSJoinLeaveJUnitTest {
   }
 
   class GMSJoinLeaveTest extends GMSJoinLeave {
-    public GMSJoinLeaveTest(final TcpClient locatorClient) {
-      super(locatorClient);
+    public GMSJoinLeaveTest(final TcpClient locatorClient, final int quorumAbsoluteLocatorCount) {
+      super(locatorClient, quorumAbsoluteLocatorCount);
     }
 
     @Override
@@ -1650,7 +1650,7 @@ public class GMSJoinLeaveJUnitTest {
     when(membershipConfig.getMcastAddress()).thenReturn("scooby.dooby.doo");
     when(services.getConfig()).thenReturn(membershipConfig);
 
-    GMSJoinLeave joinLeave = new GMSJoinLeave(null);
+    GMSJoinLeave joinLeave = new GMSJoinLeave(null, 0);
     try {
       joinLeave.init(services);
       throw new Error(

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipConfig.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipConfig.java
@@ -72,6 +72,7 @@ public interface MembershipConfig {
 
   String LOCATORS = "locators";
   String START_LOCATOR = "start-locator";
+  String QUORUM_ABSOLUTE_LOCATOR_COUNT = "quorum-absolute-locator-count";
 
   default boolean isReconnecting() {
     return false;

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipConfig.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/api/MembershipConfig.java
@@ -68,6 +68,7 @@ public interface MembershipConfig {
   Object DEFAULT_OLD_MEMBERSHIP_INFO = null;
   boolean DEFAULT_IS_RECONNECTING_DS = false;
   int DEFAULT_JOIN_TIMEOUT = 24000;
+  int DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT = 0; // 0 means use DifferentialQuorum
 
   String LOCATORS = "locators";
   String START_LOCATOR = "start-locator";
@@ -234,5 +235,9 @@ public interface MembershipConfig {
 
   default boolean getHasLocator() {
     return false;
+  }
+
+  default int getQuorumAbsoluteLocatorCount() {
+    return DEFAULT_QUORUM_ABSOLUTE_LOCATOR_COUNT;
   }
 }

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/Services.java
@@ -150,7 +150,7 @@ public class Services<ID extends MemberIdentifier> {
     this.stats = stats;
     this.config = membershipConfig;
     this.manager = membershipManager;
-    this.joinLeave = new GMSJoinLeave<>(locatorClient);
+    this.joinLeave = new GMSJoinLeave<>(locatorClient, config.getQuorumAbsoluteLocatorCount());
     this.healthMon = new GMSHealthMonitor<>(socketCreator);
     this.messenger = new JGroupsMessenger<>();
     this.auth = authenticator;

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/AbsoluteQuorum.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/AbsoluteQuorum.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal.membership.gms.membership;
+
+import static org.apache.geode.distributed.internal.membership.api.MemberIdentifier.LOCATOR_DM_TYPE;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.apache.geode.distributed.internal.membership.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
+
+class AbsoluteQuorum<ID extends MemberIdentifier> implements Quorum<ID> {
+
+  private int minimumLocatorCount;
+
+  AbsoluteQuorum(final int minimumLocatorCount) {
+    this.minimumLocatorCount = minimumLocatorCount;
+  }
+
+  @Override
+  public boolean isInitialQuorum(final Set<ID> locators) {
+    return isQuorum(locators);
+  }
+
+  @Override
+  public boolean isLostQuorum(final GMSMembershipView<ID> currentView,
+      final GMSMembershipView<ID> prospectiveView) {
+    return !isQuorum(prospectiveView.getMembers());
+  }
+
+  @Override
+  public String quorumLostMessage(final GMSMembershipView<ID> currentView,
+      final GMSMembershipView<ID> prospectiveView) {
+    return String.format("total number of locators %d is less than minimum %d. Quorum is lost!",
+        locatorCount(prospectiveView.getMembers()), minimumLocatorCount);
+  }
+
+  private boolean isQuorum(final Collection<ID> members) {
+    return locatorCount(members) >= minimumLocatorCount;
+  }
+
+  private long locatorCount(final Collection<ID> members) {
+    return members.stream().filter(
+        member -> member.getVmKind() == LOCATOR_DM_TYPE)
+        .count();
+  }
+}

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/DifferentialQuorum.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/DifferentialQuorum.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal.membership.gms.membership;
+
+import java.util.Set;
+
+import org.apache.geode.distributed.internal.membership.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
+
+class DifferentialQuorum<ID extends MemberIdentifier> implements Quorum<ID> {
+
+  /**
+   * the view where quorum was most recently lost
+   */
+  GMSMembershipView<ID> quorumLostView;
+
+  @Override
+  public boolean isInitialQuorum(final Set<ID> locators) {
+    // one locator constitutes an initial quorum in this, the legacy differential algorithm
+    return locators.size() > 0;
+  }
+
+  @Override
+  public boolean isLostQuorum(final GMSMembershipView<ID> currentView,
+      final GMSMembershipView<ID> prospectiveView) {
+    final int oldWeight = currentView.memberWeight();
+    final int failedWeight = prospectiveView.getCrashedMemberWeight(currentView);
+    if (failedWeight > 0) {
+      int failurePoint = (int) (Math.round(51.0 * oldWeight) / 100.0);
+      if (failedWeight > failurePoint && quorumLostView != prospectiveView) {
+        quorumLostView = prospectiveView;
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public String quorumLostMessage(final GMSMembershipView<ID> currentView,
+      final GMSMembershipView<ID> prospectiveView) {
+    return String
+        .format("total weight lost in this view change is %s of %s.  Quorum has been lost!",
+            prospectiveView.getCrashedMemberWeight(currentView), currentView.memberWeight());
+  }
+}

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -1667,8 +1667,6 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
       return false;
     }
 
-    final Set<ID> crashedMembers = newView.getActualCrashedMembers(currentView);
-
     if (logger.isInfoEnabled() && newView.getCreator().equals(localAddress)) { // view-creator
       // logs this
       newView.logCrashedMemberWeights(currentView, logger);
@@ -1677,6 +1675,7 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
     final boolean quorumLost = quorum.isLostQuorum(currentView, newView);
     if (quorumLost) {
       logger.warn(quorum.quorumLostMessage(currentView, newView));
+      final Set<ID> crashedMembers = newView.getActualCrashedMembers(currentView);
       services.getManager()
           .quorumLost(crashedMembers, currentView);
     }

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/Quorum.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/Quorum.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal.membership.gms.membership;
+
+import java.util.Set;
+
+import org.apache.geode.distributed.internal.membership.api.MemberIdentifier;
+import org.apache.geode.distributed.internal.membership.gms.GMSMembershipView;
+
+interface Quorum<ID extends MemberIdentifier> {
+  boolean isInitialQuorum(Set<ID> locators);
+
+  boolean isLostQuorum(GMSMembershipView<ID> currentView, GMSMembershipView<ID> prospectiveView);
+
+  String quorumLostMessage(GMSMembershipView<ID> currentView,
+      GMSMembershipView<ID> prospectiveView);
+}


### PR DESCRIPTION
There are problems with Geode's current quorum algorithm. In particular, split-brains are possible if locators are started at the same time, or if they are started during a network partition (and can't reach other locators).

This (draft) PR introduces an alternative quorum maintenance algorithm, activated by a new optional configuration parameter `quorum-absolute-locator-count`. When it's configured to a value greater-than-zero, two things are done differently:

1. when a locator is starting or restarting, and it might potentially become the coordinator, it can become the coordinator only if it has communicated with `quorum-absolute-locator-count` locators (including itself).

2. when a coordinator is considering whether a view change might result in a loss of quorum, rather than basing that decision on the change in membership weight between the current view and the prospective one, the locator count in the prospective view is compared to `quorum-absolute-locator-count`. If the locator count is below the threshold then it's treated as lost quorum, with all the usual processing that happens in that event.

The ability to switch between the legacy quorum algorithm and this new one is accomplished via a new policy object. `GMSJoinLeave` has a reference to a `Quorum` object. Legacy behavior is captured in the `DifferentialQuorum` implementation, and the new algorithm is embodied in the `AbsoluteQuorum` implementation. `GMSJoinLeave` delegates to the `Quorum` object in the `GMSJoinLeave.isLostQuorum()` method. (That method used to be called `isNetworkPartition()` but it was renamed since quorum can be lost due to reasons other than a network partition.)

In the legacy quorum algorithm, no quorum checking is done at cluster startup (when a coordinator is chosen). The new algorithm has to operate there. As a result `GMSJoinLeave.findCoordinator()` was modified to delegate to the `Quorum` object (so that the new algorithm can prevent cluster formation if too few locators are currently reachable).

This PR is very drafty so be kind.

### Checklist:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
