### PR TITLE
GEODE-8772: Fix ClusterComms test port conflicts

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -25,10 +25,10 @@ import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.cluster.RedisPartitionResolver;
 import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
 import org.apache.geode.redis.internal.executor.hash.RedisHashCommandsFunctionInvoker;
-import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommands;
-import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommandsFunctionInvoker;
 import org.apache.geode.redis.internal.executor.set.RedisSetCommands;
 import org.apache.geode.redis.internal.executor.set.RedisSetCommandsFunctionInvoker;
+import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommands;
+import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommandsFunctionInvoker;
 
 public class RegionProvider {
   /**

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -56,8 +56,8 @@ import org.apache.geode.redis.internal.executor.CommandFunction;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.UnknownExecutor;
 import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
-import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommands;
 import org.apache.geode.redis.internal.executor.set.RedisSetCommands;
+import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommands;
 import org.apache.geode.redis.internal.pubsub.PubSub;
 import org.apache.geode.redis.internal.statistics.RedisStats;
 


### PR DESCRIPTION
Change `ClusterCommunicationsDUnitTest` to assign the locator port in
the test JVM and to not start the HTTP service.

BACKGROUND

I am working on a project to allow Geode tests to run in parallel
outside of Docker. Running in parallel outside of Docker requires tests:
- To assign ports only in the test JVM, to ensure that ports are
  assigned only by the latest implementation of `AvailablePortHelper`,
  which knows how to allocate a unique range of ports to each test.
- Not to start services using default ports, to ensure that no two tests
  try to use a default port at the same time.

This commit prepares for those changes.

PROBLEMS

`ClusterCommunicationsDUnitTest` inhibits running in parallel outside of
Docker in two ways:

- It calls `createLocator()` in child VMs running prior versions of
  Geode. The method assigns a locator port by calling
  `AvailablePortHelper`. The old implementation of `AvailablePortHelper`
  in the child VM might assign a port that is "reserved" by another
  test, resulting in bind failures.
- `createLocator()` tacitly starts the HTTP service on the default port
  (7070). If multiple tests attempt to bind to this port, some will
  experience bind failures.

THIS COMMIT

Change `ClusterCommunicationsDUnitTest` to:

- Assign the locator port in the test JVM.
- Disable the HTTP service, which the test does not need.
