### PR TITLE
GEODE-9288: DeployedJarTest fails because JavaCompiler fails to delet…

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/RestFunctionExecuteDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/rest/internal/web/RestFunctionExecuteDUnitTest.java
@@ -45,7 +45,7 @@ public class RestFunctionExecuteDUnitTest {
   @ClassRule
   public static GfshCommandRule gfsh = new GfshCommandRule();
 
-  private static final JarBuilder jarBuilder = new JarBuilder();
+  private static JarBuilder jarBuilder;
 
   private static MemberVM locator;
   private static MemberVM server1;
@@ -55,6 +55,7 @@ public class RestFunctionExecuteDUnitTest {
 
   @BeforeClass
   public static void beforeClass() throws Exception {
+    jarBuilder = new JarBuilder();
     // prepare the jar to deploy
     File jarsToDeploy = new File(gfsh.getWorkingDir(), "function.jar");
     jarBuilder.buildJar(jarsToDeploy, loadClassToFile());

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/deployment/FunctionScannerTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/deployment/FunctionScannerTest.java
@@ -18,6 +18,7 @@ import static org.apache.geode.test.util.ResourceUtils.createTempFileFromResourc
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.Collection;
 
 import org.junit.Before;
@@ -40,7 +41,7 @@ public class FunctionScannerTest {
   private File outputJar;
 
   @Before
-  public void setup() {
+  public void setup() throws IOException {
     jarBuilder = new JarBuilder();
     functionScanner = new FunctionScanner();
     outputJar = new File(temporaryFolder.getRoot(), "output.jar");

--- a/geode-junit/src/integrationTest/java/org/apache/geode/test/compiler/JarBuilderTest.java
+++ b/geode-junit/src/integrationTest/java/org/apache/geode/test/compiler/JarBuilderTest.java
@@ -18,6 +18,7 @@ import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -42,7 +43,7 @@ public class JarBuilderTest {
   private File outputJar;
 
   @Before
-  public void setup() {
+  public void setup() throws IOException {
     jarBuilder = new JarBuilder();
     outputJar = new File(temporaryFolder.getRoot(), "output.jar");
   }

--- a/geode-junit/src/integrationTest/java/org/apache/geode/test/compiler/JavaCompilerTest.java
+++ b/geode-junit/src/integrationTest/java/org/apache/geode/test/compiler/JavaCompilerTest.java
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -55,7 +56,7 @@ public class JavaCompilerTest {
   }
 
   @Test
-  public void invalidSourceThrowsException() {
+  public void invalidSourceThrowsException() throws IOException {
     JavaCompiler javaCompiler = new JavaCompiler();
     String sourceCode = "public class foo {this is not valid java source code}";
     assertThatThrownBy(() -> javaCompiler.compile(sourceCode)).isInstanceOf(Exception.class);

--- a/geode-junit/src/main/java/org/apache/geode/test/compiler/JarBuilder.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/compiler/JarBuilder.java
@@ -59,7 +59,11 @@ import java.util.jar.JarOutputStream;
  * </pre>
  **/
 public class JarBuilder {
-  private final JavaCompiler javaCompiler = new JavaCompiler();
+  private final JavaCompiler javaCompiler;
+
+  public JarBuilder() throws IOException {
+    javaCompiler = new JavaCompiler();
+  }
 
   /**
    * Adds the given jarFile to the classpath that will be used for compilation by the buildJar

--- a/geode-junit/src/main/java/org/apache/geode/test/compiler/JavaCompiler.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/compiler/JavaCompiler.java
@@ -18,6 +18,8 @@ import static java.util.stream.Collectors.toList;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,17 +28,16 @@ import java.util.stream.Stream;
 import javax.tools.ToolProvider;
 
 import com.google.common.base.Charsets;
-import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
 
 
 public class JavaCompiler {
-  private File tempDir;
+  private Path tempDir;
   private String classpath;
 
-  public JavaCompiler() {
-    this.tempDir = Files.createTempDir();
-    tempDir.deleteOnExit();
+  public JavaCompiler() throws IOException {
+    this.tempDir = Files.createTempDirectory("javaCompiler");
+    tempDir.toFile().deleteOnExit();
     this.classpath = System.getProperty("java.class.path");
   }
 
@@ -108,8 +109,8 @@ public class JavaCompiler {
     }
   }
 
-  private File createSubdirectory(File parent, String directoryName) {
-    File subdirectory = parent.toPath().resolve(directoryName).toFile();
+  private File createSubdirectory(Path parent, String directoryName) {
+    File subdirectory = parent.resolve(directoryName).toFile();
     if (!subdirectory.exists()) {
       subdirectory.mkdirs();
     }


### PR DESCRIPTION
…e temp dir

Ticket description:

> DeployedJarTest.throwsIfFileIsNotValidJarFile() test failed in Windows CI https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-develop-main/jobs/WindowsUnitTestOpenJDK11/builds/225
> 
> The problem did not reproduce on macOS in 1000 runs.
> 
> I notice that the JavaCompiler constructor calls the deprecated Files.createTempDir(). I wonder if there might be a race condition where two test processes (at once) think they own that temp dir and so they can both delete it.
> 
> We might consider replacing that deprecated call with the recommended Files.createTempDirectory() which may be more robust. Looking at the deprecated method and the recommended substitute the latter might have less of a chance of collision due to its use of random suffixes (versus the former's monotonically-increasing ints).

I run the test on ubuntu but the problem did not reproduce either after 1000 runs.

I have implemented the change suggested in the ticket to avoid using the deprecated `Files.createTempDir()`. After taking a look a the implementation of the recommended substitute I agree with @Bill : this alternative might have less chances of collision when creating the directory name.