### PR TITLE
GEODE-7967: User Guide - gfsh start locator - reformat oversize table

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
@@ -120,7 +120,7 @@ start gateway-sender --id=value [--groups=value(,value)*] [--members=value(,valu
 |--------------|----------------|---------------|
 | \\-\\-id           | *Required.* ID of the GatewaySender.                      | |
 | \\-\\-groups       | Group(s) of members on which to start the Gateway Sender. | |
-| \\-\\-members      | Member(s) on which to start the Gateway Sender. | |
+| &#8209;&#8209;members      | Member(s) on which to start the Gateway Sender. | |
 | \\-\\-clean-queues | Option to clean existing queue at start of the Gateway Sender. This option is only applicable for Gateway Senders with enabled persistence. | false |
 
 **Example Commands:**
@@ -178,7 +178,7 @@ start jconsole [--interval=<seconds>] [--notile] [--version]
 |------------------|----------------|---------------|
 | \\-\\-interval   | Set the update interval to n seconds (default is 4 seconds). (Equivalent to JConsole's `-interval=n`) | 4 |
 | \\-\\-notile     | Whether to initially tile windows for two or more connections. This parameter is passed as `-notile` to JConsole. | false |
-| \\-\\-pluginpath | Directories or JAR files which are searched for JConsole plugins. The path should contain a provider-configuration file named:`META-INF/services/com.sun.tools.jconsole.JConsolePlugin` containing one line for each plugin specifying the fully qualified class name of the class implementing the `com.sun.tools.jconsole.JConsolePlugin` class. | |
+| &#8209;&#8209;pluginpath | Directories or JAR files which are searched for JConsole plugins. The path should contain a provider-configuration file named:`META-INF/services/com.sun.tools.jconsole.JConsolePlugin` containing one line for each plugin specifying the fully qualified class name of the class implementing the `com.sun.tools.jconsole.JConsolePlugin` class. | |
 | \\-\\-version    | Display the JConsole version information. This parameter is passed as `-version` to JConsole. | false |
 | \\-\\-J          | Arguments passed to the JVM on which JConsole runs | |
 
@@ -402,8 +402,8 @@ start server --name=value [--assign-buckets(=value)] [--bind-address=value]
 | \\-\\-log-level                       | Sets the level of output logged to the Cache Server log file. Possible values for log-level include: ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF. | |
 | \\-\\-mcast-address                   | The IP address or hostname used to bind the UDP socket for multi-cast networking so the Cache Server can locate other members in the <%=vars.product_name%> cluster. If mcast-port is zero, then mcast-address is ignored. | |
 | \\-\\-mcast-port                      | Sets the port used for multi-cast networking so the Cache Server can locate other members of the <%=vars.product_name%> cluster. A zero value disables mcast. | |
-| \\-\\-memcached-port                  | If specified and is non-zero, sets the port number for an embedded Gemcached server and starts the Gemcached server. | |
-| \\-\\-memcached-protocol              | Sets the protocol used by an embedded Gemcached server. Valid values are `BINARY` and `ASCII`. If you omit this property, the ASCII protocol is used. | |
+| &#8209;&#8209;memcached-port                  | If specified and is non-zero, sets the port number for an embedded Gemcached server and starts the Gemcached server. | |
+| &#8209;&#8209;memcached-protocol              | Sets the protocol used by an embedded Gemcached server. Valid values are `BINARY` and `ASCII`. If you omit this property, the ASCII protocol is used. | |
 | \\-\\-server-bind-address             | Overrides the `bind-address` on which this server will listen for client connections. Set this option in a multi-homed server environment to distinguish communications from clients. Setting a value of the empty string (&quot;&quot;) uses the value of `bind-address`. | value of `bind-address` |
 | \\-\\-server-port                     | Port the Server will listen on for client connections. | 40404 |
 | \\-\\-spring-xml-location             | Specifies the location of a Spring XML configuration file(s) for bootstrapping and configuring a <%=vars.product_name%> Server. This configuration file can exist on the CLASSPATH (default) or any location supported by Spring's Resource(Loader) location specifiers (for example, classpath:, file:, etc).<br/>ResourceLoader is described in the <a href="http://docs.spring.io/spring/docs/4.0.9.RELEASE/spring-framework-reference/htmlsingle/#resources-resourceloader">Spring documentation</a>. | |

--- a/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/start.html.md.erb
@@ -64,10 +64,10 @@ start gateway-receiver [--groups=value(,value)*] [--members=value(,value)*]
 ```
 **Parameters, start gateway-receiver**
 
-| Name                                           | Description                                                      |
-|------------------------------------------------|------------------------------------------------------------------|
-| <span class="keyword parmname">\\-\\-members</span> | Name or ID of the member(s) on which to start the Gateway Receiver. |
-| <span class="keyword parmname">\\-\\-groups</span>  | Group(s) of members on which to start the Gateway Receiver.      |
+| Name          | Description                                                         |
+|---------------|---------------------------------------------------------------------|
+| \\-\\-members | Name or ID of the member(s) on which to start the Gateway Receiver. |
+| \\-\\-groups  | Group(s) of members on which to start the Gateway Receiver.         |
 
 
 **Example Commands:**
@@ -116,12 +116,13 @@ start gateway-sender --id=value [--groups=value(,value)*] [--members=value(,valu
 ```
 **Parameters, start gateway-sender**
 
-| Name                                           | Description                                               | Default  |
-|------------------------------------------------|-----------------------------------------------------------|          |
-| <span class="keyword parmname">\\-\\-id</span>     | *Required.* ID of the GatewaySender.                      |          |
-| <span class="keyword parmname">\\-\\-groups</span>  | Group(s) of members on which to start the Gateway Sender. |          |
-| <span class="keyword parmname">\\-\\-members</span> | Member(s) on which to start the Gateway Sender                   |          |
-| <span class="keyword parmname">\\-\\-clean-queues</span> | Option to clean existing queue at start of the Gateway Sender. This option is only applicable for Gateway Senders with enabled persistence.  | false   |
+| Name         | Description    | Default Value |
+|--------------|----------------|---------------|
+| \\-\\-id           | *Required.* ID of the GatewaySender.                      | |
+| \\-\\-groups       | Group(s) of members on which to start the Gateway Sender. | |
+| \\-\\-members      | Member(s) on which to start the Gateway Sender. | |
+| \\-\\-clean-queues | Option to clean existing queue at start of the Gateway Sender. This option is only applicable for Gateway Senders with enabled persistence. | false |
+
 **Example Commands:**
 
 ``` pre
@@ -173,13 +174,13 @@ start jconsole [--interval=<seconds>] [--notile] [--version]
 
 **Parameters, start jconsole**
 
-| Name         | Description    | Default Value |
-|--------------|----------------|---------------|
-| <span class="keyword parmname">\\-\\-interval</span>   | Set the update interval to n seconds (default is 4 seconds). (Equivalent to JConsole's `-interval=n`) | 4             |
-| <span class="keyword parmname">\\-\\-notile</span>     | Whether to initially tile windows for two or more connections. This parameter is passed as `-notile` to JConsole. | false         |
-| <span class="keyword parmname">&#8209;&#8209;pluginpath</span> | Directories or JAR files which are searched for JConsole plugins. The path should contain a provider-configuration file named:`META-INF/services/com.sun.tools.jconsole.JConsolePlugin` containing one line for each plugin specifying the fully qualified class name of the class implementing the `com.sun.tools.jconsole.JConsolePlugin` class. |               |
-| <span class="keyword parmname">\\-\\-version</span>    | Display the JConsole version information. This parameter is passed as `-version` to JConsole. | false         |
-| <span class="keyword parmname">\\-\\-J</span>          | Arguments passed to the JVM on which JConsole runs |               |
+| Name             | Description    | Default Value |
+|------------------|----------------|---------------|
+| \\-\\-interval   | Set the update interval to n seconds (default is 4 seconds). (Equivalent to JConsole's `-interval=n`) | 4 |
+| \\-\\-notile     | Whether to initially tile windows for two or more connections. This parameter is passed as `-notile` to JConsole. | false |
+| \\-\\-pluginpath | Directories or JAR files which are searched for JConsole plugins. The path should contain a provider-configuration file named:`META-INF/services/com.sun.tools.jconsole.JConsolePlugin` containing one line for each plugin specifying the fully qualified class name of the class implementing the `com.sun.tools.jconsole.JConsolePlugin` class. | |
+| \\-\\-version    | Display the JConsole version information. This parameter is passed as `-version` to JConsole. | false |
+| \\-\\-J          | Arguments passed to the JVM on which JConsole runs | |
 
 **Example Commands:**
 
@@ -236,7 +237,7 @@ start jvisualvm [--J=value(,value)*]
 
 | Name       | Description |
 |------------|-------------|
-| <span class="keyword parmname">\\-\\-J</span> | VM-option passed to the spawned CacheServer VM. For example: `--J=-Dfoo.bar=true` for setting foo.bar to 'true'. |
+| \\-\\-J    | VM-option passed to the spawned CacheServer VM.<br/>For example: `--J=-Dfoo.bar=true` for setting foo.bar to 'true'. |
 
 **Example Commands:**
 
@@ -277,157 +278,33 @@ start locator --name=value [--bind-address=value] [--force(=value)]
 
 **Parameters, start locator**
 
-<table>
-<colgroup>
-<col width="33%" />
-<col width="33%" />
-<col width="33%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Name</th>
-<th>Description</th>
-<th>Default Value</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><span class="keyword parmname">\-\-name</span></td>
-<td>Name to be used for this <%=vars.product_name%> locator service. If not specified, gfsh generates a random name.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-bind-address</span></td>
-<td>IP address on which the locator will be bound.</td>
-<td>bind to all addresses</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-force</span></td>
-<td>Whether to allow the PID file from a previous locator run to be overwritten.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-groups</span></td>
-<td>Group(s) the locator will be a part of.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-hostname-for-clients</span></td>
-<td>Host name or IP address that will be sent to clients so they can connect to this locator.</td>
-<td>uses <code>bind-address</code></td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-classpath</span></td>
-<td>Application classes to be added to the locator's CLASSPATH after the core jar file. See <a href="../../../getting_started/setup_classpath.html">Setting Up the CLASSPATH</a> for details.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-locators</span></td>
-<td>List of locators used by this locator to join the appropriate <%=vars.product_name%> cluster.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-log-level</span></td>
-<td>Level of output logged to the locator log file. Possible values for log-level include: ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-mcast-address </span></td>
-<td>IP address or hostname used to bind the UPD socket for multi-cast networking so the locator can locate other members in the <%=vars.product_name%> cluster. If mcast-port is zero, then mcast-address is ignored.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-mcast-port</span></td>
-<td>Port used for multi-cast networking so the locator can locate other members of the <%=vars.product_name%> cluster. A zero value disables mcast.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-port</span></td>
-<td>Port the locator will listen on.</td>
-<td>10334</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-dir</span></td>
-<td>Directory in which the Locator will be started and run.</td>
-<td><span class="ph filepath">./&lt;locator-member-name&gt;</span></td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-properties-file</span></td>
-<td>Specify the <code class="ph codeph">gemfire.properties</code> file for configuring the locator's cluster. The file's path should be absolute or relative to gfsh's working directory.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-security-properties-file</span></td>
-<td>The <span class="ph filepath">gfsecurity.properties</span> file for configuring the Locator's security configuration in the cluster. The file's path can be absolute or relative to gfsh's working directory.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-initial-heap</span></td>
-<td>Size has the same format as the <code class="ph codeph">-Xmx</code>/<code class="ph codeph">-Xms</code> JVM options.
-<div class="note note">
-<b>Note:</b> If you use the <code class="ph codeph">-J-Xms</code> and <code class="ph codeph">-J-Xmx</code> JVM properties instead of <code class="ph codeph">-initial-heap</code> and <code class="ph codeph">-max-heap</code>, then <%=vars.product_name%> does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.
-</div></td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-max-heap</span></td>
-<td>Size has the same format as the <code class="ph codeph">-Xmx</code>/<code class="ph codeph">-Xms</code> JVM options
-<div class="note note">
-<b>Note:</b> If you use the <code class="ph codeph">-J-Xms</code> and <code class="ph codeph">-J-Xmx</code> JVM properties instead of <code class="ph codeph">-initial-heap</code> and <code class="ph codeph">-max-heap</code>, then <%=vars.product_name%> does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.<br/>
-<b>Note:</b> The additional GC parameters introduced by the <code class="ph codeph">-max-heap</code> option are not compatible with the usage of G1 garbage collector.
-</div></td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-connect</span></td>
-<td>When connect is set to false, gfsh does not automatically connect to the locator which is started using this command.</td>
-<td>true</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-enable-cluster-configuration</span></td>
-<td>Enables cluster configuration behavior where locators maintain configurations for all members of the cluster. 
-See <a href="../../../configuring/cluster_config/gfsh_persist.html">Overview of the Cluster Configuration Service</a>.</td>
-<td>true</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-load-cluster-configuration-from-dir</span></td>
-<td><b>Deprecated. Use <code>gfsh import cluster-configuration</code> for this functionality.</b> Loads the cluster configuration from the <span class="ph filepath">shared-config</span> directory. (When set to false, the configuration is loaded from the disk store of the internal, persistent region used by the locator to persist the configuration.)</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-cluster-config-dir</span></td>
-<td>Directory used by the cluster configuration service to store the cluster configuration on the filesystem</td>
-<td>cluster-config</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-redirect-output</span></td>
-<td>When true, redirect standard output and standard error to the locator log file. If specified without a value, the value is set to true.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-http-service-port</span></td>
-<td>Specifies the HTTP service port.</td>
-<td>7070</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-http-service-bind-address</span></td>
-<td>Specifies the IP address to which the HTTP service will be bound.
-</td>
-<td>the local host machine's address</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-J </span></td>
-<td>Argument passed to the JVM on which the Locator will run. For example, specifying <code class="ph codeph">--J=-Dfoo.bar=true</code> sets property &quot;foo.bar&quot; to &quot;true&quot;.
-<div class="note note">
-<b>Note:</b>
-<p>If the argument you are passing contains spaces or commas, enclose the option in single quotes. For example:</p>
-<pre class="pre codeblock"><code>start locator --name=locator1 --port=9009 --mcast-port=0\
---J=&#39;-Dgemfire.remote-locators=192.0.2.0[9009],192.0.2.1[9009]&#39;</code></pre>
-</div></td>
-<td>none</td>
-</tr>
-</tbody>
-</table>
+| Name         | Description    | Default Value |
+|--------------|----------------|---------------|
+| \\-\\-name                                | Name to be used for this <%=vars.product_name%> locator service. If not specified, gfsh generates a random name. | |
+| \\-\\-bind-address                        | IP address on which the locator will be bound. | bind to all addresses |
+| \\-\\-force                               | Whether to allow the PID file from a previous locator run to be overwritten. | false |
+| \\-\\-groups                              | Group(s) the locator will be a part of. | |
+| \\-\\-hostname-for-clients                | Host name or IP address that will be sent to clients so they can connect to this locator. | uses `bind-address` |
+| \\-\\-classpath                           | Application classes to be added to the locator's CLASSPATH after the core jar file. See <a href="../../../getting_started/setup_classpath.html">Setting Up the CLASSPATH</a> for details. | |
+| \\-\\-locators                            | List of locators used by this locator to join the appropriate <%=vars.product_name%> cluster. | |
+| \\-\\-log-level                           | Level of output logged to the locator log file. Possible values for log-level include: ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF. | |
+| \\-\\-mcast-address                       | IP address or hostname used to bind the UPD socket for multi-cast networking so the locator can locate other members in the <%=vars.product_name%> cluster. If mcast-port is zero, then mcast-address is ignored. | |
+| \\-\\-mcast-port                          | Port used for multi-cast networking so the locator can locate other members of the <%=vars.product_name%> cluster. A zero value disables mcast. | |
+| \\-\\-port                                | Port the locator will listen on. | 10334 |
+| \\-\\-dir                                 | Directory in which the Locator will be started and run. | `./&lt;locator-member-name&gt;` |
+| \\-\\-properties-file                     | Specify the `gemfire.properties` file for configuring the locator's cluster. The file's path should be absolute or relative to gfsh's working directory. | |
+| \\-\\-security-properties-file            | The `gfsecurity.properties` file for configuring the Locator's security configuration in the cluster. The file's path can be absolute or relative to gfsh's working directory. | |
+| \\-\\-initial-heap                        | Size has the same format as the `-Xmx`/`-Xms` JVM options. <p><b>Note:</b> If you use the `-J-Xms` and `-J-Xmx` JVM properties instead of `-initial-heap` and `-max-heap`, then <%=vars.product_name%> does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.</p> | |
+| \\-\\-max-heap                            | Size has the same format as the `-Xmx`/`-Xms` JVM options. <p><b>Note:</b> If you use the `-J-Xms` and `-J-Xmx` JVM properties instead of `-initial-heap` and `-max-heap`, then <%=vars.product_name%> does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.</p><p><b>Note:</b> The additional GC parameters introduced by the `-max-heap` option are not compatible with the usage of G1 garbage collector.</p> | |
+| \\-\\-connect                             | When connect is set to false, gfsh does not automatically connect to the locator which is started using this command. | true |
+| \\-\\-enable-cluster-configuration        | Enables cluster configuration behavior where locators maintain configurations for all members of the cluster.<br/>See <a href="../../../configuring/cluster_config/gfsh_persist.html">Overview of the Cluster Configuration Service</a>. | true |
+| \\-\\-load-cluster-configuration-from-dir | <b>Deprecated. Use `gfsh import cluster-configuration` for this functionality.</b><br/> Loads the cluster configuration from the `shared-config` directory. (When set to false, the configuration is loaded from the disk store of the internal, persistent region used by the locator to persist the configuration.) | false |
+| \\-\\-cluster-config-dir                  | Directory used by the cluster configuration service to store the cluster configuration on the filesystem | cluster-config |
+| \\-\\-redirect-output                     | When true, redirect standard output and standard error to the locator log file. If specified without a value, the value is set to true. | false |
+| \\-\\-http-service-port                   | Specifies the HTTP service port. | 7070 |
+| \\-\\-http-service-bind-address           | Specifies the IP address to which the HTTP service will be bound. | the local host machine's address |
+| \\-\\-J                                   | Argument passed to the JVM on which the Locator will run. For example, specifying `--J=-Dfoo.bar=true` sets property &quot;foo.bar&quot; to &quot;true&quot;.<p><b>Note:</b> If the argument you are passing contains spaces or commas, enclose the option in single quotes. For example:<br/>`start locator --name=locator1 --port=9009 --mcast-port=0 --J='-Dgemfire.remote-locators=192.0.2.0[9009],192.0.2.1[9009]'`</p> | none |
+
 
 **Example Commands:**
 
@@ -451,9 +328,9 @@ start pulse [--url=value]
 
 **Parameters, start pulse**
 
-| Name                                        | Description                      | Default                       |
-|---------------------------------------------|----------------------------------|-------------------------------|
-| <span class="keyword parmname">\\-\\-url</span> | URL of the Pulse Web application | `http://localhost:7070/pulse` |
+| Name         | Description    | Default Value |
+|--------------|----------------|---------------|
+| \\-\\-url    | URL of the Pulse Web application | `http://localhost:7070/pulse` |
 
 **Example Commands:**
 
@@ -462,13 +339,18 @@ start pulse
 start pulse --url=http://gemfire.example.com:7070/pulse
 ```
 
-**Sample Output:** See [<%=vars.product_name%> Pulse](../../pulse/pulse-overview.html) for examples of Pulse.
+**Sample Output:**
+
+```
+Launched Geode Pulse
+```
+
 
 ## <a id="topic_3764EE2DB18B4AE4A625E0354471738A" class="no-quick-link"></a>start server
 
 Start a <%=vars.product_name%> cache server process.
 
-**Note:** When both <span class="keyword parmname">\\-\\-max-heap</span> and <span class="keyword parmname">\\-\\-initial-heap</span> are specified during server startup, additional GC parameters are specified on your behalf. If you do not want the additional default GC properties set, then use the `-Xms` and `-Xmx` JVM options to set just these parameters. See [Controlling Heap Use with the Resource Manager](../../../managing/heap_use/heap_management.html#configuring_resource_manager) for more information.
+**Note:** When both `--max-heap` and `--initial-heap` are specified during server startup, additional GC parameters are specified on your behalf. If you do not want the additional default GC properties set, then use the `-Xms` and `-Xmx` JVM options to set just these parameters. See [Controlling Heap Use with the Resource Manager](../../../managing/heap_use/heap_management.html#configuring_resource_manager) for more information.
 
 **Note:** The additional GC parameters introduced by the `--max-heap` option are not compatible with the usage of G1 garbage collector.
 
@@ -500,286 +382,56 @@ start server --name=value [--assign-buckets(=value)] [--bind-address=value]
 
 **Parameters, start server**
 
-<table>
-<colgroup>
-<col width="33%" />
-<col width="33%" />
-<col width="33%" />
-</colgroup>
-<thead>
-<tr class="header">
-<th>Name</th>
-<th>Description</th>
-<th>Default Value</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td><span class="keyword parmname">\-\-name</span></td>
-<td>Member name for this server. If not specified, gfsh generates a random name.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-assign-buckets</span></td>
-<td>Whether to assign buckets to the partitioned regions of the cache on server start.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-bind-address</span></td>
-<td>The IP address on which the server will be bound.</td>
-<td>binds to all local addresses</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-cache-xml-file</span></td>
-<td>Specifies the name of the XML file or resource to initialize the cache with when it is created.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-classpath</span></td>
-<td>Application classes to be added to the server's CLASSPATH after the core jar file. See <a href="../../../getting_started/setup_classpath.html">Setting Up the CLASSPATH</a> for details.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-include-system-classpath</span></td>
-<td>When true, include the System CLASSPATH on the Server's CLASSPATH, as the System CLASSPATH is not included by default. If specified without a value, the value is set to true.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-disable-default-server</span></td>
-<td>Whether the cache server will be started by default. If the parameter is specified without a value, the value is set to true. If set to true, the cache server acts as a peer.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-disable-exit-when-out-of-memory</span></td>
-<td>Prevents the JVM from exiting when an OutOfMemoryError occurs.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-enable-time-statistics</span></td>
-<td>Causes additional time-based statistics to be gathered for <%=vars.product_name%> operations.</td>
-<td>true</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-properties-file</span></td>
-<td>The <span class="ph filepath">gemfire.properties</span> file for configuring the server's cluster. The file's path can be absolute or relative to the gfsh working directory.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-security-properties-file</span></td>
-<td>The <span class="ph filepath">gfsecurity.properties</span> file for configuring the server's security configuration in the cluster. The file's path can be absolute or relative to gfsh directory.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-groups</span></td>
-<td>Group(s) the Cache Server will be a part of.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-force</span></td>
-<td>Whether to allow the PID file from a previous Cache Server run to be overwritten.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-locators </span></td>
-<td>Sets the list of locators used by the Cache Server to join the appropriate <%=vars.product_name%> cluster.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-locator-wait-time</span></td>
-<td>Sets the number of seconds the server will wait for a locator to become available during startup before giving up.</td>
-<td>0</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-log-level</span></td>
-<td>Sets the level of output logged to the Cache Server log file. Possible values for log-level include: ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-mcast-address</span></td>
-<td>The IP address or hostname used to bind the UDP socket for multi-cast networking so the Cache Server can locate other members in the <%=vars.product_name%> cluster. If mcast-port is zero, then mcast-address is ignored.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-mcast-port</span></td>
-<td>Sets the port used for multi-cast networking so the Cache Server can locate other members of the <%=vars.product_name%> cluster. A zero value disables mcast.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-memcached-port</span></td>
-<td>If specified and is non-zero, sets the port number for an embedded Gemcached server and starts the Gemcached server.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-memcached-protocol</span></td>
-<td>Sets the protocol used by an embedded Gemcached server. Valid values are <code class="ph codeph">BINARY</code> and <code class="ph codeph">ASCII.</code> If you omit this property, the ASCII protocol is used.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-server-bind-address</span></td>
-<td>Overrides the <code>bind-address</code> on which this server will listen for client connections. Set this option in a multi-homed server environment to distinguish communications from clients. Setting a value of the empty string (&quot;&quot;) uses the value of <code>bind-address</code>.</td>
-<td>value of <code>bind-address</code></td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-server-port</span></td>
-<td>Port the Server will listen on for client connections.</td>
-<td>40404</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-spring-xml-location</span></td>
-<td>Specifies the location of a Spring XML configuration file(s) for bootstrapping and configuring a <%=vars.product_name%> Server. This configuration file can exist on the CLASSPATH (default) or any location supported by Spring's Resource(Loader) location specifiers (for example, classpath:, file:, etc). ResourceLoader is described in the 
-<a href="http://docs.spring.io/spring/docs/4.0.9.RELEASE/spring-framework-reference/htmlsingle/#resources-resourceloader">Spring documentation</a>.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-rebalance</span></td>
-<td>Whether to initiate rebalancing across the <%=vars.product_name%> cluster.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-dir</span></td>
-<td>Specify the directory in which the server will run in. This directory is written to the location where you started <code class="ph codeph">gfsh</code>.</td>
-<td>If not specified, the directory is named after the server.</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-statistic-archive-file </span></td>
-<td>The file that statistic samples are written to. For example: &quot;StatisticsArchiveFile.gfs&quot;. Must be defined to store the archiving to a file. An empty string (default) disables statistic archival.</td>
-<td><em>not set</em></td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-initial-heap</span></td>
-<td>Initial size of the heap in the same format as the JVM -Xms parameter.
-<div class="note note">
-<b>Note:</b> If you use the <code class="ph codeph">--J=-Xms</code> and <code class="ph codeph">--J=-Xmx</code> JVM properties instead of <code class="ph codeph">--initial-heap</code> and <code class="ph codeph">--max-heap</code>, then <%=vars.product_name%> does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.
-</div></td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-max-heap</span></td>
-<td>Maximum size of the heap in the same format as the JVM -Xmx parameter.
-<div class="note note">
-<b>Note:</b> If you use the <code class="ph codeph">--J=-Xms</code> and <code class="ph codeph">--J=-Xmx</code> JVM properties instead of <code class="ph codeph">--initial-heap</code> and <code class="ph codeph">--max-heap</code>, then <%=vars.product_name%> does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.<br/>
-<b>Note:</b> The additional GC parameters introduced by the <code class="ph codeph">-max-heap</code> option are not compatible with the usage of G1 garbage collector.
-</div></td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-J</span></td>
-<td>Argument passed to the JVM on which the Cache Server will run. For example, <code class="ph codeph">--J=-Dfoo.bar=true</code> will set the property &quot;foo.bar&quot; to &quot;true&quot;.
-<p>If the argument you are passing contains spaces or commas, enclose the option in single quotes.</p></td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-use-cluster-configuration</span></td>
-<td>Specifies whether the server requests a cluster configuration from the locator. 
-See <a href="../../../configuring/cluster_config/gfsh_persist.html">Overview of the Cluster Configuration Service</a>.</td>
-<td>true</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-critical-heap-percentage</span></td>
-<td>Set the percentage of heap at or above which the cache is considered in danger of becoming inoperable due to garbage collection pauses or out of memory exceptions. Past the threshold, operations that require heap space will throw a <code class="ph codeph">LowMemoryException</code>. This feature requires additional VM flags to perform properly; you must set <code class="ph codeph">--initial-heap</code> and <code class="ph codeph">--max-heap</code> or the corresponding JVM properties to use this threshold. You must also set <code class="ph codeph">--max-heap</code> and <code class="ph codeph">--initial-heap</code> to the same value.</td>
-<td>0 (no critical heap threshold enforced)</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-critical-off-heap-percentage</span></td>
-<td>The percentage of off-heap memory used at or above which the cache is considered in danger of becoming inoperable due to out of memory exceptions. Past the threshold, operations that require heap space will throw a <code class="ph codeph">LowMemoryException</code>.</td>
-<td>0 (no critical off-heap threshold enforced)</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-eviction-heap-percentage</span></td>
-<td>Set the percentage of heap at or above which the eviction should begin on Regions configured for HeapLRU eviction. Changing this value may cause eviction to begin immediately. Only one change to this attribute or critical heap percentage will be allowed at any given time and its effect will be fully realized before the next change is allowed. This feature requires additional VM flags to perform properly; you must set <code class="ph codeph">--initial-heap</code> and <code class="ph codeph">--max-heap</code> or the corresponding JVM properties to use this threshold. You must also set <code class="ph codeph">--max-heap</code> and <code class="ph codeph">--initial-heap</code> to the same value.</td>
-<td><ul>
-<li>0, if no region is configured with heap eviction</li>
-<li>If <code class="ph codeph">critical-heap-percentage</code> is set to a non-zero value, 5% less than that value.</li>
-<li>80%, if <code class="ph codeph">critical-heap-percentage</code> is not configured.</li>
-</ul></td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-eviction-off-heap-percentage</span></td>
-<td>The percentage of off-heap memory used at or above which the eviction should begin on regions configured for off-heap and HeapLRU eviction. Changing this value may cause eviction to begin immediately. Only one change to this attribute or critical off-heap percentage will be allowed at any given time, and its effect will be fully realized before the next change is allowed.</td>
-<td><ul>
-<li>0, if no region is configured with heap eviction</li>
-<li>If <code class="ph codeph">critical-off-heap-percentage</code> is set to a non-zero value, 5% less than that value.</li>
-<li>80%, if <code class="ph codeph">critical-off-heap-percentage</code> is not configured.</li>
-</ul></td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-hostname-for-clients</span></td>
-<td>Sets the IP address or host name that a locator will provide to clients. Clients use the address to connect to a server. Set this value when clients use a different address to connect with the server than the <code>bind-address</code>, as those clients might with servers in a private cloud or multi-homed environment. Not specifying this option or setting this option to the empty string (&quot;&quot;) causes the <code>bind-address</code> to be given to clients.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-max-connections</span></td>
-<td>Sets the maximum number of client connections allowed. When the maximum is reached the cache server will stop accepting connections</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-message-time-to-live</span></td>
-<td>Sets the time (in seconds ) after which a message in the client queue will expire.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-max-message-count</span></td>
-<td>Sets maximum number of messages that can be enqueued in a client-queue.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-max-threads</span></td>
-<td>Sets the maximum number of threads allowed in this cache server to service client requests. The default of 0 causes the cache server to dedicate a thread for every client connection. When client-server TLS/SSL is configured, values other than the default are not supported.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-socket-buffer-size</span></td>
-<td>Sets the buffer size in bytes of the socket connection for this CacheServer. The default is 32768 bytes.</td>
-<td> </td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-lock-memory</span></td>
-<td>(Linux only) When true, the member's heap and off-heap memory are locked in RAM, preventing them from being paged to disk. You must increase the related <code class="ph codeph">ulimit</code> operating system resource to allow the OS to lock memory chunks of sufficient size.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-off-heap-memory-size</span></td>
-<td>The integer quantity of off-heap memory to be used for storing region values. Specified in Gigabytes with a 'g' suffix, or Megabytes with an 'm' suffix. For example, allocate a 2 Gigabyte off-heap space with <code class="ph codeph">--off-heap-memory-size=2g</code>. The default value of 0 does not use any off-heap memory.</td>
-<td>0</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-start-rest-api</span></td>
-<td>When true, starts the REST API service.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-redirect-output</span></td>
-<td>When true, redirect standard output and standard error to the server log file. If specified without a value, the value is set to true.</td>
-<td>false</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-http-service-port</span></td>
-<td>Specifies the HTTP service port.</td>
-<td>7070</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-http-service-bind-address</span></td>
-<td>Specifies the IP address to which the HTTP service will be bound.
-</td>
-<td>the local host machine's address</td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-user</span></td>
-<td>The user name of the credential to use in authenticating to the cluster.
-When specified, if the <code>--password</code> option is not also specified,
-then <code>gfsh</code> will prompt for the password.
-</td>
-<td></td>
-</tr>
-<tr>
-<td><span class="keyword parmname">\-\-password</span></td>
-<td>The password portion of the credential to use in authenticating to
-the cluster.
-</td>
-<td></td>
-</tr>
-</tbody>
-</table>
+| Name         | Description    | Default Value |
+|--------------|----------------|---------------|
+| \\-\\-name                            | Member name for this server. If not specified, gfsh generates a random name. | |
+| \\-\\-assign-buckets                  | Whether to assign buckets to the partitioned regions of the cache on server start. | false |
+| \\-\\-bind-address                    | The IP address on which the server will be bound. | binds to all local addresses |
+| \\-\\-cache-xml-file                  | Specifies the name of the XML file or resource to initialize the cache with when it is created. | |
+| \\-\\-classpath                       | Application classes to be added to the server's CLASSPATH after the core jar file.<br/>See <a href="../../../getting_started/setup_classpath.html">Setting Up the CLASSPATH</a> for details. | |
+| \\-\\-include-system-classpath        | When true, include the System CLASSPATH on the Server's CLASSPATH, as the System CLASSPATH is not included by default. If specified without a value, the value is set to true. | false |
+| \\-\\-disable-default-server          | Whether the cache server will be started by default. If the parameter is specified without a value, the value is set to true. If set to true, the cache server acts as a peer. | false |
+| \\-\\-disable-exit-when-out-of-memory | Prevents the JVM from exiting when an OutOfMemoryError occurs. | false |
+| \\-\\-enable-time-statistics          | Causes additional time-based statistics to be gathered for <%=vars.product_name%> operations. | true |
+| \\-\\-properties-file                 | The `gemfire.properties` file for configuring the server's cluster. The file's path can be absolute or relative to the gfsh working directory. | |
+| \\-\\-security-properties-file        | The `gfsecurity.properties` file for configuring the server's security configuration in the cluster. The file's path can be absolute or relative to gfsh directory. | |
+| \\-\\-groups                          | Group(s) the Cache Server will be a part of. | |
+| \\-\\-force                           | Whether to allow the PID file from a previous Cache Server run to be overwritten. | false |
+| \\-\\-locators                        | Sets the list of locators used by the Cache Server to join the appropriate <%=vars.product_name%> cluster. | |
+| \\-\\-locator-wait-time               | Sets the number of seconds the server will wait for a locator to become available during startup before giving up. | 0 |
+| \\-\\-log-level                       | Sets the level of output logged to the Cache Server log file. Possible values for log-level include: ALL, TRACE, DEBUG, INFO, WARN, ERROR, FATAL, OFF. | |
+| \\-\\-mcast-address                   | The IP address or hostname used to bind the UDP socket for multi-cast networking so the Cache Server can locate other members in the <%=vars.product_name%> cluster. If mcast-port is zero, then mcast-address is ignored. | |
+| \\-\\-mcast-port                      | Sets the port used for multi-cast networking so the Cache Server can locate other members of the <%=vars.product_name%> cluster. A zero value disables mcast. | |
+| \\-\\-memcached-port                  | If specified and is non-zero, sets the port number for an embedded Gemcached server and starts the Gemcached server. | |
+| \\-\\-memcached-protocol              | Sets the protocol used by an embedded Gemcached server. Valid values are `BINARY` and `ASCII`. If you omit this property, the ASCII protocol is used. | |
+| \\-\\-server-bind-address             | Overrides the `bind-address` on which this server will listen for client connections. Set this option in a multi-homed server environment to distinguish communications from clients. Setting a value of the empty string (&quot;&quot;) uses the value of `bind-address`. | value of `bind-address` |
+| \\-\\-server-port                     | Port the Server will listen on for client connections. | 40404 |
+| \\-\\-spring-xml-location             | Specifies the location of a Spring XML configuration file(s) for bootstrapping and configuring a <%=vars.product_name%> Server. This configuration file can exist on the CLASSPATH (default) or any location supported by Spring's Resource(Loader) location specifiers (for example, classpath:, file:, etc).<br/>ResourceLoader is described in the <a href="http://docs.spring.io/spring/docs/4.0.9.RELEASE/spring-framework-reference/htmlsingle/#resources-resourceloader">Spring documentation</a>. | |
+| \\-\\-rebalance                       | Whether to initiate rebalancing across the <%=vars.product_name%> cluster. | false |
+| \\-\\-dir                             | Specify the directory in which the server will run in. This directory is written to the location where you started `gfsh`.| If not specified, the directory is named after the server. |
+| \\-\\-statistic-archive-file          | The file that statistic samples are written to. For example: &quot;StatisticsArchiveFile.gfs&quot;. Must be defined to store the archiving to a file. An empty string (default) disables statistic archival. | not set |
+| \\-\\-initial-heap                    | Initial size of the heap in the same format as the JVM -Xms parameter.<p><b>Note:</b> If you use the `--J=-Xms` and `--J=-Xmx` JVM properties instead of `--initial-heap` and `--max-heap`, then <%=vars.product_name%> does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.</p> | |
+| \\-\\-max-heap                        | Maximum size of the heap in the same format as the JVM -Xmx parameter.<p><b>Note:</b> If you use the `--J=-Xms` and `--J=-Xmx` JVM properties instead of `--initial-heap` and `--max-heap`, then <%=vars.product_name%> does not use default JVM resource management properties. If you use the JVM properties, you must then specify all properties manually for eviction, garbage collection, heap percentage, and so forth.</p><p><b>Note:</b> The additional GC parameters introduced by the `--max-heap` option are not compatible with the usage of G1 garbage collector.</p>| |
+| \\-\\-J                               | Argument passed to the JVM on which the Cache Server will run. For example, `--J=-Dfoo.bar=true` will set the property &quot;foo.bar&quot; to &quot;true&quot;.<p>If the argument you are passing contains spaces or commas, enclose the option in single quotes.</p> | |
+| \\-\\-use-cluster-configuration       | Specifies whether the server requests a cluster configuration from the locator.<p>See <a href="../../../configuring/cluster_config/gfsh_persist.html">Overview of the Cluster Configuration Service</a>.</p>| true |
+| \\-\\-critical-heap-percentage        | Set the percentage of heap at or above which the cache is considered in danger of becoming inoperable due to garbage collection pauses or out of memory exceptions. Past the threshold, operations that require heap space will throw a `LowMemoryException`. This feature requires additional VM flags to perform properly; you must set `--initial-heap` and `--max-heap` or the corresponding JVM properties to use this threshold. You must also set `--max-heap` and `--initial-heap` to the same value.</p>|0 (no critical heap threshold enforced)|
+| \\-\\-critical-off-heap-percentage    | The percentage of off-heap memory used at or above which the cache is considered in danger of becoming inoperable due to out of memory exceptions. Past the threshold, operations that require heap space will throw a `LowMemoryException`.|0 (no critical off-heap threshold enforced)|
+| \\-\\-eviction-heap-percentage        | Set the percentage of heap at or above which the eviction should begin on Regions configured for HeapLRU eviction. Changing this value may cause eviction to begin immediately. Only one change to this attribute or critical heap percentage will be allowed at any given time and its effect will be fully realized before the next change is allowed. This feature requires additional VM flags to perform properly; you must set `--initial-heap` and `--max-heap` or the corresponding JVM properties to use this threshold. You must also set `--max-heap` and `--initial-heap` to the same value.| <ul><li>0, if no region is configured with heap eviction</li><li>If `critical-heap-percentage` is set to a non-zero value, 5% less than that value.</li><li>80%, if `critical-heap-percentage` is not configured.</li></ul>|
+| \\-\\-eviction-off-heap-percentage    | The percentage of off-heap memory used at or above which the eviction should begin on regions configured for off-heap and HeapLRU eviction. Changing this value may cause eviction to begin immediately. Only one change to this attribute or critical off-heap percentage will be allowed at any given time, and its effect will be fully realized before the next change is allowed.|<ul><li>0, if no region is configured with heap eviction</li><li>If `critical-off-heap-percentage` is set to a non-zero value, 5% less than that value.</li><li>80%, if `critical-off-heap-percentage` is not configured.</li></ul>|
+| \\-\\-hostname-for-clients            | Sets the IP address or host name that a locator will provide to clients. Clients use the address to connect to a server. Set this value when clients use a different address to connect with the server than the `bind-address`, as those clients might with servers in a private cloud or multi-homed environment. Not specifying this option or setting this option to the empty string (&quot;&quot;) causes the `bind-address` to be given to clients.| |
+| \\-\\-max-connections                 | Sets the maximum number of client connections allowed. When the maximum is reached the cache server will stop accepting connections. | |
+| \\-\\-message-time-to-live            | Sets the time (in seconds ) after which a message in the client queue will expire. | |
+| \\-\\-max-message-count               | Sets maximum number of messages that can be enqueued in a client-queue.| |
+| \\-\\-max-threads                     | Sets the maximum number of threads allowed in this cache server to service client requests. The default of 0 causes the cache server to dedicate a thread for every client connection. When client-server TLS/SSL is configured, values other than the default are not supported. | |
+| \\-\\-socket-buffer-size              | Sets the buffer size in bytes of the socket connection for this CacheServer. The default is 32768 bytes.| |
+| \\-\\-lock-memory                     | (Linux only) When true, the member's heap and off-heap memory are locked in RAM, preventing them from being paged to disk. You must increase the related `ulimit` operating system resource to allow the OS to lock memory chunks of sufficient size.| false |
+| \\-\\-off-heap-memory-size            | The integer quantity of off-heap memory to be used for storing region values. Specified in Gigabytes with a 'g' suffix, or Megabytes with an 'm' suffix. For example, allocate a 2 Gigabyte off-heap space with `--off-heap-memory-size=2g`. The default value of 0 does not use any off-heap memory.| 0 |
+| \\-\\-start-rest-api                  | When true, starts the REST API service. | false |
+| \\-\\-redirect-output                 | When true, redirect standard output and standard error to the server log file. If specified without a value, the value is set to true. | false |
+| \\-\\-http-service-port               | Specifies the HTTP service port. | 7070 |
+| \\-\\-http-service-bind-address       | Specifies the IP address to which the HTTP service will be bound. | the local host machine's address |
+| \\-\\-user                            | The user name of the credential to use in authenticating to the cluster. When specified, if the `--password` option is not also specified, then `gfsh` will prompt for the password.| |
+| \\-\\-password                        | The password portion of the credential to use in authenticating to the cluster. | |
 
 
 ### <a id="topic_3764EE2DB18B4AE4A625E0354471738A__section_A50120613D3C4A848463236C4EFF18C7" class="no-quick-link"></a>Examples


### PR DESCRIPTION
Fix format issues in the start command page of the user guide.
`start locator` and `start server` command tables have been transformed from html to markdown format. Also, some html tags have been substituted by markdown tags.