### PR TITLE
GEODE-9309: Fix progress tool duration calc

### DIFF
--- a/dev-tools/progress/internal/progress/build.go
+++ b/dev-tools/progress/internal/progress/build.go
@@ -39,7 +39,11 @@ type Execution struct {
 	Status    string
 }
 
-// Duration returns the execution's EndTime minus its StartTime.
+// Duration returns the duration of the test execution. If the execution has no recorded end event (as indicated by the
+// "zero" end time), report its duration as 0.
 func (e Execution) Duration() time.Duration {
+	if e.EndTime.IsZero() {
+		return 0
+	}
 	return e.EndTime.Sub(e.StartTime)
 }

--- a/dev-tools/progress/internal/progress/build_test.go
+++ b/dev-tools/progress/internal/progress/build_test.go
@@ -1,0 +1,51 @@
+package progress
+
+import (
+	"testing"
+	"time"
+)
+
+func TestExecution_Duration(t *testing.T) {
+	now := time.Now()
+	shortDuration := 1 * time.Millisecond
+	longDuration := 27 * time.Hour
+
+	tests := map[string]struct {
+		start time.Time
+		end   time.Time
+		want  time.Duration
+	}{
+		"zero duration": {
+			start: now,
+			end:   now,
+			want:  0,
+		},
+		"short duration": {
+			start: now,
+			end:   now.Add(shortDuration),
+			want:  shortDuration,
+		},
+		"long duration": {
+			start: now,
+			end:   now.Add(longDuration),
+			want:  longDuration,
+		},
+		"duration is zero if end time is zero": {
+			start: now,
+			end:   time.Time{},
+			want:  0,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			execution := Execution{
+				StartTime: test.start,
+				EndTime:   test.end,
+			}
+			if got := execution.Duration(); got != test.want {
+				t.Errorf("Got duration %s, want %s", got, test.want)
+			}
+		})
+	}
+}

--- a/dev-tools/progress/internal/progress/build_test.go
+++ b/dev-tools/progress/internal/progress/build_test.go
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package progress
 
 import (


### PR DESCRIPTION
If a test has no end event, report its duration as 0 instead of
negative.

Authored-by: Dale Emery <demery@vmware.com>
