### PR TITLE
GEODE-9148: prevent expiration reschedules

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryExpiryTask.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryExpiryTask.java
@@ -327,7 +327,7 @@ public class EntryExpiryTask extends ExpiryTask {
         if (expTime == 0L) {
           return;
         }
-        if (getNow() >= expTime) {
+        if (hasExpired(getNow(), expTime)) {
           if (logger.isTraceEnabled()) {
             // NOTE: original finer message used this.toString() twice
             logger.trace(

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ExpiryTask.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ExpiryTask.java
@@ -107,7 +107,7 @@ public abstract class ExpiryTask extends SystemTimer.SystemTimerTask {
   /** Return true if the expiration unit is seconds; false if milliseconds */
   public boolean isExpiryUnitSeconds() {
     boolean isSeconds = true;
-    if (getLocalRegion() != null && getLocalRegion().EXPIRY_UNITS_MS) {
+    if (getLocalRegion() != null && getLocalRegion().isExpiryUnitsMilliseconds()) {
       isSeconds = false;
     }
     return isSeconds;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ExpiryTask.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ExpiryTask.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.logging.log4j.Logger;
 import org.jgroups.annotations.GuardedBy;
@@ -97,12 +98,41 @@ public abstract class ExpiryTask extends SystemTimer.SystemTimerTask {
     long ttl = getTTLAttributes().getTimeout();
     long tilt = 0;
     if (ttl > 0) {
-      if (getLocalRegion() != null && !getLocalRegion().EXPIRY_UNITS_MS) {
-        ttl *= 1000;
-      }
+      ttl = normalizeToMillis(ttl);
       tilt = getLastModifiedTime() + ttl;
     }
     return tilt;
+  }
+
+  /** Return true if the expiration unit is seconds; false if milliseconds */
+  public boolean isExpiryUnitSeconds() {
+    boolean isSeconds = true;
+    if (getLocalRegion() != null && getLocalRegion().EXPIRY_UNITS_MS) {
+      isSeconds = false;
+    }
+    return isSeconds;
+  }
+
+  /**
+   * Return the given timestamp as milliseconds.
+   * If the given secondsOrMillis is already millis then no conversion is needed.
+   */
+  public long normalizeToMillis(long secondsOrMillis) {
+    if (isExpiryUnitSeconds()) {
+      return TimeUnit.SECONDS.toMillis(secondsOrMillis);
+    }
+    return secondsOrMillis;
+  }
+
+  private static final long HALF_A_SECOND_IN_MILLIS = TimeUnit.SECONDS.toMillis(1) / 2;
+
+  public boolean hasExpired(long now, long expireTime) {
+    if (isExpiryUnitSeconds()) {
+      // Units are seconds but the internal timestamps are milliseconds.
+      // To prevent a needless reschedule, bump now by half a second.
+      now += HALF_A_SECOND_IN_MILLIS;
+    }
+    return now >= expireTime;
   }
 
   /** Return the absolute time when idle expiration occurs, or 0 if not used */
@@ -117,9 +147,7 @@ public abstract class ExpiryTask extends SystemTimer.SystemTimerTask {
   protected long getIdleTimeoutInMillis() {
     long idle = getIdleAttributes().getTimeout();
     if (idle > 0) {
-      if (getLocalRegion() != null && !getLocalRegion().EXPIRY_UNITS_MS) {
-        idle *= 1000;
-      }
+      idle = normalizeToMillis(idle);
     }
     return idle;
   }
@@ -144,13 +172,13 @@ public abstract class ExpiryTask extends SystemTimer.SystemTimerTask {
     long expTime = getExpirationTime();
     if (expTime > 0L) {
       long now = getNow();
-      if (now >= expTime) {
+      if (hasExpired(now, expTime)) {
         if (isIdleExpiredOnOthers()) {
           return true;
         } else {
           // our last access time was reset so recheck
           expTime = getExpirationTime();
-          if (expTime > 0L && now >= expTime) {
+          if (expTime > 0L && hasExpired(now, expTime)) {
             return true;
           }
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -351,13 +351,16 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
       GeodeGlossary.GEMFIRE_PREFIX + "EXPIRY_UNITS_MS";
 
   /**
-   * Used by unit tests to set expiry to milliseconds instead of the default seconds. Used in
-   * ExpiryTask.
+   * Used by unit tests to set expiry to milliseconds instead of the default seconds.
    *
    * @since GemFire 5.0
    */
+  private final boolean EXPIRY_UNITS_MS;
+
   @VisibleForTesting
-  final boolean EXPIRY_UNITS_MS;
+  boolean isExpiryUnitsMilliseconds() {
+    return EXPIRY_UNITS_MS;
+  }
 
   private final EntryEventFactory entryEventFactory;
   private final RegionMapConstructor regionMapConstructor;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionIdleExpiryTask.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionIdleExpiryTask.java
@@ -40,9 +40,7 @@ class RegionIdleExpiryTask extends RegionExpiryTask {
         if (timeout == 0) {
           return 0L;
         }
-        if (!getLocalRegion().EXPIRY_UNITS_MS) {
-          timeout *= 1000;
-        }
+        timeout = (int) normalizeToMillis(timeout);
         // Expiration should always use the DSClock instead of the System clock.
         return timeout + getLocalRegion().cacheTimeMillis();
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionTTLExpiryTask.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionTTLExpiryTask.java
@@ -40,9 +40,7 @@ class RegionTTLExpiryTask extends RegionExpiryTask {
         if (timeout == 0) {
           return 0L;
         }
-        if (!getLocalRegion().EXPIRY_UNITS_MS) {
-          timeout *= 1000;
-        }
+        timeout = (int) normalizeToMillis(timeout);
         // Sometimes region expiration depends on lastModifiedTime which in turn
         // depends on entry modification time. To make it consistent always use
         // cache time here.

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ExpiryTaskTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ExpiryTaskTest.java
@@ -14,19 +14,174 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 
+import org.apache.geode.cache.CacheException;
+import org.apache.geode.cache.EntryNotFoundException;
+import org.apache.geode.cache.ExpirationAttributes;
+
 
 public class ExpiryTaskTest {
+
+  private static class TestableExpiryTask extends ExpiryTask {
+
+    public TestableExpiryTask(LocalRegion localRegion) {
+      super(localRegion);
+    }
+
+    @Override
+    protected ExpirationAttributes getIdleAttributes() {
+      return null;
+    }
+
+    @Override
+    protected ExpirationAttributes getTTLAttributes() {
+      return null;
+    }
+
+    @Override
+    protected void basicPerformTimeout(boolean isPending) throws CacheException {}
+
+    @Override
+    protected void reschedule() throws CacheException {}
+
+    @Override
+    protected long getLastModifiedTime() throws EntryNotFoundException {
+      return 0;
+    }
+
+    @Override
+    protected long getLastAccessedTime() throws EntryNotFoundException {
+      return 0;
+    }
+
+    @Override
+    protected boolean invalidate() throws CacheException {
+      return false;
+    }
+
+    @Override
+    protected boolean destroy(boolean isPending) throws CacheException {
+      return false;
+    }
+
+    @Override
+    protected boolean localInvalidate() throws EntryNotFoundException {
+      return false;
+    }
+
+    @Override
+    protected boolean localDestroy() throws CacheException {
+      return false;
+    }
+
+    @Override
+    protected void addExpiryTask() throws EntryNotFoundException {}
+
+    @Override
+    public boolean isPending() {
+      return false;
+    }
+
+    @Override
+    public Object getKey() {
+      return null;
+    }
+  }
 
   @Test
   public void shouldBeMockable() throws Exception {
     ExpiryTask mockExpiryTask = mock(ExpiryTask.class);
     mockExpiryTask.run2();
     verify(mockExpiryTask, times(1)).run2();
+  }
+
+  @Test
+  public void isExpiryUnitsSecondsReturnsTrueIfNoRegion() {
+    ExpiryTask expiryTask = new TestableExpiryTask(null);
+
+    assertThat(expiryTask.isExpiryUnitSeconds()).isTrue();
+  }
+
+  @Test
+  public void isExpiryUnitsSecondsReturnsTrueIfRegionNotMilliseconds() {
+    LocalRegion localRegion = mock(LocalRegion.class);
+    when(localRegion.isExpiryUnitsMilliseconds()).thenReturn(false);
+    ExpiryTask expiryTask = new TestableExpiryTask(localRegion);
+
+    assertThat(expiryTask.isExpiryUnitSeconds()).isTrue();
+  }
+
+  @Test
+  public void isExpiryUnitsSecondsReturnsFalseIfRegionIsMilliseconds() {
+    LocalRegion localRegion = mock(LocalRegion.class);
+    when(localRegion.isExpiryUnitsMilliseconds()).thenReturn(true);
+    ExpiryTask expiryTask = new TestableExpiryTask(localRegion);
+
+    assertThat(expiryTask.isExpiryUnitSeconds()).isFalse();
+  }
+
+  @Test
+  public void normalizeToMillisConvertIfUnitsAreSeconds() {
+    LocalRegion localRegion = mock(LocalRegion.class);
+    when(localRegion.isExpiryUnitsMilliseconds()).thenReturn(false);
+    ExpiryTask expiryTask = new TestableExpiryTask(localRegion);
+
+    long result = expiryTask.normalizeToMillis(2);
+
+    assertThat(result).isEqualTo(2000);
+  }
+
+  @Test
+  public void normalizeToMillisDoesNothingIfExpiryUnitMillis() {
+    LocalRegion localRegion = mock(LocalRegion.class);
+    when(localRegion.isExpiryUnitsMilliseconds()).thenReturn(true);
+    ExpiryTask expiryTask = new TestableExpiryTask(localRegion);
+
+    long result = expiryTask.normalizeToMillis(2000);
+
+    assertThat(result).isEqualTo(2000);
+  }
+
+  @Test
+  public void hasExpiredReturnsFalseIfNowBeforeExpireTime() {
+    ExpiryTask expiryTask = new TestableExpiryTask(null);
+
+    boolean result = expiryTask.hasExpired(1499, 2000);
+
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  public void hasExpiredReturnsTrueIfNowEqualsExpireTime() {
+    ExpiryTask expiryTask = new TestableExpiryTask(null);
+
+    boolean result = expiryTask.hasExpired(2000, 2000);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void hasExpiredReturnsTrueIfNowAfterExpireTime() {
+    ExpiryTask expiryTask = new TestableExpiryTask(null);
+
+    boolean result = expiryTask.hasExpired(3000, 2000);
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void hasExpiredReturnsTrueIfNowLessThanHalfSecondOfExpireTime() {
+    ExpiryTask expiryTask = new TestableExpiryTask(null);
+
+    boolean result = expiryTask.hasExpired(1500, 2000);
+
+    assertThat(result).isTrue();
   }
 }


### PR DESCRIPTION
If we are within half of a second of the scheduled
expiration time then expiration will now happen.
Before we would reschedule for a fraction of a second.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
