### PR TITLE
GEODE-9313: Allow AllowExecutionInLowMemory to be usable generically

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/SingleResultRedisFunction.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/SingleResultRedisFunction.java
@@ -23,7 +23,7 @@ import org.apache.geode.internal.cache.execute.RegionFunctionContextImpl;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
 
-public abstract class SingleResultRedisFunction implements AllowExecutionInLowMemory {
+public abstract class SingleResultRedisFunction implements AllowExecutionInLowMemory<Object[]> {
 
   private static final long serialVersionUID = 3239452234149879302L;
   private final transient PartitionedRegion partitionedRegion;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/AllowExecutionInLowMemory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/AllowExecutionInLowMemory.java
@@ -18,6 +18,6 @@ package org.apache.geode.internal.cache.execute;
 /**
  * An internal marker interface used to allow functions to run in low-memory conditions.
  */
-public interface AllowExecutionInLowMemory extends InternalFunction<Object[]> {
+public interface AllowExecutionInLowMemory<T> extends InternalFunction<T> {
 
 }


### PR DESCRIPTION
The current implementation assumes that the function inputs are always
Object[] and don't allow for specifying them generically.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
