### PR TITLE
GEODE-9252: Improve startup of NativeRedisClusterTestRule

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
@@ -32,6 +32,7 @@ import org.junit.rules.RuleChain;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.testcontainers.containers.DockerComposeContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
 import redis.clients.jedis.Jedis;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -81,6 +82,8 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
         // This assumes docker-compose is installed locally. Removing this line will automatically
         // pull a container containing docker-compose, but it will run slower (at least on MacOS).
         redisCluster.withLocalCompose(true);
+        redisCluster.waitingFor("redis-cluster-init_1",
+            Wait.forLogMessage(".*Ready to accept connections.*", 1));
 
         redisCluster.start();
 


### PR DESCRIPTION
- Sometimes the docker cluster startup appears to complete but cluster
  nodes reports fewer than expected primaries.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
