### PR TITLE
GEODE-9289: Sending JarNames to pre 1.12 members

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1982,7 +1982,7 @@ toData,17
 
 org/apache/geode/management/internal/configuration/domain/Configuration,2
 fromData,112
-toData,82
+toData,93
 
 org/apache/geode/management/internal/configuration/domain/ConfigurationChangeResult,2
 fromData,31

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/Configuration.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/Configuration.java
@@ -170,7 +170,13 @@ public class Configuration implements DataSerializable {
     DataSerializer.writeProperties(gemfireProperties, out);
     // As of 1.12, it writes a jarNames HashSet to the stream, so that pre 1.12.0 members can
     // read the jarName, and will now also write the deployment map for the post 1.12.0 members.
-    HashSet<String> jarNames = new HashSet<>(deployments.keySet());
+    HashSet<String> jarNames = new HashSet<>();
+    deployments.values().forEach(d -> {
+      String jarName;
+      if ((jarName = d.getFileName()) != null) {
+        jarNames.add(jarName);
+      }
+    });
     DataSerializer.writeHashSet(jarNames, out);
     // As of 1.12, this class starting writing the current version
     VersioningIO.writeOrdinal(out, KnownVersion.getCurrentVersion().ordinal(), true);


### PR DESCRIPTION
	* Previous fix had an error where artifact IDs were sent instead of jar file names

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
