### PR TITLE
GEODE-8772: Assign TCP Server test ports in test JVM

### DIFF
--- a/geode-tcp-server/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionDUnitTest.java
+++ b/geode-tcp-server/src/distributedTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionDUnitTest.java
@@ -159,7 +159,7 @@ public class TcpServerProductVersionDUnitTest implements Serializable {
     VM clientVM = Host.getHost(0).getVM(versions.clientProductVersion.toString(), clientVMNumber);
     VM locatorVM =
         Host.getHost(0).getVM(versions.locatorProductVersion.toString(), locatorVMNumber);
-    int locatorPort = createLocator(locatorVM, true);
+    int locatorPort = createLocator(locatorVM);
 
     clientVM.invoke("issue version request",
         createRequestResponseFunction(locatorPort, VersionRequest.class.getName(),
@@ -251,17 +251,15 @@ public class TcpServerProductVersionDUnitTest implements Serializable {
         TcpSocketFactory.DEFAULT);
   }
 
-  private int createLocator(VM memberVM, boolean usingOldVersion) {
+  private int createLocator(VM memberVM) {
+    final int port = AvailablePortHelper.getRandomAvailableTCPPort();
+
     return memberVM.invoke("create locator", () -> {
       System.setProperty(GMSJoinLeave.BYPASS_DISCOVERY_PROPERTY, "true");
       try {
-        int port = 0;
         // for stress-tests make sure that an older-version locator doesn't try
         // to read state persisted by another run's newer-version locator
-        if (usingOldVersion) {
-          port = AvailablePortHelper.getRandomAvailableTCPPort();
-          DistributedTestUtils.deleteLocatorStateFile(port);
-        }
+        DistributedTestUtils.deleteLocatorStateFile(port);
         return Locator.startLocatorAndDS(port, new File(""), getDistributedSystemProperties())
             .getPort();
       } finally {


### PR DESCRIPTION
Make TcpServerProductVersionDUnitTest assign the locator port in the
test JVM rather than in child VMs.

An upcoming change to AvailablePortHelper will improve how it assigns
ports to better support tests running in parallel outside of docker.  A
child VM running an older version of Geode (as happens in this test)
will have an out-of-date implementation of AvailablePortHelper, and so
may assign a port that is in use by another test running in parallel.
