### PR TITLE
GEODE-9269: Make the lock holding has the same order. (#6470)

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/locks/DLockGrantorTest.java
@@ -18,32 +18,37 @@ import static java.util.concurrent.TimeUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.powermock.api.mockito.PowerMockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.CommitConflictException;
 import org.apache.geode.cache.TransactionDataNodeHasDepartedException;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 
 public class DLockGrantorTest {
   private DLockService dLockService;
-  private DistributionManager distributionManager;
   private DLockGrantor grantor;
+  private final DLockBatchId batchId = mock(DLockBatchId.class);
+  private final DLockBatch batch = mock(DLockBatch.class);
+  private final DLockRequestProcessor.DLockRequestMessage request = mock(
+      DLockRequestProcessor.DLockRequestMessage.class);
+  private final InternalDistributedMember owner = mock(InternalDistributedMember.class);
 
   @Before
   public void setup() {
     dLockService = mock(DLockService.class, RETURNS_DEEP_STUBS);
-    distributionManager = mock(DistributionManager.class);
-    when(dLockService.getDistributionManager()).thenReturn(distributionManager);
-    CancelCriterion cancelCriterion = mock(CancelCriterion.class);
-    when(distributionManager.getCancelCriterion()).thenReturn(cancelCriterion);
-    grantor = DLockGrantor.createGrantor(dLockService, 1);
+    when(dLockService.getDLockLessorDepartureHandler())
+        .thenReturn(mock(DLockLessorDepartureHandler.class));
+    grantor = spy(DLockGrantor.createGrantor(dLockService, 1));
   }
 
   @Test
@@ -66,7 +71,6 @@ public class DLockGrantorTest {
 
   @Test
   public void recordMemberDepartedTimeRecords() {
-    InternalDistributedMember owner = mock(InternalDistributedMember.class);
     grantor.recordMemberDepartedTime(owner);
 
     assertThat(grantor.getMembersDepartedTimeRecords()).containsKey(owner);
@@ -74,21 +78,173 @@ public class DLockGrantorTest {
 
   @Test
   public void recordMemberDepartedTimeRemovesExpiredMembers() {
-    DLockGrantor spy = spy(grantor);
     long currentTime = System.currentTimeMillis();
     doReturn(currentTime).doReturn(currentTime).doReturn(currentTime + 1 + DAYS.toMillis(1))
-        .when(spy).getCurrentTime();
+        .when(grantor).getCurrentTime();
 
     for (int i = 0; i < 2; i++) {
-      spy.recordMemberDepartedTime(mock(InternalDistributedMember.class));
+      grantor.recordMemberDepartedTime(mock(InternalDistributedMember.class));
     }
-    assertThat(spy.getMembersDepartedTimeRecords().size()).isEqualTo(2);
+    assertThat(grantor.getMembersDepartedTimeRecords().size()).isEqualTo(2);
 
-    InternalDistributedMember owner = mock(InternalDistributedMember.class);
-    spy.recordMemberDepartedTime(owner);
+    grantor.recordMemberDepartedTime(owner);
 
-    assertThat(spy.getMembersDepartedTimeRecords().size()).isEqualTo(1);
-    assertThat(spy.getMembersDepartedTimeRecords()).containsKey(owner);
+    assertThat(grantor.getMembersDepartedTimeRecords().size()).isEqualTo(1);
+    assertThat(grantor.getMembersDepartedTimeRecords()).containsKey(owner);
   }
 
+  @Test
+  public void cleanupSuspendStateIfRequestHasTimedOut() throws Exception {
+    grantor.makeReady(true);
+    when(request.checkForTimeout()).thenReturn(true);
+    doNothing().when(grantor).cleanupSuspendState(request);
+
+    grantor.handleLockBatch(request);
+
+    verify(grantor).cleanupSuspendState(request);
+    verify(grantor, never()).acquireDestroyReadLock(0);
+  }
+
+  @Test
+  public void handleLockBatchThrowsIfCanNotAcquireDestroyReadLock() throws Exception {
+    grantor.makeReady(true);
+    doReturn(false).when(grantor).acquireDestroyReadLock(0);
+    doNothing().when(grantor).waitUntilDestroyed();
+    doReturn(true).when(grantor).isDestroyed();
+
+    assertThatThrownBy(() -> grantor.handleLockBatch(request))
+        .isInstanceOf(LockGrantorDestroyedException.class);
+
+    verify(grantor).waitUntilDestroyed();
+    verify(grantor).checkDestroyed();
+    verify(grantor, never()).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void handleLockBatchMakesReservation() throws Exception {
+    grantor.makeReady(true);
+    when(request.getObjectName()).thenReturn(batch);
+    when(batch.getOwner()).thenReturn(owner);
+    when(batch.getBatchId()).thenReturn(batchId);
+    doNothing().when(grantor).makeReservation(batch);
+
+    grantor.handleLockBatch(request);
+
+    assertThat(grantor.batchLocks.get(batchId)).isEqualTo(batch);
+    verify(grantor).checkIfHostDeparted(owner);
+    verify(grantor).makeReservation(batch);
+    verify(grantor).releaseDestroyReadLock();
+    verify(request).respondWithGrant(Long.MAX_VALUE);
+  }
+
+  @Test
+  public void handleLockBatchRespondWithTryLockFailedIfMakeReservationFailed() throws Exception {
+    grantor.makeReady(true);
+    when(request.getObjectName()).thenReturn(batch);
+    when(batch.getOwner()).thenReturn(owner);
+    when(batch.getBatchId()).thenReturn(batchId);
+    String exceptionMessage = "failed";
+    doThrow(new CommitConflictException(exceptionMessage)).when(grantor).makeReservation(batch);
+
+    grantor.handleLockBatch(request);
+
+    assertThat(grantor.batchLocks.get(batchId)).isEqualTo(null);
+    verify(grantor).checkIfHostDeparted(owner);
+    verify(grantor).releaseDestroyReadLock();
+    verify(request).respondWithTryLockFailed(exceptionMessage);
+  }
+
+  @Test
+  public void getLockBatchThrowsIfCanNotAcquireDestroyReadLock() throws Exception {
+    grantor.makeReady(true);
+    doReturn(false).when(grantor).acquireDestroyReadLock(0);
+    doNothing().when(grantor).waitUntilDestroyed();
+    doReturn(true).when(grantor).isDestroyed();
+
+    assertThatThrownBy(() -> grantor.getLockBatch(batchId))
+        .isInstanceOf(LockGrantorDestroyedException.class);
+
+    verify(grantor).waitUntilDestroyed();
+    verify(grantor).checkDestroyed();
+    verify(grantor, never()).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void getLockBatchReturnsCorrectBatchLock() throws Exception {
+    grantor.makeReady(true);
+    grantor.batchLocks.put(batchId, batch);
+
+    assertThat(grantor.getLockBatch(batchId)).isEqualTo(batch);
+
+    verify(grantor).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void updateLockBatchThrowsIfCanNotAcquireDestroyReadLock() throws Exception {
+    grantor.makeReady(true);
+    doReturn(false).when(grantor).acquireDestroyReadLock(0);
+    doNothing().when(grantor).waitUntilDestroyed();
+    doReturn(true).when(grantor).isDestroyed();
+
+    assertThatThrownBy(() -> grantor.updateLockBatch(batchId, batch))
+        .isInstanceOf(LockGrantorDestroyedException.class);
+
+    verify(grantor).waitUntilDestroyed();
+    verify(grantor).checkDestroyed();
+    verify(grantor, never()).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void updateLockBatchUpdates() throws Exception {
+    grantor.makeReady(true);
+    grantor.batchLocks.put(batchId, batch);
+    DLockBatch newBatch = mock(DLockBatch.class);
+
+    grantor.updateLockBatch(batchId, newBatch);
+
+    assertThat(grantor.batchLocks.get(batchId)).isEqualTo(newBatch);
+
+    verify(grantor).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void updateLockBatchDoesNotUpdateIfNoExistingBatch() throws Exception {
+    grantor.makeReady(true);
+    DLockBatch newBatch = mock(DLockBatch.class);
+
+    grantor.updateLockBatch(batchId, newBatch);
+
+    assertThat(grantor.batchLocks.get(batchId)).isNull();
+
+    verify(grantor).releaseDestroyReadLock();
+  }
+
+
+  @Test
+  public void releaseLockBatchThrowsIfCanNotAcquireDestroyReadLock() throws Exception {
+    grantor.makeReady(true);
+    doReturn(false).when(grantor).acquireDestroyReadLock(0);
+    doNothing().when(grantor).waitUntilDestroyed();
+    doReturn(true).when(grantor).isDestroyed();
+
+    assertThatThrownBy(() -> grantor.releaseLockBatch(batchId, owner))
+        .isInstanceOf(LockGrantorDestroyedException.class);
+
+    verify(grantor).waitUntilDestroyed();
+    verify(grantor).checkDestroyed();
+    verify(grantor, never()).releaseDestroyReadLock();
+  }
+
+  @Test
+  public void releaseLockBatchReleaseReservation() throws Exception {
+    grantor.makeReady(true);
+    grantor.batchLocks.put(batchId, batch);
+    doNothing().when(grantor).releaseReservation(batch);
+
+    grantor.releaseLockBatch(batchId, null);
+
+    assertThat(grantor.batchLocks.size()).isEqualTo(0);
+    verify(grantor).releaseReservation(batch);
+    verify(grantor).releaseDestroyReadLock();
+  }
 }


### PR DESCRIPTION
  * When handling TXLockService, always trying to acquire destroy read lock
    before getting the synchronized batchLocks.
  * If destroy read lock is not acquired, thread will wait until the grantor
    is destroyed.

(cherry picked from commit 235cd1b6529f292db0212f212245308e6ebe518b)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
