### PR TITLE
GEODE-9281: fix printing results for the query when multiple indexes …

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/QueryUtils.java
@@ -39,6 +39,8 @@ import org.apache.geode.cache.query.internal.index.IndexData;
 import org.apache.geode.cache.query.internal.index.IndexManager;
 import org.apache.geode.cache.query.internal.index.IndexProtocol;
 import org.apache.geode.cache.query.internal.index.IndexUtils;
+import org.apache.geode.cache.query.internal.index.MemoryIndexStore;
+import org.apache.geode.cache.query.internal.index.MemoryIndexStore.CachedEntryWrapper;
 import org.apache.geode.cache.query.internal.index.PartitionedIndex;
 import org.apache.geode.cache.query.internal.parse.OQLLexerTokenTypes;
 import org.apache.geode.cache.query.internal.types.ObjectTypeImpl;
@@ -187,6 +189,9 @@ public class QueryUtils {
       try {
         for (Iterator itr = small.iterator(); itr.hasNext();) {
           Object element = itr.next();
+          if (element instanceof MemoryIndexStore.CachedEntryWrapper) {
+            element = ((CachedEntryWrapper) element).getKey();
+          }
           int count = large.occurrences(element);
           if (small.occurrences(element) > count) {
             // bag intersection: only retain smaller number of dups
@@ -202,6 +207,9 @@ public class QueryUtils {
       try {
         for (Iterator itr = large.iterator(); itr.hasNext();) {
           Object element = itr.next();
+          if (element instanceof MemoryIndexStore.CachedEntryWrapper) {
+            element = ((CachedEntryWrapper) element).getKey();
+          }
           int count = small.occurrences(element);
           if (large.occurrences(element) > count) {
             // bag intersection: only retain smaller number of dups

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -843,7 +843,7 @@ public class MemoryIndexStore implements IndexStore {
     }
   }
 
-  class CachedEntryWrapper {
+  public class CachedEntryWrapper {
 
     private Object key, value;
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryWithIndexesDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryWithIndexesDUnitTest.java
@@ -25,8 +25,6 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.data.Portfolio;
-import org.apache.geode.management.ManagementService;
-import org.apache.geode.management.MemberMXBean;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
@@ -36,7 +34,7 @@ import org.apache.geode.test.junit.rules.GfshCommandRule;
 public class QueryWithIndexesDUnitTest {
 
   @Rule
-  public ClusterStartupRule cluster = new ClusterStartupRule(5);
+  public ClusterStartupRule cluster = new ClusterStartupRule(2);
 
   @Rule
   public GfshCommandRule gfsh = new GfshCommandRule();
@@ -45,7 +43,7 @@ public class QueryWithIndexesDUnitTest {
 
   @Before
   public void setUpServers() throws Exception {
-    locator = cluster.startLocatorVM(0, l -> l.withoutClusterConfigurationService());
+    locator = cluster.startLocatorVM(0);
     server = cluster.startServerVM(1, locator.getPort());
 
     gfsh.connectAndVerify(locator);
@@ -66,23 +64,18 @@ public class QueryWithIndexesDUnitTest {
       populateRegion(0, 500);
     });
 
-    locator.invoke(() -> {
-      String query = "query --query=\"<trace> select value from" +
-          SEPARATOR + "exampleRegion.entrySet where value.ID >= 0 AND value.ID < 500 " +
-          "AND (value.status = 'active' or value.status = 'inactive')\"";
+    String query = "query --query=\"<trace> select value from" +
+        SEPARATOR + "exampleRegion.entrySet where value.ID >= 0 AND value.ID < 500 " +
+        "AND (value.status = 'active' or value.status = 'inactive')\"";
 
-      ManagementService service =
-          ManagementService.getExistingManagementService(ClusterStartupRule.getCache());
-      MemberMXBean member = service.getMemberMXBean();
-      String cmdResult = member.processCommand(query);
-
-      assertThat(cmdResult).contains("\"Rows\":\"100\"");
-      assertThat(cmdResult).contains("indexesUsed(2)");
-    });
+    String cmdResult = String.valueOf(gfsh.executeAndAssertThat(query).getResultModel());
+    assertThat(cmdResult).contains("\"Rows\":\"100\"");
+    assertThat(cmdResult).contains("indexesUsed(2)");
   }
 
   private static void populateRegion(int startingId, int endingId) {
-    Region exampleRegion = ClusterStartupRule.getCache().getRegion("exampleRegion");
+    Region<String, Portfolio> exampleRegion =
+        ClusterStartupRule.getCache().getRegion("exampleRegion");
     for (int i = startingId; i < endingId; i++) {
       exampleRegion.put("" + i, new Portfolio(i));
     }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryWithIndexesDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryWithIndexesDUnitTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.dunit;
+
+import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.data.Portfolio;
+import org.apache.geode.management.ManagementService;
+import org.apache.geode.management.MemberMXBean;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.categories.OQLQueryTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+
+@Category({OQLQueryTest.class})
+public class QueryWithIndexesDUnitTest {
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule(5);
+
+  @Rule
+  public GfshCommandRule gfsh = new GfshCommandRule();
+
+  private MemberVM locator, server;
+
+  @Before
+  public void setUpServers() throws Exception {
+    locator = cluster.startLocatorVM(0, l -> l.withoutClusterConfigurationService());
+    server = cluster.startServerVM(1, locator.getPort());
+
+    gfsh.connectAndVerify(locator);
+  }
+
+  @Test
+  public void testQueryExecutionWithMultipleIndexes() {
+    gfsh.executeAndAssertThat("create region --name=exampleRegion --type=PARTITION")
+        .statusIsSuccess();
+
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + "exampleRegion", 1);
+
+    server.invoke(() -> {
+      // create index.
+      QueryService cacheQS = ClusterStartupRule.getCache().getQueryService();
+      cacheQS.createIndex("IdIndex", "value.ID", SEPARATOR + "exampleRegion.entrySet");
+      cacheQS.createIndex("StatusIndex ", "value.status", SEPARATOR + "exampleRegion.entrySet");
+      populateRegion(0, 500);
+    });
+
+    locator.invoke(() -> {
+      String query = "query --query=\"<trace> select value from" +
+          SEPARATOR + "exampleRegion.entrySet where value.ID >= 0 AND value.ID < 500 " +
+          "AND (value.status = 'active' or value.status = 'inactive')\"";
+
+      ManagementService service =
+          ManagementService.getExistingManagementService(ClusterStartupRule.getCache());
+      MemberMXBean member = service.getMemberMXBean();
+      String cmdResult = member.processCommand(query);
+
+      assertThat(cmdResult).contains("\"Rows\":\"100\"");
+      assertThat(cmdResult).contains("indexesUsed(2)");
+    });
+  }
+
+  private static void populateRegion(int startingId, int endingId) {
+    Region exampleRegion = ClusterStartupRule.getCache().getRegion("exampleRegion");
+    for (int i = startingId; i < endingId; i++) {
+      exampleRegion.put("" + i, new Portfolio(i));
+    }
+  }
+}


### PR DESCRIPTION
…are used

In case entrySet() is used, entries are wrapped up by `CachedEntryWrapper` and while doing intersection between results from both indexes there are no the same entries in both bags as for some entry we have different CachedEntryWrapper in two bags.
The solution is to check its key instead of the whole object.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
