### PR TITLE
GEODE-8772: Fix ClusterComms test port conflicts

### DIFF
--- a/geode-core/src/upgradeTest/java/org/apache/geode/ClusterCommunicationsDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/ClusterCommunicationsDUnitTest.java
@@ -289,6 +289,7 @@ public class ClusterCommunicationsDUnitTest implements Serializable {
       // if you need to debug SSL communications use this property:
       // System.setProperty("javax.net.debug", "all");
       Properties props = getDistributedSystemProperties();
+      props.setProperty(HTTP_SERVICE_PORT, "0");
       // locator must restart with the same port so that it reconnects to the server
       await().atMost(getTimeout().getSeconds(), TimeUnit.SECONDS)
           .until(() -> Locator.startLocatorAndDS(locatorPort, new File(""), props) != null);


### PR DESCRIPTION
Change `ClusterCommunicationsDUnitTest.performARollingUpgrade()` to
disable the HTTP service.

BACKGROUND

I am working on a project to allow Geode tests to run in parallel
outside of Docker. Running in parallel outside of Docker requires that
tests not start services using default ports.

This commit prepares for those changes.

PROBLEMS

When `ClusterCommunicationsDUnitTest.performARollingUpgrade()` upgrades
the locator, it starts the new locator with HTTP service enabled on the
default port (7070). If another test running in parallel also uses this
default port, at least one will throw an exception when it attempts to
bind.

THIS COMMIT

Change `ClusterCommunicationsDUnitTest` to start the upgraded locator
with HTTP service disabled. The test does not use the HTTP service.
