### PR TITLE
tidy CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -284,7 +284,7 @@ geode-assembly/**/resources/**                                    @boglesby @kir
 #-----------------------------------------------------------------
 # Redis API
 #-----------------------------------------------------------------
-geode-apis-compatible-with-redis/**                               @sabbey37 @jdeppe-pivotal @nonbinaryprogrammer @ringles @upthewaterspout @donalevans
+geode-apis-compatible-with-redis/**                               @sabbey37 @jdeppe-pivotal @nonbinaryprogrammer @ringles @upthewaterspout @DonalEvans
 
 #-----------------------------------------------------------------
 # Build and tooling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -292,11 +292,12 @@ geode-apis-compatible-with-redis/**                               @sabbey37 @jde
 #etc/**
 *gradle*                                                          @rhoughton-pivot @onichols-pivotal
 buildSrc/**                                                       @rhoughton-pivot @jdeppe-pivotal
-buildSrc/**/DependencyConstraints.groovy                          @onichols-pivotal @dickcav
-ci/**                                                             @onichols-pivotal @dickcav
+buildSrc/**/DependencyConstraints.groovy                          @onichols-pivotal @dickcav @rhoughton-pivot
+ci/**                                                             @onichols-pivotal @dickcav @rhoughton-pivot
 ci/scripts/**                                                     @onichols-pivotal @dickcav @rhoughton-pivot
 ci/scripts/repeat-new-tests.sh                                    @onichols-pivotal @dickcav @rhoughton-pivot @upthewaterspout @jdeppe-pivotal
-dev-tools/**                                                      @onichols-pivotal @dickcav
+dev-tools/dependencies/**                                         @onichols-pivotal @dickcav
+dev-tools/release/**                                              @onichols-pivotal @dickcav
 docker/**                                                         @onichols-pivotal @dickcav
 geode-management/src/test/script/update-management-wiki.sh        @onichols-pivotal @dickcav
 #boms/**

--- a/CODEWATCHERS
+++ b/CODEWATCHERS
@@ -49,14 +49,12 @@ geode-core/**/org/apache/geode/**/deployment/**                   @kohlmu-pivota
 geode-deployment/**                                               @kohlmu-pivotal
 geode-core/**/org/apache/geode/cache/internal/execute/*           @kohlmu-pivotal
 
-
 #-----------------------------------------------------------------
 # Client/server messaging and cache operations
 #-----------------------------------------------------------------
 geode-core/**/org/apache/geode/cache/client/**                    @albertogpz
 geode-core/**/org/apache/geode/cache/server/**                    @albertogpz
 geode-core/**/org/apache/geode/internal/cache/tier/**             @albertogpz
-
 
 #-----------------------------------------------------------------
 # WAN messaging and queues
@@ -65,7 +63,6 @@ geode-wan/**                                                      @albertogpz @a
 geode-core/**/org/apache/geode/cache/asyncqueue/**                @albertogpz @alb3rtobr
 geode-core/**/org/apache/geode/cache/wan/**                       @albertogpz @alb3rtobr
 geode-core/**/org/apache/geode/internal/cache/wan/**              @albertogpz @alb3rtobr
-
 
 #-----------------------------------------------------------------
 # Metrics & Statistics
@@ -84,3 +81,8 @@ geode-core/**/org/apache/geode/cache/query/**                     @mkevo
 # Misc
 #-----------------------------------------------------------------
 geode-core/**/org/apache/geode/internal/cache/properties.md       @alb3rtobr
+
+#-----------------------------------------------------------------
+# Build and tooling
+#-----------------------------------------------------------------
+dev-tools/release/**                                              @demery-pivotal


### PR DESCRIPTION
* for consistency use canonical usernames throughout
* clean up overly-broad rule now that dev-tools has more in it
* add Robert for more ci ownership