### PR TITLE
GEODE-9269: Make the lock holding has the same order.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockGrantor.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/locks/DLockGrantor.java
@@ -144,7 +144,7 @@ public class DLockGrantor {
    *
    * guarded.By batchLocks
    */
-  private final Map batchLocks = new HashMap();
+  final Map<Object, DLockBatch> batchLocks = new HashMap<>();
 
   /**
    * Handles special lock-reservation type for transactions.
@@ -472,7 +472,8 @@ public class DLockGrantor {
   /**
    * Handles request for a batch of locks using optimization for transactions.
    * <p>
-   * Synchronizes on {@link #batchLocks}.
+   * Acquired destroy read lock before synchronizes on {@link #batchLocks}.
+   * If read lock not acquired, wait for the Grantor to be destroyed.
    *
    * @throws LockGrantorDestroyedException if grantor is destroyed
    */
@@ -483,21 +484,22 @@ public class DLockGrantor {
     // when the member-departure is announced.
     handler.waitForInProcessDepartures();
 
-    synchronized (this.batchLocks) { // assures serial processing
-      waitWhileInitializing();
-      if (request.checkForTimeout()) {
-        cleanupSuspendState(request);
-        return;
-      }
+    waitWhileInitializing();
+    if (request.checkForTimeout()) {
+      cleanupSuspendState(request);
+      return;
+    }
+    if (!acquireDestroyReadLock(0)) {
+      waitUntilDestroyed();
+      checkDestroyed();
+    }
 
+    synchronized (batchLocks) { // assures serial processing
       final boolean isTraceEnabled_DLS = logger.isTraceEnabled(LogMarker.DLS_VERBOSE);
       if (isTraceEnabled_DLS) {
         logger.trace(LogMarker.DLS_VERBOSE, "[DLockGrantor.handleLockBatch]");
       }
-      if (!acquireDestroyReadLock(0)) {
-        waitUntilDestroyed();
-        checkDestroyed();
-      }
+
       try {
         checkDestroyed();
         if (isTraceEnabled_DLS) {
@@ -507,12 +509,12 @@ public class DLockGrantor {
 
         DLockBatch batch = (DLockBatch) request.getObjectName();
         checkIfHostDeparted(batch.getOwner());
-        resMgr.makeReservation((IdentityArrayList) batch.getReqs());
+        makeReservation(batch);
         if (isTraceEnabled_DLS) {
           logger.trace(LogMarker.DLS_VERBOSE, "[DLockGrantor.handleLockBatch] granting {}",
               batch.getBatchId());
         }
-        this.batchLocks.put(batch.getBatchId(), batch);
+        batchLocks.put(batch.getBatchId(), batch);
         request.respondWithGrant(Long.MAX_VALUE);
       } catch (CommitConflictException ex) {
         request.respondWithTryLockFailed(ex.getMessage());
@@ -522,7 +524,11 @@ public class DLockGrantor {
     }
   }
 
-  private void checkIfHostDeparted(InternalDistributedMember owner) {
+  void makeReservation(DLockBatch batch) {
+    resMgr.makeReservation((IdentityArrayList) batch.getReqs());
+  }
+
+  void checkIfHostDeparted(InternalDistributedMember owner) {
     // Already held batchLocks; hold membersDepartedTime lock just for clarity
     synchronized (membersDepartedTime) {
       // the transaction host/txLock requester has departed.
@@ -543,7 +549,7 @@ public class DLockGrantor {
    */
   public DLockBatch[] getLockBatches(InternalDistributedMember owner) {
     // Key: Object batchId, Value: DLockBatch batch
-    synchronized (this.batchLocks) {
+    synchronized (batchLocks) {
       // put owner into the map first so that no new threads will handle in-flight requests
       // from the departed member to lock keys
       recordMemberDepartedTime(owner);
@@ -587,7 +593,8 @@ public class DLockGrantor {
    * Get the batch for the given batchId (for example use a txLockId from TXLockBatch in order to
    * update its participants). This operation was added as part of the solution to bug 32999.
    * <p>
-   * Acquires acquireDestroyReadLock. Synchronizes on batchLocks.
+   * Acquired destroy read lock before synchronizes on {@link #batchLocks}.
+   * If read lock not acquired, wait for the Grantor to be destroyed.
    * <p>
    * see org.apache.geode.internal.cache.TXCommitMessage#updateLockMembers()
    *
@@ -597,20 +604,21 @@ public class DLockGrantor {
    * @see org.apache.geode.internal.cache.locks.TXLockBatch#getBatchId()
    */
   public DLockBatch getLockBatch(Object batchId) throws InterruptedException {
-    DLockBatch ret = null;
+    DLockBatch ret;
     final boolean isTraceEnabled_DLS = logger.isTraceEnabled(LogMarker.DLS_VERBOSE);
     if (isTraceEnabled_DLS) {
       logger.trace(LogMarker.DLS_VERBOSE, "[DLockGrantor.getLockBatch] enter: {}", batchId);
     }
-    synchronized (this.batchLocks) {
-      waitWhileInitializing();
-      if (!acquireDestroyReadLock(0)) {
-        waitUntilDestroyed();
-        checkDestroyed();
-      }
+
+    waitWhileInitializing();
+    if (!acquireDestroyReadLock(0)) {
+      waitUntilDestroyed();
+      checkDestroyed();
+    }
+    synchronized (batchLocks) {
       try {
         checkDestroyed();
-        ret = (DLockBatch) this.batchLocks.get(batchId);
+        ret = batchLocks.get(batchId);
       } finally {
         releaseDestroyReadLock();
       }
@@ -625,7 +633,8 @@ public class DLockGrantor {
    * Update the batch for the given batch. This operation was added as part of the solution to bug
    * 32999.
    * <p>
-   * Acquires acquireDestroyReadLock. Synchronizes on batchLocks.
+   * Acquired destroy read lock before synchronizes on {@link #batchLocks}.
+   * If read lock not acquired, wait for the Grantor to be destroyed.
    * <p>
    * see org.apache.geode.internal.cache.locks.TXCommitMessage#updateLockMembers()
    *
@@ -639,17 +648,17 @@ public class DLockGrantor {
     if (isTraceEnabled_DLS) {
       logger.trace(LogMarker.DLS_VERBOSE, "[DLockGrantor.updateLockBatch] enter: {}", batchId);
     }
-    synchronized (this.batchLocks) {
-      waitWhileInitializing();
-      if (!acquireDestroyReadLock(0)) {
-        waitUntilDestroyed();
-        checkDestroyed();
-      }
+    waitWhileInitializing();
+    if (!acquireDestroyReadLock(0)) {
+      waitUntilDestroyed();
+      checkDestroyed();
+    }
+    synchronized (batchLocks) {
       try {
         checkDestroyed();
-        final DLockBatch oldBatch = (DLockBatch) this.batchLocks.get(batchId);
+        final DLockBatch oldBatch = batchLocks.get(batchId);
         if (oldBatch != null) {
-          this.batchLocks.put(batchId, newBatch);
+          batchLocks.put(batchId, newBatch);
         }
       } finally {
         releaseDestroyReadLock();
@@ -663,7 +672,8 @@ public class DLockGrantor {
   /**
    * Releases the transaction optimized lock batch.
    * <p>
-   * Acquires acquireDestroyReadLock. Synchronizes on batchLocks.
+   * Acquired destroy read lock before synchronizes on {@link #batchLocks}.
+   * If read lock not acquired, wait for the Grantor to be destroyed.
    *
    * @param batchId the identify of the transaction lock batch to release
    * @param owner the member that has created and locked the lock batch
@@ -674,22 +684,26 @@ public class DLockGrantor {
     if (logger.isTraceEnabled(LogMarker.DLS_VERBOSE)) {
       logger.trace(LogMarker.DLS_VERBOSE, "[DLockGrantor.releaseLockBatch]");
     }
-    synchronized (this.batchLocks) {
-      waitWhileInitializing();
-      if (!acquireDestroyReadLock(0)) {
-        waitUntilDestroyed();
-        checkDestroyed();
-      }
+    waitWhileInitializing();
+    if (!acquireDestroyReadLock(0)) {
+      waitUntilDestroyed();
+      checkDestroyed();
+    }
+    synchronized (batchLocks) {
       try {
         checkDestroyed();
-        DLockBatch batch = (DLockBatch) this.batchLocks.remove(batchId);
+        DLockBatch batch = batchLocks.remove(batchId);
         if (batch != null) {
-          this.resMgr.releaseReservation((IdentityArrayList) batch.getReqs());
+          releaseReservation(batch);
         }
       } finally {
         releaseDestroyReadLock();
       }
     }
+  }
+
+  void releaseReservation(DLockBatch batch) {
+    resMgr.releaseReservation((IdentityArrayList) batch.getReqs());
   }
 
   /**
@@ -1385,7 +1399,7 @@ public class DLockGrantor {
    * @return true if destroy read lock was acquired
    * @throws DistributedSystemDisconnectedException if system has been disconnected
    */
-  private boolean acquireDestroyReadLock(long millis) throws InterruptedException {
+  boolean acquireDestroyReadLock(long millis) throws InterruptedException {
     boolean interrupted = Thread.interrupted();
     try {
       if (interrupted && this.dlock.isInterruptibleLockRequest()) {
@@ -1411,7 +1425,7 @@ public class DLockGrantor {
   /**
    * Releases a read lock on the destroy ReadWrite lock.
    */
-  private void releaseDestroyReadLock() {
+  void releaseDestroyReadLock() {
     this.destroyLock.readLock().unlock();
   }
 

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
@@ -50,6 +50,8 @@ public class DLockGrantorTest {
     dLockService = mock(DLockService.class, RETURNS_DEEP_STUBS);
     DistributionManager distributionManager = mock(DistributionManager.class);
     when(dLockService.getDistributionManager()).thenReturn(distributionManager);
+    when(dLockService.getDLockLessorDepartureHandler())
+        .thenReturn(mock(DLockLessorDepartureHandler.class));
     CancelCriterion cancelCriterion = mock(CancelCriterion.class);
     when(distributionManager.getCancelCriterion()).thenReturn(cancelCriterion);
     grantor = DLockGrantor.createGrantor(dLockService, 1);

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
@@ -18,15 +18,20 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.CommitConflictException;
 import org.apache.geode.cache.TransactionDataNodeHasDepartedException;
 import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
@@ -34,6 +39,11 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
 public class DLockGrantorTest {
   private DLockService dLockService;
   private DLockGrantor grantor;
+  private final DLockBatchId batchId = mock(DLockBatchId.class);
+  private final DLockBatch batch = mock(DLockBatch.class);
+  private final DLockRequestProcessor.DLockRequestMessage request = mock(
+      DLockRequestProcessor.DLockRequestMessage.class);
+  private final InternalDistributedMember owner = mock(InternalDistributedMember.class);
 
   @Before
   public void setup() {
@@ -65,7 +75,6 @@ public class DLockGrantorTest {
 
   @Test
   public void recordMemberDepartedTimeRecords() {
-    InternalDistributedMember owner = mock(InternalDistributedMember.class);
     grantor.recordMemberDepartedTime(owner);
 
     assertThat(grantor.getMembersDepartedTimeRecords()).containsKey(owner);
@@ -83,11 +92,175 @@ public class DLockGrantorTest {
     }
     assertThat(spy.getMembersDepartedTimeRecords().size()).isEqualTo(2);
 
-    InternalDistributedMember owner = mock(InternalDistributedMember.class);
     spy.recordMemberDepartedTime(owner);
 
     assertThat(spy.getMembersDepartedTimeRecords().size()).isEqualTo(1);
     assertThat(spy.getMembersDepartedTimeRecords()).containsKey(owner);
   }
 
+  @Test
+  public void cleanupSuspendStateIfRequestHasTimedOut() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    when(request.checkForTimeout()).thenReturn(true);
+    doNothing().when(spy).cleanupSuspendState(request);
+
+    spy.handleLockBatch(request);
+
+    verify(spy).cleanupSuspendState(request);
+    verify(spy, never()).acquireDestroyReadLock(0);
+  }
+
+  @Test
+  public void handleLockBatchThrowsIfCanNotAcquireDestroyReadLock() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    doReturn(false).when(spy).acquireDestroyReadLock(0);
+    doNothing().when(spy).waitUntilDestroyed();
+    doReturn(true).when(spy).isDestroyed();
+
+    assertThatThrownBy(() -> spy.handleLockBatch(request))
+        .isInstanceOf(LockGrantorDestroyedException.class);
+
+    verify(spy).waitUntilDestroyed();
+    verify(spy).checkDestroyed();
+    verify(spy, never()).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void handleLockBatchMakesReservation() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    when(request.getObjectName()).thenReturn(batch);
+    when(batch.getOwner()).thenReturn(owner);
+    when(batch.getBatchId()).thenReturn(batchId);
+    doNothing().when(spy).makeReservation(batch);
+
+    spy.handleLockBatch(request);
+
+    assertThat(spy.batchLocks.get(batchId)).isEqualTo(batch);
+    verify(spy).checkIfHostDeparted(owner);
+    verify(spy).makeReservation(batch);
+    verify(spy).releaseDestroyReadLock();
+    verify(request).respondWithGrant(Long.MAX_VALUE);
+  }
+
+  @Test
+  public void handleLockBatchRespondWithTryLockFailedIfMakeReservationFailed() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    when(request.getObjectName()).thenReturn(batch);
+    when(batch.getOwner()).thenReturn(owner);
+    when(batch.getBatchId()).thenReturn(batchId);
+    String exceptionMessage = "failed";
+    doThrow(new CommitConflictException(exceptionMessage)).when(spy).makeReservation(batch);
+
+    spy.handleLockBatch(request);
+
+    assertThat(spy.batchLocks.get(batchId)).isEqualTo(null);
+    verify(spy).checkIfHostDeparted(owner);
+    verify(spy).releaseDestroyReadLock();
+    verify(request).respondWithTryLockFailed(exceptionMessage);
+  }
+
+  @Test
+  public void getLockBatchThrowsIfCanNotAcquireDestroyReadLock() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    doReturn(false).when(spy).acquireDestroyReadLock(0);
+    doNothing().when(spy).waitUntilDestroyed();
+    doReturn(true).when(spy).isDestroyed();
+
+    assertThatThrownBy(() -> spy.getLockBatch(batchId))
+        .isInstanceOf(LockGrantorDestroyedException.class);
+
+    verify(spy).waitUntilDestroyed();
+    verify(spy).checkDestroyed();
+    verify(spy, never()).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void getLockBatchReturnsCorrectBatchLock() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    spy.batchLocks.put(batchId, batch);
+
+    assertThat(spy.getLockBatch(batchId)).isEqualTo(batch);
+
+    verify(spy).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void updateLockBatchThrowsIfCanNotAcquireDestroyReadLock() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    doReturn(false).when(spy).acquireDestroyReadLock(0);
+    doNothing().when(spy).waitUntilDestroyed();
+    doReturn(true).when(spy).isDestroyed();
+
+    assertThatThrownBy(() -> spy.updateLockBatch(batchId, batch))
+        .isInstanceOf(LockGrantorDestroyedException.class);
+
+    verify(spy).waitUntilDestroyed();
+    verify(spy).checkDestroyed();
+    verify(spy, never()).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void updateLockBatchUpdates() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    spy.batchLocks.put(batchId, batch);
+    DLockBatch newBatch = mock(DLockBatch.class);
+
+    spy.updateLockBatch(batchId, newBatch);
+
+    assertThat(spy.batchLocks.get(batchId)).isEqualTo(newBatch);
+
+    verify(spy).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void updateLockBatchDoesNotUpdateIfNoExistingBatch() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    DLockBatch newBatch = mock(DLockBatch.class);
+
+    spy.updateLockBatch(batchId, newBatch);
+
+    assertThat(spy.batchLocks.get(batchId)).isNull();
+
+    verify(spy).releaseDestroyReadLock();
+  }
+
+
+  @Test
+  public void releaseLockBatchThrowsIfCanNotAcquireDestroyReadLock() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    doReturn(false).when(spy).acquireDestroyReadLock(0);
+    doNothing().when(spy).waitUntilDestroyed();
+    doReturn(true).when(spy).isDestroyed();
+
+    assertThatThrownBy(() -> spy.releaseLockBatch(batchId, owner))
+        .isInstanceOf(LockGrantorDestroyedException.class);
+
+    verify(spy).waitUntilDestroyed();
+    verify(spy).checkDestroyed();
+    verify(spy, never()).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void releaseLockBatchReleaseReservation() throws Exception {
+    DLockGrantor spy = spy(grantor);
+    spy.makeReady(true);
+    spy.batchLocks.put(batchId, batch);
+    doNothing().when(spy).releaseReservation(batch);
+
+    spy.releaseLockBatch(batchId, null);
+
+    assertThat(spy.batchLocks.size()).isEqualTo(0);
+    verify(spy).releaseReservation(batch);
+    verify(spy).releaseDestroyReadLock();
+  }
 }


### PR DESCRIPTION
  * When handling TXLockService, always trying to acquire destroy read lock
    before getting the synchronized batchLocks.
  * If destroy read lock is not acuried, thread will wait until the grantor
    is destoryed.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
