### PR TITLE
GEODE-9309: Tool to filter/format progress info

### DIFF
--- a/dev-tools/progress/.gitignore
+++ b/dev-tools/progress/.gitignore
@@ -1,0 +1,3 @@
+/progress
+/progress-linux
+

--- a/dev-tools/progress/INSTALLATION.md
+++ b/dev-tools/progress/INSTALLATION.md
@@ -1,0 +1,21 @@
+# Installing Progress
+
+## Prerequisites
+
+1. [Install the Go programming language](https://golang.org/doc/install), version 1.16 or higher.
+
+## macOS and Linux
+
+To install `progress` to `~/go/bin/progress`:
+
+    cd <geode-project-root>/dev-tools/progress
+    go install .
+
+To install `progress` to a different path:
+
+    cd <geode-project-root>/dev-tools/progress
+    go build -o <desired-path> .
+
+## Windows
+
+`progress` has not been built or tested on Windows. Use at your own risk.

--- a/dev-tools/progress/README.md
+++ b/dev-tools/progress/README.md
@@ -1,0 +1,238 @@
+# progress
+
+The `progress` tool reads, filters, and describes test results recorded in Geode test progress files.
+
+For help, run
+
+    progress -h
+
+Contents:
+
+- [Select Progress Files](#select-progress-files) to read, filter, and describe.
+- [Filter Test Results](#filter-test-results) by a variety of criteria.
+- [Describe Test Results](#describe-test-results) in a variety of formats.
+
+## Select Progress Files
+
+You can specify any number of directories, progress files, or JSON files for `progress` to read.
+
+By default, `progress` reads all progress files in and below the current directory.
+
+    progress    # Reads all progress files in and below the current directory
+
+If you specify one or more directories, `progress` searches each to find progress files.
+
+    progress geode-core geode-wan geode-cq
+
+If you specify one or more JSON files, `progress` reads each as a JSON file written by `progress -j`
+(see [Encode Test Results as JSON](#encode-test-results-as-json)).
+
+    progress all-tests.json
+
+If you specify other files, `progress` reads each as a progress file written by the Geode build process.
+
+    progress geode-core/build/distributedTest/distributedTest-progress.txt
+
+## Filter Test Results
+
+You can filter test results by:
+
+- [Status](#filter-tests-by-status)
+- [Class Name](#filter-tests-by-class-name)
+- [Method Description](#filter-tests-by-method-description)
+- [Start and End Time](#filter-tests-by-start-and-end-time)
+- [Duration](#filter-tests-by-duration)
+
+`progress` displays every test that satisfies all filters.
+
+You may specify any number of start time, end time, and duration filters.
+
+### Filter Tests By Status
+
+Each test execution has a status: `started`, `success`, `failure`, and `skipped`.
+
+The `-s` flag applies a regular expression to each test's status:
+
+    progress -s started
+    progress -s failure
+    progress -s success
+    progress -s skipped
+    progress -s st          # matches `started`
+    progress -s f           # matches `failure`
+    progress -s fail        # matches `failure`
+    progress -s succ        # matches `success`
+    progress -s 'fail|succ' # matches `failure` and `success`
+    progress -s u           # matches `failure` and `success`
+    progress -s sk          # matches `skipped`
+    progress -s s           # matches `started`, `success`, and `skipped`
+    progress -s ed          # matches `started` and `skipped`
+
+### Filter Tests by Class Name
+
+The `-c` flag applies a regular expression to each test's fully qualified class name.
+
+    progress -c 'org.apache.geode.deployment.internal.modular.ModularJarDeploymentServiceTest'
+    progress -c 'org.apache.geode.deployment.internal'
+    progress -c ModularJarDeploymentServiceTest
+
+### Filter Tests by Method Description
+
+The `-m` flag applies a regular expression to each test's method description.
+
+    progress -m addsListenerConcurrentlyWithNotification
+    progress -m 'addsListenerConcurrentlyWithNotification\(BEFORE_BOUNCE_VM\)'
+    progress -m 'addsListenerConcurrentlyWithNotification.*BOUNCE_VM'
+    progress -m BEFORE_BOUNCE_VM
+
+Note that description includes the method name, and may include the parameters passed to the method. The exact format of
+the description depends on the test runner used to run the test.
+
+### Filter Tests By Start and End Time
+
+The `-b` flag filters tests by start time.
+
+The `-e` flag filters tests by end time.
+
+The `-r` flag filters tests that were running at a given time.
+
+The `-b` and `-e` flags specify _time constraints._
+A time constraint is a relational operator (`<`, `<=`, `>`, and `>=`)
+followed by a reference time.
+
+You can specify any number of `-b`, `-e`, and `-r` filters.
+
+    progress -b '>=2021-05-24 17:35:28.031 -0700'
+    progress -e '<2021-05-24 17:35:28.031 -0700'
+    progress -b '>=2021-05-24 17:30:00.000 -0700' -b '<=2021-05-24 17:40:00.000 -0700'
+    progress -b '>=2021-05-24 17:30:00.000 -0700' -e '<2021-05-24 17:40:00.000 -0700'
+    progress -r '2021-05-24 17:35:28.031 -0700'
+
+Note that if a test has no result, `progress` considers its "end time" to be infinitely far into the future, and
+therefore greater than any reference time you specify.
+
+### Filter Tests by Duration
+
+The `-d` flag filters tests by duration _constraint_. A duration constraint is a relational operator (`<`, `<=`, `>`,
+and `>=`) followed by a reference duration.
+
+You can specify any number of `-d` constraints.
+
+    progress -d '>4m34s'
+    progress -d '>=4m' -d '<=4m30s'
+
+## Describe Test Results
+
+- [Default Format](#default-format)
+- [Apply a Custom Format](#apply-a-custom-format)
+- [Apply a Template File](#apply-a-template-file)
+- [Encode Test Results as JSON](#encode-test-results-as-json)
+- [Bundle Test Results](#bundle-test-results) for storage or copying.
+
+### Default Format
+
+The default format displays commonly useful information about each test:
+
+- The test class and method/description
+- The iteration number (useful for repeat tests)
+- The start time, end time, and duration of the test
+- The test status
+
+Example:
+
+```
+org.apache.geode.modules.session.catalina.Tomcat7CommitSessionValveTest.recycledResponseObjectDoesNotWrapAlreadyWrappedOutputBuffer
+    Iteration: 1
+    Start:     2021-05-20 22:16:18.699 +0000
+    End:       2021-05-20 22:16:20.585 +0000
+    Duration:  1.886s
+    Status:    success
+org.apache.geode.modules.session.catalina.Tomcat7CommitSessionValveTest.wrappedOutputBufferForwardsToDelegate
+    Iteration: 1
+    Start:     2021-05-20 22:16:20.585 +0000
+    End:       2021-05-20 22:16:20.589 +0000
+    Duration:  4ms
+    Status:    success
+```
+
+### Apply a Custom Format
+
+The `-f` flag formats each test execution according to the format you specify,
+using [Go's template syntax](https://golang.org/pkg/text/template/).
+
+For each test execution, `progress` passes the following Go struct to your template:
+
+    type Test struct {
+        File       string        // progress file
+        Class      string        // test class
+        Method     string        // test method, including parameters
+        Iteration  int           // iteration number (for repeat tests)
+        Status     string        // started, success, failure, or skipped
+        StartTime  time.Time     // test start time
+        EndTime    time.Time     // test end time
+        Duration   time.Duration // test duration
+    }
+
+Here are some example formats that write one line per test execution:
+
+    progress -f '{{ println .StartTime .Class .Method }}'
+    progress -f '{{ println .Class .Method }}'
+    progress -f '{{ println .Status .Class .Method }}'
+
+One-liner formats like these are useful analyzing test results in myriad ways:
+
+    progress -f '{{ println .StartTime .Class .Method }}' | sort    # sort by start time
+    progress -f '{{ println .Class .Method }}' | sort               # sort by class
+    progress -f '{{ println .Status .Class .Method }}' | sort       # sort by status
+    progress -s fail -f '{{ println .Class }}' | sort -u | uniq -c  # count failures by class
+
+### Apply a Template File
+
+For templates that you reuse often, or that are too cumbersome or complex to write on the command line, you can use your
+shell's redirect feature to read the template from a file:
+
+    progress -f "$(< my-template-file.tmpl)"
+
+### Encode Test Results as JSON
+
+The `-j` flag encodes test results as JSON, grouping test executions by progress file path, class name, and method
+description:
+
+    progress -j
+    progress -j | jq    # Use jq to pretty-print the JSON
+    progress -j -c Tomcat7CommitSessionValveTest
+
+The output (if pretty-printed) looks like this:
+
+```json
+{
+    "/path/to/geode/project/extensions/geode-modules-tomcat7/build/test/test-progress.txt": {
+        "org.apache.geode.modules.session.catalina.Tomcat7CommitSessionValveTest": {
+            "recycledResponseObjectDoesNotWrapAlreadyWrappedOutputBuffer": [
+                {
+                    "Iteration": 1,
+                    "StartTime": "2021-05-20T22:16:18.699Z",
+                    "EndTime": "2021-05-20T22:16:20.585Z",
+                    "Status": "success"
+                }
+            ],
+            "wrappedOutputBufferForwardsToDelegate": [
+                {
+                    "Iteration": 1,
+                    "StartTime": "2021-05-20T22:16:20.585Z",
+                    "EndTime": "2021-05-20T22:16:20.589Z",
+                    "Status": "success"
+                }
+            ]
+        }
+    }
+}
+  ```
+
+### Bundle Test Results
+
+You can use `progress` to bundle a set of test results for easy storage or copying, and use `progress` to analyze the
+file at a later time or on another computer:
+
+    progress -j > all-tests.json    # Bundle all test results into a single JSON file
+    ...
+    progress -s fail all-tests.json # Reads the JSON file written by progress -j

--- a/dev-tools/progress/go.mod
+++ b/dev-tools/progress/go.mod
@@ -1,0 +1,3 @@
+module github.com/apache/geode/dev-tools/progress
+
+go 1.16

--- a/dev-tools/progress/internal/cli/cli.go
+++ b/dev-tools/progress/internal/cli/cli.go
@@ -1,0 +1,328 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package cli
+
+import (
+	"flag"
+	"fmt"
+	"github.com/apache/geode/dev-tools/progress/internal/progress"
+	"os"
+	"path/filepath"
+	"regexp"
+	"text/template"
+	"time"
+)
+
+func Execute() int {
+	flags.Usage = usage
+	err := flags.Parse(os.Args[1:])
+	if err == flag.ErrHelp {
+		extraHelp()
+		os.Exit(0)
+	}
+	if err != nil {
+		os.Exit(1)
+	}
+
+	fs := os.DirFS(fsRoot)
+
+	finder := progress.Finder{
+		FS:          fs,
+		TaskMatcher: taskMatcher,
+	}
+
+	filter := progress.Filter{
+		ClassFilter:      classMatcher,
+		MethodFilter:     methodMatcher,
+		StatusFilter:     statusMatcher,
+		StartTimeFilters: startTimeFilters,
+		EndTimeFilters:   endTimeFilters,
+		DurationFilters:  durationFilters,
+	}
+
+	cmd := progress.Cmd{
+		FS:     fs,
+		Finder: finder,
+		Filter: filter,
+	}
+
+	if *reportJSON {
+		cmd.Reporter = progress.JSONReporter{
+			Out: os.Stdout,
+		}
+	} else {
+		cmd.Reporter = progress.FormatReporter{
+			Out:    os.Stdout,
+			Format: format,
+		}
+	}
+
+	err = cmd.Run(fsPaths(flags.Args()))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	return 0
+}
+
+var (
+	name       = filepath.Base(os.Args[0])
+	synopsis   = fmt.Sprintf("Usage: %s [options] [path ...]", name)
+	flags      = flag.NewFlagSet(name, flag.ContinueOnError)
+	reportJSON = flags.Bool("j", false, "Describe tests as JSON")
+	format     = template.Must(template.New("format").Parse(defaultFormat))
+
+	classMatcher  = regexp.MustCompile("")
+	methodMatcher = regexp.MustCompile("")
+	statusMatcher = regexp.MustCompile("")
+	taskMatcher   = regexp.MustCompile("")
+
+	durationFilters  []progress.DurationFilter
+	endTimeFilters   []progress.TimeFilter
+	startTimeFilters []progress.TimeFilter
+)
+
+func init() {
+	flags.Func("b", "Filter tests by start time `constraint`", addStartTimeFilter)
+	flags.Func("c", "Filter tests by class `regexp`", setClassMatcher)
+	flags.Func("d", "Filter tests by duration `constraint`", addDurationFilter)
+	flags.Func("e", "Filter tests by end time `constraint`", addEndTimeFilter)
+	flags.Func("f", "The `format` to describe each test", setFormat)
+	flags.Func("m", "Filter tests by method `regexp`", setMethodMatcher)
+	flags.Func("r", "Filter tests running at `time`", addRunningAtFilter)
+	flags.Func("s", "Filter tests by status `regexp`", setStatusMatcher)
+	flags.Func("t", "Limit directory search by task `regexp`", setTaskMatcher)
+}
+
+func addDurationFilter(v string) error {
+	f, err := progress.ParseDurationFilter(v)
+	if err != nil {
+		return err
+	}
+	durationFilters = append(durationFilters, f)
+	return nil
+}
+
+func addEndTimeFilter(v string) error {
+	f, err := progress.ParseTimeFilter(v)
+	if err != nil {
+		return err
+	}
+	endTimeFilters = append(endTimeFilters, f)
+	return nil
+}
+
+func addRunningAtFilter(v string) error {
+	if _, err := time.Parse(progress.TimeFormat, v); err != nil {
+		return err
+	}
+	_ = addStartTimeFilter("<=" + v)
+	_ = addEndTimeFilter(">=" + v)
+	return nil
+}
+
+func addStartTimeFilter(v string) error {
+	f, err := progress.ParseTimeFilter(v)
+	if err != nil {
+		return err
+	}
+	startTimeFilters = append(startTimeFilters, f)
+	return nil
+}
+
+func setClassMatcher(v string) error {
+	re, err := regexp.Compile(v)
+	if err != nil {
+		return err
+	}
+	classMatcher = re
+	return nil
+}
+
+func setFormat(v string) error {
+	t, err := template.New("format").Parse(v)
+	if err != nil {
+		return err
+	}
+	format = t
+	return nil
+}
+
+func setMethodMatcher(v string) error {
+	re, err := regexp.Compile(v)
+	if err != nil {
+		return err
+	}
+	methodMatcher = re
+	return nil
+}
+
+func setStatusMatcher(v string) error {
+	re, err := regexp.Compile(v)
+	if err != nil {
+		return err
+	}
+	statusMatcher = re
+	return nil
+}
+
+func setTaskMatcher(v string) error {
+	re, err := regexp.Compile(v)
+	if err != nil {
+		return err
+	}
+	taskMatcher = re
+	return nil
+}
+
+func usage() {
+	w := flags.Output()
+	fmt.Fprintln(w, synopsis)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, description)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "OPTIONS")
+	flags.PrintDefaults()
+}
+
+func extraHelp() {
+	w := flags.Output()
+	fmt.Fprintln(w)
+	fmt.Fprint(w, details)
+}
+
+const defaultFormat = `{{ .Class }}.{{ .Method }}
+    Iteration: {{ .Iteration }}
+    Start:     {{ .StartTime.Format "` + progress.TimeFormat + `" }}
+    End:       {{ .EndTime.Format "` + progress.TimeFormat + `" }}
+    Duration:  {{ .Duration }}
+    Status:    {{ .Status }}
+`
+
+const description = "Filter and describe test events recorded in Geode test progress files."
+
+const details = `PROGRESS FILES
+
+Progress reads test information from each regular file listed on the command
+line. If the file has a .json extension, the content must have the same
+structure as produced by progress -j. Otherwise, the content must be formatted
+as progress events written by Geode's build process.
+
+For each directory listed on the command line, progress reads each progress
+file it detects in the file tree rooted at the directory.
+
+The default path is the current working directory.
+
+If you add the -t option, progress reads only those progress files whose task
+names satisfy the regexp. Note that the -t option affects only how progress
+searches directories. It does not filter the regular files that you list.
+
+CAVEAT: When a build executes multiple instances of a test concurrently, the
+progress file does not identify which test instance produced each test event.
+Lacking this information, progress associates each test result event with the
+earliest uncompleted start event with the same class name and method name.
+
+FILTERING TESTS
+
+By default progress describes every test it reads. If you specify one or more
+filter options, progress describes only those tests that satisfy every
+specified filter.
+
+You can specify multiple time and duration filters. This is useful to specify
+a range of times or durations.
+
+The -r option takes a time string argument. The format for a time string
+(using "Mon Jan 2 15:04:05 -0700 MST 2006" as an example) is:
+
+    ` + progress.TimeFormat + `
+
+The -b and -e options take time constraint arguments. A time constraint is a
+relational operator followed by a time string. For example:
+
+    <=2021-05-10 08:57:49.000 -0700
+
+The -d option takes a duration constraint argument. A duration constraint is
+a relational operator followed by a duration string. For example:
+
+    >=2m
+
+A duration string is a possibly signed sequence of decimal numbers, each with
+optional fraction and a unit suffix, such as "300ms", "-1.5h" or "2h45m".
+Valid time units are "ns", "us" (or "µs"), "ms", "s", "m", "h".
+
+The relational operators are:
+
+    <   less than
+    <=  less than or equal to
+    >=  greater than or equal to
+    >   greater than
+
+FORMATTING
+
+By default, progress describes tests using a built in format (see below).
+
+The -j option describes tests in JSON format, grouped by progress file path,
+class name, and method name.
+
+Use the -f option to specify a custom format, using Go's template syntax
+(https://golang.org/pkg/text/template/).
+
+For each test, progress passes the following Go struct to the template:
+
+    type Test struct {
+        File       string        // progress file
+        Class      string        // test class
+        Method     string        // test method, including parameters
+        Iteration  int           // iteration number (for repeat tests)
+        Status     string        // started, success, failure, or skipped
+        StartTime  time.Time     // test start time
+        EndTime    time.Time     // test end time
+        Duration   time.Duration // test duration
+    }
+
+By default format is:
+
+` + defaultFormat
+
+const fsRoot = "/"
+
+// fsPaths maps each path to the path relative to fsRoot
+func fsPaths(paths []string) []string {
+	if len(paths) == 0 {
+		paths = append(paths, ".")
+	}
+	var fsp []string
+	for _, path := range paths {
+		fsp = append(fsp, fsPath(path))
+	}
+	return fsp
+}
+
+// fsPath maps the path to the path relative to fsRoot
+func fsPath(path string) string {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	p, err := filepath.Rel(fsRoot, absPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	return p
+}

--- a/dev-tools/progress/internal/progress/build.go
+++ b/dev-tools/progress/internal/progress/build.go
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import "time"
+
+// A Build represents the executions of tests reported by a set of progress files, grouped by progress file path.
+type Build map[string]Task
+
+// A Task represents the executions of tests reported by a single progress file, grouped by class name.
+type Task map[string]Class
+
+// A Class represents the executions of tests in a class, grouped by method description (method name and parameters).
+type Class map[string]Method
+
+// A Method represents the executions of a test method with a given set of parameters.
+type Method []Execution
+
+// An Execution describes a single execution of a test. If a test is executed multiple times in a build,
+// the Iteration distinguishes one execution from another. Note that progress assumes that each test result
+// event corresponds to the earliest uncompleted start event for the same test description.
+type Execution struct {
+	Iteration int
+	StartTime time.Time
+	EndTime   time.Time
+	Status    string
+}
+
+// Duration returns the execution's EndTime minus its StartTime.
+func (e Execution) Duration() time.Duration {
+	return e.EndTime.Sub(e.StartTime)
+}

--- a/dev-tools/progress/internal/progress/cmd.go
+++ b/dev-tools/progress/internal/progress/cmd.go
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// A finder identifies the progress file paths represented by a list of file and directory paths.
+type finder interface {
+	Find(paths []string) ([]string, error)
+}
+
+// A filter applies a set of criteria to each Execution in a Build.
+type filter interface {
+	Filter(b Build) Build
+}
+
+// A reporter writes an encoding of a Build to an output stream.
+type reporter interface {
+	Report(b Build) error
+}
+
+type Cmd struct {
+	FS       fs.FS
+	Finder   finder
+	Filter   filter
+	Reporter reporter
+}
+
+func (c Cmd) Run(paths []string) error {
+	filePaths, err := c.Finder.Find(paths)
+	if err != nil {
+		return err
+	}
+	build := c.parseFiles(filePaths)
+	filtered := c.Filter.Filter(build)
+	if err := c.Reporter.Report(filtered); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c Cmd) parseFiles(filePaths []string) Build {
+	merged := make(Build)
+	for _, path := range filePaths {
+		build, err := c.parseFile(path)
+		if err != nil {
+			fmt.Fprintf(os.Stdout, "%s: %s\n", path, err)
+			continue
+		}
+		for path, task := range build {
+			merged[path] = task
+		}
+	}
+	return merged
+}
+
+func (c Cmd) parseFile(path string) (Build, error) {
+	r, err := c.FS.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = r.Close() }()
+	if strings.HasSuffix(path, ".json") {
+		return parseJSONBuild(r)
+	}
+	task, err := parseProgressFile(r)
+	if err != nil {
+		return nil, err
+	}
+	return Build{"/" + path: task}, nil
+}

--- a/dev-tools/progress/internal/progress/event.go
+++ b/dev-tools/progress/internal/progress/event.go
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type event struct {
+	Class  string
+	Method string
+	Time   time.Time
+	Status string
+}
+
+func parseProgressFile(r io.Reader) (Task, error) {
+	task := make(Task)
+	lines := bufio.NewScanner(r)
+	for lines.Scan() {
+		e, err := parseEvent(lines.Text())
+		if err != nil {
+			return nil, err
+		}
+		task, err = addEvent(task, e)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return task, nil
+}
+
+func parseEvent(line string) (event, error) {
+	if fields := startEventRE.FindStringSubmatch(line); fields != nil {
+		return newEvent(fields[1], fields[2], fields[3], "started")
+	}
+	if fields := endEventRE.FindStringSubmatch(line); fields != nil {
+		return newEvent(fields[1], fields[2], fields[3], strings.ToLower(fields[4]))
+	}
+	return event{}, fmt.Errorf("unrecognized event: %s", line)
+}
+
+func addEvent(task Task, e event) (Task, error) {
+	switch e.Status {
+	case "started":
+		if _, ok := task[e.Class]; !ok {
+			task[e.Class] = make(Class)
+		}
+		executions := task[e.Class][e.Method]
+		execution := Execution{
+			Iteration: len(executions) + 1,
+			StartTime: e.Time,
+			Status:    e.Status,
+		}
+		task[e.Class][e.Method] = append(executions, execution)
+	default:
+		executions, ok := task[e.Class][e.Method]
+		if !ok {
+			return task, fmt.Errorf("%s event with no start event: %s.%s", e.Status, e.Class, e.Method)
+		}
+		if executions[len(executions)-1].Status != "started" {
+			return task, fmt.Errorf("%s event with no running execution: %s.%s", e.Status, e.Class, e.Method)
+		}
+		// Apply this end event to the first unfinished execution
+		for i, execution := range executions {
+			if execution.Status == "started" {
+				execution.EndTime = e.Time
+				execution.Status = e.Status
+				executions[i] = execution
+				break
+			}
+		}
+	}
+	return task, nil
+}
+
+func newEvent(timeStr, class, method, status string) (event, error) {
+	t, err := time.Parse("2006-01-02 15:04:05.000 -0700", timeStr)
+	if err != nil {
+		return event{}, err
+	}
+	return event{
+		Class:  class,
+		Method: method,
+		Time:   t,
+		Status: status,
+	}, nil
+}
+
+var (
+	startEventRE = regexp.MustCompile(`^(\S+ \S+ \S+) Starting test (\S+)\s+(.+)\s*`)
+	endEventRE   = regexp.MustCompile(`^(\S+ \S+ \S+) Completed test (\S+)\s+(.+)\s+with result: (\S+)`)
+)

--- a/dev-tools/progress/internal/progress/filter.go
+++ b/dev-tools/progress/internal/progress/filter.go
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+type TimeFilter func(time.Time) bool
+
+type DurationFilter func(time.Duration) bool
+
+// Filter applies a set of criteria to each Execution in a Build.
+type Filter struct {
+	ClassFilter      *regexp.Regexp
+	MethodFilter     *regexp.Regexp
+	StatusFilter     *regexp.Regexp
+	StartTimeFilters []TimeFilter
+	EndTimeFilters   []TimeFilter
+	DurationFilters  []DurationFilter
+}
+
+// Filter returns a Build with each Execution in b that satisfies all of f's criteria.
+func (f Filter) Filter(b Build) Build {
+	filtered := make(Build)
+	for path, task := range b {
+		for className, class := range task {
+			if !f.ClassFilter.MatchString(className) {
+				continue
+			}
+			for methodName, method := range class {
+				if !f.MethodFilter.MatchString(methodName) {
+					continue
+				}
+				for _, execution := range method {
+					if !f.acceptExecution(execution) {
+						continue
+					}
+					if _, ok := filtered[path]; !ok {
+						filtered[path] = make(Task)
+					}
+					if _, ok := filtered[path][className]; !ok {
+						filtered[path][className] = make(Class)
+					}
+					filtered[path][className][methodName] = append(filtered[path][className][methodName], execution)
+				}
+			}
+		}
+	}
+	return filtered
+}
+
+func (f Filter) acceptExecution(e Execution) bool {
+	if !f.StatusFilter.MatchString(e.Status) {
+		return false
+	}
+	for _, f := range f.StartTimeFilters {
+		if !f(e.StartTime) {
+			return false
+		}
+	}
+	for _, f := range f.EndTimeFilters {
+		if !f(e.EndTime) {
+			return false
+		}
+	}
+	for _, f := range f.DurationFilters {
+		if !f(e.Duration()) {
+			return false
+		}
+	}
+	return true
+}
+
+var constraintRE = regexp.MustCompile(`^(\D+)(.+)`)
+
+// TODO: Consider allowing simpler time formats:
+//   Omit date (Use PROGRESS_DATE env var or infer from a date mentioned in the build).
+//   Omit time zone (Use PROGRESS_TIME_ZONE env var or infer from a date mentioned in the build).
+//   Omit seconds or minutes (infer 0).
+// TODO: Allow RFC3339 dates to support copying/pasting dates from JSON.
+
+const (
+	TimeFormat = "2006-01-02 15:04:05.000 -0700"
+	opLT       = "<"
+	opLE       = "<="
+	opGE       = ">="
+	opGT       = ">"
+)
+
+// Each time comparison func treats its arg specially if its value is the zero time. The arg can be zero only if it
+// represents an Execution's end time, and only if the progress file did not record an end event for the Execution. So
+// the zero end time indicates that the Execution has not yet completed. The Execution's end time might be, so far as
+// the func can tell, infinitely far into the future. To handle this case, each func considers a zero arg to be greater
+// than any ref time.
+
+// ltTime returns a func that reports whether its arg is less than ref.
+func ltTime(ref time.Time) TimeFilter {
+	return func(arg time.Time) bool {
+		return arg.Before(ref) && !arg.IsZero()
+	}
+}
+
+// leTime returns a func that reports whether its arg is less than or equal to ref.
+func leTime(ref time.Time) TimeFilter {
+	return func(arg time.Time) bool {
+		return !arg.IsZero() && !arg.After(ref)
+	}
+}
+
+// geTime returns a func that reports whether its arg is greater than or equal to ref.
+func geTime(ref time.Time) TimeFilter {
+	return func(arg time.Time) bool {
+		return arg.IsZero() || !arg.Before(ref)
+	}
+}
+
+// gtTime returns a func that reports whether its arg is greater than ref.
+func gtTime(ref time.Time) TimeFilter {
+	return func(arg time.Time) bool {
+		return arg.IsZero() || arg.After(ref)
+	}
+}
+
+var timeFilters = map[string]func(ref time.Time) TimeFilter{
+	opLT: ltTime,
+	opLE: leTime,
+	opGE: geTime,
+	opGT: gtTime,
+}
+
+func ParseTimeFilter(c string) (TimeFilter, error) {
+	match := constraintRE.FindStringSubmatch(c)
+	if match == nil {
+		return nil, errors.New("invalid constraint")
+	}
+	op := strings.TrimSpace(match[1])
+	filterFn, ok := timeFilters[op]
+	if !ok {
+		return nil, fmt.Errorf(`invalid operator: "%s"`, op)
+	}
+	ref, err := time.Parse(TimeFormat, strings.TrimSpace(match[2]))
+	if err != nil {
+		return nil, err
+	}
+	return filterFn(ref), err
+}
+
+var durationFilters = map[string]func(ref time.Duration) DurationFilter{
+	opLT: ltDur,
+	opLE: leDur,
+	opGE: geDur,
+	opGT: gtDur,
+}
+
+func ParseDurationFilter(c string) (DurationFilter, error) {
+	match := constraintRE.FindStringSubmatch(c)
+	if match == nil {
+		return nil, errors.New("invalid constraint")
+	}
+	op := strings.TrimSpace(match[1])
+	constraintFn, ok := durationFilters[op]
+	if !ok {
+		return nil, fmt.Errorf(`invalid operator: "%s"`, op)
+	}
+	ref, err := time.ParseDuration(strings.TrimSpace(match[2]))
+	if err != nil {
+		return nil, err
+	}
+	return constraintFn(ref), nil
+}
+
+func ltDur(ref time.Duration) DurationFilter {
+	return func(arg time.Duration) bool {
+		return arg < ref
+	}
+}
+
+func leDur(ref time.Duration) DurationFilter {
+	return func(arg time.Duration) bool {
+		return arg <= ref
+	}
+}
+
+func geDur(ref time.Duration) DurationFilter {
+	return func(arg time.Duration) bool {
+		return arg >= ref
+	}
+}
+
+func gtDur(ref time.Duration) DurationFilter {
+	return func(arg time.Duration) bool {
+		return arg > ref
+	}
+}

--- a/dev-tools/progress/internal/progress/filter_test.go
+++ b/dev-tools/progress/internal/progress/filter_test.go
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+var (
+	zeroTime  = time.Time{}
+	earlyTime = time.Now().Round(time.Millisecond)
+	refTime   = earlyTime.Add(time.Millisecond)
+	lateTime  = refTime.Add(time.Millisecond)
+
+	shortDur = time.Second
+	refDur   = shortDur + time.Millisecond
+	longDur  = refDur + time.Millisecond
+)
+
+type timeConstraintTest struct {
+	constraint string
+	operand    time.Time
+	want       bool
+	wantErr    error
+}
+
+var timeConstraintTests = map[string]timeConstraintTest{
+	"early lt ref": {
+		operand:    earlyTime,
+		constraint: opLT + refTime.Format(TimeFormat),
+		want:       true,
+	},
+	"ref lt ref": {
+		operand:    refTime,
+		constraint: opLT + refTime.Format(TimeFormat),
+		want:       false,
+	},
+	"late lt ref": {
+		operand:    lateTime,
+		constraint: opLT + refTime.Format(TimeFormat),
+		want:       false,
+	},
+	"early le ref": {
+		operand:    earlyTime,
+		constraint: opLE + refTime.Format(TimeFormat),
+		want:       true,
+	},
+	"ref le ref": {
+		operand:    refTime,
+		constraint: opLE + refTime.Format(TimeFormat),
+		want:       true,
+	},
+	"late le ref": {
+		operand:    lateTime,
+		constraint: opLE + refTime.Format(TimeFormat),
+		want:       false,
+	},
+	"early ge ref": {
+		operand:    earlyTime,
+		constraint: opGE + refTime.Format(TimeFormat),
+		want:       false,
+	},
+	"ref ge ref": {
+		operand:    refTime,
+		constraint: opGE + refTime.Format(TimeFormat),
+		want:       true,
+	},
+	"late ge ref": {
+		operand:    lateTime,
+		constraint: opGE + refTime.Format(TimeFormat),
+		want:       true,
+	},
+	"early gt ref": {
+		operand:    earlyTime,
+		constraint: opGT + refTime.Format(TimeFormat),
+		want:       false,
+	},
+	"ref gt ref": {
+		operand:    refTime,
+		constraint: opGT + refTime.Format(TimeFormat),
+		want:       false,
+	},
+	"late gt ref": {
+		constraint: opGT + refTime.Format(TimeFormat),
+		operand:    lateTime,
+		want:       true,
+	},
+	// Special case: An uncompleted test's end time is the zero time. To treat this zero end time as always being
+	// in the future, time constraints consider the zero time to be greater than every time.
+	"zero lt ref": {
+		constraint: opLT + refTime.Format(TimeFormat),
+		operand:    zeroTime,
+		want:       false,
+	},
+	"zero le ref": {
+		constraint: opLE + refTime.Format(TimeFormat),
+		operand:    zeroTime,
+		want:       false,
+	},
+	"zero ge ref": {
+		constraint: opGE + refTime.Format(TimeFormat),
+		operand:    zeroTime,
+		want:       true,
+	},
+	"zero gt ref": {
+		constraint: opGT + refTime.Format(TimeFormat),
+		operand:    zeroTime,
+		want:       true,
+	},
+	// The zero time is greater than the zero time.
+	"zero lt zero": {
+		constraint: opLT + zeroTime.Format(TimeFormat),
+		operand:    zeroTime,
+		want:       false,
+	},
+	"zero le zero": {
+		constraint: opLE + zeroTime.Format(TimeFormat),
+		operand:    zeroTime,
+		want:       false,
+	},
+	"zero ge zero": {
+		constraint: opGE + zeroTime.Format(TimeFormat),
+		operand:    zeroTime,
+		want:       true,
+	},
+	"zero gt zero": {
+		constraint: opGT + zeroTime.Format(TimeFormat),
+		operand:    zeroTime,
+		want:       true,
+	},
+}
+
+func TestTimeConstraint(t *testing.T) {
+	for name, test := range timeConstraintTests {
+		t.Run(name, func(t *testing.T) {
+			constraintFn, err := ParseTimeFilter(test.constraint)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("Got error %q, want %q", err, test.wantErr)
+			}
+			got := constraintFn(test.operand)
+			if got != test.want {
+				t.Errorf("Got %t for %q %q", got, test.operand, test.constraint)
+			}
+		})
+	}
+}
+
+type durationConstraintTest struct {
+	constraint string
+	operand    time.Duration
+	want       bool
+	wantErr    error
+}
+
+var durationConstraintTests = map[string]durationConstraintTest{
+	"short lt ref": {
+		operand:    shortDur,
+		constraint: opLT + refDur.String(),
+		want:       true,
+	},
+	"ref lt ref": {
+		operand:    refDur,
+		constraint: opLT + refDur.String(),
+		want:       false,
+	},
+	"long lt ref": {
+		operand:    longDur,
+		constraint: opLT + refDur.String(),
+		want:       false,
+	},
+	"short le ref": {
+		operand:    shortDur,
+		constraint: opLE + refDur.String(),
+		want:       true,
+	},
+	"ref le ref": {
+		operand:    refDur,
+		constraint: opLE + refDur.String(),
+		want:       true,
+	},
+	"long le ref": {
+		operand:    longDur,
+		constraint: opLE + refDur.String(),
+		want:       false,
+	},
+	"short ge ref": {
+		operand:    shortDur,
+		constraint: opGE + refDur.String(),
+		want:       false,
+	},
+	"ref ge ref": {
+		operand:    refDur,
+		constraint: opGE + refDur.String(),
+		want:       true,
+	},
+	"long ge ref": {
+		operand:    longDur,
+		constraint: opGE + refDur.String(),
+		want:       true,
+	},
+	"short gt ref": {
+		operand:    shortDur,
+		constraint: opGT + refDur.String(),
+		want:       false,
+	},
+	"ref gt ref": {
+		operand:    refDur,
+		constraint: opGT + refDur.String(),
+		want:       false,
+	},
+	"long gt ref": {
+		constraint: opGT + refDur.String(),
+		operand:    longDur,
+		want:       true,
+	},
+}
+
+func TestDurationConstraint(t *testing.T) {
+	for name, test := range durationConstraintTests {
+		t.Run(name, func(t *testing.T) {
+			constraintFn, err := ParseDurationFilter(test.constraint)
+			if !errors.Is(err, test.wantErr) {
+				t.Fatalf("Got error %q, want %q", err, test.wantErr)
+			}
+			got := constraintFn(test.operand)
+			if got != test.want {
+				t.Errorf("Got %t for %q %q", got, test.operand, test.constraint)
+			}
+		})
+	}
+}

--- a/dev-tools/progress/internal/progress/find.go
+++ b/dev-tools/progress/internal/progress/find.go
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import (
+	"errors"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+)
+
+type Finder struct {
+	FS          fs.FS
+	TaskMatcher *regexp.Regexp
+}
+
+func (f Finder) Find(paths []string) ([]string, error) {
+	var progressPaths []string
+	for _, path := range paths {
+		info, err := fs.Stat(f.FS, path)
+		if err != nil {
+			return nil, err
+		}
+		if info.IsDir() {
+			found, err := f.findInDir(path)
+			if err != nil {
+				return nil, err
+			}
+			progressPaths = append(progressPaths, found...)
+			continue
+		}
+		progressPaths = append(progressPaths, path)
+	}
+	if len(progressPaths) == 0 {
+		return nil, errors.New("no progress files")
+	}
+	return progressPaths, nil
+}
+
+func (f Finder) findInDir(dir string) ([]string, error) {
+	var progFilePaths []string
+	walkFn := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.IsDir() {
+			return nil // Not a dir, and so not a task dir
+		}
+		if filepath.Base(filepath.Dir(path)) != "build" {
+			return nil // Not in a build dir, so not a task dir
+		}
+		taskName := filepath.Base(path)
+		if !f.TaskMatcher.MatchString(taskName) {
+			return nil // Task name doesn't pass filter
+		}
+		progFilePath := filepath.Join(path, taskName+"-progress.txt")
+		progFile, err := f.FS.Open(progFilePath)
+		if err != nil {
+			return nil // No progress file for the task name
+		}
+		defer progFile.Close()
+		info, err := progFile.Stat()
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil // Progress file is a dir?!
+		}
+		progFilePaths = append(progFilePaths, progFilePath)
+		return fs.SkipDir // Found this dir's progress file, so no need to look further
+	}
+	if err := fs.WalkDir(f.FS, dir, walkFn); err != nil {
+		return nil, err
+	}
+	return progFilePaths, nil
+}

--- a/dev-tools/progress/internal/progress/find_test.go
+++ b/dev-tools/progress/internal/progress/find_test.go
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import (
+	"regexp"
+	"testing"
+	"testing/fstest"
+)
+
+type progressFileFinderTest struct {
+	files []string
+	want  []string
+}
+
+var progressFileFinderTests = map[string]progressFileFinderTest{
+	"build dir + task dir + task progress file": {
+		files: []string{
+			"dir/build/distributedTestTest/distributedTestTest-progress.txt",
+			"dir/build/integrationTest/integrationTest-progress.txt",
+			"dir/build/repeatUpgradeTest/repeatUpgradeTest-progress.txt",
+		},
+		want: []string{
+			"dir/build/distributedTestTest/distributedTestTest-progress.txt",
+			"dir/build/integrationTest/integrationTest-progress.txt",
+			"dir/build/repeatUpgradeTest/repeatUpgradeTest-progress.txt",
+		},
+	},
+	"file name does not end in -progress.txt": {
+		files: []string{"dir/build/distributedTest/not-a-progress-file.txt"},
+		want:  []string{},
+	},
+	"file name prefix does match dir name": {
+		files: []string{"dir/build/distributedTest/integrationTest-progress.txt"},
+		want:  []string{},
+	},
+	"progress file does not have build grandparent": {
+		files: []string{"dir/integrationTest/integrationTest-progress.txt"},
+		want:  []string{},
+	},
+}
+
+func TestProgressFileFinder(t *testing.T) {
+	for name, test := range progressFileFinderTests {
+		t.Run(name, func(t *testing.T) {
+			fsys := make(fstest.MapFS)
+			for _, path := range test.files {
+				fsys[path] = &fstest.MapFile{}
+			}
+			finder := Finder{FS: fsys, TaskMatcher: regexp.MustCompile("")}
+			got, err := finder.findInDir(".")
+			if err != nil {
+				t.Error(err)
+			}
+			d := diff(test.want, got)
+			if len(d.missing) > 0 {
+				t.Errorf("Did not find: %s", d.missing)
+			}
+			if len(d.extra) > 0 {
+				t.Errorf("Found extra: %s", d.extra)
+			}
+		})
+	}
+}
+
+type differences struct {
+	missing []string
+	extra   []string
+}
+
+func (d differences) IsEmpty() bool {
+	return len(d.missing) == 0 && len(d.extra) == 0
+}
+
+func diff(want, got []string) differences {
+	var d differences
+wants:
+	for _, w := range want {
+		for _, g := range got {
+			if g == w {
+				continue wants
+			}
+		}
+		d.missing = append(d.missing, w)
+	}
+gots:
+	for _, g := range got {
+		for _, w := range want {
+			if w == g {
+				continue gots
+			}
+		}
+		d.extra = append(d.extra, g)
+	}
+	return d
+}

--- a/dev-tools/progress/internal/progress/format.go
+++ b/dev-tools/progress/internal/progress/format.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import (
+	"io"
+	"text/template"
+)
+
+// testReport is the struct passed to the user-specified template to describe each Execution.
+type testReport struct {
+	File   string
+	Class  string
+	Method string
+	Execution
+}
+
+// FormatReporter writes each test in a Build, formatted according to a user-specified template.
+type FormatReporter struct {
+	Format *template.Template
+	Out    io.Writer
+}
+
+// Report writes each test in the Build to the stream, formatted according to the template.
+func (r FormatReporter) Report(build Build) error {
+	var test testReport
+	for path, task := range build {
+		test.File = path
+		for className, class := range task {
+			test.Class = className
+			for methodName, method := range class {
+				test.Method = methodName
+				for _, execution := range method {
+					test.Execution = execution
+					if err := r.Format.Execute(r.Out, test); err != nil {
+						return err
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/dev-tools/progress/internal/progress/json.go
+++ b/dev-tools/progress/internal/progress/json.go
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package progress
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// JSONReporter writes the JSON encoding of a Build to an output stream.
+type JSONReporter struct {
+	Out io.Writer
+}
+
+// Report writes the JSON encoding of b to the stream.
+func (r JSONReporter) Report(b Build) error {
+	e := json.NewEncoder(r.Out)
+	return e.Encode(b)
+}
+
+// parseJSONBuild reads a Build from a JSON input stream.
+func parseJSONBuild(r io.Reader) (Build, error) {
+	build := make(Build)
+	d := json.NewDecoder(r)
+	if err := d.Decode(&build); err != nil {
+		return nil, err
+	}
+	return build, nil
+}

--- a/dev-tools/progress/main.go
+++ b/dev-tools/progress/main.go
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package main
+
+import (
+	"github.com/apache/geode/dev-tools/progress/internal/cli"
+	"os"
+)
+
+func main() {
+	os.Exit(cli.Execute())
+}

--- a/gradle/rat.gradle
+++ b/gradle/rat.gradle
@@ -40,6 +40,10 @@ rat {
     '.buildinfo',
     '**/release-features.rendered', // just for jenkins
 
+    // Go
+    '**/go.mod',
+    '**/go.sum',
+
     // Geode examples
     'geode-examples/.idea/**',
     'geode-examples/gradlew*/**',
@@ -56,7 +60,7 @@ rat {
     '**/*.iml',
     '**/*.ipr',
     '**/*.iws',
-    '.idea/**',
+    '**/.idea/**',
     '**/tags',
     '**/out/**',
 


### PR DESCRIPTION
Add a `progress` tool to find, filter, and format information from Geode
test progress files.

INSTALLATION.md describes how to install the tool.

README.md gives detailed examples of how to use the tool.

Running `progress -h` concisely describes the options for finding,
filtering, and formating test results from progress files.

Authored-by: Dale Emery <demery@vmware.com>
