### PR TITLE
GEODE-8951: Unnecessary messaging in WAN locator discovery

### DIFF
--- a/geode-wan/src/test/java/org/apache/geode/cache/wan/internal/client/locator/DistributedLocatorsRunnableTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/cache/wan/internal/client/locator/DistributedLocatorsRunnableTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.wan.internal.client.locator;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import org.apache.geode.internal.admin.remote.DistributionLocatorId;
+
+public class DistributedLocatorsRunnableTest {
+
+  private AutoCloseable mocks;
+
+  @Mock
+  LocatorMembershipListenerImpl.DistributeLocatorsRunnable dlr;
+
+  @Before
+  public void before() {
+    mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @After
+  public void after() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  public void notifyRemoteLocatorAndJoiningLocatorDoesNotSendAnyMessageIfBothLocatorsAreTheSame() {
+    DistributionLocatorId id = new DistributionLocatorId(40404, "localhost", null);
+    dlr.notifyRemoteLocatorAndJoiningLocator(id, 1, id, null);
+    verify(dlr, times(0)).sendMessage(any(), any(), any());
+  }
+
+  @Test
+  public void notifyRemoteLocatorAndJoiningLocatorSendsMessagesToBothLocatorsIfTheyAreDifferent() {
+    DistributionLocatorId id1 = new DistributionLocatorId(40404, "localhost", "locator1");
+    DistributionLocatorId id2 = new DistributionLocatorId(40406, "localhost", "locator2");
+    doCallRealMethod().when(dlr).notifyRemoteLocatorAndJoiningLocator(id1, 1, id2, null);
+    doNothing().when(dlr).sendMessage(any(), any(), any());
+
+    dlr.notifyRemoteLocatorAndJoiningLocator(id1, 1, id2, null);
+
+    verify(dlr, times(1)).sendMessage(eq(id1), any(), any());
+    verify(dlr, times(1)).sendMessage(eq(id2), any(), any());
+  }
+}


### PR DESCRIPTION
Ticket description:

> While debugging another issue I noticed that a locator was trying to send a notice to another locator in its cluster telling it that the recipient had joined.
> ```
> [warn 2021/02/16 15:16:56.195 PST locatorgemfire_4_3_host2_9736 <LocatorsDistributorThread1> tid=0x153] Locator Membership listener permanently failed to exchange locator information rs-GEM-3188-VJ1459-1a0i3large-hydra-client-1:27878 with rs-GEM-3188-VJ1459-1a0i3large-hydra-client-2:28778 after 3 retry attempts
> ```
> This messaging is unnecessary.  The locator that this message was being sent to already knows about itself.   This is being done in DistributeLocatorsRunnable.run(). 
> ```
>        for (DistributionLocatorId remoteLocator : entry.getValue()) {
>        // Notify known remote locator about the advertised locator.
>        LocatorJoinMessage advertiseNewLocatorMessage = new LocatorJoinMessage(
>           joiningLocatorDistributedSystemId, joiningLocator, localLocatorId, "");
>        sendMessage(remoteLocator, advertiseNewLocatorMessage, failedMessages);
>
>        // Notify the advertised locator about remote known locator.
>        LocatorJoinMessage advertiseKnownLocatorMessage =
>            new LocatorJoinMessage(entry.getKey(), remoteLocator, localLocatorId, "");
>        sendMessage(joiningLocator, advertiseKnownLocatorMessage, failedMessages);
>       }
>  ```
>  It should check to see if the joiningLocator ID is equal to the remoteLocator ID and, if so, not create messages in that iteration.



I tried to reproduce the issue using a distributed test, with no success. I have not been able to find a scenario in which the joining locator and the remote locator are the same.

After that, I realized that the assumption in the ticket is wrong because the two locators in the log message are different: one ends in `client-1:27878` and the other one in `-2:28778`.

Its true that it is not verified in the code that joining locator and remote locator are different but Im not sure if this situation could ever happen. I have implemented the changes anyway, adding a unit test to verify that messages are sent to both locators when they are different, and no message is sent when the locators are the same.

Does it worth it to merge this PR? Or should I discard it and close the ticket?