### PR TITLE
GEODE-9070: Improve ClientServerSessionCacheDUnitTest and add additional logging

### DIFF
--- a/extensions/geode-modules/src/distributedTest/java/org/apache/geode/modules/util/ClientServerSessionCacheDUnitTest.java
+++ b/extensions/geode-modules/src/distributedTest/java/org/apache/geode/modules/util/ClientServerSessionCacheDUnitTest.java
@@ -77,8 +77,8 @@ public class ClientServerSessionCacheDUnitTest implements Serializable {
 
     client.invoke(this::startClientSessionCache);
 
-    server0.invoke(this::validateServer);
-    server1.invoke(this::validateServer);
+    server0.invoke(() -> await().untilAsserted(this::validateServer));
+    server1.invoke(() -> await().untilAsserted(this::validateServer));
   }
 
   @Test
@@ -91,7 +91,7 @@ public class ClientServerSessionCacheDUnitTest implements Serializable {
 
     client.invoke(this::startClientSessionCache);
 
-    server0.invoke(this::validateServer);
+    server0.invoke(() -> await().untilAsserted(this::validateServer));
 
     server1.invoke(this::startCacheServer);
 
@@ -106,15 +106,13 @@ public class ClientServerSessionCacheDUnitTest implements Serializable {
     final VM client = VM.getVM(2);
 
     server0.invoke(this::startCacheServer);
-
-
     server0.invoke(this::createSessionRegion);
-
+    server0.invoke(() -> await().untilAsserted(this::validateSessionRegion));
 
     client.invoke(this::startClientSessionCache);
     server1.invoke(this::startCacheServer);
 
-    server0.invoke(() -> await().untilAsserted(this::validateBootstrapped));
+    server0.invoke(() -> await().untilAsserted(this::validateServer));
     server1.invoke(() -> await().untilAsserted(this::validateBootstrapped));
 
     // server1 should not have created the session region
@@ -147,13 +145,13 @@ public class ClientServerSessionCacheDUnitTest implements Serializable {
     server0.invoke(this::createSessionRegion);
     server1.invoke(this::createSessionRegion);
 
-    server0.invoke(this::validateSessionRegion);
-    server1.invoke(this::validateSessionRegion);
+    server0.invoke(() -> await().untilAsserted(this::validateSessionRegion));
+    server1.invoke(() -> await().untilAsserted(this::validateSessionRegion));
 
     client.invoke(this::startClientSessionCache);
 
-    server0.invoke(this::validateServer);
-    server1.invoke(this::validateServer);
+    server0.invoke(() -> await().untilAsserted(this::validateServer));
+    server1.invoke(() -> await().untilAsserted(this::validateServer));
   }
 
   @Test

--- a/extensions/geode-modules/src/distributedTest/java/org/apache/geode/modules/util/ClientServerSessionCacheDUnitTest.java
+++ b/extensions/geode-modules/src/distributedTest/java/org/apache/geode/modules/util/ClientServerSessionCacheDUnitTest.java
@@ -147,6 +147,9 @@ public class ClientServerSessionCacheDUnitTest implements Serializable {
     server0.invoke(this::createSessionRegion);
     server1.invoke(this::createSessionRegion);
 
+    server0.invoke(this::validateSessionRegion);
+    server1.invoke(this::validateSessionRegion);
+
     client.invoke(this::startClientSessionCache);
 
     server0.invoke(this::validateServer);
@@ -154,7 +157,7 @@ public class ClientServerSessionCacheDUnitTest implements Serializable {
   }
 
   @Test
-  public void cantPreCreateMismatchedSessionRegionBeforeStartingClient() {
+  public void cannotPreCreateMismatchedSessionRegionBeforeStartingClient() {
     final VM server0 = VM.getVM(0);
     final VM server1 = VM.getVM(1);
     final VM client = VM.getVM(2);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -1082,16 +1082,7 @@ public class ClusterDistributionManager implements DistributionManager {
       if (observer != null) {
         observer.beforeSendMessage(this, msg);
       }
-      Set<InternalDistributedMember> membersNotSent = sendMessage(msg);
-
-      if (membersNotSent != null && !membersNotSent.isEmpty()) {
-        logger.warn(
-            "The following members: {} were not properly sent the message: {}. If unhandled this may"
-                + " cause the result processor to hang while collecting results.",
-            membersNotSent, msg.getShortClassName());
-      }
-
-      return membersNotSent;
+      return sendMessage(msg);
     } catch (NotSerializableException e) {
       throw new InternalGemFireException(e);
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ClusterDistributionManager.java
@@ -1082,7 +1082,16 @@ public class ClusterDistributionManager implements DistributionManager {
       if (observer != null) {
         observer.beforeSendMessage(this, msg);
       }
-      return sendMessage(msg);
+      Set<InternalDistributedMember> membersNotSent = sendMessage(msg);
+
+      if (membersNotSent != null && !membersNotSent.isEmpty()) {
+        logger.warn(
+            "The following members: {} were not properly sent the message: {}. If unhandled this may"
+                + " cause the result processor to hang while collecting results.",
+            membersNotSent, msg.getShortClassName());
+      }
+
+      return membersNotSent;
     } catch (NotSerializableException e) {
       throw new InternalGemFireException(e);
     }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -388,8 +388,8 @@ public class DistributionImpl implements Distribution {
 
         if (!membership.hasMember(member) || (th instanceof ShunnedMemberException)) {
           if (logger.isDebugEnabled()) {
-            logger.debug(String.format("Failed to send message <%s> to member <%s> view, %s",
-                content, member, membership.getView()), th);
+            logger.debug(String.format("Failed to send message <%s> to member <%s> no longer in view",
+                content.getShortClassName(), member), th);
           }
           continue;
         }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -386,16 +386,20 @@ public class DistributionImpl implements Distribution {
         InternalDistributedMember member = it_mem.next();
         Throwable th = it_causes.next();
 
+        if (!membership.hasMember(member) || (th instanceof ShunnedMemberException)) {
+          if (logger.isDebugEnabled()) {
+            logger.debug(String.format("Failed to send message <%s> to member <%s> view, %s",
+                content, member, membership.getView()), th);
+          }
+          continue;
+        }
+
         logger
             .fatal(String.format("Failed to send message <%s> to member <%s> view, %s",
                 // TODO - This used to be services.getJoinLeave().getView(), which is a different
                 // view object. Is it ok to log membershipManager.getView here?
                 new Object[] {content, member, membership.getView()}),
                 th);
-
-        if (!membership.hasMember(member) || (th instanceof ShunnedMemberException)) {
-          continue;
-        }
 
         // Assert.assertTrue(false, "messaging contract failure");
       }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -386,15 +386,17 @@ public class DistributionImpl implements Distribution {
         InternalDistributedMember member = it_mem.next();
         Throwable th = it_causes.next();
 
-        if (!membership.hasMember(member) || (th instanceof ShunnedMemberException)) {
-          continue;
-        }
         logger
             .fatal(String.format("Failed to send message <%s> to member <%s> view, %s",
                 // TODO - This used to be services.getJoinLeave().getView(), which is a different
                 // view object. Is it ok to log membershipManager.getView here?
                 new Object[] {content, member, membership.getView()}),
                 th);
+
+        if (!membership.hasMember(member) || (th instanceof ShunnedMemberException)) {
+          continue;
+        }
+
         // Assert.assertTrue(false, "messaging contract failure");
       }
       return new HashSet<>(members);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -388,8 +388,9 @@ public class DistributionImpl implements Distribution {
 
         if (!membership.hasMember(member) || (th instanceof ShunnedMemberException)) {
           if (logger.isDebugEnabled()) {
-            logger.debug(String.format("Failed to send message <%s> to member <%s> no longer in view",
-                content.getShortClassName(), member), th);
+            logger
+                .debug(String.format("Failed to send message <%s> to member <%s> no longer in view",
+                    content.getShortClassName(), member), th);
           }
           continue;
         }

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionImpl.java
@@ -393,15 +393,12 @@ public class DistributionImpl implements Distribution {
           }
           continue;
         }
-
         logger
             .fatal(String.format("Failed to send message <%s> to member <%s> view, %s",
                 // TODO - This used to be services.getJoinLeave().getView(), which is a different
                 // view object. Is it ok to log membershipManager.getView here?
                 new Object[] {content, member, membership.getView()}),
                 th);
-
-        // Assert.assertTrue(false, "messaging contract failure");
       }
       return new HashSet<>(members);
     } // catch ConnectionExceptions


### PR DESCRIPTION
This issue occurs when the function tries to execute on a member that has just joined the cluster, but because the new view is not done processing by membership, the member is considered shunned and nonexistent.  This root issue will be fixed by [GEODE-9350](https://issues.apache.org/jira/projects/GEODE/issues/GEODE-9350).  

This PR just makes some small test improvements and adds additional logging to assist in diagnosing the problem if it occurs in the future.