### PR TITLE
GEODE-9362: Implement zadd with INCR option.

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZAddIncrOptionDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZAddIncrOptionDUnitTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
+
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.Region;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PartitionedRegionHelper;
+import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.data.RedisData;
+import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+public class ZAddIncrOptionDUnitTest {
+  @Rule
+  public ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  @Rule
+  public RedisClusterStartupRule clusterStartUp = new RedisClusterStartupRule(4);
+
+  private JedisCluster jedis;
+  private List<MemberVM> servers;
+  private static final String sortedSetKey = "key";
+  private final String baseMemberName = "member";
+  private final int setSize = 1000;
+  private final double increment1 = 355.681000005;
+  private final double increment2 = 9554257.921450001;
+  private final double total = increment1 + increment2;
+
+  @Before
+  public void setup() {
+    MemberVM locator = clusterStartUp.startLocatorVM(0);
+    int locatorPort = locator.getPort();
+    MemberVM server1 = clusterStartUp.startRedisVM(1, locatorPort);
+    MemberVM server2 = clusterStartUp.startRedisVM(2, locatorPort);
+    MemberVM server3 = clusterStartUp.startRedisVM(3, locatorPort);
+    servers = new ArrayList<>();
+    servers.add(server1);
+    servers.add(server2);
+    servers.add(server3);
+
+    int redisServerPort = clusterStartUp.getRedisPort(1);
+
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    jedis.close();
+  }
+
+  @Test
+  public void zAddWithIncrOptionCanAddAndIncrementScoresConcurrently() {
+    new ConcurrentLoopingThreads(setSize,
+        (i) -> doZAddIncr(i, increment1, total, true),
+        (i) -> doZAddIncr(i, increment2, total, true)).run();
+
+    assertThat(jedis.zcard(sortedSetKey)).isEqualTo(setSize);
+    verifyZScores();
+  }
+
+  private void verifyZScores() {
+    for (int i = 0; i < setSize; i++) {
+      assertThat(jedis.zscore(sortedSetKey, baseMemberName + i)).isEqualTo(total);
+    }
+  }
+
+  private void doZAddIncr(int i, double increment, double total, boolean isConcurrentExecution) {
+    Object result =
+        jedis.sendCommand(sortedSetKey, Protocol.Command.ZADD, sortedSetKey, "INCR",
+            Coder.doubleToString(increment), baseMemberName + i);
+    if (isConcurrentExecution) {
+      assertThat(Coder.bytesToDouble((byte[]) result)).isIn(increment, total);
+    } else {
+      assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(total);
+    }
+  }
+
+  @Test
+  public void zAddWithIncrOptionCanIncrementScoresAfterPrimaryShutsDown() {
+    doZAddIncrForAllMembers(increment1, increment1);
+
+    stopNodeWithPrimaryBucketOfTheKey(false);
+
+    doZCardWithRetries();
+    doZAddIncrForAllMembers(increment2, total);
+    verifyZScores();
+  }
+
+  private void doZAddIncrForAllMembers(double increment1, double increment12) {
+    for (int i = 0; i < setSize; i++) {
+      doZAddIncr(i, increment1, increment12, false);
+    }
+  }
+
+  private void doZCardWithRetries() {
+    int maxRetryAttempts = 10;
+    int retryAttempts = 0;
+    while (!zCardWithRetries(retryAttempts, maxRetryAttempts)) {
+      retryAttempts++;
+    }
+  }
+
+  private boolean zCardWithRetries(int retries, int maxRetries) {
+    long memberSize;
+    try {
+      memberSize = jedis.zcard(sortedSetKey);
+    } catch (JedisClusterMaxAttemptsException e) {
+      if (retries < maxRetries) {
+        return false;
+      }
+      throw e;
+    }
+    assertThat(memberSize).isEqualTo(setSize);
+    return true;
+  }
+
+  private boolean hitJedisClusterIssue2347 = false;
+
+  @Test
+  @Ignore("Fails due to GEODE-9310 and/or GEODE-9311")
+  public void zAddWithIncrOptionCanIncrementScoresDuringPrimaryIsCrashed() throws Exception {
+    doZAddIncrForAllMembers(increment1, increment1);
+
+    Future<Void> future1 = executor.submit(this::doZAddIncrForAllMembersDuringCrash);
+    Future<Void> future2 = executor.submit(() -> stopNodeWithPrimaryBucketOfTheKey(true));
+
+    future1.get();
+    future2.get();
+
+    if (!hitJedisClusterIssue2347) {
+      doZCardWithRetries();
+      verifyZScores();
+    }
+  }
+
+  private void doZAddIncrForAllMembersDuringCrash() {
+    for (int i = 0; i < setSize; i++) {
+      try {
+        doZAddIncr(i, increment2, total, false);
+      } catch (JedisClusterMaxAttemptsException ignore) {
+        hitJedisClusterIssue2347 = true;
+      }
+    }
+  }
+
+  private void stopNodeWithPrimaryBucketOfTheKey(boolean isCrash) {
+    boolean isPrimary;
+    for (MemberVM server : servers) {
+      isPrimary = server.invoke(ZAddIncrOptionDUnitTest::isPrimaryForKey);
+      if (isPrimary) {
+        if (isCrash) {
+          server.getVM().bounceForcibly();
+        } else {
+          server.stop();
+        }
+        return;
+      }
+    }
+  }
+
+  private static boolean isPrimaryForKey() {
+    int bucketId = getBucketId(new RedisKey(Coder.stringToBytes(sortedSetKey)));
+    return isPrimaryForBucket(bucketId);
+  }
+
+  private static int getBucketId(Object key) {
+    return PartitionedRegionHelper.getHashKey((PartitionedRegion) getDataRegion(), Operation.GET,
+        key, null, null);
+  }
+
+  private static Region<RedisKey, RedisData> getDataRegion() {
+    return ClusterStartupRule.getCache().getRegion(RegionProvider.REDIS_DATA_REGION);
+  }
+
+  private static boolean isPrimaryForBucket(int bucketId) {
+    return ((PartitionedRegion) getDataRegion()).getLocalPrimaryBucketsListTestOnly()
+        .contains(bucketId);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -35,8 +35,8 @@ fromData,14
 toData,9
 
 org/apache/geode/redis/internal/executor/sortedset/ZAddOptions,2
-fromData,17
-toData,17
+fromData,27
+toData,27
 
 org/apache/geode/redis/internal/executor/string/SetOptions,2
 fromData,27

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -59,7 +59,8 @@ public class RedisConstants {
       "Unknown subcommand or wrong number of arguments for '%s'. Try CLUSTER HELP.";
   public static final String ERROR_INVALID_ZADD_OPTION_NX_XX =
       "XX and NX options at the same time are not compatible";
-
   public static final String ERROR_UNKNOWN_PUBSUB_SUBCOMMAND =
       "Unknown subcommand or wrong number of arguments for '%s'";
+  public static final String ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR =
+      "INCR option supports a single increment-element pair";
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -36,16 +36,31 @@ class NullRedisSortedSet extends RedisSortedSet {
   }
 
   @Override
-  long zadd(Region<RedisKey, RedisData> region, RedisKey key, List<byte[]> membersToAdd,
+  Object zadd(Region<RedisKey, RedisData> region, RedisKey key, List<byte[]> membersToAdd,
       ZAddOptions options) {
     if (options.isXX()) {
+      if (options.isINCR()) {
+        return null;
+      }
       return 0L;
+    }
+
+    if (options.isINCR()) {
+      return zaddIncr(region, key, membersToAdd);
     }
 
     RedisSortedSet sortedSet = new RedisSortedSet(membersToAdd);
     region.create(key, sortedSet);
 
     return sortedSet.getSortedSetSize();
+  }
+
+  private Object zaddIncr(Region<RedisKey, RedisData> region, RedisKey key,
+      List<byte[]> membersToAdd) {
+    // for zadd incr option, only one incrementing element pair is allowed to get here.
+    byte[] increment = membersToAdd.get(0);
+    byte[] member = membersToAdd.get(1);
+    return zincrby(region, key, increment, member);
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -184,10 +184,13 @@ public class RedisSortedSet extends AbstractRedisData {
    * @param region the region this instance is stored in
    * @param key the name of the set to add to
    * @param membersToAdd members to add to this set; NOTE this list may by modified by this call
-   * @return the number of members actually added
+   * @return the number of members actually added OR incremented value if INCR option specified
    */
-  long zadd(Region<RedisKey, RedisData> region, RedisKey key, List<byte[]> membersToAdd,
+  Object zadd(Region<RedisKey, RedisData> region, RedisKey key, List<byte[]> membersToAdd,
       ZAddOptions options) {
+    if (options.isINCR()) {
+      return zaddIncr(region, key, membersToAdd, options);
+    }
     AddsDeltaInfo deltaInfo = null;
     Iterator<byte[]> iterator = membersToAdd.iterator();
     int initialSize = getSortedSetSize();
@@ -216,6 +219,20 @@ public class RedisSortedSet extends AbstractRedisData {
 
     storeChanges(region, key, deltaInfo);
     return getSortedSetSize() - initialSize + changesCount;
+  }
+
+  private byte[] zaddIncr(Region<RedisKey, RedisData> region, RedisKey key,
+      List<byte[]> membersToAdd, ZAddOptions options) {
+    // for zadd incr option, only one incrementing element pair is allowed to get here.
+    byte[] increment = membersToAdd.get(0);
+    byte[] member = membersToAdd.get(1);
+    if (options.isNX() && members.containsKey(member)) {
+      return null;
+    }
+    if (options.isXX() && !members.containsKey(member)) {
+      return null;
+    }
+    return zincrby(region, key, increment, member);
   }
 
   byte[] zscore(byte[] member) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -35,7 +35,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
-  public long zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options) {
+  public Object zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options) {
     return stripedExecute(key,
         () -> getRedisSortedSet(key, false).zadd(getRegion(), key, scoresAndMembersToAdd, options));
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -21,7 +21,7 @@ import org.apache.geode.redis.internal.data.RedisKey;
 
 public interface RedisSortedSetCommands {
 
-  long zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options);
+  Object zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options);
 
   byte[] zscore(RedisKey key, byte[] member);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
@@ -14,10 +14,10 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_ZADD_OPTION_NX_XX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -30,11 +30,10 @@ import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class ZAddExecutor extends AbstractExecutor {
-  private final ZAddExecutorState zAddExecutorState = new ZAddExecutorState();
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    zAddExecutorState.initialize();
+    ZAddExecutorState zAddExecutorState = new ZAddExecutorState();
     RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
     List<byte[]> commandElements = command.getProcessedCommand();
     Iterator<byte[]> commandIterator = commandElements.iterator();
@@ -46,11 +45,17 @@ public class ZAddExecutor extends AbstractExecutor {
       return RedisResponse.error(zAddExecutorState.exceptionMessage);
     }
 
-    long retVal = redisSortedSetCommands.zadd(command.getKey(),
+    Object retVal = redisSortedSetCommands.zadd(command.getKey(),
         new ArrayList<>(commandElements.subList(optionsFoundCount + 2, commandElements.size())),
         makeOptions(zAddExecutorState));
+    if (zAddExecutorState.incrFound) {
+      if (retVal == null) {
+        return RedisResponse.nil();
+      }
+      return RedisResponse.string((byte[]) retVal);
+    }
 
-    return RedisResponse.integer(retVal);
+    return RedisResponse.integer((int) retVal);
   }
 
   private void skipCommandAndKey(Iterator<byte[]> commandIterator) {
@@ -86,6 +91,10 @@ public class ZAddExecutor extends AbstractExecutor {
         case "-infinity":
           scoreFound = true;
           break;
+        case "incr":
+          executorState.incrFound = true;
+          optionsFoundCount++;
+          break;
         default:
           try {
             Double.valueOf(subCommandString);
@@ -99,6 +108,9 @@ public class ZAddExecutor extends AbstractExecutor {
       executorState.exceptionMessage = ERROR_SYNTAX;
     } else if (executorState.nxFound && executorState.xxFound) {
       executorState.exceptionMessage = ERROR_INVALID_ZADD_OPTION_NX_XX;
+    } else if (executorState.incrFound
+        && command.getProcessedCommand().size() - optionsFoundCount - 2 > 2) {
+      executorState.exceptionMessage = ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR;
     }
     return optionsFoundCount;
   }
@@ -112,20 +124,14 @@ public class ZAddExecutor extends AbstractExecutor {
     if (executorState.xxFound) {
       existsOption = ZAddOptions.Exists.XX;
     }
-    return new ZAddOptions(existsOption, executorState.chFound);
+    return new ZAddOptions(existsOption, executorState.chFound, executorState.incrFound);
   }
 
-  static class ZAddExecutorState {
-    public boolean nxFound;
-    public boolean xxFound;
-    public boolean chFound;
-    public String exceptionMessage;
-
-    public void initialize() {
-      nxFound = false;
-      xxFound = false;
-      chFound = false;
-      exceptionMessage = null;
-    }
+  private static class ZAddExecutorState {
+    private boolean nxFound = false;
+    private boolean xxFound = false;
+    private boolean chFound = false;
+    private boolean incrFound = false;
+    private String exceptionMessage = null;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
@@ -52,7 +52,7 @@ public class ZAddExecutor extends AbstractExecutor {
       if (retVal == null) {
         return RedisResponse.nil();
       }
-      return RedisResponse.string((byte[]) retVal);
+      return RedisResponse.bulkString(retVal);
     }
 
     return RedisResponse.integer((int) retVal);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddOptions.java
@@ -30,15 +30,21 @@ import org.apache.geode.redis.internal.executor.BaseSetOptions;
  */
 public class ZAddOptions extends BaseSetOptions {
   private boolean isCH;
+  private boolean isINCR;
 
-  public ZAddOptions(Exists existsOption, boolean isCH) {
+  public ZAddOptions(Exists existsOption, boolean isCH, boolean isINCR) {
     super(existsOption);
 
     this.isCH = isCH;
+    this.isINCR = isINCR;
   }
 
   public boolean isCH() {
-    return this.isCH;
+    return isCH;
+  }
+
+  public boolean isINCR() {
+    return isINCR;
   }
 
   public ZAddOptions() {}
@@ -52,12 +58,14 @@ public class ZAddOptions extends BaseSetOptions {
   public void toData(DataOutput out, SerializationContext context) throws IOException {
     super.toData(out, context);
     out.writeBoolean(isCH);
+    out.writeBoolean(isINCR);
   }
 
   @Override
   public void fromData(DataInput in, DeserializationContext context) throws IOException {
     super.fromData(in, context);
     isCH = in.readBoolean();
+    isINCR = in.readBoolean();
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZIncrByExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZIncrByExecutor.java
@@ -33,6 +33,6 @@ public class ZIncrByExecutor extends AbstractExecutor {
     byte[] member = commandElements.get(3);
 
     byte[] retVal = redisSortedSetCommands.zincrby(command.getKey(), increment, member);
-    return RedisResponse.string(retVal);
+    return RedisResponse.bulkString(retVal);
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -128,7 +128,7 @@ public class RedisSortedSetTest {
     adds.add("1.61803".getBytes());
     adds.add("v3".getBytes());
 
-    sortedSet1.zadd(region, null, adds, new ZAddOptions(ZAddOptions.Exists.NONE, false));
+    sortedSet1.zadd(region, null, adds, new ZAddOptions(ZAddOptions.Exists.NONE, false, false));
     assertThat(sortedSet1.hasDelta()).isTrue();
 
     HeapDataOutputStream out = new HeapDataOutputStream(100);


### PR DESCRIPTION
  * allow zadd to return byte[] if INCR option is specified.
  * fixes a race issue of ZAddExecutorState in ZAddExecutor
  * added an ignored dunit test case showing score incrmented multiple times due to retry

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
