### PR TITLE
GEODE-9344: Ignore DistributedSystemDisconnectedException in RollingUpgradeDUnitTest

### DIFF
--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
@@ -51,7 +51,6 @@ import org.apache.geode.cache.persistence.ConflictingPersistentDataException;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.distributed.DistributedSystem;
-import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionManager;
@@ -135,9 +134,9 @@ public abstract class RollingUpgradeDUnitTest extends JUnit4DistributedTestCase 
   @Override
   public void postSetUp() throws Exception {
     deleteWorkingDirFiles();
+    addIgnoredException("Abandoned because shutdown is in progress");
     addIgnoredException("cluster configuration service not available");
     addIgnoredException(ConflictingPersistentDataException.class);
-    addIgnoredException(DistributedSystemDisconnectedException.class);
   }
 
   // We start an "old" locator and old servers

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeDUnitTest.java
@@ -18,6 +18,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -46,9 +47,11 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.control.RebalanceOperation;
 import org.apache.geode.cache.control.RebalanceResults;
+import org.apache.geode.cache.persistence.ConflictingPersistentDataException;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.DistributedSystemDisconnectedException;
 import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.DistributionManager;
@@ -61,7 +64,6 @@ import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
-import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
@@ -133,8 +135,9 @@ public abstract class RollingUpgradeDUnitTest extends JUnit4DistributedTestCase 
   @Override
   public void postSetUp() throws Exception {
     deleteWorkingDirFiles();
-    IgnoredException.addIgnoredException(
-        "cluster configuration service not available|ConflictingPersistentDataException");
+    addIgnoredException("cluster configuration service not available");
+    addIgnoredException(ConflictingPersistentDataException.class);
+    addIgnoredException(DistributedSystemDisconnectedException.class);
   }
 
   // We start an "old" locator and old servers


### PR DESCRIPTION
The fix for GEODE-8609 now detects the following suspect string logged by FederatingManager just before the test bounces the JVM to upgrade it.

I believe the best fix for the following suspect string is to `addIgnoredException(DistributedSystemDisconnectedException.class)` to the setup of RollingUpgradeDUnitTest.
```
> Task :geode-core:upgradeTest

org.apache.geode.internal.cache.rollingupgrade.RollingUpgradeRollServersOnReplicatedRegion_dataserializable > testRollServersOnReplicatedRegion_dataserializable[from_v1.13.2] FAILED
    java.lang.AssertionError: Suspicious strings were written to the log during this run.
    Fix the strings or use IgnoredException.addIgnoredException to ignore.
    -----------------------------------------------------------------------
    Found suspect string in 'dunit_suspect-vm2.log' at line 780

    [fatal 2021/06/03 17:30:10.534 GMT <FederatingManager6> tid=116] Uncaught exception in thread Thread[FederatingManager6,5,RMI Runtime]
    org.apache.geode.management.ManagementException: org.apache.geode.distributed.DistributedSystemDisconnectedException: Abandoned because shutdown is in progress
      at org.apache.geode.management.internal.FederatingManager.addMemberArtifacts(FederatingManager.java:486)
      at org.apache.geode.management.internal.FederatingManager$AddMemberTask.call(FederatingManager.java:596)
      at org.apache.geode.management.internal.FederatingManager.lambda$addMember$1(FederatingManager.java:199)
      at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
      at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
      at java.base/java.lang.Thread.run(Thread.java:829)
    Caused by: org.apache.geode.distributed.DistributedSystemDisconnectedException: Abandoned because shutdown is in progress
      at org.apache.geode.internal.tcp.TCPConduit.getConnection(TCPConduit.java:866)
      at org.apache.geode.distributed.internal.direct.DirectChannel.getConnections(DirectChannel.java:465)
      at org.apache.geode.distributed.internal.direct.DirectChannel.sendToMany(DirectChannel.java:280)
      at org.apache.geode.distributed.internal.direct.DirectChannel.send(DirectChannel.java:527)
      at org.apache.geode.distributed.internal.DistributionImpl.directChannelSend(DistributionImpl.java:348)
      at org.apache.geode.distributed.internal.DistributionImpl.send(DistributionImpl.java:293)
      at org.apache.geode.distributed.internal.ClusterDistributionManager.sendViaMembershipManager(ClusterDistributionManager.java:2064)
      at org.apache.geode.distributed.internal.ClusterDistributionManager.sendOutgoing(ClusterDistributionManager.java:1991)
      at org.apache.geode.distributed.internal.ClusterDistributionManager.sendMessage(ClusterDistributionManager.java:2028)
      at org.apache.geode.distributed.internal.ClusterDistributionManager.putOutgoing(ClusterDistributionManager.java:1085)
      at org.apache.geode.internal.cache.CreateRegionProcessor.initializeRegion(CreateRegionProcessor.java:115)
      at org.apache.geode.internal.cache.DistributedRegion.getInitialImageAndRecovery(DistributedRegion.java:1164)
      at org.apache.geode.internal.cache.DistributedRegion.initialize(DistributedRegion.java:1095)
      at org.apache.geode.internal.cache.GemFireCacheImpl.createVMRegion(GemFireCacheImpl.java:3108)
      at org.apache.geode.internal.cache.InternalRegionFactory.create(InternalRegionFactory.java:78)
      at org.apache.geode.management.internal.FederatingManager.addMemberArtifacts(FederatingManager.java:429)
      ... 5 more
        at org.junit.Assert.fail(Assert.java:89)
        at org.apache.geode.test.dunit.internal.DUnitLauncher.closeAndCheckForSuspects(DUnitLauncher.java:409)
        at org.apache.geode.test.dunit.internal.DUnitLauncher.closeAndCheckForSuspects(DUnitLauncher.java:425)
        at org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase.cleanupAllVms(JUnit4DistributedTestCase.java:550)
        at org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase.doTearDownDistributedTestCase(JUnit4DistributedTestCase.java:497)
        at org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase.tearDownDistributedTestCase(JUnit4DistributedTestCase.java:480)
        <snip>
```