### PR TITLE
GEODE-8772: ClientServer test port assignment

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,8 +47,9 @@ public class ClientServerMiscDUnitTest extends ClientServerMiscDUnitTestBase {
   public void testInvalidateOnInvalidEntryInServerReachesClient() throws Exception {
     VM server = VM.getVM(0);
     String regionPath = SEPARATOR + REGION_NAME2;
+    int serverPort = getRandomAvailableTCPPort();
     PORT1 = server.invoke(() -> {
-      int port = createServerCache(true, -1, false);
+      int port = createServerCache(true, -1, false, serverPort);
       getCache().getRegion(regionPath).put(server_k1, "VALUE1");
       getCache().getRegion(regionPath).invalidate(server_k1);
       return port;

--- a/geode-cq/src/upgradeTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
+++ b/geode-cq/src/upgradeTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscBCDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -190,7 +191,8 @@ public class ClientServerMiscBCDUnitTest extends ClientServerMiscDUnitTestBase {
 
     int server2Port = initServerCache2();
 
-    int server3Port = server3.invoke(() -> createServerCache(true, getMaxThreads(), false));
+    int server3Port = getRandomAvailableTCPPort();
+    server3.invoke(() -> createServerCache(true, getMaxThreads(), false, server3Port));
 
     System.out.println("old server is vm 2 and new server is vm 3");
     System.out

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
@@ -169,7 +169,8 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   }
 
   int initServerCache(boolean notifyBySub, VM vm, boolean isHA) {
-    return vm.invoke(() -> createServerCache(notifyBySub, getMaxThreads(), isHA));
+    int port = getRandomAvailableTCPPort();
+    return vm.invoke(() -> createServerCache(notifyBySub, getMaxThreads(), isHA, port));
   }
 
   @Test
@@ -945,8 +946,8 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   }
 
 
-  public static Integer createServerCache(Boolean notifyBySubscription, Integer maxThreads,
-      boolean isHA) throws Exception {
+  protected static Integer createServerCache(Boolean notifyBySubscription, Integer maxThreads,
+      boolean isHA, int port) throws Exception {
     Cache cache = new ClientServerMiscDUnitTestBase().createCacheV(new Properties());
     unsetSlowDispatcherFlag();
     AttributesFactory factory = new AttributesFactory();
@@ -971,7 +972,6 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
     assertNotNull(pr);
 
     CacheServer server = cache.addCacheServer();
-    int port = getRandomAvailableTCPPort();
     r1.getCache().getDistributedSystem().getLogWriter().info("Starting server on port " + port);
     server.setPort(port);
     server.setMaxThreads(maxThreads);


### PR DESCRIPTION
Change `ClientServerMiscDUnitTestBase`, `ClientServerMiscDUnitTest`, and
`ClientServerMiscBCDUnitTest` to assign ports only in the test JVM.

BACKGROUND

As part of my project to allow Geode tests to run in parallel outside of
Docker, I am changing our build system to allocate a distinct range of
ports to each test JVM, and changing `AvailablePort` and
`AvailablePortHelper` to honor these allocated port ranges.

This commit prepares for those changes.

PROBLEM

To test compatibility, `ClientServerMiscDUnitTestBase` executes
`createServerCache()` in a child VMs running old versions of Geode. The
`createServerCache()` method assigns a server port via
`AvailablePortHelper`.  The old implementation of `AvailablePortHelper`
in the child VM does not honor the range of ports allocated to the child
VM.

If such tests run in parallel outside of Docker, the
`createServerCache()` method in each test may assign the same port. If
the servers in multiple tests attempt to bind to that port at the same
time, all but one server will fail.

GENERAL SOLUTION

Make tests assign ports only in the test JVM. The test JVM always
includes the latest implementations of `AvailablePort` and
`AvailablePortHelper`, and so the tests  will honor any port allocation
scheme defined in the latest implementation.

THIS COMMIT

- Add a `port` parameter to `createServerCache()`.
- Change `ClientServerMiscDUnitTestBase`, `ClientServerMiscDUnitTest`,
  and `ClientServerMiscBCDUnitTest` to assign ports only methods called
  in the test JVM.
