### PR TITLE
GEODE-9260: One test class per JVM in repeat tests

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -142,6 +142,7 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 
 configure([repeatDistributedTest, repeatIntegrationTest, repeatUpgradeTest, repeatUnitTest, repeatAcceptanceTest]) {
   times = Integer.parseInt(repeat)
+  forkEvery 1
   useJUnit {}
   outputs.upToDateWhen { false }
 


### PR DESCRIPTION
Repeat test tasks are now configured to `forkEvery 1` in order to run
each test class in a fresh test worker JVM. Many of the tests run by
these tasks leave the JVM in a state that other test classes cannot
tolerate.

Authored-by: Dale Emery <demery@vmware.com>
