### PR TITLE
Disable Gradle-metadata-module publishing.

### DIFF
--- a/gradle/publish-common.gradle
+++ b/gradle/publish-common.gradle
@@ -105,3 +105,7 @@ signing {
 task install(dependsOn: publishToMavenLocal) {}
 
 apply from: "${rootDir}/${scriptDir}/check-pom.gradle"
+
+tasks.withType(GenerateModuleMetadata) {
+  enabled = false
+}


### PR DESCRIPTION
We have not implemented this for geode-all-bom, so the .module file is
incomplete for downstream projects compared to the .pom.

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
