### PR TITLE
GEODE-9256: Adding a jmh test of the Object2ObjectOpenCustomHashmapWithCursor

### DIFF
--- a/geode-apis-compatible-with-redis/build.gradle
+++ b/geode-apis-compatible-with-redis/build.gradle
@@ -19,6 +19,7 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
 apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 apply from: "${rootDir}/${scriptDir}/warnings.gradle"
+apply from: "${project.projectDir}/../gradle/jmh.gradle"
 
 apply plugin: 'nebula.facet'
 facets {

--- a/geode-apis-compatible-with-redis/src/jmh/java/org/apache/geode/redis/internal/collections/Object2ObjectOpenCustomHashmapWithCursorBenchmark.java
+++ b/geode-apis-compatible-with-redis/src/jmh/java/org/apache/geode/redis/internal/collections/Object2ObjectOpenCustomHashmapWithCursorBenchmark.java
@@ -1,3 +1,17 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package org.apache.geode.redis.internal.collections;
 
 import java.util.Iterator;

--- a/geode-apis-compatible-with-redis/src/jmh/java/org/apache/geode/redis/internal/collections/Object2ObjectOpenCustomHashmapWithCursorBenchmark.java
+++ b/geode-apis-compatible-with-redis/src/jmh/java/org/apache/geode/redis/internal/collections/Object2ObjectOpenCustomHashmapWithCursorBenchmark.java
@@ -1,0 +1,56 @@
+package org.apache.geode.redis.internal.collections;
+
+import java.util.Iterator;
+import java.util.Random;
+
+import it.unimi.dsi.fastutil.bytes.ByteArrays;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+
+public class Object2ObjectOpenCustomHashmapWithCursorBenchmark {
+
+  @State(Scope.Benchmark)
+  public static class BenchmarkState {
+    @Param({"1000", "10000", "100000"})
+    private int numEntries;
+    @Param({"32"})
+    private int keySize;
+    private Object2ObjectOpenCustomHashMapWithCursor<byte[], byte[]> map;
+    private int cursor;
+    private Iterator<byte[]> iterator;
+
+    @Setup
+    public void createMap() {
+      Random random = new Random(0);
+      map = new Object2ObjectOpenCustomHashMapWithCursor<>(numEntries, ByteArrays.HASH_STRATEGY);
+      for (int i = 0; i < numEntries; i++) {
+        byte[] key = new byte[keySize];
+        random.nextBytes(key);
+        map.put(key, key);
+      }
+
+      iterator = map.keySet().iterator();
+    }
+  }
+
+  @Benchmark
+  public void iterateWithCursor(BenchmarkState state, Blackhole blackhole) {
+    state.cursor =
+        state.map.scan(state.cursor, 1, (hole, key, value) -> hole.consume(key), blackhole);
+  }
+
+  @Benchmark
+  public void iterateWithIterator(BenchmarkState state, Blackhole blackhole) {
+    if (!state.iterator.hasNext()) {
+      state.iterator = state.map.keySet().iterator();
+    }
+
+    blackhole.consume(state.iterator.next());
+  }
+
+
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/Object2ObjectOpenCustomHashMapWithCursor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/Object2ObjectOpenCustomHashMapWithCursor.java
@@ -122,8 +122,9 @@ public class Object2ObjectOpenCustomHashMapWithCursor<K, V>
       // those as well. This may even wrap around to the front of the hashtable.
       int position = cursor;
       while (key[position & mask] != null) {
-        if (elementAtHashesTo(position, cursor & mask)) {
-          consumer.consume(privateData, key[position & mask], value[position & mask]);
+        K currentKey = key[position & mask];
+        if (keyHashesTo(currentKey, position, cursor & mask)) {
+          consumer.consume(privateData, currentKey, value[position & mask]);
           count--;
         }
         position++;
@@ -163,20 +164,23 @@ public class Object2ObjectOpenCustomHashMapWithCursor<K, V>
   }
 
   /**
-   * Check to see if the element at position hashes to the expected hash.
+   * Check to see if given key hashes to the expected hash.
+   *
+   * @param currentKey The key to key
+   * @param currentPosition The position of the key in the key[] array
+   * @parma expectedHash - the expected hash of the key.
    */
-  private boolean elementAtHashesTo(int position, int expectedHash) {
+  private boolean keyHashesTo(K currentKey, int currentPosition, int expectedHash) {
     // There is a small optimization here. If the previous element
     // is null, we know that the element at position does hash to the expected
     // hash because it is not here as a result of a collision at some previous position.
 
-    K previousEntry = key[(position - 1) & mask];
-    return previousEntry == null
-        || (hash(key[position & mask]) & mask) == expectedHash;
+    K previousKey = key[(currentPosition - 1) & mask];
+    return previousKey == null || hash(currentKey) == expectedHash;
   }
 
   private int hash(K key) {
-    return mix(strategy.hashCode(key));
+    return mix(strategy.hashCode(key)) & mask;
   }
 
   public interface EntryConsumer<K, V, D> {


### PR DESCRIPTION
The test compares the performance of the cursor with the performance
of an iterator. Although the cursor is about an order of magnitude
slower than an iterator, the iteration time still looks like it's
O(1) - eg the time to iterate per entry does not go up with the
number of entries.

Tweaking the name of the elementAtHashesTo method, based on feedback from the
last PR. Trying to make that code a little more readable.
