### PR TITLE
GEODE-6685: fix flaky test

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/EntriesDoNotExpireDuringGiiRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/EntriesDoNotExpireDuringGiiRegressionTest.java
@@ -116,7 +116,7 @@ public class EntriesDoNotExpireDuringGiiRegressionTest implements Serializable {
 
     assertThat(region.values()).hasSize(0);
     assertThat(region.keySet()).hasSize(ENTRY_COUNT);
-    assertThat(expirationCount.get()).isGreaterThan(ENTRY_COUNT);
+    assertThat(expirationCount.get()).isGreaterThanOrEqualTo(ENTRY_COUNT);
   }
 
   private void doRegionOps() {
@@ -169,6 +169,8 @@ public class EntriesDoNotExpireDuringGiiRegressionTest implements Serializable {
           afterRegionCreateInvoked.get(), is(true));
       errorCollector.checkThat("Region should have been initialized",
           ((LocalRegion) event.getRegion()).isInitialized(), is(true));
+      errorCollector.checkThat("all invalidates should be from expiration",
+          event.getOperation().isExpiration(), is(true));
 
       expirationCount.incrementAndGet();
 


### PR DESCRIPTION
The test was asserting that we did more than 100 expirations.
But race conditions exist that allow the test to do exactly 100 expirations.
Since this test is only meant to make sure that expirations are disabled during GII,
I changed the assertion to allow 100 or more expirations.
I also added an assertion that all invalidates should be from expiration.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
