### PR TITLE
GEODE-9265: Introduce redis SlotAdvisor to manage slot information

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -28,7 +28,7 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 public class RedisClusterStartupRule extends ClusterStartupRule {
 
-  private static final String LOCALHOST = "127.0.0.1";
+  private static final String BIND_ADDRESS = "127.0.0.1";
 
   public RedisClusterStartupRule() {
     super();
@@ -62,7 +62,7 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
   }
 
   private ServerStarterRule withRedis(ServerStarterRule rule) {
-    return rule.withProperty(REDIS_BIND_ADDRESS, LOCALHOST)
+    return rule.withProperty(REDIS_BIND_ADDRESS, BIND_ADDRESS)
         .withProperty(REDIS_PORT, "0")
         .withProperty(REDIS_ENABLED, "true")
         .withSystemProperty(GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM,
@@ -70,7 +70,7 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
   }
 
   private ServerStarterRule withRedis(ServerStarterRule rule, String redisPort) {
-    return rule.withProperty(REDIS_BIND_ADDRESS, LOCALHOST)
+    return rule.withProperty(REDIS_BIND_ADDRESS, BIND_ADDRESS)
         .withProperty(REDIS_PORT, redisPort)
         .withProperty(REDIS_ENABLED, "true")
         .withSystemProperty(GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM,

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -28,6 +28,8 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 
 public class RedisClusterStartupRule extends ClusterStartupRule {
 
+  private static final String LOCALHOST = "127.0.0.1";
+
   public RedisClusterStartupRule() {
     super();
   }
@@ -60,7 +62,7 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
   }
 
   private ServerStarterRule withRedis(ServerStarterRule rule) {
-    return rule.withProperty(REDIS_BIND_ADDRESS, "localhost")
+    return rule.withProperty(REDIS_BIND_ADDRESS, LOCALHOST)
         .withProperty(REDIS_PORT, "0")
         .withProperty(REDIS_ENABLED, "true")
         .withSystemProperty(GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM,
@@ -68,7 +70,7 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
   }
 
   private ServerStarterRule withRedis(ServerStarterRule rule, String redisPort) {
-    return rule.withProperty(REDIS_BIND_ADDRESS, "localhost")
+    return rule.withProperty(REDIS_BIND_ADDRESS, LOCALHOST)
         .withProperty(REDIS_PORT, redisPort)
         .withProperty(REDIS_ENABLED, "true")
         .withSystemProperty(GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM,

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/DeltaDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/DeltaDUnitTest.java
@@ -35,6 +35,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.internal.cache.BucketDump;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -194,7 +195,8 @@ public class DeltaDUnitTest {
   private void compareBuckets() {
     server1.invoke(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
-      PartitionedRegion region = (PartitionedRegion) cache.getRegion("__REDIS_DATA");
+      PartitionedRegion region =
+          (PartitionedRegion) cache.getRegion(RegionProvider.REDIS_DATA_REGION);
       for (int j = 0; j < region.getTotalNumberOfBuckets(); j++) {
         List<BucketDump> buckets = region.getAllBucketEntries(j);
         assertThat(buckets.size()).isEqualTo(2);

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/cluster/ClusterSlotsAndNodesDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/cluster/ClusterSlotsAndNodesDUnitTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.data.Offset;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -61,7 +62,6 @@ public class ClusterSlotsAndNodesDUnitTest {
   private static Jedis jedis1;
   private static Jedis jedis2;
   private static JedisCluster jedisCluster;
-  private static int redisServerPort1;
 
   @BeforeClass
   public static void classSetup() {
@@ -69,7 +69,7 @@ public class ClusterSlotsAndNodesDUnitTest {
     server1 = cluster.startRedisVM(1, locator.getPort());
     cluster.startRedisVM(2, locator.getPort());
 
-    redisServerPort1 = cluster.getRedisPort(1);
+    int redisServerPort1 = cluster.getRedisPort(1);
     int redisServerPort2 = cluster.getRedisPort(2);
 
     jedis1 = new Jedis(LOCAL_HOST, redisServerPort1, JEDIS_TIMEOUT);
@@ -83,6 +83,11 @@ public class ClusterSlotsAndNodesDUnitTest {
     jedis1.close();
     jedis2.close();
     jedisCluster.close();
+  }
+
+  @After
+  public void testCleanup() {
+    rebalanceAllRegions(server1);
   }
 
   @Test
@@ -122,7 +127,6 @@ public class ClusterSlotsAndNodesDUnitTest {
 
   @Test
   public void slotsDistributionIsFairlyUniform() {
-    rebalanceAllRegions(server1);
     List<Object> slots = jedis1.clusterSlots();
     List<ClusterNode> nodes = ClusterNodes.parseClusterSlots(slots).getNodes();
 

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
@@ -33,6 +33,7 @@ import org.springframework.web.client.RestTemplate;
 import org.apache.geode.internal.cache.BucketDump;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.data.RedisHash;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -132,7 +133,8 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
   private void compareMaxInactiveIntervals() {
     cluster.getVM(1).invoke(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
-      PartitionedRegion region = (PartitionedRegion) cache.getRegion("__REDIS_DATA");
+      PartitionedRegion region =
+          (PartitionedRegion) cache.getRegion(RegionProvider.REDIS_DATA_REGION);
       for (int j = 0; j < region.getTotalNumberOfBuckets(); j++) {
         List<BucketDump> buckets = region.getAllBucketEntries(j);
         if (buckets.isEmpty()) {

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -1,1 +1,2 @@
+org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction
 org/apache/geode/redis/internal/collections/Object2ObjectOpenCustomHashMapWithCursor

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1,3 +1,7 @@
+org/apache/geode/redis/internal/cluster/RedisMemberInfo,2
+fromData,28
+toData,27
+
 org/apache/geode/redis/internal/data/AbstractRedisData,2
 fromData,11
 toData,11

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -85,6 +85,7 @@ public class GeodeRedisServer {
 
     CommandFunction.register(regionProvider.getDataRegion(), stripedExecutor, redisStats);
     RenameFunction.register(regionProvider.getDataRegion(), stripedExecutor, redisStats);
+    RedisMemberInfoRetrievalFunction infoFunction = RedisMemberInfoRetrievalFunction.register();
 
     passiveExpirationManager =
         new PassiveExpirationManager(regionProvider.getDataRegion(), redisStats);
@@ -99,7 +100,7 @@ public class GeodeRedisServer {
         this::allowUnsupportedCommands, this::shutdown, port, bindAddress, redisStats,
         redisCommandExecutor, member, commandHelper);
 
-    RedisMemberInfoRetrievalFunction.register(bindAddress, nettyRedisServer.getPort());
+    infoFunction.initialize(bindAddress, nettyRedisServer.getPort());
   }
 
   @VisibleForTesting

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -79,13 +79,14 @@ public class GeodeRedisServer {
     pubSub = new PubSubImpl(new Subscriptions());
     redisStats = createStats(cache);
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
+    RedisMemberInfoRetrievalFunction infoFunction = RedisMemberInfoRetrievalFunction.register();
+
     regionProvider = new RegionProvider(cache);
     CommandHelper commandHelper =
         new CommandHelper(regionProvider.getDataRegion(), redisStats, stripedExecutor);
 
     CommandFunction.register(regionProvider.getDataRegion(), stripedExecutor, redisStats);
     RenameFunction.register(regionProvider.getDataRegion(), stripedExecutor, redisStats);
-    RedisMemberInfoRetrievalFunction infoFunction = RedisMemberInfoRetrievalFunction.register();
 
     passiveExpirationManager =
         new PassiveExpirationManager(regionProvider.getDataRegion(), redisStats);
@@ -100,7 +101,7 @@ public class GeodeRedisServer {
         this::allowUnsupportedCommands, this::shutdown, port, bindAddress, redisStats,
         redisCommandExecutor, member, commandHelper);
 
-    infoFunction.initialize(bindAddress, nettyRedisServer.getPort());
+    infoFunction.initialize(member, bindAddress, nettyRedisServer.getPort());
   }
 
   @VisibleForTesting

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
@@ -28,6 +28,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.internal.beans.CacheServiceMBeanBase;
+import org.apache.geode.redis.internal.cluster.RedisMemberInfo;
 import org.apache.geode.redis.internal.data.ByteArrayWrapper;
 import org.apache.geode.redis.internal.data.NullRedisData;
 import org.apache.geode.redis.internal.data.RedisHash;
@@ -76,6 +77,9 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
     InternalDataSerializer.getDSFIDSerializer().registerDSFID(
         DataSerializableFixedID.REDIS_SET_OPTIONS_ID,
         SetOptions.class);
+    InternalDataSerializer.getDSFIDSerializer().registerDSFID(
+        DataSerializableFixedID.REDIS_MEMBER_INFO_ID,
+        RedisMemberInfo.class);
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -333,7 +333,7 @@ public enum RedisCommandType {
   }
 
   public RedisResponse executeCommand(Command command,
-      ExecutionHandlerContext executionHandlerContext) {
+      ExecutionHandlerContext executionHandlerContext) throws Exception {
 
     parameterRequirements.checkParameters(command, executionHandlerContext);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -30,8 +30,7 @@ public class RegionProvider {
   /**
    * The name of the region that holds data stored in redis.
    */
-  public static final String REDIS_DATA_REGION = "__REDIS_DATA";
-  public static final String REDIS_CONFIG_REGION = "__REDIS_CONFIG";
+  public static final String REDIS_DATA_REGION = "REDIS_DATA";
   public static final String REDIS_REGION_BUCKETS_PARAM = "redis.region.buckets";
 
   // Ideally the bucket count should be a power of 2, but technically it is not required.
@@ -43,7 +42,6 @@ public class RegionProvider {
   public static final int REDIS_SLOTS_PER_BUCKET = REDIS_SLOTS / REDIS_REGION_BUCKETS;
 
   private final Region<RedisKey, RedisData> dataRegion;
-  private final Region<String, Object> configRegion;
   private final RedisHashCommandsFunctionInvoker hashCommands;
   private final SlotAdvisor slotAdvisor;
 
@@ -52,7 +50,6 @@ public class RegionProvider {
 
     InternalRegionFactory<RedisKey, RedisData> redisDataRegionFactory =
         cache.createInternalRegionFactory(RegionShortcut.PARTITION_REDUNDANT);
-    redisDataRegionFactory.setInternalRegion(true).setIsUsedForMetaRegion(true);
 
     PartitionAttributesFactory<RedisKey, RedisData> attributesFactory =
         new PartitionAttributesFactory<>();
@@ -62,22 +59,13 @@ public class RegionProvider {
 
     dataRegion = redisDataRegionFactory.create(REDIS_DATA_REGION);
 
-    InternalRegionFactory<String, Object> redisConfigRegionFactory =
-        cache.createInternalRegionFactory(RegionShortcut.REPLICATE);
-    redisConfigRegionFactory.setInternalRegion(true).setIsUsedForMetaRegion(true);
-    configRegion = redisConfigRegionFactory.create(REDIS_CONFIG_REGION);
-
-    this.hashCommands = new RedisHashCommandsFunctionInvoker(dataRegion);
+    hashCommands = new RedisHashCommandsFunctionInvoker(dataRegion);
 
     slotAdvisor = new SlotAdvisor(dataRegion);
   }
 
   public Region<RedisKey, RedisData> getDataRegion() {
     return dataRegion;
-  }
-
-  public Region<String, Object> getConfigRegion() {
-    return configRegion;
   }
 
   public SlotAdvisor getSlotAdvisor() {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -69,7 +69,7 @@ public class RegionProvider {
 
     this.hashCommands = new RedisHashCommandsFunctionInvoker(dataRegion);
 
-    slotAdvisor = new SlotAdvisor(dataRegion, configRegion);
+    slotAdvisor = new SlotAdvisor(dataRegion);
   }
 
   public Region<RedisKey, RedisData> getDataRegion() {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -45,6 +45,7 @@ public class RegionProvider {
   private final Region<RedisKey, RedisData> dataRegion;
   private final Region<String, Object> configRegion;
   private final RedisHashCommandsFunctionInvoker hashCommands;
+  private final SlotAdvisor slotAdvisor;
 
   public RegionProvider(InternalCache cache) {
     validateBucketCount(REDIS_REGION_BUCKETS);
@@ -67,6 +68,8 @@ public class RegionProvider {
     configRegion = redisConfigRegionFactory.create(REDIS_CONFIG_REGION);
 
     this.hashCommands = new RedisHashCommandsFunctionInvoker(dataRegion);
+
+    slotAdvisor = new SlotAdvisor(dataRegion, configRegion);
   }
 
   public Region<RedisKey, RedisData> getDataRegion() {
@@ -75,6 +78,10 @@ public class RegionProvider {
 
   public Region<String, Object> getConfigRegion() {
     return configRegion;
+  }
+
+  public SlotAdvisor getSlotAdvisor() {
+    return slotAdvisor;
   }
 
   /**

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
@@ -148,6 +148,7 @@ public class SlotAdvisor {
       resultCollector =
           FunctionService.onRegion(dataRegion).execute(RedisMemberInfoRetrievalFunction.ID);
     } catch (FunctionException e) {
+      logger.warn("Unable to execute {}: {}", RedisMemberInfoRetrievalFunction.ID, e.getMessage());
       return null;
     }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
@@ -20,7 +20,6 @@ import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUC
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -143,13 +142,8 @@ public class SlotAdvisor {
       return hostPorts.get(member);
     }
 
-    Set<DistributedMember> membersWithDataRegion = new HashSet<>();
-    for (PartitionMemberInfo memberInfo : getRegionMembers(dataRegion)) {
-      membersWithDataRegion.add(memberInfo.getDistributedMember());
-    }
     ResultCollector<RedisMemberInfo, List<RedisMemberInfo>> resultCollector =
-        FunctionService.onMembers(membersWithDataRegion)
-            .execute(RedisMemberInfoRetrievalFunction.ID);
+        FunctionService.onRegion(dataRegion).execute(RedisMemberInfoRetrievalFunction.ID);
 
     hostPorts.clear();
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
@@ -134,7 +134,6 @@ public class SlotAdvisor {
     return null;
   }
 
-  @SuppressWarnings("unchecked")
   private Pair<String, Integer> getHostPort0(int bucketId) {
     InternalDistributedMember member = getOrCreateMember(bucketId);
 
@@ -142,6 +141,7 @@ public class SlotAdvisor {
       return hostPorts.get(member);
     }
 
+    @SuppressWarnings("unchecked")
     ResultCollector<RedisMemberInfo, List<RedisMemberInfo>> resultCollector =
         FunctionService.onRegion(dataRegion).execute(RedisMemberInfoRetrievalFunction.ID);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal;
+
+import static org.apache.geode.redis.internal.RegionProvider.REDIS_REGION_BUCKETS;
+import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
+import static org.apache.geode.redis.internal.cluster.RedisMemberInfoRetrievalFunction.RedisMemberInfo;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.cache.partition.PartitionMemberInfo;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.cache.partition.PartitionRegionInfo;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.cache.BucketAdvisor;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.cluster.RedisMemberInfoRetrievalFunction;
+import org.apache.geode.redis.internal.data.RedisData;
+import org.apache.geode.redis.internal.data.RedisKey;
+
+public class SlotAdvisor {
+
+  private static final Logger logger = LogService.getLogger();
+
+  /**
+   * Mapping buckets to slot information
+   */
+  private final List<MemberBucketSlot> memberBucketSlots;
+
+  /**
+   * Cache of member ids to member IP address and redis listening port
+   */
+  private final Map<String, Pair<String, Integer>> hostPorts = new HashMap<>();
+  private final PartitionedRegion dataRegion;
+  private final Region<String, Object> configRegion;
+
+  SlotAdvisor(Region<RedisKey, RedisData> dataRegion, Region<String, Object> configRegion) {
+    this.dataRegion = (PartitionedRegion) dataRegion;
+    this.configRegion = configRegion;
+    memberBucketSlots = new ArrayList<>(RegionProvider.REDIS_REGION_BUCKETS);
+    for (int i = 0; i < REDIS_REGION_BUCKETS; i++) {
+      memberBucketSlots.add(null);
+    }
+  }
+
+  public boolean isLocal(RedisKey key) {
+    return dataRegion.getRegionAdvisor().getBucket(key.getBucketId()).getBucketAdvisor()
+        .isPrimary();
+  }
+
+  public Pair<String, Integer> getHostAndPortForKey(RedisKey key) {
+    int bucketId = key.getBucketId();
+    MemberBucketSlot mbs = updateBucketDetails(bucketId);
+
+    return Pair.of(mbs.getPrimaryIpAddress(), mbs.getPrimaryPort());
+  }
+
+  public Map<String, List<Integer>> getMemberBuckets() {
+    Map<String, List<Integer>> memberBuckets = new HashMap<>();
+
+    for (Map.Entry<Integer, BucketAdvisor> entry : dataRegion.getRegionAdvisor()
+        .getAllBucketAdvisors().entrySet()) {
+      String memberId = entry.getValue().getPrimary().getUniqueId();
+      memberBuckets.computeIfAbsent(memberId, k -> new ArrayList<>()).add(entry.getKey());
+    }
+
+    return memberBuckets;
+  }
+
+  public synchronized List<MemberBucketSlot> getBucketSlots() {
+    // Initialize all buckets if necessary
+    if (!haveBucketsBeenInitialized(dataRegion)) {
+      PartitionRegionHelper.assignBucketsToPartitions(dataRegion);
+    }
+
+    for (int bucketId = 0; bucketId < REDIS_REGION_BUCKETS; bucketId++) {
+      updateBucketDetails(bucketId);
+    }
+
+    return Collections.unmodifiableList(memberBucketSlots);
+  }
+
+  private synchronized MemberBucketSlot updateBucketDetails(int bucketId) {
+    MemberBucketSlot mbs = null;
+    try {
+      Pair<String, Integer> hostPort = getHostPort(bucketId);
+
+      mbs = memberBucketSlots.get(bucketId);
+      if (mbs == null) {
+        mbs = new MemberBucketSlot(bucketId, hostPort.getLeft(), hostPort.getRight());
+        memberBucketSlots.set(bucketId, mbs);
+      } else {
+        mbs.setPrimaryIpAddress(hostPort.getLeft());
+        mbs.setPrimaryPort(hostPort.getRight());
+      }
+    } catch (Exception ex) {
+      logger.error("Unable to update bucket detail for bucketId: {}", bucketId, ex);
+    }
+
+    return mbs;
+  }
+
+  private boolean haveBucketsBeenInitialized(PartitionedRegion region) {
+    return region.getDataStore() != null && !region.getDataStore().getAllLocalBucketIds().isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Pair<String, Integer> getHostPort(int bucketId) {
+    String memberId =
+        dataRegion.getRegionAdvisor().getBucketAdvisor(bucketId).getPrimary().getUniqueId();
+
+    if (hostPorts.containsKey(memberId)) {
+      return hostPorts.get(memberId);
+    }
+
+    Set<DistributedMember> membersWithDataRegion = new HashSet<>();
+    for (PartitionMemberInfo memberInfo : getRegionMembers(dataRegion)) {
+      membersWithDataRegion.add(memberInfo.getDistributedMember());
+    }
+
+    ResultCollector<RedisMemberInfo, List<RedisMemberInfo>> resultCollector =
+        FunctionService.onMembers(membersWithDataRegion)
+            .execute(RedisMemberInfoRetrievalFunction.ID);
+
+    hostPorts.clear();
+
+    for (RedisMemberInfo memberInfo : resultCollector.getResult()) {
+      Pair<String, Integer> hostPort =
+          Pair.of(memberInfo.getHostAddress(), memberInfo.getRedisPort());
+      hostPorts.put(memberInfo.getMemberId(), hostPort);
+    }
+
+    if (!hostPorts.containsKey(memberId)) {
+      // There is a very tiny window where this might happen - a member was hosting a bucket and
+      // died before the fn call above could even complete.
+      throw new RuntimeException("Unable to retrieve host and redis port for member: " + memberId);
+    }
+
+    return hostPorts.get(memberId);
+  }
+
+  private Set<PartitionMemberInfo> getRegionMembers(PartitionedRegion dataRegion) {
+    PartitionRegionInfo info = PartitionRegionHelper.getPartitionRegionInfo(dataRegion);
+    assert info != null; // Mostly to appease IJ since the region is always a PR
+
+    return info.getPartitionMemberInfo();
+  }
+
+  public static class MemberBucketSlot {
+    private final Integer bucketId;
+    private String primaryIpAddress;
+    private Integer primaryPort;
+    private final Integer slotStart;
+    private final Integer slotEnd;
+
+    public MemberBucketSlot(Integer bucketId, String primaryIpAddress, Integer primaryPort) {
+      this.bucketId = bucketId;
+      this.primaryIpAddress = primaryIpAddress;
+      this.primaryPort = primaryPort;
+      this.slotStart = bucketId * REDIS_SLOTS_PER_BUCKET;
+      this.slotEnd = ((bucketId + 1) * REDIS_SLOTS_PER_BUCKET) - 1;
+    }
+
+    public Integer getBucketId() {
+      return bucketId;
+    }
+
+    public String getPrimaryIpAddress() {
+      return primaryIpAddress;
+    }
+
+    public void setPrimaryIpAddress(String primaryIpAddress) {
+      this.primaryIpAddress = primaryIpAddress;
+    }
+
+    public Integer getPrimaryPort() {
+      return primaryPort;
+    }
+
+    public void setPrimaryPort(Integer primaryPort) {
+      this.primaryPort = primaryPort;
+    }
+
+    public Integer getSlotStart() {
+      return slotStart;
+    }
+
+    public Integer getSlotEnd() {
+      return slotEnd;
+    }
+
+    @Override
+    public String toString() {
+      return "BucketSlot{" +
+          "bucketId=" + bucketId +
+          ", primaryIpAddress='" + primaryIpAddress + '\'' +
+          ", primaryPort=" + primaryPort +
+          ", slotStart=" + slotStart +
+          ", slotEnd=" + slotEnd +
+          '}';
+    }
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/cluster/RedisMemberInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/cluster/RedisMemberInfo.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.cluster;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.geode.DataSerializer;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.serialization.DataSerializableFixedID;
+import org.apache.geode.internal.serialization.DeserializationContext;
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.internal.serialization.SerializationContext;
+
+public class RedisMemberInfo implements DataSerializableFixedID {
+  private DistributedMember member;
+  private String hostAddress;
+  private int redisPort;
+
+  // For serialization
+  public RedisMemberInfo() {}
+
+  public RedisMemberInfo(DistributedMember member, String hostAddress, int redisPort) {
+    this.member = member;
+    this.hostAddress = hostAddress;
+    this.redisPort = redisPort;
+  }
+
+  public DistributedMember getMember() {
+    return member;
+  }
+
+  public String getHostAddress() {
+    return hostAddress;
+  }
+
+  public int getRedisPort() {
+    return redisPort;
+  }
+
+  @Override
+  public int getDSFID() {
+    return REDIS_MEMBER_INFO_ID;
+  }
+
+  @Override
+  public void toData(DataOutput out, SerializationContext context) throws IOException {
+    DataSerializer.writeObject(member, out);
+    DataSerializer.writeString(hostAddress, out);
+    out.writeInt(redisPort);
+  }
+
+  @Override
+  public void fromData(DataInput in, DeserializationContext context)
+      throws IOException, ClassNotFoundException {
+    member = DataSerializer.readObject(in);
+    hostAddress = DataSerializer.readString(in);
+    redisPort = DataSerializer.readPrimitiveInt(in);
+  }
+
+  @Override
+  public KnownVersion[] getSerializationVersions() {
+    return null;
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction.java
@@ -35,8 +35,7 @@ public class RedisMemberInfoRetrievalFunction implements InternalFunction<Void> 
   public static final String ID = RedisMemberInfoRetrievalFunction.class.getName();
   private static final long serialVersionUID = 2207969011229079993L;
 
-  private String hostAddress = null;
-  private Integer redisPort = null;
+  private RedisMemberInfo myself = null;
 
   public static RedisMemberInfoRetrievalFunction register() {
     RedisMemberInfoRetrievalFunction infoFunction = new RedisMemberInfoRetrievalFunction();
@@ -44,7 +43,8 @@ public class RedisMemberInfoRetrievalFunction implements InternalFunction<Void> 
     return infoFunction;
   }
 
-  public void initialize(String address, Integer redisPort) {
+  public void initialize(DistributedMember member, String address, int redisPort) {
+    String hostAddress;
     if (address == null || address.isEmpty() || address.equals("0.0.0.0")) {
       InetAddress localhost = null;
       try {
@@ -56,17 +56,12 @@ public class RedisMemberInfoRetrievalFunction implements InternalFunction<Void> 
       hostAddress = address;
     }
 
-    this.redisPort = redisPort;
+    myself = new RedisMemberInfo(member, hostAddress, redisPort);
   }
 
   @Override
   public void execute(FunctionContext<Void> context) {
-    if (hostAddress == null || redisPort == null) {
-      context.getResultSender().lastResult(null);
-    }
-
-    DistributedMember member = context.getCache().getDistributedSystem().getDistributedMember();
-    context.getResultSender().lastResult(new RedisMemberInfo(member, hostAddress, redisPort));
+    context.getResultSender().lastResult(myself);
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction.java
@@ -17,27 +17,21 @@ package org.apache.geode.redis.internal.cluster;
 
 import java.io.Serializable;
 import java.net.InetAddress;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
-import org.apache.geode.cache.Region;
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.inet.LocalHostUtil;
-import org.apache.geode.redis.internal.RegionProvider;
-import org.apache.geode.redis.internal.data.ByteArrayWrapper;
-import org.apache.geode.redis.internal.data.RedisKey;
 
-public class BucketInfoRetrievalFunction implements InternalFunction<Void> {
+public class RedisMemberInfoRetrievalFunction implements InternalFunction<Void> {
 
-  public static final String ID = BucketInfoRetrievalFunction.class.getName();
+  public static final String ID = RedisMemberInfoRetrievalFunction.class.getName();
+  private static final long serialVersionUID = 2207969011229079993L;
+
   private final String hostAddress;
   private final int redisPort;
 
-  private BucketInfoRetrievalFunction(String address, int redisPort) {
+  private RedisMemberInfoRetrievalFunction(String address, int redisPort) {
     if (address == null || address.isEmpty() || address.equals("0.0.0.0")) {
       InetAddress localhost = null;
       try {
@@ -53,20 +47,15 @@ public class BucketInfoRetrievalFunction implements InternalFunction<Void> {
   }
 
   public static void register(String address, int redisPort) {
-    FunctionService.registerFunction(new BucketInfoRetrievalFunction(address, redisPort));
+    FunctionService.registerFunction(new RedisMemberInfoRetrievalFunction(address, redisPort));
   }
 
   @Override
   public void execute(FunctionContext<Void> context) {
-    Region<RedisKey, ByteArrayWrapper> region =
-        context.getCache().getRegion(RegionProvider.REDIS_DATA_REGION);
-
     String memberId =
         context.getCache().getDistributedSystem().getDistributedMember().getUniqueId();
 
-    MemberBuckets mb = new MemberBuckets(memberId, hostAddress, redisPort,
-        getLocalPrimaryBucketIds(region));
-    context.getResultSender().lastResult(mb);
+    context.getResultSender().lastResult(new RedisMemberInfo(memberId, hostAddress, redisPort));
   }
 
   @Override
@@ -74,28 +63,15 @@ public class BucketInfoRetrievalFunction implements InternalFunction<Void> {
     return ID;
   }
 
-  @SuppressWarnings("unchecked")
-  public static Set<Integer> getLocalPrimaryBucketIds(Region region) {
-    PartitionedRegion pr = (PartitionedRegion) region;
-    if (pr.getDataStore() != null) {
-      return new HashSet<>(pr.getDataStore().getAllLocalPrimaryBucketIds());
-    } else {
-      return Collections.EMPTY_SET;
-    }
-  }
-
-  public static class MemberBuckets implements Serializable {
+  public static class RedisMemberInfo implements Serializable {
     private final String memberId;
     private final String hostAddress;
-    private final int port;
-    private final Set<Integer> primaryBucketIds;
+    private final int redisPort;
 
-    public MemberBuckets(String memberId, String hostAddress, int port,
-        Set<Integer> primaryBucketIds) {
+    public RedisMemberInfo(String memberId, String hostAddress, int redisPort) {
       this.memberId = memberId;
       this.hostAddress = hostAddress;
-      this.port = port;
-      this.primaryBucketIds = primaryBucketIds;
+      this.redisPort = redisPort;
     }
 
     public String getMemberId() {
@@ -106,13 +82,8 @@ public class BucketInfoRetrievalFunction implements InternalFunction<Void> {
       return hostAddress;
     }
 
-    public int getPort() {
-      return port;
+    public int getRedisPort() {
+      return redisPort;
     }
-
-    public Set<Integer> getPrimaryBucketIds() {
-      return primaryBucketIds;
-    }
-
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction.java
@@ -15,11 +15,11 @@
 
 package org.apache.geode.redis.internal.cluster;
 
-import java.io.Serializable;
 import java.net.InetAddress;
 
 import org.apache.geode.cache.execute.FunctionContext;
 import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.internal.cache.execute.InternalFunction;
 import org.apache.geode.internal.inet.LocalHostUtil;
 
@@ -52,10 +52,8 @@ public class RedisMemberInfoRetrievalFunction implements InternalFunction<Void> 
 
   @Override
   public void execute(FunctionContext<Void> context) {
-    String memberId =
-        context.getCache().getDistributedSystem().getDistributedMember().getUniqueId();
-
-    context.getResultSender().lastResult(new RedisMemberInfo(memberId, hostAddress, redisPort));
+    DistributedMember member = context.getCache().getDistributedSystem().getDistributedMember();
+    context.getResultSender().lastResult(new RedisMemberInfo(member, hostAddress, redisPort));
   }
 
   @Override
@@ -63,27 +61,8 @@ public class RedisMemberInfoRetrievalFunction implements InternalFunction<Void> 
     return ID;
   }
 
-  public static class RedisMemberInfo implements Serializable {
-    private final String memberId;
-    private final String hostAddress;
-    private final int redisPort;
-
-    public RedisMemberInfo(String memberId, String hostAddress, int redisPort) {
-      this.memberId = memberId;
-      this.hostAddress = hostAddress;
-      this.redisPort = redisPort;
-    }
-
-    public String getMemberId() {
-      return memberId;
-    }
-
-    public String getHostAddress() {
-      return hostAddress;
-    }
-
-    public int getRedisPort() {
-      return redisPort;
-    }
+  @Override
+  public boolean optimizeForWrite() {
+    return true;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
@@ -28,8 +28,7 @@ import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
 public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunctionExecutor implements
     RedisHashCommands {
 
-  public RedisHashCommandsFunctionExecutor(
-      CommandHelper helper) {
+  public RedisHashCommandsFunctionExecutor(CommandHelper helper) {
     super(helper);
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
@@ -15,6 +15,9 @@
 
 package org.apache.geode.redis.internal.data;
 
+import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
+import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -53,6 +56,11 @@ public class RedisKey extends ByteArrayWrapper implements DataSerializableFixedI
     }
 
     crc16 = CRC16.calculate(value, startHashtag + 1, endHashtag);
+  }
+
+  public int getBucketId() {
+    // & (REDIS_SLOTS - 1) is equivalent to % REDIS_SLOTS but supposedly faster
+    return getCrc16() & (REDIS_SLOTS - 1) / REDIS_SLOTS_PER_BUCKET;
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/Executor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/Executor.java
@@ -31,5 +31,5 @@ public interface Executor {
    * @param command The command to be executed
    * @param context The execution context by which this command is to be executed
    */
-  RedisResponse executeCommand(Command command, ExecutionHandlerContext context);
+  RedisResponse executeCommand(Command command, ExecutionHandlerContext context) throws Exception;
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
@@ -16,32 +16,23 @@
 package org.apache.geode.redis.internal.executor.cluster;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_CLUSTER_SUBCOMMAND;
-import static org.apache.geode.redis.internal.RegionProvider.REDIS_REGION_BUCKETS;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
-import static org.apache.geode.redis.internal.cluster.BucketInfoRetrievalFunction.MemberBuckets;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.cache.partition.PartitionMemberInfo;
 import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.cache.partition.PartitionRegionInfo;
-import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.logging.internal.log4j.api.LogService;
-import org.apache.geode.redis.internal.cluster.BucketInfoRetrievalFunction;
+import org.apache.geode.redis.internal.SlotAdvisor;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
@@ -74,65 +65,20 @@ public class ClusterExecutor extends AbstractExecutor {
   }
 
   private RedisResponse getSlots(ExecutionHandlerContext ctx) {
-    List<MemberBuckets> memberBuckets = getMemberBuckets(ctx);
-
-    Map<Integer, String> primaryBucketToMemberMap = new HashMap<>();
-    Map<String, Pair<String, Integer>> memberToHostPortMap = new TreeMap<>();
-    int retrievedBucketCount = 0;
-
-    for (MemberBuckets m : memberBuckets) {
-      memberToHostPortMap.put(m.getMemberId(), Pair.of(m.getHostAddress(), m.getPort()));
-      for (Integer id : m.getPrimaryBucketIds()) {
-        primaryBucketToMemberMap.put(id, m.getMemberId());
-        retrievedBucketCount++;
-      }
-    }
-
-    if (retrievedBucketCount != REDIS_REGION_BUCKETS) {
-      logger.warn("Bucket count mismatch {} != {}", retrievedBucketCount, REDIS_REGION_BUCKETS);
-    }
-
-    int index = 0;
     List<Object> slots = new ArrayList<>();
 
-    for (int i = 0; i < REDIS_REGION_BUCKETS; i++) {
-      String member = primaryBucketToMemberMap.get(i);
-      if (member == null) {
-        continue;
-      }
-
-      Pair<String, Integer> primaryHostAndPort = memberToHostPortMap.get(member);
-
+    for (SlotAdvisor.MemberBucketSlot memberBucketSlot : ctx.getRegionProvider().getSlotAdvisor()
+        .getBucketSlots()) {
       List<Object> entry = new ArrayList<>();
-      entry.add(index * REDIS_SLOTS_PER_BUCKET);
-      entry.add(((index + 1) * REDIS_SLOTS_PER_BUCKET) - 1);
-      entry.add(Arrays.asList(primaryHostAndPort.getLeft(), primaryHostAndPort.getRight()));
+      entry.add(memberBucketSlot.getSlotStart());
+      entry.add(memberBucketSlot.getSlotEnd());
+      entry.add(
+          Arrays.asList(memberBucketSlot.getPrimaryIpAddress(), memberBucketSlot.getPrimaryPort()));
 
       slots.add(entry);
-      index++;
     }
 
     return RedisResponse.array(slots);
-  }
-
-  @SuppressWarnings("unchecked")
-  private List<MemberBuckets> getMemberBuckets(
-      ExecutionHandlerContext ctx) {
-    Region<RedisKey, RedisData> dataRegion = ctx.getRegionProvider().getDataRegion();
-
-    if (BucketInfoRetrievalFunction.getLocalPrimaryBucketIds(dataRegion).isEmpty()) {
-      PartitionRegionHelper.assignBucketsToPartitions(dataRegion);
-    }
-
-    Set<DistributedMember> membersWithDataRegion = new HashSet<>();
-    for (PartitionMemberInfo memberInfo : getRegionMembers(ctx)) {
-      membersWithDataRegion.add(memberInfo.getDistributedMember());
-    }
-
-    ResultCollector<MemberBuckets, List<MemberBuckets>> resultCollector =
-        FunctionService.onMembers(membersWithDataRegion).execute(BucketInfoRetrievalFunction.ID);
-
-    return resultCollector.getResult();
   }
 
   /**
@@ -145,28 +91,34 @@ public class ClusterExecutor extends AbstractExecutor {
    * </pre>
    *
    * Note that there are no 'slave' entries since Geode does not host all secondary data apart from
-   * primary as redis does. The cluster port is provided only for consistency with the format
-   * of the output.
+   * primary as redis does. The cluster port is provided only for consistency with the format of the
+   * output.
    */
   private RedisResponse getNodes(ExecutionHandlerContext ctx) {
-    List<MemberBuckets> memberBuckets = getMemberBuckets(ctx);
     String memberId = ctx.getMemberName();
+    Map<String, List<Integer>> memberBuckets =
+        ctx.getRegionProvider().getSlotAdvisor().getMemberBuckets();
+    List<SlotAdvisor.MemberBucketSlot> memberBucketSlots =
+        ctx.getRegionProvider().getSlotAdvisor().getBucketSlots();
 
     StringBuilder response = new StringBuilder();
-    for (MemberBuckets m : memberBuckets) {
-      response.append(String.format("%s %s:%d@%d master",
-          m.getMemberId(), m.getHostAddress(), m.getPort(), m.getPort()));
+    for (Map.Entry<String, List<Integer>> member : memberBuckets.entrySet()) {
+      List<Integer> buckets = member.getValue();
+      SlotAdvisor.MemberBucketSlot mbs = memberBucketSlots.get(buckets.get(0));
 
-      if (m.getMemberId().equals(memberId)) {
+      response.append(String.format("%s %s:%3$d@%3$d master",
+          member.getKey(), mbs.getPrimaryIpAddress(), mbs.getPrimaryPort()));
+
+      if (member.getKey().equals(memberId)) {
         response.append(",myself");
       }
       response.append(" - 0 0 1 connected");
 
-      for (Integer index : m.getPrimaryBucketIds()) {
+      for (Integer bucket : member.getValue()) {
         response.append(" ");
-        response.append(index * REDIS_SLOTS_PER_BUCKET);
+        response.append(bucket * REDIS_SLOTS_PER_BUCKET);
         response.append("-");
-        response.append(((index + 1) * REDIS_SLOTS_PER_BUCKET) - 1);
+        response.append(((bucket + 1) * REDIS_SLOTS_PER_BUCKET) - 1);
       }
 
       response.append("\n");
@@ -174,7 +126,6 @@ public class ClusterExecutor extends AbstractExecutor {
 
     return RedisResponse.bulkString(response.toString());
   }
-
 
   private RedisResponse getInfo(ExecutionHandlerContext ctx) {
     int memberCount = getRegionMembers(ctx).size();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
@@ -40,7 +40,8 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 public class ClusterExecutor extends AbstractExecutor {
 
   @Override
-  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context)
+      throws Exception {
 
     List<byte[]> args = command.getProcessedCommand();
     String subCommand = new String(args.get(1));
@@ -59,7 +60,7 @@ public class ClusterExecutor extends AbstractExecutor {
     }
   }
 
-  private RedisResponse getSlots(ExecutionHandlerContext ctx) {
+  private RedisResponse getSlots(ExecutionHandlerContext ctx) throws InterruptedException {
     List<Object> slots = new ArrayList<>();
 
     for (SlotAdvisor.MemberBucketSlot mbs : ctx.getRegionProvider().getSlotAdvisor()
@@ -92,7 +93,7 @@ public class ClusterExecutor extends AbstractExecutor {
    * primary as redis does. The cluster port is provided only for consistency with the format of the
    * output.
    */
-  private RedisResponse getNodes(ExecutionHandlerContext ctx) {
+  private RedisResponse getNodes(ExecutionHandlerContext ctx) throws InterruptedException {
     String memberId = ctx.getMemberName();
     Map<String, List<Integer>> memberBuckets =
         ctx.getRegionProvider().getSlotAdvisor().getMemberBuckets();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/RedisPartitionResolver.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/RedisPartitionResolver.java
@@ -15,9 +15,6 @@
 
 package org.apache.geode.redis.internal.executor.cluster;
 
-import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
-import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
-
 import org.apache.geode.cache.EntryOperation;
 import org.apache.geode.cache.PartitionResolver;
 import org.apache.geode.redis.internal.data.RedisData;
@@ -27,8 +24,7 @@ public class RedisPartitionResolver implements PartitionResolver<RedisKey, Redis
 
   @Override
   public Object getRoutingObject(EntryOperation<RedisKey, RedisData> opDetails) {
-    // & (REDIS_SLOTS - 1) is equivalent to % REDIS_SLOTS but supposedly faster
-    return opDetails.getKey().getCrc16() & (REDIS_SLOTS - 1) / REDIS_SLOTS_PER_BUCKET;
+    return opDetails.getKey().getBucketId();
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
@@ -183,7 +183,7 @@ public class Command {
     return builder.toString();
   }
 
-  public RedisResponse execute(ExecutionHandlerContext executionHandlerContext) {
+  public RedisResponse execute(ExecutionHandlerContext executionHandlerContext) throws Exception {
     RedisCommandType type = getCommandType();
     return type.executeCommand(this, executionHandlerContext);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -285,7 +285,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     }
   }
 
-  private void executeCommand(Command command) {
+  private void executeCommand(Command command) throws Exception {
     try {
       if (logger.isDebugEnabled()) {
         logger.debug("Executing Redis command: {} - {}", command,
@@ -336,7 +336,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     return allowUnsupportedSupplier.get();
   }
 
-  private RedisResponse handleUnAuthenticatedCommand(Command command) {
+  private RedisResponse handleUnAuthenticatedCommand(Command command) throws Exception {
     RedisResponse response;
     if (command.isOfType(RedisCommandType.AUTH)) {
       response = command.execute(this);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -50,6 +50,7 @@ import org.apache.geode.redis.internal.ParameterRequirements.RedisParametersMism
 import org.apache.geode.redis.internal.RedisCommandType;
 import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.data.CommandHelper;
 import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.executor.CommandFunction;
 import org.apache.geode.redis.internal.executor.RedisResponse;
@@ -84,6 +85,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   private final RedisStats redisStats;
   private final EventLoopGroup subscriberGroup;
   private final DistributedMember member;
+  private final CommandHelper commandHelper;
   private BigInteger scanCursor;
   private BigInteger sscanCursor;
   private final AtomicBoolean channelInactive = new AtomicBoolean();
@@ -113,7 +115,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
       EventLoopGroup subscriberGroup,
       byte[] password,
       int serverPort,
-      DistributedMember member) {
+      DistributedMember member,
+      CommandHelper commandHelper) {
     this.channel = channel;
     this.regionProvider = regionProvider;
     this.pubsub = pubsub;
@@ -127,6 +130,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     this.isAuthenticated = password == null;
     this.serverPort = serverPort;
     this.member = member;
+    this.commandHelper = commandHelper;
     this.scanCursor = new BigInteger("0");
     this.sscanCursor = new BigInteger("0");
     redisStats.addClient();
@@ -436,6 +440,11 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     return member.getUniqueId();
   }
 
+
+  public CommandHelper getCommandHelper() {
+    return commandHelper;
+  }
+
   /**
    * This method and {@link #eventLoopReady()} are relevant for pubsub related commands which need
    * to return responses on a different EventLoopGroup. We need to ensure that the EventLoopGroup
@@ -468,4 +477,5 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   public RedisHashCommands getRedisHashCommands() {
     return regionProvider.getHashCommands();
   }
+
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/NettyRedisServer.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/NettyRedisServer.java
@@ -60,6 +60,7 @@ import org.apache.geode.logging.internal.executors.LoggingThreadFactory;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.ManagementException;
 import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.data.CommandHelper;
 import org.apache.geode.redis.internal.pubsub.PubSub;
 import org.apache.geode.redis.internal.statistics.RedisStats;
 
@@ -87,12 +88,14 @@ public class NettyRedisServer {
   private final Channel serverChannel;
   private final int serverPort;
   private final DistributedMember member;
+  private final CommandHelper commandHelper;
 
   public NettyRedisServer(Supplier<DistributionConfig> configSupplier,
       RegionProvider regionProvider, PubSub pubsub,
       Supplier<Boolean> allowUnsupportedSupplier,
       Runnable shutdownInvoker, int port, String requestedAddress,
-      RedisStats redisStats, ExecutorService backgroundExecutor, DistributedMember member) {
+      RedisStats redisStats, ExecutorService backgroundExecutor, DistributedMember member,
+      CommandHelper commandHelper) {
     this.configSupplier = configSupplier;
     this.regionProvider = regionProvider;
     this.pubsub = pubsub;
@@ -101,6 +104,7 @@ public class NettyRedisServer {
     this.redisStats = redisStats;
     this.backgroundExecutor = backgroundExecutor;
     this.member = member;
+    this.commandHelper = commandHelper;
 
     if (port < RANDOM_PORT_INDICATOR) {
       throw new IllegalArgumentException(
@@ -178,7 +182,7 @@ public class NettyRedisServer {
         pipeline.addLast(ExecutionHandlerContext.class.getSimpleName(),
             new ExecutionHandlerContext(socketChannel, regionProvider, pubsub,
                 allowUnsupportedSupplier, shutdownInvoker, redisStats, backgroundExecutor,
-                subscriberGroup, redisPasswordBytes, getPort(), member));
+                subscriberGroup, redisPasswordBytes, getPort(), member, commandHelper));
       }
     };
   }

--- a/geode-apis-compatible-with-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-apis-compatible-with-redis-serializables.txt
+++ b/geode-apis-compatible-with-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-apis-compatible-with-redis-serializables.txt
@@ -1,8 +1,6 @@
 org/apache/geode/redis/internal/ParameterRequirements/RedisParametersMismatchException,true,-643700717871858072
 org/apache/geode/redis/internal/RedisCommandSupportLevel,false
 org/apache/geode/redis/internal/RedisCommandType,false,deferredParameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,executor:org/apache/geode/redis/internal/executor/Executor,parameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,supportLevel:org/apache/geode/redis/internal/RedisCommandSupportLevel
-org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction,true,2207969011229079993,hostAddress:java/lang/String,redisPort:int
-org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction$RedisMemberInfo,false,hostAddress:java/lang/String,memberId:java/lang/String,redisPort:int
 org/apache/geode/redis/internal/data/NullRedisSet$SetOp,false
 org/apache/geode/redis/internal/data/NullRedisString$BitOp,false
 org/apache/geode/redis/internal/data/RedisDataType,false,toStringValue:java/lang/String

--- a/geode-apis-compatible-with-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-apis-compatible-with-redis-serializables.txt
+++ b/geode-apis-compatible-with-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-apis-compatible-with-redis-serializables.txt
@@ -1,8 +1,8 @@
 org/apache/geode/redis/internal/ParameterRequirements/RedisParametersMismatchException,true,-643700717871858072
 org/apache/geode/redis/internal/RedisCommandSupportLevel,false
 org/apache/geode/redis/internal/RedisCommandType,false,deferredParameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,executor:org/apache/geode/redis/internal/executor/Executor,parameterRequirements:org/apache/geode/redis/internal/ParameterRequirements/ParameterRequirements,supportLevel:org/apache/geode/redis/internal/RedisCommandSupportLevel
-org/apache/geode/redis/internal/cluster/BucketInfoRetrievalFunction,false,hostAddress:java/lang/String,redisPort:int
-org/apache/geode/redis/internal/cluster/BucketInfoRetrievalFunction$MemberBuckets,false,hostAddress:java/lang/String,memberId:java/lang/String,port:int,primaryBucketIds:java/util/Set
+org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction,true,2207969011229079993,hostAddress:java/lang/String,redisPort:int
+org/apache/geode/redis/internal/cluster/RedisMemberInfoRetrievalFunction$RedisMemberInfo,false,hostAddress:java/lang/String,memberId:java/lang/String,redisPort:int
 org/apache/geode/redis/internal/data/NullRedisSet$SetOp,false
 org/apache/geode/redis/internal/data/NullRedisString$BitOp,false
 org/apache/geode/redis/internal/data/RedisDataType,false,toStringValue:java/lang/String

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
@@ -687,6 +687,7 @@ public interface DataSerializableFixedID extends SerializationVersions, BasicSer
   short REDIS_HASH_ID = 2188;
   short REDIS_NULL_DATA_ID = 2189;
   short REDIS_SET_OPTIONS_ID = 2190;
+  short REDIS_MEMBER_INFO_ID = 2191;
   // NOTE, codes > 65535 will take 4 bytes to serialize
 
   /**


### PR DESCRIPTION
We're currently using a function to pull bucket/slot info from each
member. However, members already contain the most current view of bucket
locations so we should use that instead. This will avoid an unnecessary
fn call as well as providing more up-to-date information.

This commit introduces a `SlotAdvisor` which is intended to be the
central point of information regarding buckets/slots/members. This will
also be used to support the MOVED response.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
