### PR TITLE
Revert "GEODE-9239: Update PersistDUnitTest to use JedisCluster (#6438)"

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/ExistsDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/ExistsDUnitTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.key;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+import org.apache.geode.test.junit.categories.RedisTest;
+
+@Category({RedisTest.class})
+public class ExistsDUnitTest implements Serializable {
+
+  @ClassRule
+  public static RedisClusterStartupRule cluster = new RedisClusterStartupRule(3);
+
+  private static String LOCALHOST = "localhost";
+
+  private static int server1Port;
+  private static int server2Port;
+
+  private static final int JEDIS_TIMEOUT = Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+
+  @BeforeClass
+  public static void setup() {
+    MemberVM locator = cluster.startLocatorVM(0);
+
+    cluster.startRedisVM(1, locator.getPort());
+    cluster.startRedisVM(2, locator.getPort());
+
+    server1Port = cluster.getRedisPort(1);
+    server2Port = cluster.getRedisPort(2);
+  }
+
+  @Test
+  public void testDistributedExistsOperations() {
+    Jedis jedis = new Jedis(LOCALHOST, server1Port, JEDIS_TIMEOUT);
+    Jedis jedis2 = new Jedis(LOCALHOST, server2Port, JEDIS_TIMEOUT);
+
+    jedis.set("key", "value");
+    assertThat(jedis2.exists("key")).isTrue();
+
+    jedis2.del("key");
+    assertThat(jedis.exists("key")).isFalse();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/ExpireDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/ExpireDUnitTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.key;
+
+import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Properties;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+
+public class ExpireDUnitTest {
+
+  @ClassRule
+  public static RedisClusterStartupRule clusterStartUp = new RedisClusterStartupRule(4);
+
+  static final String LOCAL_HOST = "127.0.0.1";
+  private static final int JEDIS_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+  private static Jedis jedis1;
+  private static Jedis jedis2;
+  private static Jedis jedis3;
+
+  private static Properties locatorProperties;
+
+  private static MemberVM locator;
+  private static MemberVM server1;
+  private static MemberVM server2;
+  private static MemberVM server3;
+
+  private static int redisServerPort1;
+  private static int redisServerPort2;
+  private static int redisServerPort3;
+
+  @BeforeClass
+  public static void classSetup() {
+
+    locatorProperties = new Properties();
+    locatorProperties.setProperty(MAX_WAIT_TIME_RECONNECT, "15000");
+
+    locator = clusterStartUp.startLocatorVM(0, locatorProperties);
+    server1 = clusterStartUp.startRedisVM(1, locator.getPort());
+    server2 = clusterStartUp.startRedisVM(2, locator.getPort());
+    server3 = clusterStartUp.startRedisVM(3, locator.getPort());
+
+    redisServerPort1 = clusterStartUp.getRedisPort(1);
+    redisServerPort2 = clusterStartUp.getRedisPort(2);
+    redisServerPort3 = clusterStartUp.getRedisPort(3);
+
+    jedis1 = new Jedis(LOCAL_HOST, redisServerPort1, JEDIS_TIMEOUT);
+    jedis2 = new Jedis(LOCAL_HOST, redisServerPort2, JEDIS_TIMEOUT);
+    jedis3 = new Jedis(LOCAL_HOST, redisServerPort3, JEDIS_TIMEOUT);
+  }
+
+  @After
+  public void testCleanUp() {
+    jedis1.flushAll();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    jedis1.disconnect();
+    jedis2.disconnect();
+    jedis3.disconnect();
+
+    server1.stop();
+    server2.stop();
+    server3.stop();
+  }
+
+  @Test
+  public void expireOnOneServer_shouldPropagateToAllServers() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.expire(key, 20);
+
+    assertThat(jedis2.ttl(key)).isGreaterThan(0);
+  }
+
+  @Test
+  public void expireOnOneServer_shouldResultInKeyRemovalFromOtherServer() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.expire(key, 1);
+
+    GeodeAwaitility.await().until(() -> jedis2.ttl(key) == -2);
+  }
+
+  @Test
+  public void whenExpirationIsSet_andIsUpdatedOnAnotherServer_itIsReflectedOnFirstServer() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.expire(key, 20);
+    jedis2.expire(key, 10000);
+
+    assertThat(jedis1.ttl(key)).isGreaterThan(20L);
+  }
+
+  @Test
+  public void whenExpirationIsSet_andKeyIsResetOnAnotherServer_ttlIsRemovedOnFirstServer() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.expire(key, 20);
+    jedis2.del(key);
+    jedis2.sadd(key, "newValue");
+
+    assertThat(jedis1.ttl(key)).isEqualTo(-1);
+  }
+
+  @Test
+  public void whenExpirationIsSet_andKeyIsPersistedOnAnotherServer_ttlIsRemovedOnFirstServer() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.expire(key, 20);
+    jedis2.persist(key);
+
+    assertThat(jedis1.ttl(key)).isEqualTo(-1);
+  }
+
+  @Test
+  public void whenExpirationIsSet_andKeyIsDeletedOnAnotherServerThenReset_ttlIsRemoved() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.expire(key, 10000);
+    jedis2.del(key);
+    jedis2.sadd(key, "newVal");
+
+    assertThat(jedis1.ttl(key)).isEqualTo(-1);
+    assertThat(jedis2.ttl(key)).isEqualTo(-1);
+  }
+
+
+  @Test
+  public void whenExpirationIsSet_andKeyWithoutExpirationIsRenamedOnAnotherServer_expirationIsCorrectlyTransferred() {
+    String key1 = "key1";
+    String key2 = "key2";
+
+    jedis1.sadd(key1, "value");
+    jedis1.sadd(key2, "value");
+    jedis1.expire(key1, 200);
+    jedis2.rename(key1, key2);
+
+    assertThat(jedis1.ttl(key2)).isGreaterThan(0L);
+    assertThat(jedis2.ttl(key2)).isGreaterThan(0L);
+  }
+
+  @Test
+  public void pExpireOnOneServer_shouldResultInKeyRemovalFromOtherServer() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.pexpire(key, 50);
+
+    GeodeAwaitility.await().until(() -> jedis2.ttl(key) == -2);
+  }
+
+  @Test
+  public void expireAtOnOneServer_shouldResultInKeyRemovalFromOtherServer() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.expireAt(key, System.currentTimeMillis() / 1000 + 2);
+
+    GeodeAwaitility.await().until(() -> jedis2.ttl(key) == -2);
+  }
+
+  @Test
+  public void pExpireAtOnOneServer_shouldResultInKeyRemovalFromOtherServer() {
+    String key = "key";
+
+    jedis1.sadd(key, "value");
+    jedis1.pexpireAt(key, System.currentTimeMillis() + 100);
+
+    GeodeAwaitility.await().until(() -> jedis2.ttl(key) == -2);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/PersistDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/PersistDUnitTest.java
@@ -23,8 +23,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Jedis;
 
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.AsyncInvocation;
@@ -89,7 +88,7 @@ public class PersistDUnitTest implements Serializable {
 
     @Override
     public AtomicLong call() {
-      JedisCluster jedis = new JedisCluster(new HostAndPort(LOCALHOST, port), JEDIS_TIMEOUT);
+      Jedis jedis = new Jedis(LOCALHOST, port, JEDIS_TIMEOUT);
 
       for (int i = 0; i < this.iterationCount; i++) {
         String key = this.keyBaseName + i;
@@ -104,7 +103,7 @@ public class PersistDUnitTest implements Serializable {
   @Test
   public void testConcurrentPersistOperations() throws InterruptedException {
     Long iterationCount = 5000L;
-    JedisCluster jedis = new JedisCluster(new HostAndPort(LOCALHOST, server1Port), JEDIS_TIMEOUT);
+    Jedis jedis = new Jedis(LOCALHOST, server1Port, JEDIS_TIMEOUT);
     setKeysWithExpiration(jedis, iterationCount, "key");
 
     AsyncInvocation<AtomicLong> remotePersistInvocationClient1 =
@@ -122,7 +121,7 @@ public class PersistDUnitTest implements Serializable {
         .isEqualTo(iterationCount);
   }
 
-  private void setKeysWithExpiration(JedisCluster jedis, Long iterationCount, String key) {
+  private void setKeysWithExpiration(Jedis jedis, Long iterationCount, String key) {
     for (int i = 0; i < iterationCount; i++) {
       jedis.sadd(key + i, "value" + 9);
       jedis.expire(key + i, 600);


### PR DESCRIPTION
This reverts commit 8be8ebf010e8e6a7de3cadab4994655e9692359c.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
