### PR TITLE
GEODE-9202: implement PUBSUB CHANNELS subcommand

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/NativeRedisSubCommandsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/NativeRedisSubCommandsIntegrationTest.java
@@ -1,0 +1,38 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal.executor.pubsub;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.NativeRedisClusterTestRule;
+
+
+public class NativeRedisSubCommandsIntegrationTest extends AbstractSubCommandsIntegrationTest {
+
+  @ClassRule
+  public static NativeRedisClusterTestRule cluster = new NativeRedisClusterTestRule();
+
+  @Override
+  public int getPort() {
+    return cluster.getExposedPorts().get(0);
+  }
+
+  public void flushAll() {
+    cluster.flushAll();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubCommandsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubCommandsIntegrationTest.java
@@ -1,0 +1,199 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal.executor.pubsub;
+
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtMostNArgsForSubCommand;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_PUBSUB_SUBCOMMAND;
+import static org.apache.geode.redis.internal.executor.pubsub.AbstractPubSubIntegrationTest.JEDIS_TIMEOUT;
+import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static redis.clients.jedis.Protocol.PUBSUB_CHANNELS;
+
+import java.net.SocketException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Protocol;
+
+import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.redis.mocks.MockSubscriber;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+
+public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegrationTest {
+  private Jedis subscriber;
+  private Jedis introspector;
+  private MockSubscriber mockSubscriber;
+
+  @Before
+  public void setup() {
+    mockSubscriber = new MockSubscriber();
+    subscriber = new Jedis("localhost", getPort());
+    introspector = new Jedis("localhost", getPort());
+  }
+
+  @After
+  public void teardown() {
+    if (mockSubscriber.getSubscribedChannels() > 0) {
+      mockSubscriber.unsubscribe();
+    }
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
+  }
+
+  @Test
+  public void pubsub_shouldError_givenTooFewArguments() {
+    assertAtLeastNArgs(introspector, Protocol.Command.PUBSUB, 1);
+  }
+
+  @Test
+  public void channels_shouldError_givenTooManyArguments() {
+    assertAtMostNArgsForSubCommand(introspector,
+        Protocol.Command.PUBSUB,
+        Coder.stringToBytes(PUBSUB_CHANNELS),
+        1);
+  }
+
+  @Test
+  public void pubsub_shouldReturnError_givenUnknownSubcommand() {
+    String expected = String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, "nonesuch");
+
+    assertThatThrownBy(() -> introspector.sendCommand(Protocol.Command.PUBSUB, "nonesuch"))
+        .hasMessageContaining(expected);
+  }
+
+  @Test
+  public void channels_shouldReturnListOfAllChannels_withActiveChannelSubscribers_whenCalledWithoutPattern() {
+    List<byte[]> expectedChannels = new ArrayList<>();
+    expectedChannels.add(Coder.stringToBytes("foo"));
+    expectedChannels.add(Coder.stringToBytes("bar"));
+    Runnable runnable =
+        () -> subscriber.subscribe(mockSubscriber, "foo", "bar");
+    Thread subscriberThread = new Thread(runnable);
+
+    subscriberThread.start();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+
+    List<byte[]> result =
+        uncheckedCast(introspector.sendCommand(Protocol.Command.PUBSUB, PUBSUB_CHANNELS));
+
+    assertThat(result).containsExactlyInAnyOrderElementsOf(expectedChannels);
+  }
+
+  @Test
+  public void channels_shouldNeverReturnPsubscribedChannels_givenNoActiveChannelSubscribers() {
+
+    Runnable runnable = () -> subscriber.psubscribe(mockSubscriber, "f*");
+    Thread patternSubscriberThread = new Thread(runnable);
+
+    patternSubscriberThread.start();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+    List<String> result = introspector.pubsubChannels("f*");
+
+    assertThat(result).isEmpty();
+
+    mockSubscriber.punsubscribe();
+  }
+
+
+  @Test
+  public void channels_shouldReturnListOfMatchingChannels_withActiveChannelSubscribers_whenCalledWithPattern() {
+
+    List<String> expectedChannels = new ArrayList<>();
+    expectedChannels.add("foo");
+
+    Runnable runnable =
+        () -> subscriber.subscribe(mockSubscriber, "foo", "bar");
+
+    Thread subscriberThread = new Thread(runnable);
+    subscriberThread.start();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+    List<String> result = introspector.pubsubChannels("fo*");
+
+    assertThat(result).containsExactlyInAnyOrderElementsOf(expectedChannels);
+  }
+
+  @Test
+  public void channels_should_returnEmptyArray_givenPatternWithNoMatches() {
+    List<String> result = introspector.pubsubChannels("fo*");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  public void channels_shouldOnlyReturnChannelsWithActiveSubscribers() {
+    List<byte[]> expectedChannels = new ArrayList<>();
+    expectedChannels.add(Coder.stringToBytes("bar"));
+    Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "foo", "bar");
+    Thread subscriberThread = new Thread(runnable);
+
+    subscriberThread.start();
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
+    mockSubscriber.unsubscribe("foo");
+    waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
+    List<byte[]> result =
+        uncheckedCast(introspector.sendCommand(Protocol.Command.PUBSUB, PUBSUB_CHANNELS));
+
+    assertThat(result).containsExactlyInAnyOrderElementsOf(expectedChannels);
+  }
+
+  @Test
+  public void channels_shouldNotReturnDuplicates_givenMultipleSubscribersToSameChannel_whenCalledWithoutPattern() {
+
+    Jedis subscriber2 = new Jedis("localhost", getPort(), JEDIS_TIMEOUT);
+
+    MockSubscriber mockSubscriber2 = new MockSubscriber();
+    List<byte[]> expectedChannels = new ArrayList<>();
+    expectedChannels.add(Coder.stringToBytes("foo"));
+
+    Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "foo");
+    Thread subscriber1Thread = new Thread(runnable);
+    subscriber1Thread.start();
+
+    Runnable runnable2 = () -> subscriber2.subscribe(mockSubscriber2, "foo");
+    Thread subscriber2Thread = new Thread(runnable2);
+    subscriber2Thread.start();
+
+    waitFor(() -> (mockSubscriber.getSubscribedChannels() == 1)
+        && (mockSubscriber2.getSubscribedChannels() == 1));
+
+    List<byte[]> result =
+        uncheckedCast(introspector
+            .sendCommand(Protocol.Command.PUBSUB, PUBSUB_CHANNELS));
+
+    assertThat(result).containsExactlyInAnyOrderElementsOf(expectedChannels);
+    assertThat(result.size()).isEqualTo(1);
+
+    mockSubscriber2.unsubscribe();
+    waitFor(() -> mockSubscriber2.getSubscribedChannels() == 0);
+
+    subscriber2.close();
+  }
+
+  private void waitFor(Callable<Boolean> booleanCallable) {
+    GeodeAwaitility.await()
+        .ignoreExceptionsInstanceOf(SocketException.class)
+        .until(booleanCallable);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubCommandsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/SubCommandsIntegrationTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal.executor.pubsub;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+
+public class SubCommandsIntegrationTest extends AbstractSubCommandsIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -68,6 +68,7 @@ import org.apache.geode.redis.internal.executor.key.ScanExecutor;
 import org.apache.geode.redis.internal.executor.key.TTLExecutor;
 import org.apache.geode.redis.internal.executor.key.TypeExecutor;
 import org.apache.geode.redis.internal.executor.pubsub.PsubscribeExecutor;
+import org.apache.geode.redis.internal.executor.pubsub.PubSubExecutor;
 import org.apache.geode.redis.internal.executor.pubsub.PublishExecutor;
 import org.apache.geode.redis.internal.executor.pubsub.PunsubscribeExecutor;
 import org.apache.geode.redis.internal.executor.pubsub.SubscribeExecutor;
@@ -213,6 +214,7 @@ public enum RedisCommandType {
   PSUBSCRIBE(new PsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(2)),
   PUNSUBSCRIBE(new PunsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(1)),
   UNSUBSCRIBE(new UnsubscribeExecutor(), SUPPORTED, new MinimumParameterRequirements(1)),
+  PUBSUB(new PubSubExecutor(), SUPPORTED, new MinimumParameterRequirements(2)),
 
   /************* Cluster *****************/
   CLUSTER(new ClusterExecutor(), SUPPORTED, new ClusterParameterRequirements()),

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -59,4 +59,7 @@ public class RedisConstants {
       "Unknown subcommand or wrong number of arguments for '%s'. Try CLUSTER HELP.";
   public static final String ERROR_INVALID_ZADD_OPTION_NX_XX =
       "XX and NX options at the same time are not compatible";
+
+  public static final String ERROR_UNKNOWN_PUBSUB_SUBCOMMAND =
+      "Unknown subcommand or wrong number of arguments for '%s'";
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PubSubExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PubSubExecutor.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+
+package org.apache.geode.redis.internal.executor.pubsub;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_PUBSUB_SUBCOMMAND;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.geode.redis.internal.executor.Executor;
+import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.redis.internal.netty.Command;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+
+public class PubSubExecutor implements Executor {
+
+  @Override
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
+
+    byte[] subCommand = command.getProcessedCommand().get(1);
+
+    if (!Arrays.equals(subCommand, Coder.stringToBytes("channels"))) {
+      return RedisResponse
+          .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, new String(subCommand)));
+    }
+
+    // in a subsequent story, a new parameter requirement class
+    // specific to subCommands might be a better way to do this
+    if (command.getProcessedCommand().size() > 3) {
+      return RedisResponse
+          .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, new String(subCommand)));
+    }
+
+    List<byte[]> response;
+    if (command.getProcessedCommand().size() > 2) {
+      byte[] pattern = command.getProcessedCommand().get(2);
+      response = context.getPubSub().findChannelNames(pattern);
+    } else {
+      response = context.getPubSub().findChannelNames();
+    }
+
+    return RedisResponse.array(response);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -94,6 +94,9 @@ public interface PubSub {
    * @param client the Client which is to be queried
    * @return the list of channels and patterns
    */
-  List<byte[]> findSubscriptionNames(Client client);;
+  List<byte[]> findSubscriptionNames(Client client);
 
+  List<byte[]> findChannelNames();
+
+  List<byte[]> findChannelNames(byte[] pattern);
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -144,6 +144,16 @@ public class PubSubImpl implements PubSub {
   }
 
   @Override
+  public List<byte[]> findChannelNames() {
+    return subscriptions.findChannelNames();
+  }
+
+  @Override
+  public List<byte[]> findChannelNames(byte[] pattern) {
+    return subscriptions.findChannelNames(pattern);
+  }
+
+  @Override
   public List<byte[]> findSubscriptionNames(Client client, Subscription.Type type) {
     return subscriptions.findSubscriptions(client).stream()
         .filter(s -> s.getType() == (type))

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -67,6 +67,7 @@ public class SupportedCommandsJUnitTest {
       "PEXPIREAT",
       "PING",
       "PSUBSCRIBE",
+      "PUBSUB",
       "PTTL",
       "PUBLISH",
       "PUNSUBSCRIBE",


### PR DESCRIPTION
-add PUBSUB to supported commands in RedisCommandType
-create subcommands executor in PubSub dir
-implement mehtod for finding channel names in subscriptions class
-implement pattern matching for finding channel names
-add methods to pubsub impl and PubSub interface for returning channel names
-add to PUBSUB to Supported Comands list in SupportedCommandsJunitTest

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
