### PR TITLE
GEODE-9295: prevent expiry message hangs

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessage.java
@@ -61,26 +61,33 @@ public class LatestLastAccessTimeMessage<K> extends PooledDistributionMessage
 
   @Override
   protected void process(ClusterDistributionManager dm) {
-    long latestLastAccessTime = 0L;
     InternalCache cache = dm.getCache();
     if (cache == null) {
+      sendReply(dm, 0);
       return;
     }
     InternalDistributedRegion region =
         (InternalDistributedRegion) cache.getRegion(this.regionName);
     if (region == null) {
+      sendReply(dm, 0);
       return;
     }
     RegionEntry entry = region.getRegionEntry(this.key);
     if (entry == null) {
+      sendReply(dm, 0);
       return;
     }
+    long lastAccessed = 0L;
     try {
-      latestLastAccessTime = entry.getLastAccessed();
+      lastAccessed = entry.getLastAccessed();
     } catch (InternalStatisticsDisabledException ignored) {
       // last access time is not available
     }
-    ReplyMessage.send(getSender(), this.processorId, latestLastAccessTime, dm);
+    sendReply(dm, lastAccessed);
+  }
+
+  void sendReply(ClusterDistributionManager dm, long lastAccessTime) {
+    ReplyMessage.send(getSender(), this.processorId, lastAccessTime, dm);
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessageTest.java
@@ -20,32 +20,39 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Set;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.InternalStatisticsDisabledException;
-import org.apache.geode.internal.inet.LocalHostUtil;
 
 public class LatestLastAccessTimeMessageTest {
+  private InternalDistributedRegion region;
+  private ClusterDistributionManager dm;
+  private LatestLastAccessTimeMessage<String> lastAccessTimeMessage;
+  private InternalCache cache;
+
+  @Before
+  public void setUp() throws UnknownHostException {
+    final LatestLastAccessTimeReplyProcessor replyProcessor =
+        mock(LatestLastAccessTimeReplyProcessor.class);
+    region = mock(InternalDistributedRegion.class);
+    Set<InternalDistributedMember> recipients =
+        Collections.singleton(mock(InternalDistributedMember.class));
+    lastAccessTimeMessage =
+        spy(new LatestLastAccessTimeMessage<>(replyProcessor, recipients, region, "foo"));
+    lastAccessTimeMessage.setSender(mock(InternalDistributedMember.class));
+    dm = mock(ClusterDistributionManager.class);
+    cache = mock(InternalCache.class);
+  }
 
   @Test
   public void processWithNullCacheRepliesZero() throws Exception {
-    final LatestLastAccessTimeReplyProcessor replyProcessor =
-        mock(LatestLastAccessTimeReplyProcessor.class);
-    final InternalDistributedRegion region = mock(InternalDistributedRegion.class);
-    Set<InternalDistributedMember> recipients = Collections.singleton(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 1234));
-    final LatestLastAccessTimeMessage<String> realLastAccessTimeMessage =
-        new LatestLastAccessTimeMessage<>(replyProcessor, recipients, region, "foo");
-    final LatestLastAccessTimeMessage<String> lastAccessTimeMessage =
-        spy(realLastAccessTimeMessage);
-    lastAccessTimeMessage.setSender(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 12345));
-    final ClusterDistributionManager dm = mock(ClusterDistributionManager.class);
     when(dm.getCache()).thenReturn(null);
 
     lastAccessTimeMessage.process(dm);
@@ -55,19 +62,6 @@ public class LatestLastAccessTimeMessageTest {
 
   @Test
   public void processWithNullRegionRepliesZero() throws Exception {
-    final LatestLastAccessTimeReplyProcessor replyProcessor =
-        mock(LatestLastAccessTimeReplyProcessor.class);
-    final InternalDistributedRegion region = mock(InternalDistributedRegion.class);
-    Set<InternalDistributedMember> recipients = Collections.singleton(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 1234));
-    final LatestLastAccessTimeMessage<String> realLastAccessTimeMessage =
-        new LatestLastAccessTimeMessage<>(replyProcessor, recipients, region, "foo");
-    final LatestLastAccessTimeMessage<String> lastAccessTimeMessage =
-        spy(realLastAccessTimeMessage);
-    lastAccessTimeMessage.setSender(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 12345));
-    final ClusterDistributionManager dm = mock(ClusterDistributionManager.class);
-    final InternalCache cache = mock(InternalCache.class);
     when(dm.getCache()).thenReturn(cache);
     when(cache.getRegion(any())).thenReturn(null);
 
@@ -78,19 +72,6 @@ public class LatestLastAccessTimeMessageTest {
 
   @Test
   public void processWithNullEntryRepliesZero() throws Exception {
-    final LatestLastAccessTimeReplyProcessor replyProcessor =
-        mock(LatestLastAccessTimeReplyProcessor.class);
-    final InternalDistributedRegion region = mock(InternalDistributedRegion.class);
-    Set<InternalDistributedMember> recipients = Collections.singleton(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 1234));
-    final LatestLastAccessTimeMessage<String> realLastAccessTimeMessage =
-        new LatestLastAccessTimeMessage<>(replyProcessor, recipients, region, "foo");
-    final LatestLastAccessTimeMessage<String> lastAccessTimeMessage =
-        spy(realLastAccessTimeMessage);
-    lastAccessTimeMessage.setSender(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 12345));
-    final ClusterDistributionManager dm = mock(ClusterDistributionManager.class);
-    final InternalCache cache = mock(InternalCache.class);
     when(dm.getCache()).thenReturn(cache);
     when(cache.getRegion(any())).thenReturn(region);
     when(region.getRegionEntry(any())).thenReturn(null);
@@ -102,19 +83,6 @@ public class LatestLastAccessTimeMessageTest {
 
   @Test
   public void processWithEntryStatsDisabledRepliesZero() throws Exception {
-    final LatestLastAccessTimeReplyProcessor replyProcessor =
-        mock(LatestLastAccessTimeReplyProcessor.class);
-    final InternalDistributedRegion region = mock(InternalDistributedRegion.class);
-    Set<InternalDistributedMember> recipients = Collections.singleton(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 1234));
-    final LatestLastAccessTimeMessage<String> realLastAccessTimeMessage =
-        new LatestLastAccessTimeMessage<>(replyProcessor, recipients, region, "foo");
-    final LatestLastAccessTimeMessage<String> lastAccessTimeMessage =
-        spy(realLastAccessTimeMessage);
-    lastAccessTimeMessage.setSender(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 12345));
-    final ClusterDistributionManager dm = mock(ClusterDistributionManager.class);
-    final InternalCache cache = mock(InternalCache.class);
     when(dm.getCache()).thenReturn(cache);
     when(cache.getRegion(any())).thenReturn(region);
     RegionEntry regionEntry = mock(RegionEntry.class);
@@ -128,19 +96,6 @@ public class LatestLastAccessTimeMessageTest {
 
   @Test
   public void processWithRegionEntryRepliesWithLastAccessed() throws Exception {
-    final LatestLastAccessTimeReplyProcessor replyProcessor =
-        mock(LatestLastAccessTimeReplyProcessor.class);
-    final InternalDistributedRegion region = mock(InternalDistributedRegion.class);
-    Set<InternalDistributedMember> recipients = Collections.singleton(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 1234));
-    final LatestLastAccessTimeMessage<String> realLastAccessTimeMessage =
-        new LatestLastAccessTimeMessage<>(replyProcessor, recipients, region, "foo");
-    final LatestLastAccessTimeMessage<String> lastAccessTimeMessage =
-        spy(realLastAccessTimeMessage);
-    lastAccessTimeMessage.setSender(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 12345));
-    final ClusterDistributionManager dm = mock(ClusterDistributionManager.class);
-    final InternalCache cache = mock(InternalCache.class);
     when(dm.getCache()).thenReturn(cache);
     when(cache.getRegion(any())).thenReturn(region);
     RegionEntry regionEntry = mock(RegionEntry.class);


### PR DESCRIPTION
The process method on LatestLastAccessTimeMessage 
will now send a reply of zero when it finds a null cache, region, or entry.
This will prevent the thread that sent the message from waiting forever for a reply.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
