### PR TITLE
GEODE-9146: have idle expiration ignore timestamp on removed remote e…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessage.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.Set;
 
 import org.apache.geode.DataSerializer;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.MessageWithReply;
 import org.apache.geode.distributed.internal.PooledDistributionMessage;
@@ -61,26 +62,39 @@ public class LatestLastAccessTimeMessage<K> extends PooledDistributionMessage
 
   @Override
   protected void process(ClusterDistributionManager dm) {
-    long latestLastAccessTime = 0L;
-    InternalCache cache = dm.getCache();
+    final InternalCache cache = dm.getCache();
     if (cache == null) {
+      sendReply(dm, 0);
       return;
     }
-    InternalDistributedRegion region =
+    final InternalDistributedRegion region =
         (InternalDistributedRegion) cache.getRegion(this.regionName);
     if (region == null) {
+      sendReply(dm, 0);
       return;
     }
-    RegionEntry entry = region.getRegionEntry(this.key);
+    final RegionEntry entry = region.getRegionEntry(this.key);
     if (entry == null) {
+      sendReply(dm, 0);
       return;
     }
-    try {
-      latestLastAccessTime = entry.getLastAccessed();
-    } catch (InternalStatisticsDisabledException ignored) {
-      // last access time is not available
+    long lastAccessed = 0L;
+    // noinspection SynchronizationOnLocalVariableOrMethodParameter
+    synchronized (entry) {
+      if (!entry.isInvalidOrRemoved()) {
+        try {
+          lastAccessed = entry.getLastAccessed();
+        } catch (InternalStatisticsDisabledException ignored) {
+          // last access time is not available
+        }
+      }
     }
-    ReplyMessage.send(getSender(), this.processorId, latestLastAccessTime, dm);
+    sendReply(dm, lastAccessed);
+  }
+
+  @VisibleForTesting
+  void sendReply(ClusterDistributionManager dm, long lastAccessTime) {
+    ReplyMessage.send(getSender(), this.processorId, lastAccessTime, dm);
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessageTest.java
@@ -14,7 +14,11 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.Set;
@@ -22,22 +26,106 @@ import java.util.Set;
 import org.junit.Test;
 
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
-import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
-import org.apache.geode.internal.inet.LocalHostUtil;
+import org.apache.geode.internal.InternalStatisticsDisabledException;
 
 public class LatestLastAccessTimeMessageTest {
+  private final ClusterDistributionManager dm = mock(ClusterDistributionManager.class);
+  private final InternalCache cache = mock(InternalCache.class);
+  private final InternalDistributedRegion region = mock(InternalDistributedRegion.class);
+  private final RegionEntry regionEntry = mock(RegionEntry.class);
+  private final long LAST_ACCESSED = 47;
 
-  @Test
-  public void processMessageShouldLookForNullCache() throws Exception {
-    final DistributionManager distributionManager = mock(DistributionManager.class);
+  private LatestLastAccessTimeMessage<String> lastAccessTimeMessage;
+
+  private void setupMessage() {
     final LatestLastAccessTimeReplyProcessor replyProcessor =
         mock(LatestLastAccessTimeReplyProcessor.class);
-    final InternalDistributedRegion region = mock(InternalDistributedRegion.class);
-    Set<InternalDistributedMember> recipients = Collections.singleton(new InternalDistributedMember(
-        LocalHostUtil.getLocalHost(), 1234));
-    final LatestLastAccessTimeMessage<String> lastAccessTimeMessage =
-        new LatestLastAccessTimeMessage<>(replyProcessor, recipients, region, "foo");
-    lastAccessTimeMessage.process(mock(ClusterDistributionManager.class));
+    final Set<InternalDistributedMember> recipients =
+        Collections.singleton(mock(InternalDistributedMember.class));
+    lastAccessTimeMessage =
+        spy(new LatestLastAccessTimeMessage<>(replyProcessor, recipients, region, "foo"));
+    lastAccessTimeMessage.setSender(mock(InternalDistributedMember.class));
+  }
+
+  private void setupRegion(boolean hasRegion, boolean hasEntry) {
+    when(dm.getCache()).thenReturn(cache);
+    if (hasRegion) {
+      when(cache.getRegion(any())).thenReturn(region);
+    } else {
+      when(cache.getRegion(any())).thenReturn(null);
+    }
+    if (hasEntry) {
+      when(region.getRegionEntry(any())).thenReturn(regionEntry);
+      try {
+        when(regionEntry.getLastAccessed()).thenReturn(LAST_ACCESSED);
+      } catch (InternalStatisticsDisabledException e) {
+        throw new RuntimeException("should never happen when mocking", e);
+      }
+    } else {
+      when(region.getRegionEntry(any())).thenReturn(null);
+    }
+  }
+
+  @Test
+  public void processWithNullCacheRepliesZero() {
+    setupMessage();
+    when(dm.getCache()).thenReturn(null);
+
+    lastAccessTimeMessage.process(dm);
+
+    verify(lastAccessTimeMessage).sendReply(dm, 0);
+  }
+
+  @Test
+  public void processWithNullRegionRepliesZero() {
+    setupMessage();
+    setupRegion(false, false);
+
+    lastAccessTimeMessage.process(dm);
+
+    verify(lastAccessTimeMessage).sendReply(dm, 0);
+  }
+
+  @Test
+  public void processWithNullEntryRepliesZero() {
+    setupMessage();
+    setupRegion(true, false);
+
+    lastAccessTimeMessage.process(dm);
+
+    verify(lastAccessTimeMessage).sendReply(dm, 0);
+  }
+
+  @Test
+  public void processWithEntryStatsDisabledRepliesZero() throws Exception {
+    setupMessage();
+    setupRegion(true, true);
+    when(regionEntry.getLastAccessed()).thenThrow(new InternalStatisticsDisabledException());
+
+    lastAccessTimeMessage.process(dm);
+
+    verify(lastAccessTimeMessage).sendReply(dm, 0);
+  }
+
+  @Test
+  public void processWithRegionEntryRepliesWithLastAccessed() {
+    setupMessage();
+    setupRegion(true, true);
+
+    lastAccessTimeMessage.process(dm);
+
+    verify(lastAccessTimeMessage).sendReply(dm, LAST_ACCESSED);
+  }
+
+  @Test
+  public void processWithRemovedRegionEntryRepliesZero() {
+    setupMessage();
+    setupRegion(true, true);
+    when(regionEntry.isInvalidOrRemoved()).thenReturn(true);
+
+    lastAccessTimeMessage.process(dm);
+
+    verify(lastAccessTimeMessage).sendReply(dm, 0);
   }
 }


### PR DESCRIPTION
…ntries

LatestLastAccessTimeMessage now ignores the last access time
of both invalid and removed entries.

(cherry picked from commit e4e10ace74a8a74868690d0c78f97814380a566d)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
