### PR TITLE
GEODE-9314: Redis CLUSTER NODES incorrect when primary buckets are moving

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/cluster/ClusterSlotsAndNodesDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/cluster/ClusterSlotsAndNodesDUnitTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.assertj.core.data.Offset;
 import org.junit.After;
-import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -63,24 +63,28 @@ public class ClusterSlotsAndNodesDUnitTest {
   private static Jedis jedis1;
   private static Jedis jedis2;
   private static JedisCluster jedisCluster;
+  private static int redisServerPort1;
+  private static int redisServerPort2;
 
   @BeforeClass
   public static void classSetup() {
     locator = cluster.startLocatorVM(0);
     server1 = cluster.startRedisVM(1, locator.getPort());
     server2 = cluster.startRedisVM(2, locator.getPort());
+  }
 
-    int redisServerPort1 = cluster.getRedisPort(1);
-    int redisServerPort2 = cluster.getRedisPort(2);
-
+  @Before
+  public void setup() {
+    redisServerPort1 = cluster.getRedisPort(1);
+    redisServerPort2 = cluster.getRedisPort(2);
     jedis1 = new Jedis(LOCAL_HOST, redisServerPort1, JEDIS_TIMEOUT);
     jedis2 = new Jedis(LOCAL_HOST, redisServerPort2, JEDIS_TIMEOUT);
 
     jedisCluster = new JedisCluster(new HostAndPort("localhost", redisServerPort1), JEDIS_TIMEOUT);
   }
 
-  @AfterClass
-  public static void teardown() {
+  @After
+  public void cleanup() {
     jedis1.close();
     jedis2.close();
     jedisCluster.close();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/SlotAdvisor.java
@@ -125,7 +125,7 @@ public class SlotAdvisor {
 
   public static class MemberBucketSlot {
     private final int bucketId;
-    private DistributedMember member;
+    private final DistributedMember member;
     private final String primaryIpAddress;
     private final int primaryPort;
     private final int slotStart;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
@@ -131,14 +131,14 @@ public class ClusterExecutor extends AbstractExecutor {
 
   private Map<String, List<Integer>> getMemberBuckets(
       List<SlotAdvisor.MemberBucketSlot> bucketSlots) {
-    Map<String, List<Integer>> result = new HashMap<>();
+    Map<String, List<Integer>> memberBuckets = new HashMap<>();
 
     for (SlotAdvisor.MemberBucketSlot mbs : bucketSlots) {
-      result.computeIfAbsent(mbs.getMember().getUniqueId(), k -> new ArrayList<>())
+      memberBuckets.computeIfAbsent(mbs.getMember().getUniqueId(), k -> new ArrayList<>())
           .add(mbs.getBucketId());
     }
 
-    return result;
+    return memberBuckets;
   }
 
   private RedisResponse getInfo(ExecutionHandlerContext ctx) {


### PR DESCRIPTION

- Node information may be reported incorrectly. Specifically, host/port
  info may end up being duplicated between nodes (in the output).

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
