### PR TITLE
GEODE-9300: write-buffer-size value not used when creating disk store

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/OplogRVVJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/OplogRVVJUnitTest.java
@@ -40,6 +40,7 @@ import org.junit.rules.TemporaryFolder;
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.Statistics;
 import org.apache.geode.StatisticsFactory;
+import org.apache.geode.cache.DiskStoreFactory;
 import org.apache.geode.internal.cache.DiskInitFile.DiskRegionFlag;
 import org.apache.geode.internal.cache.DiskStoreImpl.OplogEntryIdSet;
 import org.apache.geode.internal.cache.persistence.DiskRecoveryStore;
@@ -75,7 +76,7 @@ public class OplogRVVJUnitTest {
     final DiskStoreID m1 = DiskStoreID.random();
     final DiskStoreID m2 = DiskStoreID.random();
     final DiskRecoveryStore drs = mock(DiskRecoveryStore.class);
-    when(parent.getWriteBufferSize()).thenReturn(32768);
+    when(parent.getWriteBufferSize()).thenReturn(DiskStoreFactory.DEFAULT_WRITE_BUFFER_SIZE);
     when(df.getOrCreateCanonicalId(m1)).thenReturn(1);
     when(df.getOrCreateCanonicalId(m2)).thenReturn(2);
     when(df.getOrCreateCanonicalId(ownerId)).thenReturn(3);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/OplogRVVJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/OplogRVVJUnitTest.java
@@ -75,6 +75,7 @@ public class OplogRVVJUnitTest {
     final DiskStoreID m1 = DiskStoreID.random();
     final DiskStoreID m2 = DiskStoreID.random();
     final DiskRecoveryStore drs = mock(DiskRecoveryStore.class);
+    when(parent.getWriteBufferSize()).thenReturn(32768);
     when(df.getOrCreateCanonicalId(m1)).thenReturn(1);
     when(df.getOrCreateCanonicalId(m2)).thenReturn(2);
     when(df.getOrCreateCanonicalId(ownerId)).thenReturn(3);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -120,6 +120,9 @@ import org.apache.geode.util.internal.GeodeGlossary;
 public class Oplog implements CompactableOplog, Flushable {
   private static final Logger logger = LogService.getLogger();
 
+  /* System property to override the disk store write buffer size. */
+  public final String WRITE_BUFFER_SIZE_SYS_PROP_NAME = "WRITE_BUF_SIZE";
+
   /** Extension of the oplog file * */
   public static final String CRF_FILE_EXT = ".crf";
   public static final String DRF_FILE_EXT = ".drf";
@@ -1088,14 +1091,15 @@ public class Oplog implements CompactableOplog, Flushable {
   }
 
   @VisibleForTesting
-  boolean writeBufferSizeSystemPropertyIsDefined() {
-    return (Integer.getInteger("WRITE_BUF_SIZE") != null);
+  Integer getWriteBufferSizeProperty() {
+    return Integer.getInteger(WRITE_BUFFER_SIZE_SYS_PROP_NAME);
   }
 
   @VisibleForTesting
   Integer getWriteBufferCapacity() {
-    if (writeBufferSizeSystemPropertyIsDefined()) {
-      return Integer.getInteger("WRITE_BUF_SIZE");
+    Integer writeBufferSizeProperty = getWriteBufferSizeProperty();
+    if (writeBufferSizeProperty != null) {
+      return writeBufferSizeProperty;
     }
     return getParent().getWriteBufferSize();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/OverflowOplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/OverflowOplog.java
@@ -53,6 +53,9 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
 class OverflowOplog implements CompactableOplog, Flushable {
   private static final Logger logger = LogService.getLogger();
 
+  /* System property to override the disk store write buffer size. */
+  public final String WRITE_BUFFER_SIZE_SYS_PROP_NAME = "WRITE_BUF_SIZE";
+
   /** Extension of the oplog file * */
   static final String CRF_FILE_EXT = ".crf";
 
@@ -186,14 +189,15 @@ class OverflowOplog implements CompactableOplog, Flushable {
   }
 
   @VisibleForTesting
-  boolean writeBufferSizeSystemPropertyIsDefined() {
-    return (Integer.getInteger("WRITE_BUF_SIZE") != null);
+  Integer getWriteBufferSizeProperty() {
+    return Integer.getInteger(WRITE_BUFFER_SIZE_SYS_PROP_NAME);
   }
 
   @VisibleForTesting
   Integer getWriteBufferCapacity() {
-    if (writeBufferSizeSystemPropertyIsDefined()) {
-      return Integer.getInteger("WRITE_BUF_SIZE");
+    Integer writeBufferSizeProperty = getWriteBufferSizeProperty();
+    if (writeBufferSizeProperty != null) {
+      return writeBufferSizeProperty;
     }
     return getParent().getWriteBufferSize();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/properties.md
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/properties.md
@@ -216,7 +216,7 @@ DistributionConfigImpl constructor prepends `gemfire.` to each valid attribute n
 | stats.name | String | `Thread.currentThread().getName()` | See `org.apache.geode.internal.LocalStatisticsFactory#initName`.|
 | stats.sample-rate | Integer | `1000` | See `org.apache.geode.internal.SimpleStatSampler#sampleRate`.<p>Units are in milliseconds.|
 | tcpServerPort | Integer | tcp-port property in the distribution config | See `org.apache.geode.distributed.internal.direct.DirectChannel#DirectChannel(MembershipManager, DistributedMembershipListener, DistributionConfig, LogWriter, Properties)`.|
-
+| WRITE_BUF_SIZE | Integer | `32768` (disk store `--write-buffer-size` option default value) | Sets the disk store write buffer size. If set, it takes precedence over the disk store `--write-buffer-size` option value.<p>See `org.apache.geode.internal.cache.Oplog#allocateWriteBuf(OplogFile prevOlf)`<br/>See `org.apache.geode.internal.cache.OverflowOplog#allocateWriteBuf(OverflowOplog previous)`<p>Units are in bytes.|
 
 ## Properties used by other Jars
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -758,7 +758,7 @@ public class CliStrings {
       "For asynchronous queueing. The number of milliseconds that can elapse before data is flushed to disk. Reaching this limit or the queue-size limit causes the queue to flush.";
   public static final String CREATE_DISK_STORE__WRITE_BUFFER_SIZE = "write-buffer-size";
   public static final String CREATE_DISK_STORE__WRITE_BUFFER_SIZE__HELP =
-      "Size of the buffer used to write to disk.";
+      "Size in bytes of the buffer used to write to disk.";
   public static final String CREATE_DISK_STORE__DIRECTORY_AND_SIZE = "dir";
   public static final String CREATE_DISK_STORE__DIRECTORY_AND_SIZE__HELP =
       "Directories where the disk store files will be written, the directories will be created if they don't exist.  Optionally, directory names may be followed by # and the maximum number of megabytes that the disk store can use in the directory.  Example: --dir=/data/ds1 --dir=/data/ds2#5000";

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/OplogTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/OplogTest.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.cache.DiskStoreFactory;
+
 
 public class OplogTest {
   private final DiskStoreImpl.OplogCompactor compactor = mock(DiskStoreImpl.OplogCompactor.class);
@@ -38,7 +40,8 @@ public class OplogTest {
   @Before
   public void setup() {
     DiskStoreImpl parentDiskStore = mock(DiskStoreImpl.class);
-    when(parentDiskStore.getWriteBufferSize()).thenReturn(32768);
+    when(parentDiskStore.getWriteBufferSize())
+        .thenReturn(DiskStoreFactory.DEFAULT_WRITE_BUFFER_SIZE);
     when(parent.getParent()).thenReturn(parentDiskStore);
     oplogSpy = spy(new Oplog(oplogId, parent));
     doReturn(true).when(oplogSpy).needsCompaction();
@@ -85,13 +88,14 @@ public class OplogTest {
 
   @Test
   public void writeBufferSizeValueIsObtainedFromParentIfSystemPropertyNotDefined() {
-    when(oplogSpy.writeBufferSizeSystemPropertyIsDefined()).thenReturn(false);
-    assertThat(oplogSpy.getWriteBufferCapacity()).isEqualTo(32768);
+    when(oplogSpy.getWriteBufferSizeProperty()).thenReturn(null);
+    assertThat(oplogSpy.getWriteBufferCapacity())
+        .isEqualTo(DiskStoreFactory.DEFAULT_WRITE_BUFFER_SIZE);
   }
 
   @Test
   public void writeBufferSizeValueIsObtainedFromSystemPropertyWhenDefined() {
-    when(oplogSpy.writeBufferSizeSystemPropertyIsDefined()).thenReturn(true);
-    assertThat(oplogSpy.getWriteBufferCapacity()).isNull();
+    when(oplogSpy.getWriteBufferSizeProperty()).thenReturn(12345);
+    assertThat(oplogSpy.getWriteBufferCapacity()).isEqualTo(12345);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/OplogTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/OplogTest.java
@@ -33,51 +33,65 @@ public class OplogTest {
   private final DiskStoreImpl.OplogCompactor compactor = mock(DiskStoreImpl.OplogCompactor.class);
   private final PersistentOplogSet parent = mock(PersistentOplogSet.class);
   private final long oplogId = 1;
-  private Oplog oplog;
+  private Oplog oplogSpy;
 
   @Before
   public void setup() {
-    when(parent.getParent()).thenReturn(mock(DiskStoreImpl.class));
-    oplog = spy(new Oplog(oplogId, parent));
-    doReturn(true).when(oplog).needsCompaction();
-    doReturn(true).when(oplog).calledByCompactorThread();
+    DiskStoreImpl parentDiskStore = mock(DiskStoreImpl.class);
+    when(parentDiskStore.getWriteBufferSize()).thenReturn(32768);
+    when(parent.getParent()).thenReturn(parentDiskStore);
+    oplogSpy = spy(new Oplog(oplogId, parent));
+    doReturn(true).when(oplogSpy).needsCompaction();
+    doReturn(true).when(oplogSpy).calledByCompactorThread();
   }
 
   @Test
   public void noCompactIfDoesNotNeedCompaction() {
-    doReturn(false).when(oplog).needsCompaction();
-    assertThat(oplog.compact(compactor)).isEqualTo(0);
+    doReturn(false).when(oplogSpy).needsCompaction();
+    assertThat(oplogSpy.compact(compactor)).isEqualTo(0);
   }
 
   @Test
   public void noCompactIfNotKeepCompactorRunning() {
     when(compactor.keepCompactorRunning()).thenReturn(false);
-    assertThat(oplog.compact(compactor)).isEqualTo(0);
+    assertThat(oplogSpy.compact(compactor)).isEqualTo(0);
   }
 
   @Test
   public void handlesNoLiveValuesIfNoLiveValueInOplog() {
     when(compactor.keepCompactorRunning()).thenReturn(true);
 
-    doReturn(true).when(oplog).hasNoLiveValues();
-    assertThat(oplog.compact(compactor)).isEqualTo(0);
-    verify(oplog, times(1)).handleNoLiveValues();
+    doReturn(true).when(oplogSpy).hasNoLiveValues();
+    assertThat(oplogSpy.compact(compactor)).isEqualTo(0);
+    verify(oplogSpy, times(1)).handleNoLiveValues();
   }
 
   @Test
   public void invockeCleanupAfterCompaction() {
     when(compactor.keepCompactorRunning()).thenReturn(true);
-    doReturn(mock(DiskStoreStats.class)).when(oplog).getStats();
-    doReturn(false).when(oplog).hasNoLiveValues();
-    oplog.compact(compactor);
-    verify(oplog, times(1)).cleanupAfterCompaction(eq(false));
+    doReturn(mock(DiskStoreStats.class)).when(oplogSpy).getStats();
+    doReturn(false).when(oplogSpy).hasNoLiveValues();
+    oplogSpy.compact(compactor);
+    verify(oplogSpy, times(1)).cleanupAfterCompaction(eq(false));
   }
 
   @Test
   public void handlesNoLiveValuesIfCompactSuccessful() {
-    oplog.getTotalLiveCount().set(5);
-    oplog.cleanupAfterCompaction(false);
-    verify(oplog, times(1)).handleNoLiveValues();
-    assertThat(oplog.getTotalLiveCount().get()).isEqualTo(0);
+    oplogSpy.getTotalLiveCount().set(5);
+    oplogSpy.cleanupAfterCompaction(false);
+    verify(oplogSpy, times(1)).handleNoLiveValues();
+    assertThat(oplogSpy.getTotalLiveCount().get()).isEqualTo(0);
+  }
+
+  @Test
+  public void writeBufferSizeValueIsObtainedFromParentIfSystemPropertyNotDefined() {
+    when(oplogSpy.writeBufferSizeSystemPropertyIsDefined()).thenReturn(false);
+    assertThat(oplogSpy.getWriteBufferCapacity()).isEqualTo(32768);
+  }
+
+  @Test
+  public void writeBufferSizeValueIsObtainedFromSystemPropertyWhenDefined() {
+    when(oplogSpy.writeBufferSizeSystemPropertyIsDefined()).thenReturn(true);
+    assertThat(oplogSpy.getWriteBufferCapacity()).isNull();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/OverflowOplogTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/OverflowOplogTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class OverflowOplogTest {
+
+  private OverflowOplog oplogMock;
+
+  @Before
+  public void setup() {
+    DiskStoreImpl parentDiskStoreMock = mock(DiskStoreImpl.class);
+    when(parentDiskStoreMock.getWriteBufferSize()).thenReturn(32768);
+
+    oplogMock = mock(OverflowOplog.class);
+    when(oplogMock.getParent()).thenReturn(parentDiskStoreMock);
+    when(oplogMock.getWriteBufferCapacity()).thenCallRealMethod();
+  }
+
+  @Test
+  public void writeBufferSizeValueIsObtainedFromParentIfSystemPropertyNotDefined() {
+    when(oplogMock.writeBufferSizeSystemPropertyIsDefined()).thenReturn(false);
+    assertThat(oplogMock.getWriteBufferCapacity()).isEqualTo(32768);
+  }
+
+  @Test
+  public void writeBufferSizeValueIsObtainedFromSystemPropertyWhenDefined() {
+    when(oplogMock.writeBufferSizeSystemPropertyIsDefined()).thenReturn(true);
+    assertThat(oplogMock.getWriteBufferCapacity()).isNull();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/OverflowOplogTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/OverflowOplogTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.when;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.cache.DiskStoreFactory;
+
 public class OverflowOplogTest {
 
   private OverflowOplog oplogMock;
@@ -28,7 +30,8 @@ public class OverflowOplogTest {
   @Before
   public void setup() {
     DiskStoreImpl parentDiskStoreMock = mock(DiskStoreImpl.class);
-    when(parentDiskStoreMock.getWriteBufferSize()).thenReturn(32768);
+    when(parentDiskStoreMock.getWriteBufferSize())
+        .thenReturn(DiskStoreFactory.DEFAULT_WRITE_BUFFER_SIZE);
 
     oplogMock = mock(OverflowOplog.class);
     when(oplogMock.getParent()).thenReturn(parentDiskStoreMock);
@@ -37,13 +40,14 @@ public class OverflowOplogTest {
 
   @Test
   public void writeBufferSizeValueIsObtainedFromParentIfSystemPropertyNotDefined() {
-    when(oplogMock.writeBufferSizeSystemPropertyIsDefined()).thenReturn(false);
-    assertThat(oplogMock.getWriteBufferCapacity()).isEqualTo(32768);
+    when(oplogMock.getWriteBufferSizeProperty()).thenReturn(null);
+    assertThat(oplogMock.getWriteBufferCapacity())
+        .isEqualTo(DiskStoreFactory.DEFAULT_WRITE_BUFFER_SIZE);
   }
 
   @Test
   public void writeBufferSizeValueIsObtainedFromSystemPropertyWhenDefined() {
-    when(oplogMock.writeBufferSizeSystemPropertyIsDefined()).thenReturn(true);
-    assertThat(oplogMock.getWriteBufferCapacity()).isNull();
+    when(oplogMock.getWriteBufferSizeProperty()).thenReturn(12345);
+    assertThat(oplogMock.getWriteBufferCapacity()).isEqualTo(12345);
   }
 }

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -325,7 +325,7 @@ If the specified directory does not exist, the command will create the directory
 </tr>
 <tr>
 <td><span class="keyword parmname">\-\-write-buffer-size</span></td>
-<td>The size of the write buffer that this disk store uses when writing data to disk. Larger values may increase performance but use more memory. The disk store allocates one direct memory buffer of this size.</td>
+<td>The size in bytes of the write buffer that this disk store uses when writing data to disk. Larger values may increase performance but use more memory. The disk store allocates one direct memory buffer of this size.</td>
 <td>32768</td>
 </tr>
 <tr>


### PR DESCRIPTION
According to the Geode User Guide, it is possible to set the write buffer size by using the `--write-buffer-size` option when creating a disk store.
Nevertheless, setting a value for that parameter either by using gfsh, cache.xml or the `DiskStoreFactory.setWriteBuffer()` method has no effect.

The current implementation checks if the `WRITE_BUF_SIZE` system property is set, and if that is not the case, the default value of `32768` bytes is used.
This PR changes the behavior so first the disk store write buffer size is obtained (which default value is `32768`). Then, if the `WRITE_BUF_SIZE` system property is set, its value will take precedence over the disk store buffer size.

References:
* `create disk-store` command reference: https://geode.apache.org/docs/guide/113/tools_modules/gfsh/command-pages/create.html
* Question in the dev list about this issue: https://markmail.org/thread/d4ypp7qcw5lfqtf5