### PR TITLE
GEODE-8772: WAN upgrade test port assignment

### DIFF
--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeCreateGatewaySenderMixedSiteOneCurrentSiteTwo.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeCreateGatewaySenderMixedSiteOneCurrentSiteTwo.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.wan;
 
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertTrue;
@@ -93,9 +94,9 @@ public class WANRollingUpgradeCreateGatewaySenderMixedSiteOneCurrentSiteTwo
     // Roll mixed site locator to current with jmx manager
     site1Locator.invoke(() -> stopLocator());
     VM site1RolledLocator = host.getVM(VersionManager.CURRENT_VERSION, site1Locator.getId());
-    int jmxManagerPort =
-        site1RolledLocator.invoke(() -> startLocatorWithJmxManager(site1LocatorPort,
-            site1DistributedSystemId, site1Locators, site2Locators));
+    int jmxManagerPort = getRandomAvailableTCPPort();
+    site1RolledLocator.invoke(startLocatorWithJmxManager(site1LocatorPort,
+        site1DistributedSystemId, site1Locators, site2Locators, jmxManagerPort));
 
     // Roll one mixed site server to current
     site1Server2.invoke(() -> closeCache());

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeDUnitTest.java
@@ -25,6 +25,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.REMOTE_LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertEquals;
 
@@ -52,7 +53,6 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.ForceReattemptException;
 import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.parallel.BatchRemovalThreadHelper;
@@ -62,6 +62,7 @@ import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.internal.DUnitLauncher;
@@ -106,15 +107,18 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     Locator.startLocatorAndDS(port, null, props);
   }
 
-  int startLocatorWithJmxManager(int port, int distributedSystemId, String locators,
-      String remoteLocators) throws IOException {
-    Properties props = getLocatorProperties(distributedSystemId, locators, remoteLocators);
-    int jmxPort = AvailablePortHelper.getRandomAvailableTCPPort();
-    props.put(JMX_MANAGER_PORT, String.valueOf(jmxPort));
-    props.put(JMX_MANAGER, "true");
-    props.put(JMX_MANAGER_START, "true");
-    Locator.startLocatorAndDS(port, null, props);
-    return jmxPort;
+  SerializableRunnable startLocatorWithJmxManager(int port, int distributedSystemId,
+      String locators, String remoteLocators, int jmxManagerPort) {
+    return new SerializableRunnable() {
+      @Override
+      public void run() throws Exception {
+        Properties props = getLocatorProperties(distributedSystemId, locators, remoteLocators);
+        props.put(JMX_MANAGER_PORT, String.valueOf(jmxManagerPort));
+        props.put(JMX_MANAGER, "true");
+        props.put(JMX_MANAGER_START, "true");
+        Locator.startLocatorAndDS(port, null, props);
+      }
+    };
   }
 
   private Properties getLocatorProperties(int distributedSystemId, String locators,
@@ -179,15 +183,17 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
 
     // Start and configure server 1
     server1.invoke(() -> createCache(locators));
-    server1.invoke(() -> addCacheServer());
+    int server1Port = getRandomAvailableTCPPort();
+    server1.invoke(addCacheServer(server1Port));
     server1.invoke(() -> createGatewaySender(senderId, distributedSystem, messageSyncInterval));
     server1.invoke(() -> createGatewayReceiver());
     server1.invoke(() -> createPartitionedRegion(regionName, senderId));
 
     // Start and configure server 2 if necessary
     if (server2 != null) {
+      int server2Port = getRandomAvailableTCPPort();
       server2.invoke(() -> createCache(locators));
-      server2.invoke(() -> addCacheServer());
+      server2.invoke(addCacheServer(server2Port));
       server2.invoke(() -> createGatewaySender(senderId, distributedSystem, messageSyncInterval));
       server2.invoke(() -> createGatewayReceiver());
       server2.invoke(() -> createPartitionedRegion(regionName, senderId));
@@ -262,11 +268,15 @@ public abstract class WANRollingUpgradeDUnitTest extends JUnit4CacheTestCase {
     getCache(props);
   }
 
-  private void addCacheServer() throws Exception {
-    CacheServer server = getCache().addCacheServer();
-    int port = AvailablePortHelper.getRandomAvailableTCPPort();
-    server.setPort(port);
-    server.start();
+  private SerializableRunnable addCacheServer(int port) {
+    return new SerializableRunnable() {
+      @Override
+      public void run() throws Exception {
+        CacheServer server = getCache().addCacheServer();
+        server.setPort(port);
+        server.start();
+      }
+    };
   }
 
   protected void startClient(String hostName, int locatorPort, String regionName) {


### PR DESCRIPTION
Change `WANRollingUpgradeDUnitTest` and
`WANRollingUpgradeCreateSenderGatewaySenderMixedSiteOneCurrentSiteTwo`
to assign ports only in the test JVM.

BACKGROUND

As part of my project to allow Geode tests to run in parallel outside of
Docker, I am changing our build system to allocate a distinct range of
ports to each test JVM, and changing `AvailablePort` and
`AvailablePortHelper` to honor these allocated port ranges.

This commit prepares for those changes.

PROBLEM

- `WANRollingUpgradeCreateSenderGatewaySenderMixedSiteOneCurrentSiteTwo`
  calls `startLocatorWithJmxManager()` in a child VM running a prior
  version of Geode. This method then calls `AvailablePortHelper` to get
  a JMX manager port.
- `WANRollingUpgradeDUnitTest` calls `addCacheServer()` in a child VM
  running a prior version of Geode. This method them calls
  `AvailablePortHelper` to get a server port.
- In each case, the old implementation of `AvailablePortHelper` in the
  child VM does not honor the range of ports allocated to the test.
- If these tests run in parallel outside of Docker, the old
  implementations of `AvailablePortHelper` may assign the same port
  number in each test.  If different tests try to bind to the same port
  at the same time, all but one will fail.

GENERAL SOLUTION

Make tests assign ports only in the test JVM. The test JVM always
includes the latest implementations of `AvailablePort` and
`AvailablePortHelper`, and so the tests  will honor any port allocation
scheme defined in the latest implementation.

THIS COMMIT

- Change `startLocatorWithJmxManager()` and `addCacheServer()` to be
  factory functions that take the relevant port as a parameter and
  return a `SerializableRunnable` that serializes the port and can be
  invoked in the child VM.
- Change each test to assign the relevant port in the test JVM, call the
  relevant factory method to get a runnable, and execute the runnable in
  the child VM.

In this way, all ports are assigned in the test JVM, which includes the
latest implementation of `AvailablePortHelper`, which will (after my
eventual enhancement) honor the port ranges allocated to the test JVM
and ensure that no two tests try to bind to the same port.
