### PR TITLE
GEODE-9229: Avoid possible duplicate events sent with group-transacti…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -787,6 +787,18 @@ public class SerialGatewaySenderQueue implements RegionQueue {
 
   @VisibleForTesting
   public KeyAndEventPair peekAhead() throws CacheException {
+    // When group-transaction-events is true, peekAhead must
+    // be synchronized in order to get a consistent view
+    // of extraPeekedIds and currentKey as provided by remove()
+    if (mustGroupTransactionEvents()) {
+      synchronized (this) {
+        return peekAheadNotSynchronized();
+      }
+    }
+    return peekAheadNotSynchronized();
+  }
+
+  private KeyAndEventPair peekAheadNotSynchronized() throws CacheException {
     AsyncEvent object = null;
     Long currentKey = getCurrentKey();
     if (currentKey == null) {


### PR DESCRIPTION
…on-events

When group-transaction-events is set to true
the SerialGatewaySenderQueue class stores those events
peeked from the queue to complete transactions
for a batch inside the extraPeekedIds member. This is done
so that, when new events are peeked from the queue
by peekAhead() to be put in a batch, the
events in extraPeekedIds are skipped. Otherwise
those events will be sent several times.
When the remove method of SerialGatewaySenderQueue
is called, the peekedIds member and the head key
of the queue are updated and events from extraPeekedIds
are removed if necessary.
Given that the peekAhead() method first gets the
currentKey (that depends on the peekedIds and the headkey)
and then checks if the event to be removed is in extraPeekedIds,
it could be that in between those two calls,
remove() is called from another thread, causing that
peekAhead() returns an event that
belonged to extraPeekedIds when the currentKey was
obtained but was deleted from extraPeekedIds by remove()
before it was checked that the event belonged to
extraPeekedIds.
This provokes that an event already peeked is returned
again by peekAhead() leading to duplicate events
sent by the gateway sender.

The solution proposed to solve this problem is to make
synchronized the peekAhead() function when group-transaction-events
is set given that remove() is already synchronized. This will
prevent the race condition described above.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
