### PR TITLE
GEODE-9254: Make repeat test tasks honor excludes

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -230,6 +230,11 @@ gradle.taskGraph.whenReady({ graph ->
       }
     }
   }
+  repeatAcceptanceTest.exclude acceptanceTest.excludes
+  repeatDistributedTest.exclude distributedTest.excludes
+  repeatIntegrationTest.exclude integrationTest.excludes
+  repeatUnitTest.exclude test.excludes
+  repeatUpgradeTest.exclude upgradeTest.excludes
 })
 
 acceptanceTest {


### PR DESCRIPTION
Each repeat test task now honors the excludes defined in the underlying
test task.

Before this change, repeat test tasks ignored these excludes, causing
them to run tests that the underlying test tasks would not.
