### PR TITLE
GEODE-9006: fix flaky native Redis memory usage test

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/server/MemoryStatsNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/server/MemoryStatsNativeRedisAcceptanceTest.java
@@ -31,7 +31,7 @@ public class MemoryStatsNativeRedisAcceptanceTest extends AbstractRedisMemorySta
 
   @Override
   public void configureMemoryAndEvictionPolicy(Jedis jedis) {
-    jedis.configSet("maxmemory", "18000000");
+    jedis.configSet("maxmemory", "10000000");
     jedis.configSet("maxmemory-policy", "allkeys-lru");
   }
 }

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/server/MemoryStatsNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/server/MemoryStatsNativeRedisAcceptanceTest.java
@@ -31,7 +31,7 @@ public class MemoryStatsNativeRedisAcceptanceTest extends AbstractRedisMemorySta
 
   @Override
   public void configureMemoryAndEvictionPolicy(Jedis jedis) {
-    jedis.configSet("maxmemory", "2000000");
+    jedis.configSet("maxmemory", "18000000");
     jedis.configSet("maxmemory-policy", "allkeys-lru");
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
@@ -24,7 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
-import org.apache.geode.internal.size.ReflectionObjectSizer;
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
@@ -63,19 +62,20 @@ public abstract class AbstractRedisMemoryStatsIntegrationTest implements RedisIn
 
   @Test
   public void memoryFragmentationRatio_shouldBeGreaterThanZero() {
-    double memoryFragmentationRatio = Double.valueOf(getInfo(jedis).get(MEM_FRAGMENTATION_RATIO));
+    double memoryFragmentationRatio =
+        Double.parseDouble(getInfo(jedis).get(MEM_FRAGMENTATION_RATIO));
     assertThat(memoryFragmentationRatio).isGreaterThan(0.0);
   }
 
   @Test
   public void usedMemory_shouldIncrease_givenAdditionalValuesAdded() {
-    Map addedData = makeHashMap(100_000, "field", "value");
+    Map<String, String> addedData = makeHashMap(100_000, "field", "value");
 
-    long initialUsedMemory = Long.valueOf(getInfo(jedis).get(USED_MEMORY));
+    long initialUsedMemory = Long.parseLong(getInfo(jedis).get(USED_MEMORY));
 
     jedis.hset(EXISTING_HASH_KEY, addedData);
 
-    long finalUsedMemory = Long.valueOf(getInfo(jedis).get(USED_MEMORY));
+    long finalUsedMemory = Long.parseLong(getInfo(jedis).get(USED_MEMORY));
     assertThat(finalUsedMemory).isGreaterThan(initialUsedMemory);
   }
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
@@ -24,6 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
+import org.apache.geode.internal.size.ReflectionObjectSizer;
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
@@ -68,7 +69,7 @@ public abstract class AbstractRedisMemoryStatsIntegrationTest implements RedisIn
 
   @Test
   public void usedMemory_shouldIncrease_givenAdditionalValuesAdded() {
-    Map addedData = makeHashMap(300_000, "field", "value");
+    Map addedData = makeHashMap(100_000, "field", "value");
 
     long initialUsedMemory = Long.valueOf(getInfo(jedis).get(USED_MEMORY));
 


### PR DESCRIPTION
- move test to only be run against apis-compatable-with-redis
- rename test be more specific

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
