### PR TITLE
GEODE-8772: Disable HTTP service in Client Server TX test

### DIFF
--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverWithMixedVersionServersDistributedTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverWithMixedVersionServersDistributedTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache;
 
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_NETWORK_PARTITION_DETECTION;
+import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
@@ -185,6 +186,7 @@ public class ClientServerTransactionFailoverWithMixedVersionServersDistributedTe
     config.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
     config.setProperty(ENABLE_NETWORK_PARTITION_DETECTION, "false");
     config.setProperty(USE_CLUSTER_CONFIGURATION, "false");
+    config.setProperty(HTTP_SERVICE_PORT, "0");
     return config;
   }
 


### PR DESCRIPTION
PROBLEM

`ClientServerTransactionFailoverWithMixedVersionServersDistributedTest`
launches a locator with HTTP service enabled on the default port (7070).
If these tests run in parallel outside of docker, each locator tries to
bind the HTTP service to port 7070, and all but the first will fail.

This happens even though the tests do not need the HTTP service.

THIS COMMIT

Starts the locators with HTTP service disabled.

Authored-by: Dale Emery <demery@vmware.com>
