### PR TITLE
GEODE-8772: Pre-assign ports in the test JVM

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -222,9 +222,9 @@ public class ClusterStartupRule implements SerializableTestRule {
       SerializableFunction<LocatorStarterRule> ruleOperator) {
     final String defaultName = "locator-" + index;
     VM locatorVM = getVM(index, version);
+    LocatorStarterRule locatorStarter = new LocatorStarterRule();
     Locator server = locatorVM.invoke("start locator in vm" + index, () -> {
-      memberStarter = new LocatorStarterRule();
-      LocatorStarterRule locatorStarter = (LocatorStarterRule) memberStarter;
+      memberStarter = locatorStarter;
       if (logFile) {
         locatorStarter.withLogFile();
       }
@@ -265,9 +265,9 @@ public class ClusterStartupRule implements SerializableTestRule {
       SerializableFunction<ServerStarterRule> ruleOperator) {
     final String defaultName = "server-" + index;
     VM serverVM = getVM(index, version);
+    ServerStarterRule serverStarter = new ServerStarterRule();
     Server server = serverVM.invoke("startServerVM", () -> {
-      memberStarter = new ServerStarterRule();
-      ServerStarterRule serverStarter = (ServerStarterRule) memberStarter;
+      memberStarter = serverStarter;
       if (logFile) {
         serverStarter.withLogFile();
       }

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/MemberStarterRule.java
@@ -89,6 +89,8 @@ import org.apache.geode.test.junit.rules.serializable.SerializableExternalResour
  * created in the test will be cleaned up after the test.
  */
 public abstract class MemberStarterRule<T> extends SerializableExternalResource implements Member {
+  private final int availableJmxPort;
+  private final int availableHttpPort;
   protected int memberPort = 0;
   protected int jmxPort = -1;
   protected int httpPort = -1;
@@ -99,7 +101,6 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
   protected Properties systemProperties = new Properties();
 
   protected boolean autoStart = false;
-  private final transient UniquePortSupplier portSupplier;
 
   private List<File> firstLevelChildrenFile = new ArrayList<>();
   private boolean cleanWorkingDir = true;
@@ -117,7 +118,8 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
   }
 
   public MemberStarterRule(UniquePortSupplier portSupplier) {
-    this.portSupplier = portSupplier;
+    availableJmxPort = portSupplier.getAvailablePort();
+    availableHttpPort = portSupplier.getAvailablePort();
 
     // initial values
     properties.setProperty(MCAST_PORT, "0");
@@ -279,8 +281,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
   public T withJMXManager(boolean useProductDefaultPorts) {
     if (!useProductDefaultPorts) {
       // do no override these properties if already exists
-      properties.putIfAbsent(JMX_MANAGER_PORT,
-          portSupplier.getAvailablePort() + "");
+      properties.putIfAbsent(JMX_MANAGER_PORT, availableJmxPort + "");
       this.jmxPort = Integer.parseInt(properties.getProperty(JMX_MANAGER_PORT));
     } else {
       // the real port numbers will be set after we started the server/locator.
@@ -294,8 +295,7 @@ public abstract class MemberStarterRule<T> extends SerializableExternalResource 
   public T withHttpService(boolean useDefaultPort) {
     properties.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
     if (!useDefaultPort) {
-      properties.put(HTTP_SERVICE_PORT,
-          portSupplier.getAvailablePort() + "");
+      properties.put(HTTP_SERVICE_PORT, availableHttpPort + "");
       this.httpPort = Integer.parseInt(properties.getProperty(HTTP_SERVICE_PORT));
     } else {
       // indicate start http service but with default port


### PR DESCRIPTION
Change `ClusterStartupRule` to assign ports only in the test JVM.

BACKGROUND
==========

As part of my project to allow Geode tests to run in parallel outside of
Docker, I am changing our build system to allocate a distinct range of
ports to each test JVM, and changing `AvailablePort` and
`AvailablePortHelper` to honor these allocated port ranges.

This commit prepares for those changes.

PROBLEM
=======

Certain tests use `ClusterStartupRule` to start a member in a child VM
using a prior version of Geode.  When such tests run in parallel outside
of Docker, the child VM can attempt to bind to ports that are in use by
tests in other JVMs.

CAUSE
=====

When the `ClusterStartupRule` starts a member in a child VM, it does so
by creating the appropriate member starter rule (`LocatorStarterRule` or
`ServerStarterRule`) in the child VM. Depending on how this member
starter rule is configured, it may call `AvailablePort` in the child VM
to assign certain ports. The `AvailablePort` in the child VM is a prior
version that knows nothing of the port partitioning scheme I’m currently
adding, and so may assign ports from outside of the range of ports
allocated to test. These ports may conflict with ports already in use by
tests in other JVMs, or ports that are "reserved" by those tests.

GENERAL SOLUTION
================

Make tests assign ports only in the test JVM. The test JVM always
includes the latest implementations of `AvailablePort` and
`AvailablePortHelper`, and so the tests  will honor any port allocation
scheme defined in the latest implementation.

THIS COMMIT
===========

- Change `LocatorStarterRule`, `ServerStarterRule`, and their common
  base class `MemberStarterRule` to pre-assign available ports in their
  constructors. They use `AvailablePortHelper` to assign the ports, and
  store the assigned port numbers as fields.
- Change `ClusterStartupRule` to construct any required member starter
  rules in the test JVM instead of in the child VM. As a result, the
  member starter rules call `AvailablePort` and `AvailablePortHelper`
  only in the test JVM, where (eventually) the implementation will honor
  the range of ports allocated to the JVM.
- When the `ClusterStartupRule` sends the member starter rule to the
  child VM, the member starter rule is deserialized in the child VM with
  the pre-assigned port numbers.  If the member starter rule is
  configured to assign a port, it uses the one that was pre-assigned in
  the test JVM.
