### PR TITLE
GEODE-9339: bump json-smart from 2.3 to 2.3.1

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -273,6 +273,11 @@
         <version>5.8.0</version>
       </dependency>
       <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+      <dependency>
         <groupId>net.openhft</groupId>
         <artifactId>compiler</artifactId>
         <version>2.4.1</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -129,6 +129,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'mysql', name: 'mysql-connector-java', version: '5.1.46')
         api(group: 'net.java.dev.jna', name: 'jna', version: '5.8.0')
         api(group: 'net.java.dev.jna', name: 'jna-platform', version: '5.8.0')
+        api(group: 'net.minidev', name: 'json-smart', version: '2.3.1')
         api(group: 'net.openhft', name: 'compiler', version: '2.4.1')
         api(group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '5.0.4')
         api(group: 'net.sourceforge.pmd', name: 'pmd-java', version: '6.33.0')


### PR DESCRIPTION
updates json-smart from 2.3 -> 2.3.1

json-smart is used by json-path, not directly by Geode