### PR TITLE
GEODE-4826: Use spotlessCheck, not spotlessApply, as input to srcDistTar

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -623,7 +623,7 @@ def spotlessProjects = rootProject.subprojects.findAll { subproj ->
 tasks.named('srcDistTar').configure {
   classifier 'src'
   spotlessProjects.each {spotlessProj ->
-    dependsOn {spotlessProj.tasks.named("spotlessApply")}
+    dependsOn {spotlessProj.tasks.named("spotlessCheck")}
   }
 }
 


### PR DESCRIPTION
Using spotlessApply as an input to srcDistTar allowed `build` and other
CI tasks to pass while still having style errors on the repo.

Authored-by: Robert Houghton <rhoughton@pivotal.io>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
