### PR TITLE
GEODE-9287: Always use Coder for Radish String/byte[] conversion

### DIFF
--- a/geode-apis-compatible-with-redis/build.gradle
+++ b/geode-apis-compatible-with-redis/build.gradle
@@ -49,6 +49,7 @@ dependencies {
   testImplementation('redis.clients:jedis')
   testImplementation('com.pholser:junit-quickcheck-core')
   testImplementation('com.pholser:junit-quickcheck-generators')
+  testImplementation('pl.pragmatists:JUnitParams')
 
   commonTestImplementation(project(':geode-junit'))
   commonTestImplementation(project(':geode-dunit'))

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/ClusterNodes.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/ClusterNodes.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -40,9 +42,9 @@ public class ClusterNodes {
       long slotEnd = (long) firstLevel.get(1);
 
       List<Object> primary = (List<Object>) firstLevel.get(2);
-      String primaryIp = new String((byte[]) primary.get(0));
+      String primaryIp = bytesToString((byte[]) primary.get(0));
       long primaryPort = (long) primary.get(1);
-      String primaryGUID = primary.size() > 2 ? new String((byte[]) primary.get(2)) : "";
+      String primaryGUID = primary.size() > 2 ? bytesToString((byte[]) primary.get(2)) : "";
 
       result.addSlot(primaryGUID, primaryIp, primaryPort, slotStart, slotEnd);
     }

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/RenameDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/RenameDUnitTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.executor.key;
 
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -118,7 +120,7 @@ public class RenameDUnitTest {
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {
     Random random = new Random();
     String key1 = "{rename}keyz" + random.nextInt();
-    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
+    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     Set<String> keys = new HashSet<>();
     keys.add(key1);
@@ -126,7 +128,7 @@ public class RenameDUnitTest {
     do {
       String key2 = "{rename}key" + random.nextInt();
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(key2.getBytes())) == 0) {
+          new RedisKey(stringToBytes(key2))) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +43,6 @@ import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
@@ -221,7 +221,7 @@ public class ZRemDUnitTest {
   }
 
   private static boolean isPrimaryForKey() {
-    int bucketId = getBucketId(new RedisKey(Coder.stringToBytes(sortedSetKey)));
+    int bucketId = getBucketId(new RedisKey(stringToBytes(sortedSetKey)));
     return isPrimaryForBucket(bucketId);
   }
 

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
@@ -16,6 +16,8 @@
 package org.apache.geode.redis.session;
 
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+
 import java.net.HttpCookie;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -253,7 +255,7 @@ public abstract class SessionDUnitTest {
   protected String getSessionId(String sessionCookie) {
     List<HttpCookie> cookies = HttpCookie.parse(sessionCookie);
     byte[] decodedCookie = Base64.getDecoder().decode(cookies.get(0).getValue());
-    return new String(decodedCookie);
+    return bytesToString(decodedCookie);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.session;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -165,7 +166,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
       return 0;
     }
     ObjectInputStream inputStream;
-    byte[] bytes = redisHash.hget("maxInactiveInterval".getBytes());
+    byte[] bytes = redisHash.hget(stringToBytes("maxInactiveInterval"));
     ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
     try {
       inputStream = new ObjectInputStream(byteStream);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.function.BiFunction;
@@ -23,7 +25,6 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 
-import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisCommandArgumentsTestHelper {
   public static void assertExactNumberOfArgs(Jedis jedis, Protocol.Command command, int numArgs) {
@@ -32,7 +33,8 @@ public class RedisCommandArgumentsTestHelper {
 
   public static void assertExactNumberOfArgs(JedisCluster jedis,
       Protocol.Command command, int numArgs) {
-    assertExactNumberOfArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args), command,
+    assertExactNumberOfArgs0(
+        (cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args), command,
         numArgs);
   }
 
@@ -56,7 +58,8 @@ public class RedisCommandArgumentsTestHelper {
 
   public static void assertAtLeastNArgs(JedisCluster jedis, Protocol.Command command,
       int minNumArgs) {
-    assertAtLeastNArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args), command,
+    assertAtLeastNArgs0((cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args),
+        command,
         minNumArgs);
   }
 
@@ -83,7 +86,8 @@ public class RedisCommandArgumentsTestHelper {
 
   public static void assertAtMostNArgs(JedisCluster jedis, Protocol.Command command,
       int maxNumArgs) {
-    assertAtMostNArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args), command,
+    assertAtMostNArgs0((cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args),
+        command,
         maxNumArgs);
   }
 
@@ -107,7 +111,7 @@ public class RedisCommandArgumentsTestHelper {
 
       assertThatThrownBy(() -> runMe.apply(command, args))
           .hasMessageContaining("ERR Unknown subcommand or wrong number of arguments for '"
-              + Coder.bytesToString(firstParameter));
+              + bytesToString(firstParameter));
     }
   }
 
@@ -119,7 +123,7 @@ public class RedisCommandArgumentsTestHelper {
     }
 
     for (int i = 0; i < numArgs; i++) {
-      args[i] = String.valueOf(i).getBytes();
+      args[i] = stringToBytes(String.valueOf(i));
     }
 
     return args;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis;
 
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.intToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -123,7 +124,7 @@ public class RedisCommandArgumentsTestHelper {
     }
 
     for (int i = 0; i < numArgs; i++) {
-      args[i] = stringToBytes(String.valueOf(i));
+      args[i] = intToBytes(i);
     }
 
     return args;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.executor;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.After;
@@ -44,46 +45,54 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
 
   @Test
   public void givenUnknownCommand_returnsUnknownCommandError() {
-    assertThatThrownBy(() -> jedis.sendCommand("fhqwhgads"::getBytes))
+    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("fhqwhgads")))
         .hasMessage("ERR unknown command `fhqwhgads`, with args beginning with: ");
   }
 
   @Test
   public void givenUnknownCommand_withArguments_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand("fhqwhgads"::getBytes, "EVERYBODY", "TO THE LIMIT"))
-        .hasMessage(
-            "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, `TO THE LIMIT`, ");
+    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("fhqwhgads"), "EVERYBODY",
+        "TO THE LIMIT"))
+            .hasMessage(
+                "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, `TO THE LIMIT`, ");
   }
 
   @Test
   public void givenUnknownCommand_withEmptyStringArgument_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand("fhqwhgads"::getBytes, "EVERYBODY", ""))
-        .hasMessage("ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, ``, ");
+    assertThatThrownBy(
+        () -> jedis.sendCommand(() -> stringToBytes("fhqwhgads"), "EVERYBODY", ""))
+            .hasMessage(
+                "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, ``, ");
   }
 
   @Test // HELLO is not a recognized command until Redis 6.0.0
   public void givenHelloCommand_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand("HELLO"::getBytes))
+    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("HELLO")))
         .hasMessage("ERR unknown command `HELLO`, with args beginning with: ");
   }
 
   @Test
   public void givenInternalSMembersCommand_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand("INTERNALSMEMBERS"::getBytes, "something", "somethingElse"))
-            .hasMessage(
-                "ERR unknown command `INTERNALSMEMBERS`, with args beginning with: `something`, `somethingElse`, ");
+        () -> jedis.sendCommand(() -> stringToBytes("INTERNALSMEMBERS"), "something",
+            "somethingElse"))
+                .hasMessage(
+                    "ERR unknown command `INTERNALSMEMBERS`, with args beginning with: `something`, `somethingElse`, ");
   }
 
   @Test
   public void givenInternalPTTLCommand_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand("INTERNALPTTL"::getBytes, "something"))
-        .hasMessage("ERR unknown command `INTERNALPTTL`, with args beginning with: `something`, ");
+    assertThatThrownBy(
+        () -> jedis.sendCommand(() -> stringToBytes("INTERNALPTTL"), "something"))
+            .hasMessage(
+                "ERR unknown command `INTERNALPTTL`, with args beginning with: `something`, ");
   }
 
   @Test
   public void givenInternalTypeCommand_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand("INTERNALTYPE"::getBytes, "something"))
-        .hasMessage("ERR unknown command `INTERNALTYPE`, with args beginning with: `something`, ");
+    assertThatThrownBy(
+        () -> jedis.sendCommand(() -> stringToBytes("INTERNALTYPE"), "something"))
+            .hasMessage(
+                "ERR unknown command `INTERNALTYPE`, with args beginning with: `something`, ");
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/cluster/AbstractClusterIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/cluster/AbstractClusterIntegrationTest.java
@@ -52,5 +52,9 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
         () -> jedis.getConnectionFromSlot(0).sendCommand(Protocol.Command.CLUSTER, "SLOTS", "1"))
             .hasMessage(
                 "ERR Unknown subcommand or wrong number of arguments for 'SLOTS'. Try CLUSTER HELP.");
+    assertThatThrownBy(
+        () -> jedis.getConnectionFromSlot(0).sendCommand(Protocol.Command.CLUSTER, "NOTACOMMAND"))
+            .hasMessage(
+                "ERR Unknown subcommand or wrong number of arguments for 'NOTACOMMAND'. Try CLUSTER HELP.");
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -20,6 +20,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -230,7 +232,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     scanParams.match("\\p");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
-        jedis.hscan("a".getBytes(), "0".getBytes(), scanParams);
+        jedis.hscan(stringToBytes("a"), stringToBytes("0"), scanParams);
 
     assertThat(result.getResult()).isEmpty();
   }
@@ -285,10 +287,10 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
           "COUNT", "1");
 
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
   }
 
   @Test
@@ -306,7 +308,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.hscan(stringToBytes("colors"), stringToBytes(cursor), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
@@ -317,17 +319,17 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   @Test
   public void givenMatch_returnsAllMatchingEntries() {
     Map<byte[], byte[]> entryMap = new HashMap<>();
-    byte[] field3 = "3".getBytes();
-    entryMap.put("1".getBytes(), "yellow".getBytes());
-    entryMap.put("12".getBytes(), "green".getBytes());
-    entryMap.put(field3, "grey".getBytes());
-    jedis.hmset("colors".getBytes(), entryMap);
+    byte[] field3 = stringToBytes("3");
+    entryMap.put(stringToBytes("1"), stringToBytes("yellow"));
+    entryMap.put(stringToBytes("12"), stringToBytes("green"));
+    entryMap.put(field3, stringToBytes("grey"));
+    jedis.hmset(stringToBytes("colors"), entryMap);
 
     ScanParams scanParams = new ScanParams();
     scanParams.match("1*");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
-        jedis.hscan("colors".getBytes(), "0".getBytes(), scanParams);
+        jedis.hscan(stringToBytes("colors"), stringToBytes("0"), scanParams);
 
     entryMap.remove(field3);
     assertThat(result.isCompleteIteration()).isTrue();
@@ -355,23 +357,25 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hmset("colors", entryMap);
 
     List<Object> result =
-        (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
-            "colors".getBytes(), "0".getBytes(), "MATCH".getBytes(), "3*".getBytes(),
-            "MATCH".getBytes(), "1*".getBytes());
+        (List<Object>) jedis.sendCommand(stringToBytes("colors"), Protocol.Command.HSCAN,
+            stringToBytes("colors"), stringToBytes("0"), stringToBytes("MATCH"),
+            stringToBytes("3*"),
+            stringToBytes("MATCH"), stringToBytes("1*"));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
     assertThat((List<Object>) result.get(1)).containsAll(
-        Arrays.asList("1".getBytes(), "yellow".getBytes(), "12".getBytes(), "green".getBytes()));
+        Arrays.asList(stringToBytes("1"), stringToBytes("yellow"),
+            stringToBytes("12"), stringToBytes("green")));
   }
 
   @Test
   public void givenMatchAndCount_returnsAllMatchingKeys() {
     Map<byte[], byte[]> entryMap = new HashMap<>();
-    byte[] field3 = "3".getBytes();
-    entryMap.put("1".getBytes(), "yellow".getBytes());
-    entryMap.put("12".getBytes(), "green".getBytes());
-    entryMap.put(field3, "orange".getBytes());
-    jedis.hmset("colors".getBytes(), entryMap);
+    byte[] field3 = stringToBytes("3");
+    entryMap.put(stringToBytes("1"), stringToBytes("yellow"));
+    entryMap.put(stringToBytes("12"), stringToBytes("green"));
+    entryMap.put(field3, stringToBytes("orange"));
+    jedis.hmset(stringToBytes("colors"), entryMap);
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
@@ -381,7 +385,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.hscan(stringToBytes("colors"), stringToBytes(cursor), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
@@ -407,17 +411,22 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
-          "colors".getBytes(), cursor.getBytes(), "COUNT".getBytes(), "37".getBytes(),
-          "MATCH".getBytes(), "3*".getBytes(), "COUNT".getBytes(), "2".getBytes(),
-          "COUNT".getBytes(), "1".getBytes(), "MATCH".getBytes(), "1*".getBytes());
+      result =
+          (List<Object>) jedis.sendCommand(stringToBytes("colors"), Protocol.Command.HSCAN,
+              stringToBytes("colors"), stringToBytes(cursor),
+              stringToBytes("COUNT"), stringToBytes("37"),
+              stringToBytes("MATCH"), stringToBytes("3*"), stringToBytes("COUNT"),
+              stringToBytes("2"),
+              stringToBytes("COUNT"), stringToBytes("1"), stringToBytes("MATCH"),
+              stringToBytes("1*"));
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(), "yellow".getBytes(),
-        "12".getBytes(), "green".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("yellow"),
+        stringToBytes("12"), stringToBytes("green"));
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -886,8 +887,8 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
       blob[i] = (byte) i;
     }
 
-    jedis.hset("key".getBytes(), blob, blob);
-    Map<byte[], byte[]> result = jedis.hgetAll("key".getBytes());
+    jedis.hset(stringToBytes("key"), blob, blob);
+    Map<byte[], byte[]> result = jedis.hgetAll(stringToBytes("key"));
 
     assertThat(result.keySet()).containsExactly(blob);
     assertThat(result.values()).containsExactly(blob);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHincrByFloatIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHincrByFloatIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.hash;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.offset;
@@ -112,13 +113,13 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
     String field = "field";
 
     Object response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "1.23");
-    assertThat(new String((byte[]) response)).isEqualTo("1.23");
+    assertThat(bytesToString((byte[]) response)).isEqualTo("1.23");
 
     response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "0.77");
-    assertThat(new String((byte[]) response)).isEqualTo("2");
+    assertThat(bytesToString((byte[]) response)).isEqualTo("2");
 
     response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "-0.1");
-    assertThat(new String((byte[]) response)).isEqualTo("1.9");
+    assertThat(bytesToString((byte[]) response)).isEqualTo("1.9");
   }
 
   @Test
@@ -149,7 +150,7 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
     // Beyond this, native redis produces inconsistent results.
     Object rawResult =
         jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "1");
-    BigDecimal result = new BigDecimal(new String((byte[]) rawResult));
+    BigDecimal result = new BigDecimal(bytesToString((byte[]) rawResult));
 
     assertThat(result.toPlainString()).isEqualTo(biggy.add(BigDecimal.ONE).toPlainString());
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractDelIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractDelIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -109,7 +110,7 @@ public abstract class AbstractDelIntegrationTest implements RedisIntegrationTest
   public void testDel_withBinaryKey() {
     byte[] key = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    jedis.set(key, "foo".getBytes());
+    jedis.set(key, stringToBytes("foo"));
     jedis.del(key);
 
     assertThat(jedis.get(key)).isNull();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
@@ -16,10 +16,10 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 
 import org.junit.After;
 import org.junit.Before;
@@ -94,7 +94,7 @@ public abstract class AbstractKeysIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenBinaryValue_withExactMatch_preservesBinaryData() {
     String chineseHashTag = "{子}";
-    byte[] utf8encodedBytes = chineseHashTag.getBytes(StandardCharsets.UTF_8);
+    byte[] utf8encodedBytes = stringToBytes(chineseHashTag);
     byte[] stringKey =
         new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'};
     byte[] allByteArray = new byte[utf8encodedBytes.length + stringKey.length];
@@ -105,7 +105,7 @@ public abstract class AbstractKeysIntegrationTest implements RedisIntegrationTes
     byte[] combined = buff.array();
 
     jedis.set(combined, combined);
-    assertThat(jedis.keys("{子}*".getBytes(StandardCharsets.UTF_8)))
+    assertThat(jedis.keys(stringToBytes("{子}*")))
         .containsExactlyInAnyOrder(combined);
   }
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractRenameIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractRenameIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -237,7 +238,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   private List<String> getKeysOnDifferentStripes() {
     String key1 = "{user1}keyz" + new Random().nextInt();
 
-    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
+    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     int iterator = 0;
     String key2;
@@ -245,7 +246,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
       key2 = "{user1}key" + iterator;
       iterator++;
     } while (stripedExecutor.compareStripes(key1RedisKey,
-        new RedisKey(key2.getBytes())) == 0);
+        new RedisKey(stringToBytes(key2))) == 0);
 
     return Arrays.asList(key1, key2);
   }
@@ -253,7 +254,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {
     Random random = new Random();
     String key1 = "{user1}keyz" + random.nextInt();
-    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
+    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     Set<String> keys = new HashSet<>();
     keys.add(key1);
@@ -261,7 +262,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     do {
       String key2 = "{user1}key" + random.nextInt();
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(key2.getBytes())) == 0) {
+          new RedisKey(stringToBytes(key2))) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);
@@ -319,14 +320,14 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     RedisKey key1RedisKey;
     do {
       key1 = "{user1}keyz" + new Random().nextInt();
-      key1RedisKey = new RedisKey(key1.getBytes());
+      key1RedisKey = new RedisKey(stringToBytes(key1));
     } while (stripedExecutor.compareStripes(key1RedisKey, toAvoid) == 0 && keys.add(key1));
 
     do {
       String key2 = "{user1}key" + new Random().nextInt();
 
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(key2.getBytes())) == 0) {
+          new RedisKey(stringToBytes(key2))) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractScanIntegrationTest.java
@@ -18,6 +18,8 @@ package org.apache.geode.redis.internal.executor.key;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -176,12 +178,12 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
           (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, cursor, "COUNT", "2",
               "COUNT", "1");
       allKeysFromScan.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a".getBytes(),
-        "{user1}b".getBytes(), "{user1}c".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder(stringToBytes("{user1}a"),
+        stringToBytes("{user1}b"), stringToBytes("{user1}c"));
   }
 
   @Test
@@ -209,8 +211,8 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
         (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, "0", "MATCH", "{user1}b*",
             "MATCH", "{user1}a*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat((List<byte[]>) result.get(1)).containsExactly("{user1}a".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat((List<byte[]>) result.get(1)).containsExactly(stringToBytes("{user1}a"));
   }
 
   @Test
@@ -252,12 +254,12 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
           (List<Object>) jedis.sendCommand("{user1}", Protocol.Command.SCAN, cursor, "COUNT", "37",
               "MATCH", "{user1}b*", "COUNT", "2", "COUNT", "1", "MATCH", "{user1}a*");
       allKeysFromScan.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a".getBytes(),
-        "{user1}aardvark".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder(stringToBytes("{user1}a"),
+        stringToBytes("{user1}aardvark"));
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractUnlinkIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractUnlinkIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -109,7 +110,7 @@ public abstract class AbstractUnlinkIntegrationTest implements RedisIntegrationT
   public void testUnlink_withBinaryKey() {
     byte[] key = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    jedis.set(key, "foo".getBytes());
+    jedis.set(key, stringToBytes("foo"));
     jedis.unlink(key);
 
     assertThat(jedis.get(key)).isNull();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.executor.pubsub;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedReader;
@@ -75,21 +76,22 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
   @SuppressWarnings("unchecked")
   public void punsubscribe_whenNonexistent() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.PUNSUBSCRIBE, "Nonexistent"))
-        .containsExactly("punsubscribe".getBytes(), "Nonexistent".getBytes(), 0L);
+        .containsExactly(stringToBytes("punsubscribe"), stringToBytes("Nonexistent"),
+            0L);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void unsubscribe_whenNoSubscriptionsExist_shouldNotHang() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.UNSUBSCRIBE))
-        .containsExactly("unsubscribe".getBytes(), null, 0L);
+        .containsExactly(stringToBytes("unsubscribe"), null, 0L);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void punsubscribe_whenNoSubscriptionsExist_shouldNotHang() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.PUNSUBSCRIBE))
-        .containsExactly("punsubscribe".getBytes(), null, 0L);
+        .containsExactly(stringToBytes("punsubscribe"), null, 0L);
   }
 
   @Test
@@ -290,17 +292,17 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
     MockBinarySubscriber mockSubscriber = new MockBinarySubscriber();
 
     Runnable runnable = () -> {
-      subscriber.subscribe(mockSubscriber, "salutations".getBytes());
+      subscriber.subscribe(mockSubscriber, stringToBytes("salutations"));
     };
 
     Thread subscriberThread = new Thread(runnable);
     subscriberThread.start();
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
 
-    Long result = publisher.publish("salutations".getBytes(), expectedMessage);
+    Long result = publisher.publish(stringToBytes("salutations"), expectedMessage);
     assertThat(result).isEqualTo(1);
 
-    mockSubscriber.unsubscribe("salutations".getBytes());
+    mockSubscriber.unsubscribe(stringToBytes("salutations"));
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
     waitFor(() -> !subscriberThread.isAlive());
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubCommandsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubCommandsIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLea
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtMostNArgsForSubCommand;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_PUBSUB_SUBCOMMAND;
 import static org.apache.geode.redis.internal.executor.pubsub.AbstractPubSubIntegrationTest.JEDIS_TIMEOUT;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -38,7 +39,6 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.mocks.MockSubscriber;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
@@ -71,7 +71,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   public void channels_shouldError_givenTooManyArguments() {
     assertAtMostNArgsForSubCommand(introspector,
         Protocol.Command.PUBSUB,
-        Coder.stringToBytes(PUBSUB_CHANNELS),
+        stringToBytes(PUBSUB_CHANNELS),
         1);
   }
 
@@ -86,8 +86,8 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   @Test
   public void channels_shouldReturnListOfAllChannels_withActiveChannelSubscribers_whenCalledWithoutPattern() {
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add(Coder.stringToBytes("foo"));
-    expectedChannels.add(Coder.stringToBytes("bar"));
+    expectedChannels.add(stringToBytes("foo"));
+    expectedChannels.add(stringToBytes("bar"));
     Runnable runnable =
         () -> subscriber.subscribe(mockSubscriber, "foo", "bar");
     Thread subscriberThread = new Thread(runnable);
@@ -144,7 +144,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   @Test
   public void channels_shouldOnlyReturnChannelsWithActiveSubscribers() {
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add(Coder.stringToBytes("bar"));
+    expectedChannels.add(stringToBytes("bar"));
     Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "foo", "bar");
     Thread subscriberThread = new Thread(runnable);
 
@@ -165,7 +165,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
 
     MockSubscriber mockSubscriber2 = new MockSubscriber();
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add(Coder.stringToBytes("foo"));
+    expectedChannels.add(stringToBytes("foo"));
 
     Runnable runnable = () -> subscriber.subscribe(mockSubscriber, "foo");
     Thread subscriber1Thread = new Thread(runnable);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSPopIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSPopIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.executor.set;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -256,7 +257,7 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
 
       byte[] inputBuffer = new byte[1024];
       int n = redisSocket.getInputStream().read(inputBuffer);
-      String result = new String(Arrays.copyOfRange(inputBuffer, 0, n));
+      String result = bytesToString(Arrays.copyOfRange(inputBuffer, 0, n));
 
       assertThat(result).isEqualTo("$3\r\none\r\n");
     }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
@@ -18,6 +18,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -78,7 +80,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<Object> result =
         (List<Object>) jedis.sendCommand("key!", Protocol.Command.SSCAN, "key!", "0", "a*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
     assertThat((List<Object>) result.get(1)).isEmpty();
   }
 
@@ -199,13 +201,14 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<byte[]> allMembersFromScan = new ArrayList<>();
 
     do {
-      result = jedis.sscan("a".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.sscan(stringToBytes("a"), stringToBytes(cursor), scanParams);
       allMembersFromScan.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(allMembersFromScan).containsExactlyInAnyOrder("1".getBytes(), "2".getBytes(),
-        "3".getBytes());
+    assertThat(allMembersFromScan).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("2"),
+        stringToBytes("3"));
   }
 
   @Test
@@ -223,12 +226,13 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
           (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", cursor, "COUNT", "2",
               "COUNT", "1");
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(), "12".getBytes(),
-        "3".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"),
+        stringToBytes("3"));
   }
 
   @Test
@@ -238,10 +242,12 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     ScanParams scanParams = new ScanParams();
     scanParams.match("1*");
 
-    ScanResult<byte[]> result = jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
+    ScanResult<byte[]> result =
+        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
 
     assertThat(result.isCompleteIteration()).isTrue();
-    assertThat(result.getResult()).containsExactlyInAnyOrder("1".getBytes(), "12".getBytes());
+    assertThat(result.getResult()).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"));
   }
 
   @Test
@@ -252,9 +258,9 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<Object> result = (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", "0",
         "MATCH", "3*", "MATCH", "1*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat((List<byte[]>) result.get(1)).containsExactlyInAnyOrder("1".getBytes(),
-        "12".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat((List<byte[]>) result.get(1)).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"));
   }
 
   @Test
@@ -269,12 +275,13 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.sscan("a".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.sscan(stringToBytes("a"), stringToBytes(cursor), scanParams);
       allMembersFromScan.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(allMembersFromScan).containsExactlyInAnyOrder("1".getBytes(), "12".getBytes());
+    assertThat(allMembersFromScan).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"));
   }
 
   @Test
@@ -291,11 +298,12 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
           (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", cursor, "COUNT", "37",
               "MATCH", "3*", "COUNT", "2", "COUNT", "1", "MATCH", "1*");
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(), "12".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"));
   }
 
   @Test
@@ -334,7 +342,8 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     scanParams.count(1);
     scanParams.match("\\p");
 
-    ScanResult<byte[]> result = jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
+    ScanResult<byte[]> result =
+        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
 
     assertThat(result.getResult()).isEmpty();
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSetsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSetsIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.executor.set;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -118,8 +119,8 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
       blob[i] = (byte) i;
     }
 
-    jedis.sadd("key".getBytes(), blob, blob);
-    Set<byte[]> result = jedis.smembers("key".getBytes());
+    jedis.sadd(stringToBytes("key"), blob, blob);
+    Set<byte[]> result = jedis.smembers(stringToBytes("key"));
 
     assertThat(result).containsExactly(blob);
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -41,15 +42,16 @@ public class SScanIntegrationTest extends AbstractSScanIntegrationTest {
     List<byte[]> memberList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       jedis.sadd("a", String.valueOf(i));
-      memberList.add(String.valueOf(i).getBytes());
+      memberList.add(stringToBytes(String.valueOf(i)));
     }
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(5);
-    ScanResult<byte[]> result = jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
+    ScanResult<byte[]> result =
+        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
     assertThat(result.isCompleteIteration()).isFalse();
 
-    result = jedis.sscan("a".getBytes(), "100".getBytes());
+    result = jedis.sscan(stringToBytes("a"), stringToBytes("100"));
 
     assertThat(result.getResult()).containsExactlyInAnyOrderElementsOf(memberList);
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
+import static org.apache.geode.redis.internal.netty.Coder.intToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,7 +43,7 @@ public class SScanIntegrationTest extends AbstractSScanIntegrationTest {
     List<byte[]> memberList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       jedis.sadd("a", String.valueOf(i));
-      memberList.add(stringToBytes(String.valueOf(i)));
+      memberList.add(intToBytes(i));
     }
 
     ScanParams scanParams = new ScanParams();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZIncrByIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZIncrByIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.executor.sortedset;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -35,14 +36,13 @@ import redis.clients.jedis.Protocol;
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;
-import org.apache.geode.redis.internal.netty.Coder;
 
 public abstract class AbstractZIncrByIntegrationTest implements RedisIntegrationTest {
   JedisCluster jedis;
   final String STRING_KEY = "key";
   final String STRING_MEMBER = "member";
-  final byte[] KEY = Coder.stringToBytes(STRING_KEY);
-  final byte[] MEMBER = Coder.stringToBytes(STRING_MEMBER);
+  final byte[] KEY = stringToBytes(STRING_KEY);
+  final byte[] MEMBER = stringToBytes(STRING_MEMBER);
 
   @Before
   public void setUp() {
@@ -142,7 +142,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void memberShouldBeCreatedWhenItDoesNotExist_withIncrementOfPositiveInfinity() {
     final double increment = POSITIVE_INFINITY;
-    jedis.zadd(KEY, 0.0, Coder.stringToBytes("something")); // init the key but not the member
+    jedis.zadd(KEY, 0.0, stringToBytes("something")); // init the key but not the member
 
     assertKeyIsCreatedWithIncrementOf(increment);
   }
@@ -150,7 +150,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void memberShouldBeCreatedWhenItDoesNotExist_withIncrementOfNegativeInfinity() {
     final double increment = NEGATIVE_INFINITY;
-    jedis.zadd(KEY, 0.0, Coder.stringToBytes("something")); // init the key but not the member
+    jedis.zadd(KEY, 0.0, stringToBytes("something")); // init the key but not the member
 
     assertKeyIsCreatedWithIncrementOf(increment);
   }
@@ -226,7 +226,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void shouldCreateNewMember_whenIncrementedMemberDoesNotExist() {
     final double increment = 1.5;
-    jedis.zadd(KEY, increment, Coder.stringToBytes("something"));
+    jedis.zadd(KEY, increment, stringToBytes("something"));
 
     assertThat(jedis.zincrby(KEY, increment, MEMBER)).isEqualTo(increment);
     assertThat(jedis.zscore(KEY, MEMBER)).isEqualTo(increment);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByFloatIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByFloatIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -151,7 +152,7 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
 
     // Beyond this, native redis produces inconsistent results.
     Object rawResult = jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "1");
-    BigDecimal result = new BigDecimal(new String((byte[]) rawResult));
+    BigDecimal result = new BigDecimal(bytesToString((byte[]) rawResult));
 
     assertThat(result.toPlainString()).isEqualTo(biggy.add(BigDecimal.ONE).toPlainString());
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetIntegrationTest.java
@@ -489,39 +489,43 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
-    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "bar", "EX", "a"))
+    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "EX", "a"))
         .as("invalid options #3")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("value is not an integer");
 
-    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "bar", "PX", "1", "EX", "0"))
+    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "1", "EX", "0"))
         .as("invalid options #4")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
-    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "bar", "PX", "1", "XX", "0"))
+    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "1", "XX", "0"))
         .as("invalid options #5")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
-    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "bar", "PX", "XX", "0"))
+    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "XX", "0"))
         .as("invalid options #6")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
-    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "bar", "1", "PX", "1"))
+    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "1", "PX", "1"))
         .as("invalid options #7")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
-    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "bar", "NX", "XX"))
+    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "NX", "XX"))
         .as("invalid options #8")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
+    soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "NX", "a"))
+        .as("invalid options #9")
+        .isInstanceOf(JedisDataException.class)
+        .hasMessageContaining("syntax error");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "blah"))
-        .as("invalid options #9")
+        .as("invalid options #10")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractSetIntegrationTest.java
@@ -481,51 +481,51 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
     SoftAssertions soft = new SoftAssertions();
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET))
-        .as("invalid options #1")
+        .as("no key")
         .isInstanceOf(JedisDataException.class);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "EX", "0"))
-        .as("invalid options #2")
+        .as("no value")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "EX", "a"))
-        .as("invalid options #3")
+        .as("non-integer expiration value")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("value is not an integer");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "1", "EX", "0"))
-        .as("invalid options #4")
+        .as("both PX and EX provided")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "1", "XX", "0"))
-        .as("invalid options #5")
+        .as("extra integer option as last option")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "XX", "0"))
-        .as("invalid options #6")
+        .as("expiration option used with no integer value")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "1", "PX", "1"))
-        .as("invalid options #7")
+        .as("extra integer option as first option")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "NX", "XX"))
-        .as("invalid options #8")
+        .as("both NX and XX provided")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "NX", "a"))
-        .as("invalid options #9")
+        .as("invalid option after valid option")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "blah"))
-        .as("invalid options #10")
+        .as("invalid option")
         .isInstanceOf(JedisDataException.class)
         .hasMessageContaining("syntax error");
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -95,7 +96,7 @@ public class SubscriptionsIntegrationTest {
 
     new ConcurrentLoopingThreads(ITERATIONS,
         i -> subscriptions.add(new DummySubscription()),
-        i -> subscriptions.findSubscriptions("channel".getBytes()))
+        i -> subscriptions.findSubscriptions(stringToBytes("channel")))
             .run();
 
     assertThat(subscriptions.size()).isEqualTo(ITERATIONS);
@@ -113,7 +114,8 @@ public class SubscriptionsIntegrationTest {
       Client client = new Client(channel);
       clients.add(client);
       subscriptions
-          .add(new ChannelSubscription(client, "channel".getBytes(), context, subscriptions));
+          .add(new ChannelSubscription(client, stringToBytes("channel"), context,
+              subscriptions));
     }
 
     new ConcurrentLoopingThreads(1,
@@ -137,12 +139,13 @@ public class SubscriptionsIntegrationTest {
 
       clients.add(client);
       subscriptions
-          .add(new ChannelSubscription(client, "channel".getBytes(), context, subscriptions));
+          .add(new ChannelSubscription(client, stringToBytes("channel"), context,
+              subscriptions));
     }
 
     new ConcurrentLoopingThreads(1,
-        i -> clients.forEach(c -> subscriptions.remove("channel".getBytes(), c)),
-        i -> clients.forEach(c -> subscriptions.remove("channel".getBytes(), c)))
+        i -> clients.forEach(c -> subscriptions.remove(stringToBytes("channel"), c)),
+        i -> clients.forEach(c -> subscriptions.remove(stringToBytes("channel"), c)))
             .run();
 
     assertThat(subscriptions.size()).isEqualTo(0);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/SpopParameterRequirements.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/SpopParameterRequirements.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.ParameterRequirements;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToInt;
 
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
@@ -25,7 +26,7 @@ public class SpopParameterRequirements implements ParameterRequirements {
   public void checkParameters(Command command, ExecutionHandlerContext context) {
     if (command.getProcessedCommand().size() == 3) {
       try {
-        Integer.parseInt(new String(command.getProcessedCommand().get(2)));
+        bytesToInt(command.getProcessedCommand().get(2));
       } catch (NumberFormatException nex) {
         throw new RedisParametersMismatchException(ERROR_NOT_INTEGER);
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -18,11 +18,6 @@ package org.apache.geode.redis.internal;
 public class RedisConstants {
 
   /*
-   * Responses
-   */
-  public static final String QUIT_RESPONSE = "OK";
-
-  /*
    * Error responses
    */
   public static final String PARSING_EXCEPTION_MESSAGE =

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisString.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisString.java
@@ -17,6 +17,8 @@
 package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_STRING;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NUMBER_1_BYTE;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -89,7 +91,7 @@ public class NullRedisString extends RedisString {
   @Override
   public long incr(Region<RedisKey, RedisData> region, RedisKey key)
       throws NumberFormatException, ArithmeticException {
-    byte[] newValue = {Coder.NUMBER_1_BYTE};
+    byte[] newValue = {NUMBER_1_BYTE};
     region.put(key, new RedisString(newValue));
     return 1;
   }
@@ -113,7 +115,7 @@ public class NullRedisString extends RedisString {
   @Override
   public long decr(Region<RedisKey, RedisData> region, RedisKey key)
       throws NumberFormatException, ArithmeticException {
-    region.put(key, new RedisString(Coder.stringToBytes("-1")));
+    region.put(key, new RedisString(stringToBytes("-1")));
     return -1;
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_OVERFLOW;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -287,7 +288,7 @@ public class RedisHash extends AbstractRedisData {
   private void addIfMatching(Pattern matchPattern, List<byte[]> resultList, byte[] key,
       byte[] value) {
     if (matchPattern != null) {
-      if (matchPattern.matcher(Coder.bytesToString(key)).matches()) {
+      if (matchPattern.matcher(bytesToString(key)).matches()) {
         resultList.add(key);
         resultList.add(value);
       }
@@ -313,7 +314,7 @@ public class RedisHash extends AbstractRedisData {
 
     long value;
     try {
-      value = Long.parseLong(Coder.bytesToString(oldValue));
+      value = Long.parseLong(bytesToString(oldValue));
     } catch (NumberFormatException ex) {
       throw new NumberFormatException(ERROR_NOT_INTEGER);
     }
@@ -346,7 +347,7 @@ public class RedisHash extends AbstractRedisData {
       return increment.stripTrailingZeros();
     }
 
-    String valueS = Coder.bytesToString(oldValue);
+    String valueS = bytesToString(oldValue);
     if (valueS.contains(" ")) {
       throw new NumberFormatException("hash value is not a float");
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_OVERFLOW;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.io.DataInput;
@@ -314,7 +315,7 @@ public class RedisHash extends AbstractRedisData {
 
     long value;
     try {
-      value = Long.parseLong(bytesToString(oldValue));
+      value = bytesToLong(oldValue);
     } catch (NumberFormatException ex) {
       throw new NumberFormatException(ERROR_NOT_INTEGER);
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -30,7 +31,6 @@ import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.redis.internal.executor.cluster.CRC16;
 import org.apache.geode.redis.internal.executor.cluster.RedisPartitionResolver;
-import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisKey implements DataSerializableFixedID {
 
@@ -111,7 +111,7 @@ public class RedisKey implements DataSerializableFixedID {
 
   @Override
   public String toString() {
-    return Coder.bytesToString(value);
+    return bytesToString(value);
   }
 
   public byte[] toBytes() {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.data;
 
 import static java.util.Collections.emptyList;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SET;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -47,7 +48,6 @@ import org.apache.geode.redis.internal.collections.SizeableObjectOpenCustomHashS
 import org.apache.geode.redis.internal.delta.AddsDeltaInfo;
 import org.apache.geode.redis.internal.delta.DeltaInfo;
 import org.apache.geode.redis.internal.delta.RemsDeltaInfo;
-import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisSet extends AbstractRedisData {
   private SizeableObjectOpenCustomHashSet<byte[]> members;
@@ -84,7 +84,7 @@ public class RedisSet extends AbstractRedisData {
       }
 
       if (matchPattern != null) {
-        if (matchPattern.matcher(Coder.bytesToString(value)).matches()) {
+        if (matchPattern.matcher(bytesToString(value)).matches()) {
           returnList.add(value);
           numElements++;
         }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -20,6 +20,7 @@ import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SORTED_SET;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -323,7 +324,7 @@ public class RedisSortedSet extends AbstractRedisData {
   }
 
   private double processByteArrayAsDouble(byte[] value) {
-    String stringValue = Coder.bytesToString(value).toLowerCase();
+    String stringValue = bytesToString(value).toLowerCase();
     double processedDouble;
     switch (stringValue) {
       case "inf":

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.redis.internal.data;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -141,7 +143,7 @@ public class RedisString extends AbstractRedisData {
   }
 
   private BigDecimal parseValueAsBigDecimal() {
-    String valueString = Coder.bytesToString(value);
+    String valueString = bytesToString(value);
     if (valueString.contains(" ")) {
       throw new NumberFormatException(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
     }
@@ -435,7 +437,7 @@ public class RedisString extends AbstractRedisData {
   public String toString() {
     return "RedisString{" +
         super.toString() + ", " +
-        "value=" + new String(value) +
+        "value=" + bytesToString(value) +
         '}';
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
@@ -82,7 +82,7 @@ public class RedisResponse {
   }
 
   public static RedisResponse ok() {
-    return new RedisResponse((buffer) -> Coder.getSimpleStringResponse(buffer, "OK"));
+    return new RedisResponse(Coder::getOKResponse);
   }
 
   public static RedisResponse nil() {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/UnknownExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/UnknownExecutor.java
@@ -16,10 +16,10 @@
 package org.apache.geode.redis.internal.executor;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_COMMAND;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.util.List;
 
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -34,14 +34,14 @@ public class UnknownExecutor extends AbstractExecutor {
     List<byte[]> commandElems = command.getProcessedCommand();
 
     if (commandElems != null && !commandElems.isEmpty()) {
-      commandText = Coder.bytesToString(commandElems.get(0));
+      commandText = bytesToString(commandElems.get(0));
 
       if (commandElems.size() > 1) {
         for (int i = 1; i < commandElems.size(); i++) {
           if (commandElems.get(i) == null) {
             continue;
           }
-          commandArguments.append("`").append(Coder.bytesToString(commandElems.get(i)))
+          commandArguments.append("`").append(bytesToString(commandElems.get(i)))
               .append("`, ");
         }
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/CRC16.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/CRC16.java
@@ -15,6 +15,9 @@
 
 package org.apache.geode.redis.internal.executor.cluster;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+
+
 /**
  * Helper class to calculate the CRC-16/XMODEM value of a byte array. This is the same algorithm
  * that Redis uses.
@@ -60,7 +63,7 @@ public class CRC16 {
   }
 
   public static int calculate(String data) {
-    byte[] bytes = data.getBytes();
+    byte[] bytes = stringToBytes(data);
     return calculate(bytes, 0, bytes.length);
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
@@ -18,6 +18,11 @@ package org.apache.geode.redis.internal.executor.cluster;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_CLUSTER_SUBCOMMAND;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINFO;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNODES;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSLOTS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -45,19 +50,17 @@ public class ClusterExecutor extends AbstractExecutor {
       throws Exception {
 
     List<byte[]> args = command.getProcessedCommand();
-    String subCommand = new String(args.get(1));
+    byte[] bytes = args.get(1);
 
-    switch (subCommand.toLowerCase()) {
-      case "info":
-        return getInfo(context);
-      case "nodes":
-        return getNodes(context);
-      case "slots":
-        return getSlots(context);
-      default: {
-        return RedisResponse.error(
-            String.format(ERROR_UNKNOWN_CLUSTER_SUBCOMMAND, subCommand));
-      }
+    if (equalsIgnoreCaseBytes(bytes, bINFO)) {
+      return getInfo(context);
+    } else if (equalsIgnoreCaseBytes(bytes, bNODES)) {
+      return getNodes(context);
+    } else if (equalsIgnoreCaseBytes(bytes, bSLOTS)) {
+      return getSlots(context);
+    } else {
+      return RedisResponse.error(
+          String.format(ERROR_UNKNOWN_CLUSTER_SUBCOMMAND, bytesToString(bytes)));
     }
   }
 
@@ -165,4 +168,5 @@ public class ClusterExecutor extends AbstractExecutor {
 
     return info.getPartitionMemberInfo();
   }
+
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -15,6 +15,10 @@
  */
 package org.apache.geode.redis.internal.executor.connection;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPING_RESPONSE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPING_RESPONSE_LOWERCASE;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,8 +28,6 @@ import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class PingExecutor extends AbstractExecutor {
-
-  private final String PING_RESPONSE = "PONG";
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
@@ -39,7 +41,7 @@ public class PingExecutor extends AbstractExecutor {
       if (commandElems.size() > 1) {
         result = commandElems.get(1);
       } else {
-        result = PING_RESPONSE.getBytes();
+        result = bPING_RESPONSE;
       }
       redisResponse = RedisResponse.string(result);
     } else {
@@ -48,10 +50,9 @@ public class PingExecutor extends AbstractExecutor {
       if (commandElems.size() > 1) {
         result = commandElems.get(1);
       } else {
-        result = "".getBytes();
+        result = stringToBytes("");
       }
-      redisResponse =
-          RedisResponse.array(Arrays.asList(PING_RESPONSE.toLowerCase().getBytes(), result));
+      redisResponse = RedisResponse.array(Arrays.asList(bPING_RESPONSE_LOWERCASE, result));
     }
 
     return redisResponse;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/QuitExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/QuitExecutor.java
@@ -15,7 +15,6 @@
  */
 package org.apache.geode.redis.internal.executor.connection;
 
-import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -29,7 +28,7 @@ public class QuitExecutor extends AbstractExecutor {
 
     context.eventLoopReady();
 
-    return RedisResponse.string(RedisConstants.QUIT_RESPONSE);
+    return RedisResponse.ok();
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/SelectExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/SelectExecutor.java
@@ -27,8 +27,8 @@ public class SelectExecutor extends AbstractExecutor {
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    byte[] bytes = command.getBytesKey();
-    if (bytes.length == 1 && bytes[0] == NUMBER_0_BYTE) {
+    byte[] dbIndexBytes = command.getBytesKey();
+    if (dbIndexBytes.length == 1 && dbIndexBytes[0] == NUMBER_0_BYTE) {
       return RedisResponse.ok();
     }
     return RedisResponse.error(ERROR_SELECT);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/SelectExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/SelectExecutor.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.connection;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SELECT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NUMBER_0_BYTE;
 
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
@@ -26,13 +27,11 @@ public class SelectExecutor extends AbstractExecutor {
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    String dbIndexString = command.getStringKey();
-
-    if (!dbIndexString.equals("0")) {
-      return RedisResponse.error(ERROR_SELECT);
+    byte[] bytes = command.getBytesKey();
+    if (bytes.length == 1 && bytes[0] == NUMBER_0_BYTE) {
+      return RedisResponse.ok();
     }
-
-    return RedisResponse.ok();
+    return RedisResponse.error(ERROR_SELECT);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -19,6 +19,10 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_HASH;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -50,7 +54,7 @@ public class HScanExecutor extends AbstractScanExecutor {
 
     List<byte[]> commandElems = command.getProcessedCommand();
 
-    String cursorString = Coder.bytesToString(commandElems.get(2));
+    String cursorString = bytesToString(commandElems.get(2));
     int cursor;
     Pattern matchPattern;
     String globPattern = null;
@@ -76,12 +80,11 @@ public class HScanExecutor extends AbstractScanExecutor {
 
     for (int i = 3; i < commandElems.size(); i = i + 2) {
       byte[] commandElemBytes = commandElems.get(i);
-      String keyword = Coder.bytesToString(commandElemBytes);
-      if (keyword.equalsIgnoreCase("MATCH")) {
+      if (equalsIgnoreCaseBytes(commandElemBytes, bMATCH)) {
         commandElemBytes = commandElems.get(i + 1);
-        globPattern = Coder.bytesToString(commandElemBytes);
+        globPattern = bytesToString(commandElemBytes);
 
-      } else if (keyword.equalsIgnoreCase("COUNT")) {
+      } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
         commandElemBytes = commandElems.get(i + 1);
         try {
           count = Coder.bytesToInt(commandElemBytes);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/KeysExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/KeysExecutor.java
@@ -15,6 +15,8 @@
  */
 package org.apache.geode.redis.internal.executor.key;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -28,7 +30,6 @@ import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -38,7 +39,7 @@ public class KeysExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
-    String glob = Coder.bytesToString(commandElems.get(1));
+    String glob = bytesToString(commandElems.get(1));
     Set<RedisKey> allKeys = getDataRegion(context).keySet();
     List<RedisKey> matchingKeys = new ArrayList<>();
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/RenameExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/RenameExecutor.java
@@ -37,13 +37,13 @@ public class RenameExecutor extends AbstractExecutor {
     RedisKeyCommands redisKeyCommands = context.getKeyCommands();
 
     if (key.equals(newKey)) {
-      return RedisResponse.string("OK");
+      return RedisResponse.ok();
     }
 
     if (!redisKeyCommands.rename(key, newKey)) {
       return RedisResponse.error(ERROR_NO_SUCH_KEY);
     }
 
-    return RedisResponse.string("OK");
+    return RedisResponse.ok();
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
@@ -18,6 +18,10 @@ package org.apache.geode.redis.internal.executor.key;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -64,12 +68,11 @@ public class ScanExecutor extends AbstractScanExecutor {
 
     for (int i = 2; i < commandElems.size(); i = i + 2) {
       byte[] commandElemBytes = commandElems.get(i);
-      String keyword = Coder.bytesToString(commandElemBytes);
-      if (keyword.equalsIgnoreCase("MATCH")) {
+      if (equalsIgnoreCaseBytes(commandElemBytes, bMATCH)) {
         commandElemBytes = commandElems.get(i + 1);
-        globPattern = Coder.bytesToString(commandElemBytes);
+        globPattern = bytesToString(commandElemBytes);
 
-      } else if (keyword.equalsIgnoreCase("COUNT")) {
+      } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
         commandElemBytes = commandElems.get(i + 1);
         try {
           count = Coder.bytesToInt(commandElemBytes);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PsubscribeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PsubscribeExecutor.java
@@ -30,8 +30,7 @@ import org.apache.geode.redis.internal.pubsub.SubscribeResult;
 public class PsubscribeExecutor extends AbstractExecutor {
 
   @Override
-  public RedisResponse executeCommand(Command command,
-      ExecutionHandlerContext context) {
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
 
     context.eventLoopReady();
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PubSubExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PubSubExecutor.java
@@ -18,13 +18,14 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_PUBSUB_SUBCOMMAND;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCHANNELS;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.geode.redis.internal.executor.Executor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -35,16 +36,16 @@ public class PubSubExecutor implements Executor {
 
     byte[] subCommand = command.getProcessedCommand().get(1);
 
-    if (!Arrays.equals(subCommand, Coder.stringToBytes("channels"))) {
+    if (!equalsIgnoreCaseBytes(subCommand, bCHANNELS)) {
       return RedisResponse
-          .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, new String(subCommand)));
+          .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, bytesToString(subCommand)));
     }
 
     // in a subsequent story, a new parameter requirement class
     // specific to subCommands might be a better way to do this
     if (command.getProcessedCommand().size() > 3) {
       return RedisResponse
-          .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, new String(subCommand)));
+          .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, bytesToString(subCommand)));
     }
 
     List<byte[]> response;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PunsubscribeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PunsubscribeExecutor.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal.executor.pubsub;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.pubsub.Subscription.Type.PATTERN;
 
 import java.util.ArrayList;
@@ -59,7 +60,7 @@ public class PunsubscribeExecutor extends AbstractExecutor {
     } else {
       for (byte[] pattern : patternNames) {
         long subscriptionCount =
-            context.getPubSub().punsubscribe(new GlobPattern(new String(pattern)),
+            context.getPubSub().punsubscribe(new GlobPattern(bytesToString(pattern)),
                 context.getClient());
         response.add(createItem(pattern, subscriptionCount));
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/FlushAllExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/FlushAllExecutor.java
@@ -37,7 +37,7 @@ public class FlushAllExecutor extends AbstractExecutor {
       redisKeyCommands.del((RedisKey) skey);
     }
 
-    return RedisResponse.string("OK");
+    return RedisResponse.ok();
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/InfoExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/InfoExecutor.java
@@ -15,13 +15,24 @@
 
 package org.apache.geode.redis.internal.executor.server;
 
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bALL;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCLIENTS;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCLUSTER;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bDEFAULT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bKEYSPACE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMEMORY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPERSISTENCE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bREPLICATION;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSERVER;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSTATS;
+
 import java.text.DecimalFormat;
 import java.util.List;
 
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.statistics.RedisStats;
@@ -50,44 +61,29 @@ public class InfoExecutor extends AbstractExecutor {
     return commands.size() == 2;
   }
 
-  private String getSpecifiedSection(ExecutionHandlerContext context,
-      List<byte[]> commands) {
-    String result;
-    String section = Coder.bytesToString(commands.get(1)).toLowerCase();
-    switch (section) {
-      case "server":
-        result = getServerSection(context);
-        break;
-      case "cluster":
-        result = getClusterSection();
-        break;
-      case "persistence":
-        result = getPersistenceSection();
-        break;
-      case "replication":
-        result = getReplicationSection();
-        break;
-      case "stats":
-        result = getStatsSection(context);
-        break;
-      case "clients":
-        result = getClientsSection(context);
-        break;
-      case "memory":
-        result = getMemorySection(context);
-        break;
-      case "keyspace":
-        result = getKeyspaceSection(context);
-        break;
-      case "default":
-      case "all":
-        result = getAllSections(context);
-        break;
-      default:
-        result = "";
-        break;
+  private String getSpecifiedSection(ExecutionHandlerContext context, List<byte[]> commands) {
+    byte[] bytes = commands.get(1);
+    if (equalsIgnoreCaseBytes(bytes, bSERVER)) {
+      return getServerSection(context);
+    } else if (equalsIgnoreCaseBytes(bytes, bCLUSTER)) {
+      return getClusterSection();
+    } else if (equalsIgnoreCaseBytes(bytes, bPERSISTENCE)) {
+      return getPersistenceSection();
+    } else if (equalsIgnoreCaseBytes(bytes, bREPLICATION)) {
+      return getReplicationSection();
+    } else if (equalsIgnoreCaseBytes(bytes, bSTATS)) {
+      return getStatsSection(context);
+    } else if (equalsIgnoreCaseBytes(bytes, bCLIENTS)) {
+      return getClientsSection(context);
+    } else if (equalsIgnoreCaseBytes(bytes, bMEMORY)) {
+      return getMemorySection(context);
+    } else if (equalsIgnoreCaseBytes(bytes, bKEYSPACE)) {
+      return getKeyspaceSection(context);
+    } else if (equalsIgnoreCaseBytes(bytes, bDEFAULT) || equalsIgnoreCaseBytes(bytes, bALL)) {
+      return getAllSections(context);
+    } else {
+      return "";
     }
-    return result;
   }
 
   private String getStatsSection(ExecutionHandlerContext context) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/InfoExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/InfoExecutor.java
@@ -15,7 +15,7 @@
 
 package org.apache.geode.redis.internal.executor.server;
 
-import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bALL;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCLIENTS;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCLUSTER;
@@ -28,6 +28,7 @@ import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSERVER;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSTATS;
 
 import java.text.DecimalFormat;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.geode.internal.cache.PartitionedRegion;
@@ -62,24 +63,24 @@ public class InfoExecutor extends AbstractExecutor {
   }
 
   private String getSpecifiedSection(ExecutionHandlerContext context, List<byte[]> commands) {
-    byte[] bytes = commands.get(1);
-    if (equalsIgnoreCaseBytes(bytes, bSERVER)) {
+    byte[] bytes = toUpperCaseBytes(commands.get(1));
+    if (Arrays.equals(bytes, bSERVER)) {
       return getServerSection(context);
-    } else if (equalsIgnoreCaseBytes(bytes, bCLUSTER)) {
+    } else if (Arrays.equals(bytes, bCLUSTER)) {
       return getClusterSection();
-    } else if (equalsIgnoreCaseBytes(bytes, bPERSISTENCE)) {
+    } else if (Arrays.equals(bytes, bPERSISTENCE)) {
       return getPersistenceSection();
-    } else if (equalsIgnoreCaseBytes(bytes, bREPLICATION)) {
+    } else if (Arrays.equals(bytes, bREPLICATION)) {
       return getReplicationSection();
-    } else if (equalsIgnoreCaseBytes(bytes, bSTATS)) {
+    } else if (Arrays.equals(bytes, bSTATS)) {
       return getStatsSection(context);
-    } else if (equalsIgnoreCaseBytes(bytes, bCLIENTS)) {
+    } else if (Arrays.equals(bytes, bCLIENTS)) {
       return getClientsSection(context);
-    } else if (equalsIgnoreCaseBytes(bytes, bMEMORY)) {
+    } else if (Arrays.equals(bytes, bMEMORY)) {
       return getMemorySection(context);
-    } else if (equalsIgnoreCaseBytes(bytes, bKEYSPACE)) {
+    } else if (Arrays.equals(bytes, bKEYSPACE)) {
       return getKeyspaceSection(context);
-    } else if (equalsIgnoreCaseBytes(bytes, bDEFAULT) || equalsIgnoreCaseBytes(bytes, bALL)) {
+    } else if (Arrays.equals(bytes, bDEFAULT) || Arrays.equals(bytes, bALL)) {
       return getAllSections(context);
     } else {
       return "";

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/ShutDownExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/ShutDownExecutor.java
@@ -23,8 +23,7 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 public class ShutDownExecutor extends AbstractExecutor {
 
   @Override
-  public RedisResponse executeCommand(Command command,
-      ExecutionHandlerContext context) {
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     context.shutdown();
     return RedisResponse.nil();
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/SlowlogExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/SlowlogExecutor.java
@@ -15,10 +15,12 @@
 
 package org.apache.geode.redis.internal.executor.server;
 
-import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGET;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEN;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bRESET;
+
+import java.util.Arrays;
 
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
@@ -30,12 +32,12 @@ public class SlowlogExecutor extends AbstractExecutor {
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    byte[] subCommand = command.getBytesKey();
-    if (equalsIgnoreCaseBytes(subCommand, bGET)) {
+    byte[] subCommand = toUpperCaseBytes(command.getBytesKey());
+    if (Arrays.equals(subCommand, bGET)) {
       return RedisResponse.emptyArray();
-    } else if (equalsIgnoreCaseBytes(subCommand, bLEN)) {
+    } else if (Arrays.equals(subCommand, bLEN)) {
       return RedisResponse.integer(0);
-    } else if (equalsIgnoreCaseBytes(subCommand, bRESET)) {
+    } else if (Arrays.equals(subCommand, bRESET)) {
       return RedisResponse.ok();
     } else {
       return null;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/SlowlogExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/SlowlogExecutor.java
@@ -15,6 +15,11 @@
 
 package org.apache.geode.redis.internal.executor.server;
 
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGET;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEN;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bRESET;
+
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
@@ -24,18 +29,16 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 public class SlowlogExecutor extends AbstractExecutor {
 
   @Override
-  public RedisResponse executeCommand(Command command,
-      ExecutionHandlerContext context) {
-    String subCommand = command.getStringKey().toLowerCase();
-    switch (subCommand) {
-      case "get":
-        return RedisResponse.emptyArray();
-      case "len":
-        return RedisResponse.integer(0);
-      case "reset":
-        return RedisResponse.ok();
-      default:
-        return null; // Should never happen
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
+    byte[] subCommand = command.getBytesKey();
+    if (equalsIgnoreCaseBytes(subCommand, bGET)) {
+      return RedisResponse.emptyArray();
+    } else if (equalsIgnoreCaseBytes(subCommand, bLEN)) {
+      return RedisResponse.integer(0);
+    } else if (equalsIgnoreCaseBytes(subCommand, bRESET)) {
+      return RedisResponse.ok();
+    } else {
+      return null;
     }
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMoveExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMoveExecutor.java
@@ -29,10 +29,6 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class SMoveExecutor extends AbstractExecutor {
 
-  private static final int MOVED = 1;
-
-  private static final int NOT_MOVED = 0;
-
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
@@ -50,10 +46,9 @@ public class SMoveExecutor extends AbstractExecutor {
 
     boolean removed =
         redisSetCommands.srem(source, new ArrayList<>(Collections.singletonList(member))) == 1;
-    if (!removed) {
-      return RedisResponse.integer(NOT_MOVED);
+    if (removed) {
+      redisSetCommands.sadd(destination, new ArrayList<>(Collections.singletonList(member)));
     }
-    redisSetCommands.sadd(destination, new ArrayList<>(Collections.singletonList(member)));
-    return RedisResponse.integer(MOVED);
+    return RedisResponse.integer(removed);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
+
 import java.util.Collection;
 import java.util.List;
 
@@ -46,7 +47,7 @@ public class SPopExecutor extends AbstractExecutor {
     }
 
     if (!isCountPassed) {
-      return RedisResponse.bulkString(Coder.bytesToString(popped.iterator().next()));
+      return RedisResponse.bulkString(popped.iterator().next());
     }
 
     return RedisResponse.array(popped);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -20,6 +20,10 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SET;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -43,7 +47,7 @@ public class SScanExecutor extends AbstractScanExecutor {
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
 
-    String cursorString = Coder.bytesToString(commandElems.get(2));
+    String cursorString = bytesToString(commandElems.get(2));
     BigInteger cursor;
     Pattern matchPattern;
     String globPattern = null;
@@ -78,12 +82,11 @@ public class SScanExecutor extends AbstractScanExecutor {
 
     for (int i = 3; i < commandElems.size(); i = i + 2) {
       byte[] commandElemBytes = commandElems.get(i);
-      String keyword = Coder.bytesToString(commandElemBytes);
-      if (keyword.equalsIgnoreCase("MATCH")) {
+      if (equalsIgnoreCaseBytes(commandElemBytes, bMATCH)) {
         commandElemBytes = commandElems.get(i + 1);
-        globPattern = Coder.bytesToString(commandElemBytes);
+        globPattern = bytesToString(commandElemBytes);
 
-      } else if (keyword.equalsIgnoreCase("COUNT")) {
+      } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
         commandElemBytes = commandElems.get(i + 1);
         try {
           count = Coder.bytesToInt(commandElemBytes);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
@@ -18,6 +18,13 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_ZADD_
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCH;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINCR;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bXX;
 
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -25,7 +32,6 @@ import java.util.List;
 
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -69,39 +75,28 @@ public class ZAddExecutor extends AbstractExecutor {
     int optionsFoundCount = 0;
 
     while (commandIterator.hasNext() && !scoreFound) {
-      String subCommandString = Coder.bytesToString(commandIterator.next()).toLowerCase();
-      switch (subCommandString) {
-        case "nx":
-          executorState.nxFound = true;
-          optionsFoundCount++;
-          break;
-        case "xx":
-          executorState.xxFound = true;
-          optionsFoundCount++;
-          break;
-        case "ch":
-          executorState.chFound = true;
-          optionsFoundCount++;
-          break;
-        case "inf":
-        case "+inf":
-        case "-inf":
-        case "infinity":
-        case "+infinity":
-        case "-infinity":
-          scoreFound = true;
-          break;
-        case "incr":
-          executorState.incrFound = true;
-          optionsFoundCount++;
-          break;
-        default:
-          try {
-            Double.valueOf(subCommandString);
-          } catch (NumberFormatException nfe) {
-            executorState.exceptionMessage = ERROR_NOT_A_VALID_FLOAT;
-          }
-          scoreFound = true;
+      byte[] subCommand = commandIterator.next();
+      if (equalsIgnoreCaseBytes(subCommand, bNX)) {
+        executorState.nxFound = true;
+        optionsFoundCount++;
+      } else if (equalsIgnoreCaseBytes(subCommand, bXX)) {
+        executorState.xxFound = true;
+        optionsFoundCount++;
+      } else if (equalsIgnoreCaseBytes(subCommand, bCH)) {
+        executorState.chFound = true;
+        optionsFoundCount++;
+      } else if (equalsIgnoreCaseBytes(subCommand, bINCR)) {
+        executorState.incrFound = true;
+        optionsFoundCount++;
+      } else if (isInfinity(subCommand)) {
+        scoreFound = true;
+      } else {
+        try {
+          Double.valueOf(bytesToString(subCommand));
+        } catch (NumberFormatException nfe) {
+          executorState.exceptionMessage = ERROR_NOT_A_VALID_FLOAT;
+        }
+        scoreFound = true;
       }
     }
     if ((command.getProcessedCommand().size() - optionsFoundCount - 2) % 2 != 0) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
@@ -19,14 +19,15 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_F
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
+import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCH;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINCR;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNX;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bXX;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -75,17 +76,17 @@ public class ZAddExecutor extends AbstractExecutor {
     int optionsFoundCount = 0;
 
     while (commandIterator.hasNext() && !scoreFound) {
-      byte[] subCommand = commandIterator.next();
-      if (equalsIgnoreCaseBytes(subCommand, bNX)) {
+      byte[] subCommand = toUpperCaseBytes(commandIterator.next());
+      if (Arrays.equals(subCommand, bNX)) {
         executorState.nxFound = true;
         optionsFoundCount++;
-      } else if (equalsIgnoreCaseBytes(subCommand, bXX)) {
+      } else if (Arrays.equals(subCommand, bXX)) {
         executorState.xxFound = true;
         optionsFoundCount++;
-      } else if (equalsIgnoreCaseBytes(subCommand, bCH)) {
+      } else if (Arrays.equals(subCommand, bCH)) {
         executorState.chFound = true;
         optionsFoundCount++;
-      } else if (equalsIgnoreCaseBytes(subCommand, bINCR)) {
+      } else if (Arrays.equals(subCommand, bINCR)) {
         executorState.incrFound = true;
         optionsFoundCount++;
       } else if (isInfinity(subCommand)) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScoreExecutor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+
 import java.util.List;
 
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
@@ -34,6 +36,6 @@ public class ZScoreExecutor extends AbstractExecutor {
     if (score == null) {
       return RedisResponse.nil();
     }
-    return RedisResponse.bulkString(new String(score));
+    return RedisResponse.bulkString(bytesToString(score));
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScoreExecutor.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.util.List;
 
@@ -33,9 +32,6 @@ public class ZScoreExecutor extends AbstractExecutor {
     byte[] score =
         redisSortedSetCommands.zscore(command.getKey(), commandElements.get(2));
 
-    if (score == null) {
-      return RedisResponse.nil();
-    }
-    return RedisResponse.bulkString(bytesToString(score));
+    return RedisResponse.bulkString(score);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/BitOpExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/BitOpExecutor.java
@@ -35,6 +35,8 @@ public class BitOpExecutor extends AbstractExecutor {
       ExecutionHandlerContext context) {
     List<byte[]> commandElems = command.getProcessedCommand();
 
+    // TODO: When BitOp becomes a supported command, replace this String conversion with byte[]
+    // comparison and a class similar to ZAddOptions which should be passed into the bitop() methods
     String operation = command.getStringKey().toUpperCase();
     if (!operation.equals("AND")
         && !operation.equals("OR")

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/DecrByExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/DecrByExecutor.java
@@ -16,13 +16,13 @@ package org.apache.geode.redis.internal.executor.string;
 
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 
 import java.util.List;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -36,11 +36,10 @@ public class DecrByExecutor extends AbstractExecutor {
     RedisKey key = command.getKey();
 
     byte[] decrArray = commandElems.get(DECREMENT_INDEX);
-    String decrString = Coder.bytesToString(decrArray);
     long decrement;
 
     try {
-      decrement = Long.parseLong(decrString);
+      decrement = bytesToLong(decrArray);
     } catch (NumberFormatException e) {
       return RedisResponse.error(ERROR_NOT_INTEGER);
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/IncrByFloatExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/IncrByFloatExecutor.java
@@ -18,7 +18,6 @@ import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
 
 import java.math.BigDecimal;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
@@ -33,9 +32,6 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 public class IncrByFloatExecutor extends AbstractExecutor {
 
   private static final int INCREMENT_INDEX = 2;
-
-  private static final Pattern invalidArgs =
-      Pattern.compile("[+-]?(inf|infinity)", Pattern.CASE_INSENSITIVE);
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/IncrByFloatExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/IncrByFloatExecutor.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.redis.internal.executor.string;
 
+import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
+
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -53,8 +55,7 @@ public class IncrByFloatExecutor extends AbstractExecutor {
   }
 
   public static Pair<BigDecimal, RedisResponse> validateIncrByFloatArgument(byte[] incrArray) {
-    String doub = Coder.bytesToString(incrArray).toLowerCase();
-    if (invalidArgs.matcher(doub).matches()) {
+    if (isInfinity(incrArray)) {
       return Pair.of(null, RedisResponse.error(RedisConstants.ERROR_NAN_OR_INFINITY));
     }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetEXExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetEXExecutor.java
@@ -34,8 +34,6 @@ public class SetEXExecutor extends AbstractExecutor {
   private static final String ERROR_SECONDS_NOT_LEGAL =
       "invalid expire time in setex";
 
-  private static final String SUCCESS = "OK";
-
   private static final int VALUE_INDEX = 3;
 
   @Override
@@ -66,7 +64,7 @@ public class SetEXExecutor extends AbstractExecutor {
 
     stringCommands.set(key, value, setOptions);
 
-    return RedisResponse.string(SUCCESS);
+    return RedisResponse.ok();
   }
 
   protected boolean timeUnitMillis() {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetExecutor.java
@@ -14,48 +14,149 @@
  */
 package org.apache.geode.redis.internal.executor.string;
 
-import static java.lang.Long.parseLong;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_EXPIRE_TIME;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bEX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bXX;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
+import org.apache.geode.redis.internal.executor.BaseSetOptions;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class SetExecutor extends AbstractExecutor {
 
   private static final int VALUE_INDEX = 2;
-  private static final String SUCCESS = "OK";
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
 
     RedisKey keyToSet = command.getKey();
     List<byte[]> commandElementsBytes = command.getProcessedCommand();
-    List<byte[]> optionalParameterBytes = getOptionalParameters(commandElementsBytes);
-    RedisStringCommands redisStringCommands = context.getStringCommands();
-    SetOptions setOptions;
 
+    SetOptions setOptions;
+    List<byte[]> optionalParameters =
+        commandElementsBytes.subList(VALUE_INDEX + 1, commandElementsBytes.size());
     try {
-      setOptions = parseOptionalParameters(optionalParameterBytes);
+      setOptions = parseOptionalParameters(optionalParameters);
     } catch (IllegalArgumentException ex) {
       return RedisResponse.error(ex.getMessage());
     }
 
+    RedisStringCommands redisStringCommands = context.getStringCommands();
     return doSet(keyToSet, commandElementsBytes.get(VALUE_INDEX), redisStringCommands, setOptions);
   }
 
-  private List<byte[]> getOptionalParameters(List<byte[]> commandElementsBytes) {
-    return commandElementsBytes.subList(3, commandElementsBytes.size());
+  private SetOptions parseOptionalParameters(List<byte[]> optionalParameters)
+      throws IllegalArgumentException {
+
+    SetOptionsCollector options = new SetOptionsCollector();
+
+    // Iterate the list in reverse order to allow similar error reporting behaviour to native redis
+    for (int index = optionalParameters.size() - 1; index >= 0; --index) {
+      if (equalsIgnoreCaseBytes(optionalParameters.get(index), bXX)) {
+        handleXX(options);
+      } else if (equalsIgnoreCaseBytes(optionalParameters.get(index), bNX)) {
+        handleNX(options);
+      } else {
+        // Yhe only valid possibility now is that the parameter is a number preceded by either EX or
+        // PX
+        handleNumber(options, optionalParameters, index);
+        // If the above method doesn't throw, we successfully parsed a pair of parameters, so skip
+        // the next parameter
+        --index;
+      }
+    }
+
+    if ((options.foundPX || options.foundEX) && options.expirationMillis <= 0) {
+      throw new IllegalArgumentException(ERROR_INVALID_EXPIRE_TIME);
+    }
+
+    return new SetOptions(options.existsOption, options.expirationMillis, false);
+  }
+
+  private void handleXX(SetOptionsCollector options) {
+    if (options.foundNX) {
+      throw new IllegalArgumentException(ERROR_SYNTAX);
+    } else {
+      options.existsOption = BaseSetOptions.Exists.XX;
+      options.foundXX = true;
+    }
+  }
+
+  private void handleNX(SetOptionsCollector options) {
+    if (options.foundXX) {
+      throw new IllegalArgumentException(ERROR_SYNTAX);
+    } else {
+      options.existsOption = BaseSetOptions.Exists.NX;
+      options.foundNX = true;
+    }
+  }
+
+  private void handleNumber(SetOptionsCollector options, List<byte[]> parameters, int index) {
+    doBasicValidation(options, index);
+
+    byte[] previousParameter = parameters.get(index - 1);
+    throwIfNotExpirationParameter(previousParameter);
+
+    long expiration;
+    try {
+      expiration = bytesToLong(parameters.get(index));
+    } catch (NumberFormatException ex) {
+      throw new IllegalArgumentException(ERROR_NOT_INTEGER);
+    }
+
+    if (equalsIgnoreCaseBytes(previousParameter, bEX)) {
+      handleEX(options, expiration);
+    } else {
+      handlePX(options, expiration);
+    }
+  }
+
+  private void doBasicValidation(SetOptionsCollector options, int index) {
+    // The first optional parameter cannot be a number
+    if (index == 0) {
+      throw new IllegalArgumentException(ERROR_SYNTAX);
+    }
+
+    // We already found and set an expiration value
+    if (options.expirationMillis != 0) {
+      throw new IllegalArgumentException(ERROR_SYNTAX);
+    }
+  }
+
+  private void throwIfNotExpirationParameter(byte[] previousParameter) {
+    // Numbers must be preceded by either EX or PX
+    if (!equalsIgnoreCaseBytes(previousParameter, bEX)
+        && !equalsIgnoreCaseBytes(previousParameter, bPX)) {
+      throw new IllegalArgumentException(ERROR_SYNTAX);
+    }
+  }
+
+  private void handleEX(SetOptionsCollector options, long expiration) {
+    if (options.foundPX) {
+      throw new IllegalArgumentException(ERROR_SYNTAX);
+    }
+    options.expirationMillis = SECONDS.toMillis(expiration);
+    options.foundEX = true;
+  }
+
+  private void handlePX(SetOptionsCollector options, long expiration) {
+    if (options.foundEX) {
+      throw new IllegalArgumentException(ERROR_SYNTAX);
+    }
+    options.expirationMillis = expiration;
+    options.foundPX = true;
   }
 
   private RedisResponse doSet(RedisKey key, byte[] value, RedisStringCommands redisStringCommands,
@@ -64,156 +165,18 @@ public class SetExecutor extends AbstractExecutor {
     boolean setCompletedSuccessfully = redisStringCommands.set(key, value, setOptions);
 
     if (setCompletedSuccessfully) {
-      return RedisResponse.string(SUCCESS);
+      return RedisResponse.ok();
     } else {
       return RedisResponse.nil();
     }
   }
 
-  private SetOptions parseOptionalParameters(List<byte[]> optionalParameterBytes)
-      throws IllegalArgumentException {
-
-    boolean keepTTL = false;
+  private static class SetOptionsCollector {
     SetOptions.Exists existsOption = SetOptions.Exists.NONE;
-    long millisecondsUntilExpiration = 0L;
-
-    List<String> optionalParametersStrings =
-        optionalParameterBytes.stream()
-            .map(item -> Coder.bytesToString(item).toUpperCase())
-            .collect(Collectors.toList());
-
-    throwExceptionIfIncompatableParameterOptions(optionalParametersStrings);
-    throwErrorIfNumberInWrongPosition(optionalParametersStrings);
-    throwExceptionIfUnknownParameter(optionalParametersStrings);
-
-    // uncomment below when this functionality is reimplemented see GEODE-8263
-    // keepTTL = optionalParametersStrings.contains("KEEPTTL");
-
-    if (optionalParametersStrings.contains("PX")) {
-      millisecondsUntilExpiration =
-          handleExpiration(optionalParametersStrings, "PX");
-
-    } else if (optionalParametersStrings.contains("EX")) {
-      millisecondsUntilExpiration =
-          handleExpiration(optionalParametersStrings, "EX");
-    }
-
-    if (optionalParametersStrings.contains("NX")) {
-      existsOption = SetOptions.Exists.NX;
-    } else if (optionalParametersStrings.contains("XX")) {
-      existsOption = SetOptions.Exists.XX;
-    }
-
-    return new SetOptions(existsOption, millisecondsUntilExpiration, keepTTL);
-  }
-
-  private long handleExpiration(List<String> optionalParametersStrings, String expirationType) {
-    long timeUntilExpiration;
-    long millisecondsUntilExpiration;
-
-    String nextParameter =
-        getNextParameter(expirationType, optionalParametersStrings);
-
-    timeUntilExpiration =
-        convertToLongOrThrowException(nextParameter);
-
-    if (timeUntilExpiration <= 0) {
-      throw new IllegalArgumentException(ERROR_INVALID_EXPIRE_TIME);
-    }
-
-    if (expirationType.equals("EX")) {
-      millisecondsUntilExpiration =
-          SECONDS.toMillis(timeUntilExpiration);
-    } else {
-      millisecondsUntilExpiration = timeUntilExpiration;
-    }
-    return millisecondsUntilExpiration;
-  }
-
-  private String getNextParameter(String currentParameter,
-      List<String> optionalParametersStrings) {
-    int index = optionalParametersStrings.indexOf(currentParameter);
-    if (optionalParametersStrings.size() <= index + 1) {
-      throw new IllegalArgumentException(ERROR_SYNTAX);
-    }
-    return optionalParametersStrings.get(index + 1);
-  }
-
-  private void throwExceptionIfUnknownParameter(List<String> optionalParameters) {
-    List<String> validOptionalParamaters = Arrays.asList("EX", "PX", "NX", "XX");
-
-    List<String> parametersInQuestion =
-        optionalParameters
-            .stream()
-            .filter(parameter -> (!validOptionalParamaters.contains(parameter)))
-            .collect(Collectors.toList());
-
-    parametersInQuestion.forEach(parameter -> {
-
-      int index = optionalParameters.indexOf(parameter);
-
-      if (!isANumber(parameter)) {
-        if (index == 0) {
-          throw new IllegalArgumentException(ERROR_SYNTAX);
-        }
-
-        String previousParameter = optionalParameters.get(index - 1);
-        if (previousOptionIsValidAndExpectsANumber(previousParameter)) {
-          throw new IllegalArgumentException(ERROR_NOT_INTEGER);
-        }
-
-        throw new IllegalArgumentException(ERROR_SYNTAX);
-      }
-    });
-  }
-
-  private boolean previousOptionIsValidAndExpectsANumber(String previousParameter) {
-    List<String> validParamaters = Arrays.asList("EX", "PX");
-    return validParamaters.contains(previousParameter);
-  }
-
-  private void throwErrorIfNumberInWrongPosition(List<String> optionalParameters) {
-    for (int i = 0; i < optionalParameters.size(); i++) {
-      String parameter = optionalParameters.get(i);
-      if (isANumber(parameter)) {
-        if (i == 0) {
-          throw new IllegalArgumentException(ERROR_SYNTAX);
-        }
-        String previousParameter = optionalParameters.get(i - 1);
-        if (!previousOptionIsValidAndExpectsANumber(previousParameter)) {
-          throw new IllegalArgumentException(ERROR_SYNTAX);
-        }
-      }
-    }
-  }
-
-  private boolean isANumber(String parameter) {
-    try {
-      Long.parseLong(parameter);
-      return true;
-    } catch (NumberFormatException e) {
-      return false;
-    }
-  }
-
-  private void throwExceptionIfIncompatableParameterOptions(List<String> passedParametersStrings) {
-
-    if (passedParametersStrings.contains("PX")
-        && passedParametersStrings.contains("EX")) {
-      throw new IllegalArgumentException(ERROR_SYNTAX);
-    }
-
-    if (passedParametersStrings.contains("XX")
-        && passedParametersStrings.contains("NX")) {
-      throw new IllegalArgumentException(ERROR_SYNTAX);
-    }
-  }
-
-  private long convertToLongOrThrowException(String expirationTime) {
-    try {
-      return parseLong(expirationTime);
-    } catch (NumberFormatException e) {
-      throw new IllegalArgumentException(ERROR_NOT_INTEGER);
-    }
+    long expirationMillis = 0L;
+    boolean foundXX = false;
+    boolean foundNX = false;
+    boolean foundPX = false;
+    boolean foundEX = false;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -390,6 +390,25 @@ public class Coder {
     return true;
   }
 
+  /**
+   * Transforms a byte array representing a String into a byte array representing the uppercase
+   * version of that String.
+   *
+   * @param bytes the byte array representing a String to be transformed
+   * @return a byte array representing the result of calling String.toUpperCase() on the input
+   *         String
+   */
+  public static byte[] toUpperCaseBytes(byte[] bytes) {
+    if (bytes == null) {
+      return null;
+    }
+    byte[] uppercase = new byte[bytes.length];
+    for (int i = 0; i < bytes.length; ++i) {
+      uppercase[i] = toUpperCase(bytes[i]);
+    }
+    return uppercase;
+  }
+
   private static byte toUpperCase(byte b) {
     return isLowerCase(b) ? (byte) (b - CHARSET_CASE_OFFSET) : b;
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -15,6 +15,31 @@
  */
 package org.apache.geode.redis.internal.netty;
 
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ARRAY_ID;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.BULK_STRING_ID;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ERROR_ID;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INTEGER_ID;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.N_INF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.P_INF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.SIMPLE_STRING_ID;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCRLF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bEMPTY_ARRAY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bEMPTY_STRING;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bERR;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINFINITY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLOWERCASE_A;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLOWERCASE_Z;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNIL;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INFINITY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bOK;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bOOM;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bP_INF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bP_INFINITY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWRONGTYPE;
+
+import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
@@ -32,64 +57,12 @@ import org.apache.geode.redis.internal.data.RedisKey;
 public class Coder {
 
   /**
-   * byte identifier of a bulk string
-   */
-  public static final byte BULK_STRING_ID = 36; // '$'
-
-  /**
-   * byte identifier of an array
-   */
-  public static final byte ARRAY_ID = 42; // '*'
-
-  /**
-   * byte identifier of an error
-   */
-  public static final byte ERROR_ID = 45; // '-'
-
-  /**
-   * byte identifier of an integer
-   */
-  public static final byte INTEGER_ID = 58; // ':'
-  public static final byte NUMBER_1_BYTE = 0x31; // '1'
-  /**
-   * byte identifier of a simple string
-   */
-  public static final byte SIMPLE_STRING_ID = 43; // '+'
-  public static final String CRLF = "\r\n";
-  @MakeImmutable
-  public static final byte[] CRLFar = stringToBytes(CRLF); // {13, 10} == {'\r', '\n'}
-
-  /**
-   * byte array of a nil response
-   */
-  @MakeImmutable
-  public static final byte[] bNIL = stringToBytes("$-1\r\n"); // {'$', '-', '1', '\r', '\n'};
-
-  /**
-   * byte array of an empty array
-   */
-  @MakeImmutable
-  public static final byte[] bEMPTY_ARRAY = stringToBytes("*0\r\n"); // {'*', '0', '\r', '\n'};
-
-  /**
-   * byte array of an empty string
-   */
-  @MakeImmutable
-  public static final byte[] bEMPTY_STRING = stringToBytes("$0\r\n\r\n");
-
-  @MakeImmutable
-  public static final byte[] err = stringToBytes("ERR ");
-
-  @MakeImmutable
-  public static final byte[] oom = stringToBytes("OOM ");
-
-  @MakeImmutable
-  public static final byte[] wrongType = stringToBytes("WRONGTYPE ");
-
-  /**
    * The charset being used by this coder, {@value #CHARSET}.
    */
   public static final String CHARSET = "UTF-8";
+
+  // In UTF-8 encoding, upper- and lowercase versions of the same character differ by this amount
+  public static final int CHARSET_CASE_OFFSET = 32;
 
   @MakeImmutable
   protected static final DecimalFormat decimalFormatter = new DecimalFormat("#");
@@ -97,16 +70,6 @@ public class Coder {
   static {
     decimalFormatter.setMaximumFractionDigits(10);
   }
-
-  /**
-   * Positive infinity string
-   */
-  public static final String P_INF = "+inf";
-
-  /**
-   * Negative infinity string
-   */
-  public static final String N_INF = "-inf";
 
   public static ByteBuf getBulkStringResponse(ByteBuf buffer, Object v)
       throws CoderException {
@@ -130,11 +93,11 @@ public class Coder {
     } else if (v instanceof Integer) {
       buffer.writeByte(INTEGER_ID);
       buffer.writeBytes(intToBytes((Integer) v));
-      buffer.writeBytes(CRLFar);
+      buffer.writeBytes(bCRLF);
     } else if (v instanceof Long) {
       buffer.writeByte(INTEGER_ID);
       buffer.writeBytes(intToBytes(((Long) v).intValue()));
-      buffer.writeBytes(CRLFar);
+      buffer.writeBytes(bCRLF);
     } else {
       throw new CoderException();
     }
@@ -145,9 +108,9 @@ public class Coder {
   private static void writeStringResponse(ByteBuf buffer, byte[] toWrite) {
     buffer.writeByte(BULK_STRING_ID);
     buffer.writeBytes(intToBytes(toWrite.length));
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     buffer.writeBytes(toWrite);
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
   }
 
   public static ByteBuf getFlattenedArrayResponse(ByteBuf buffer, Collection<Collection<?>> items)
@@ -163,7 +126,7 @@ public class Coder {
       throws CoderException {
     buffer.writeByte(ARRAY_ID);
     buffer.writeBytes(intToBytes(items.size()));
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     for (Object next : items) {
       writeCollectionOrString(buffer, next);
     }
@@ -184,16 +147,16 @@ public class Coder {
       List<?> scanResult) {
     buffer.writeByte(ARRAY_ID);
     buffer.writeBytes(intToBytes(2));
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     buffer.writeByte(BULK_STRING_ID);
     byte[] cursorBytes = stringToBytes(cursor.toString());
     buffer.writeBytes(intToBytes(cursorBytes.length));
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     buffer.writeBytes(cursorBytes);
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     buffer.writeByte(ARRAY_ID);
     buffer.writeBytes(intToBytes(scanResult.size()));
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
 
     for (Object nextObject : scanResult) {
       byte[] bytes;
@@ -208,9 +171,9 @@ public class Coder {
 
       buffer.writeByte(BULK_STRING_ID);
       buffer.writeBytes(intToBytes(bytes.length));
-      buffer.writeBytes(CRLFar);
+      buffer.writeBytes(bCRLF);
       buffer.writeBytes(bytes);
-      buffer.writeBytes(CRLFar);
+      buffer.writeBytes(bCRLF);
     }
     return buffer;
   }
@@ -233,25 +196,25 @@ public class Coder {
   public static ByteBuf getSimpleStringResponse(ByteBuf buffer, byte[] byteArray) {
     buffer.writeByte(SIMPLE_STRING_ID);
     buffer.writeBytes(byteArray);
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     return buffer;
   }
 
   public static ByteBuf getErrorResponse(ByteBuf buffer, String error) {
     byte[] errorAr = stringToBytes(error);
     buffer.writeByte(ERROR_ID);
-    buffer.writeBytes(err);
+    buffer.writeBytes(bERR);
     buffer.writeBytes(errorAr);
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     return buffer;
   }
 
   public static ByteBuf getOOMResponse(ByteBuf buffer, String error) {
     byte[] errorAr = stringToBytes(error);
     buffer.writeByte(ERROR_ID);
-    buffer.writeBytes(oom);
+    buffer.writeBytes(bOOM);
     buffer.writeBytes(errorAr);
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     return buffer;
   }
 
@@ -259,30 +222,30 @@ public class Coder {
     byte[] errorAr = stringToBytes(error);
     buffer.writeByte(ERROR_ID);
     buffer.writeBytes(errorAr);
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     return buffer;
   }
 
   public static ByteBuf getWrongTypeResponse(ByteBuf buffer, String error) {
     byte[] errorAr = stringToBytes(error);
     buffer.writeByte(ERROR_ID);
-    buffer.writeBytes(wrongType);
+    buffer.writeBytes(bWRONGTYPE);
     buffer.writeBytes(errorAr);
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     return buffer;
   }
 
   public static ByteBuf getIntegerResponse(ByteBuf buffer, int integer) {
     buffer.writeByte(INTEGER_ID);
     buffer.writeBytes(intToBytes(integer));
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     return buffer;
   }
 
   public static ByteBuf getIntegerResponse(ByteBuf buffer, long l) {
     buffer.writeByte(INTEGER_ID);
     buffer.writeBytes(longToBytes(l));
-    buffer.writeBytes(CRLFar);
+    buffer.writeBytes(bCRLF);
     return buffer;
   }
 
@@ -291,17 +254,25 @@ public class Coder {
     return buffer;
   }
 
+  public static ByteBuf getOKResponse(ByteBuf buffer) {
+    buffer.writeBytes(bOK);
+    return buffer;
+  }
+
   public static ByteBuf getNilResponse(ByteBuf buffer) {
     buffer.writeBytes(bNIL);
     return buffer;
   }
 
-
   public static String bytesToString(byte[] bytes) {
     if (bytes == null) {
       return null;
     }
-    return new String(bytes);
+    try {
+      return new String(bytes, CHARSET);
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   public static String doubleToString(double d) {
@@ -323,7 +294,11 @@ public class Coder {
     if (string == null) {
       return null;
     }
-    return string.getBytes();
+    try {
+      return string.getBytes(CHARSET);
+    } catch (UnsupportedEncodingException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
   /*
@@ -386,5 +361,66 @@ public class Coder {
     } else {
       return Double.parseDouble(d);
     }
+  }
+
+  /**
+   * This method allows comparison of byte array representations of Strings, ignoring case, allowing
+   * the return of String.equalsIgnoreCase() to be evaluated without performing expensive String
+   * conversion. This method should only be used to compare against known constant byte arrays found
+   * in the {@link StringBytesGlossary} class.
+   *
+   * @param test the byte array representation of the String we wish to compare
+   * @param expected a byte array constant from the {@link StringBytesGlossary} class representing
+   *        the String we wish to compare against
+   * @return true if the Strings represented by the byte arrays would return true from
+   *         {@code test.equalsIgnoreCase(expected)}, false otherwise
+   */
+  public static boolean equalsIgnoreCaseBytes(byte[] test, byte[] expected) {
+    if (test == expected) {
+      return true;
+    }
+    if (test == null || expected == null || test.length != expected.length) {
+      return false;
+    }
+    for (int i = 0; i < expected.length; ++i) {
+      if (toUpperCase(test[i]) != toUpperCase(expected[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static byte toUpperCase(byte b) {
+    return isLowerCase(b) ? (byte) (b - CHARSET_CASE_OFFSET) : b;
+  }
+
+  private static boolean isLowerCase(byte value) {
+    return value >= bLOWERCASE_A && value <= bLOWERCASE_Z;
+  }
+
+  public static boolean isInfinity(byte[] bytes) {
+    return isPositiveInfinity(bytes) || isNegativeInfinity(bytes);
+  }
+
+  // Checks if the given byte array is equivalent to the Strings "INF", "INFINITY", "+INF" or
+  // "+INFINITY", ignoring case.
+  public static boolean isPositiveInfinity(byte[] bytes) {
+    if (bytes == null) {
+      return false;
+    }
+    return equalsIgnoreCaseBytes(bytes, bINF)
+        || equalsIgnoreCaseBytes(bytes, bP_INF)
+        || equalsIgnoreCaseBytes(bytes, bINFINITY)
+        || equalsIgnoreCaseBytes(bytes, bP_INFINITY);
+  }
+
+  // Checks if the given byte array is equivalent to the Strings "-INF" or "-INFINITY", ignoring
+  // case.
+  public static boolean isNegativeInfinity(byte[] bytes) {
+    if (bytes == null) {
+      return false;
+    }
+    return equalsIgnoreCaseBytes(bytes, bN_INF)
+        || equalsIgnoreCaseBytes(bytes, bN_INFINITY);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
@@ -35,8 +35,8 @@ public class Command {
 
   private final List<byte[]> commandElems;
   private final RedisCommandType commandType;
-  private String key;
-  private byte[] bytes;
+  private String keyString;
+  private byte[] keyBytes;
 
   /**
    * Constructor used to create a static marker Command for shutting down executors.
@@ -118,10 +118,10 @@ public class Command {
    */
   public byte[] getBytesKey() {
     if (this.commandElems.size() > 1) {
-      if (this.bytes == null) {
-        this.bytes = this.commandElems.get(1);
+      if (this.keyBytes == null) {
+        this.keyBytes = this.commandElems.get(1);
       }
-      return this.bytes;
+      return this.keyBytes;
     } else {
       return null;
     }
@@ -136,13 +136,13 @@ public class Command {
    */
   public String getStringKey() {
     if (this.commandElems.size() > 1) {
-      if (this.bytes == null) {
-        this.bytes = this.commandElems.get(1);
-        this.key = bytesToString(this.bytes);
-      } else if (this.key == null) {
-        this.key = bytesToString(this.bytes);
+      if (this.keyBytes == null) {
+        this.keyBytes = this.commandElems.get(1);
+        this.keyString = bytesToString(this.keyBytes);
+      } else if (this.keyString == null) {
+        this.keyString = bytesToString(this.keyBytes);
       }
-      return this.key;
+      return this.keyString;
     } else {
       return null;
     }
@@ -150,10 +150,10 @@ public class Command {
 
   public RedisKey getKey() {
     if (this.commandElems.size() > 1) {
-      if (this.bytes == null) {
-        this.bytes = this.commandElems.get(1);
+      if (this.keyBytes == null) {
+        this.keyBytes = this.commandElems.get(1);
       }
-      return new RedisKey(this.bytes);
+      return new RedisKey(this.keyBytes);
     } else {
       return null;
     }
@@ -207,16 +207,6 @@ public class Command {
     result = String.format("wrong number of arguments for '%s' command",
         getCommandType().toString().toLowerCase());
     return result;
-  }
-
-  private long asyncStartTime;
-
-  public void setAsyncStartTime(long start) {
-    asyncStartTime = start;
-  }
-
-  public long getAsyncStartTime() {
-    return asyncStartTime;
   }
 
   private ChannelHandlerContext channelHandlerContext;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Command.java
@@ -15,6 +15,8 @@
  */
 package org.apache.geode.redis.internal.netty;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+
 import java.nio.channels.SocketChannel;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -60,7 +62,7 @@ public class Command {
     RedisCommandType type;
     try {
       byte[] charCommand = commandElems.get(0);
-      String commandName = Coder.bytesToString(charCommand).toUpperCase();
+      String commandName = bytesToString(charCommand).toUpperCase();
       type = RedisCommandType.valueOf(commandName);
     } catch (Exception e) {
       type = RedisCommandType.UNKNOWN;
@@ -108,6 +110,24 @@ public class Command {
   }
 
   /**
+   * Convenience method to get the byte array representation of the key in a Redis command, always
+   * at the second position in the sent command array
+   *
+   * @return Returns the second element in the parsed command list, which is always the key for
+   *         commands indicating a key
+   */
+  public byte[] getBytesKey() {
+    if (this.commandElems.size() > 1) {
+      if (this.bytes == null) {
+        this.bytes = this.commandElems.get(1);
+      }
+      return this.bytes;
+    } else {
+      return null;
+    }
+  }
+
+  /**
    * Convenience method to get a String representation of the key in a Redis command, always at the
    * second position in the sent command array
    *
@@ -118,9 +138,9 @@ public class Command {
     if (this.commandElems.size() > 1) {
       if (this.bytes == null) {
         this.bytes = this.commandElems.get(1);
-        this.key = Coder.bytesToString(this.bytes);
+        this.key = bytesToString(this.bytes);
       } else if (this.key == null) {
-        this.key = Coder.bytesToString(this.bytes);
+        this.key = bytesToString(this.bytes);
       }
       return this.key;
     } else {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/NettyRedisServer.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/NettyRedisServer.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.redis.internal.netty;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.InetAddress;
@@ -161,7 +163,7 @@ public class NettyRedisServer {
   private ChannelInitializer<SocketChannel> createChannelInitializer() {
     String redisPassword = configSupplier.get().getRedisPassword();
     final byte[] redisPasswordBytes =
-        StringUtils.isBlank(redisPassword) ? null : Coder.stringToBytes(redisPassword);
+        StringUtils.isBlank(redisPassword) ? null : stringToBytes(redisPassword);
 
     return new ChannelInitializer<SocketChannel>() {
       @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -187,7 +187,7 @@ public class StringBytesGlossary {
 
   // ********** Miscellaneous constants for convenience **********
   /**
-   * byte value of the number 1
+   * byte value of the number 0
    */
   public static final byte NUMBER_0_BYTE = 48; // '0'
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.netty;
+
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+
+import org.apache.geode.annotations.internal.MakeImmutable;
+
+/**
+ * Important note
+ * <p>
+ * Do not use '' <-- java primitive chars. Redis uses {@link Coder#CHARSET} encoding so we should
+ * not risk java handling char to byte conversions, rather just hard code {@link Coder#CHARSET}
+ * chars as bytes
+ */
+public class StringBytesGlossary {
+
+  // ********** Single byte RedisResponse identifier constants **********
+  /**
+   * byte identifier of a bulk string
+   */
+  public static final byte BULK_STRING_ID = 36; // '$'
+
+  /**
+   * byte identifier of an array
+   */
+  public static final byte ARRAY_ID = 42; // '*'
+
+  /**
+   * byte identifier of a simple string
+   */
+  public static final byte SIMPLE_STRING_ID = 43; // '+'
+
+  /**
+   * byte identifier of an error
+   */
+  public static final byte ERROR_ID = 45; // '-'
+
+  /**
+   * byte identifier of an integer
+   */
+  public static final byte INTEGER_ID = 58; // ':'
+
+  // ********** RedisResponse constants **********
+  /**
+   * byte array of an OK response
+   */
+  @MakeImmutable
+  public static final byte[] bOK = stringToBytes("+OK\r\n");
+
+  /**
+   * byte array of a nil response
+   */
+  @MakeImmutable
+  public static final byte[] bNIL = stringToBytes("$-1\r\n");
+
+  /**
+   * byte array of an empty array
+   */
+  @MakeImmutable
+  public static final byte[] bEMPTY_ARRAY = stringToBytes("*0\r\n");
+
+  /**
+   * byte array of an empty string
+   */
+  @MakeImmutable
+  public static final byte[] bEMPTY_STRING = stringToBytes("$0\r\n\r\n");
+
+  @MakeImmutable
+  public static final byte[] bCRLF = stringToBytes("\r\n");
+
+  @MakeImmutable
+  public static final byte[] bERR = stringToBytes("ERR ");
+
+  @MakeImmutable
+  public static final byte[] bOOM = stringToBytes("OOM ");
+
+  @MakeImmutable
+  public static final byte[] bWRONGTYPE = stringToBytes("WRONGTYPE ");
+
+  // ********** Redis Command constants **********
+
+  // ClusterExecutor
+  @MakeImmutable
+  public static final byte[] bINFO = stringToBytes("INFO");
+  @MakeImmutable
+  public static final byte[] bSLOTS = stringToBytes("SLOTS");
+  @MakeImmutable
+  public static final byte[] bNODES = stringToBytes("NODES");
+
+  // ScanExecutor, HScanExecutor and SScanExecutor
+  @MakeImmutable
+  public static final byte[] bMATCH = stringToBytes("MATCH");
+  @MakeImmutable
+  public static final byte[] bCOUNT = stringToBytes("COUNT");
+
+  // PubSubExecutor
+  @MakeImmutable
+  public static final byte[] bCHANNELS = stringToBytes("CHANNELS");
+
+  // InfoExecutor
+  @MakeImmutable
+  public static final byte[] bSERVER = stringToBytes("SERVER");
+  @MakeImmutable
+  public static final byte[] bCLUSTER = stringToBytes("CLUSTER");
+  @MakeImmutable
+  public static final byte[] bPERSISTENCE = stringToBytes("PERSISTENCE");
+  @MakeImmutable
+  public static final byte[] bREPLICATION = stringToBytes("REPLICATION");
+  @MakeImmutable
+  public static final byte[] bSTATS = stringToBytes("STATS");
+  @MakeImmutable
+  public static final byte[] bCLIENTS = stringToBytes("CLIENTS");
+  @MakeImmutable
+  public static final byte[] bMEMORY = stringToBytes("MEMORY");
+  @MakeImmutable
+  public static final byte[] bKEYSPACE = stringToBytes("KEYSPACE");
+  @MakeImmutable
+  public static final byte[] bDEFAULT = stringToBytes("DEFAULT");
+  @MakeImmutable
+  public static final byte[] bALL = stringToBytes("ALL");
+
+  // SlowlogExecutor and SlowlogParameterRequirements
+  @MakeImmutable
+  public static final byte[] bGET = stringToBytes("GET");
+  @MakeImmutable
+  public static final byte[] bLEN = stringToBytes("LEN");
+  @MakeImmutable
+  public static final byte[] bRESET = stringToBytes("RESET");
+
+  // ZAddExecutor and SetExecutor
+  @MakeImmutable
+  public static final byte[] bNX = stringToBytes("NX");
+  @MakeImmutable
+  public static final byte[] bXX = stringToBytes("XX");
+
+  // ZAddExecutor
+  @MakeImmutable
+  public static final byte[] bCH = stringToBytes("CH");
+  @MakeImmutable
+  public static final byte[] bINCR = stringToBytes("INCR");
+
+  // SetExecutor
+  @MakeImmutable
+  public static final byte[] bEX = stringToBytes("EX");
+  @MakeImmutable
+  public static final byte[] bPX = stringToBytes("PX");
+
+  // ********** Constants for Double Infinity comparisons **********
+  public static final String P_INF = "+inf";
+  public static final String INF = "inf";
+  public static final String P_INFINITY = "+Infinity";
+  public static final String INFINITY = "Infinity";
+  public static final String N_INF = "-inf";
+  public static final String N_INFINITY = "-Infinity";
+
+  @MakeImmutable
+  public static final byte[] bP_INF = stringToBytes(P_INF);
+
+  @MakeImmutable
+  public static final byte[] bINF = stringToBytes(INF);
+
+  @MakeImmutable
+  public static final byte[] bP_INFINITY = stringToBytes(P_INFINITY);
+
+  @MakeImmutable
+  public static final byte[] bINFINITY = stringToBytes(INFINITY);
+
+  @MakeImmutable
+  public static final byte[] bN_INF = stringToBytes(N_INF);
+
+  @MakeImmutable
+  public static final byte[] bN_INFINITY = stringToBytes(N_INFINITY);
+
+
+  // ********** Miscellaneous constants for convenience **********
+  /**
+   * byte value of the number 1
+   */
+  public static final byte NUMBER_0_BYTE = 48; // '0'
+
+  /**
+   * byte value of the number 1
+   */
+  public static final byte NUMBER_1_BYTE = 49; // '1'
+
+  public static final byte bLOWERCASE_A = 97; // a
+
+  public static final byte bLOWERCASE_Z = 122; // z
+
+  public static final String PING_RESPONSE = "PONG";
+
+  @MakeImmutable
+  public static final byte[] bPING_RESPONSE = stringToBytes(PING_RESPONSE);
+
+  @MakeImmutable
+  public static final byte[] bPING_RESPONSE_LOWERCASE = stringToBytes(PING_RESPONSE.toLowerCase());
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscription.java
@@ -16,6 +16,9 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -57,11 +60,11 @@ class PatternSubscription extends AbstractSubscription {
 
   @Override
   public boolean matches(byte[] channel) {
-    return pattern.matches(new String(channel));
+    return pattern.matches(bytesToString(channel));
   }
 
   @Override
   public byte[] getSubscriptionName() {
-    return pattern.globPattern().getBytes();
+    return stringToBytes(pattern.globPattern());
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
@@ -16,6 +16,8 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -28,7 +30,6 @@ import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 /**
@@ -86,11 +87,11 @@ public class Subscriptions {
 
   public List<byte[]> findChannelNames(byte[] pattern) {
 
-    GlobPattern globPattern = new GlobPattern(Coder.bytesToString(pattern));
+    GlobPattern globPattern = new GlobPattern(bytesToString(pattern));
 
     return findChannelNames()
         .stream()
-        .filter(name -> globPattern.matches(Coder.bytesToString(name)))
+        .filter(name -> globPattern.matches(bytesToString(name)))
         .collect(Collectors.toList());
   }
 
@@ -144,7 +145,7 @@ public class Subscriptions {
 
   public SubscribeResult psubscribe(byte[] patternBytes, ExecutionHandlerContext context,
       Client client) {
-    GlobPattern pattern = new GlobPattern(new String(patternBytes));
+    GlobPattern pattern = new GlobPattern(bytesToString(patternBytes));
     Subscription createdSubscription = null;
     synchronized (this) {
       if (!exists(pattern, client)) {

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal;
 
 import static java.util.Arrays.asList;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -140,7 +141,7 @@ public class SupportedCommandsJUnitTest {
   public void crossCheckAllUnsupportedCommands_areMarkedUnsupported() {
     for (String commandName : unSupportedCommands) {
       List<byte[]> args = new ArrayList<>();
-      args.add(commandName.getBytes());
+      args.add(stringToBytes(commandName));
 
       Command command = new Command(args);
 
@@ -154,7 +155,7 @@ public class SupportedCommandsJUnitTest {
   public void crossCheckAllSupportedCommands_areMarkedSupported() {
     for (String commandName : supportedCommands) {
       List<byte[]> args = new ArrayList<>();
-      args.add(commandName.getBytes());
+      args.add(stringToBytes(commandName));
 
       Command command = new Command(args);
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.data;
 
 import static java.lang.Math.round;
 import static org.apache.geode.redis.internal.data.RedisHash.BASE_REDIS_HASH_OVERHEAD;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.data.Offset.offset;
@@ -121,8 +122,8 @@ public class RedisHashTest {
   public void hset_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = Mockito.mock(Region.class);
     RedisHash o1 = createRedisHash("k1", "v1", "k2", "v2");
-    byte[] k3 = Coder.stringToBytes("k3");
-    byte[] v3 = Coder.stringToBytes("v3");
+    byte[] k3 = stringToBytes("k3");
+    byte[] v3 = stringToBytes("v3");
     ArrayList<byte[]> adds = new ArrayList<>();
     adds.add(k3);
     adds.add(v3);
@@ -143,7 +144,7 @@ public class RedisHashTest {
   public void hdel_stores_delta_that_is_stable() throws IOException {
     Region<RedisKey, RedisData> region = mock(Region.class);
     RedisHash o1 = createRedisHash("k1", "v1", "k2", "v2");
-    byte[] k1 = Coder.stringToBytes("k1");
+    byte[] k1 = stringToBytes("k1");
     ArrayList<byte[]> removes = new ArrayList<>();
     removes.add(k1);
     o1.hdel(region, null, removes);
@@ -257,8 +258,8 @@ public class RedisHashTest {
   @Test
   public void should_calculateSize_closeToROSSize_ofIndividualInstanceWithSingleValue() {
     ArrayList<byte[]> data = new ArrayList<>();
-    data.add("field".getBytes());
-    data.add("valuethatisverylonggggggggg".getBytes());
+    data.add(stringToBytes("field"));
+    data.add(stringToBytes("valuethatisverylonggggggggg"));
 
     RedisHash redisHash = new RedisHash(data);
 
@@ -290,8 +291,8 @@ public class RedisHashTest {
 
     ArrayList<byte[]> elements = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      elements.add(Coder.stringToBytes(baseField + i));
-      elements.add(Coder.stringToBytes(baseValue + i));
+      elements.add(stringToBytes(baseField + i));
+      elements.add(stringToBytes(baseValue + i));
     }
     RedisHash hash = new RedisHash(elements);
 
@@ -306,7 +307,7 @@ public class RedisHashTest {
   @SuppressWarnings("unchecked")
   @Test
   public void hsetShould_calculateSize_equalToSizeCalculatedInConstructor_forMultipleEntries() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String baseField = "field";
     final String baseValue = "value";
 
@@ -317,8 +318,8 @@ public class RedisHashTest {
     RedisHash hash = new RedisHash(Collections.emptyList());
     List<byte[]> data = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      data.add(Coder.stringToBytes((baseField + i)));
-      data.add(Coder.stringToBytes((baseValue + i)));
+      data.add(stringToBytes((baseField + i)));
+      data.add(stringToBytes((baseValue + i)));
     }
 
     hash.hset(region, key, data, false);
@@ -329,7 +330,7 @@ public class RedisHashTest {
 
   @Test
   public void hsetShould_calculateSizeDifference_whenUpdatingExistingEntry_newIsShorterThanOld() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String field = "field";
     final String initialValue = "initialValue";
     final String finalValue = "finalValue";
@@ -339,7 +340,7 @@ public class RedisHashTest {
 
   @Test
   public void hsetShould_calculateSizeDifference_whenUpdatingExistingEntry_oldIsShorterThanNew() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String field = "field";
     final String initialValue = "initialValue";
     final String finalValue = "longerfinalValue";
@@ -349,7 +350,7 @@ public class RedisHashTest {
 
   @Test
   public void hsetShould_calculateSizeDifference_whenUpdatingExistingEntry_valuesAreSameLength() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String field = "field";
     final String initialValue = "initialValue";
     final String finalValue = "finalValueee";
@@ -365,20 +366,20 @@ public class RedisHashTest {
 
     RedisHash hash = new RedisHash(Collections.emptyList());
     List<byte[]> initialData = new ArrayList<>();
-    initialData.add(Coder.stringToBytes(field));
-    initialData.add(Coder.stringToBytes(initialValue));
+    initialData.add(stringToBytes(field));
+    initialData.add(stringToBytes(initialValue));
 
     hash.hset(region, key, initialData, false);
     RedisHash expectedRedisHash = new RedisHash(new ArrayList<>(initialData));
 
     List<byte[]> finalData = new ArrayList<>();
-    finalData.add(Coder.stringToBytes(field));
-    finalData.add(Coder.stringToBytes(finalValue));
+    finalData.add(stringToBytes(field));
+    finalData.add(stringToBytes(finalValue));
 
     hash.hset(region, key, finalData, false);
 
     int expectedUpdatedRedisHashSize = expectedRedisHash.getSizeInBytes()
-        + (Coder.stringToBytes(finalValue).length - Coder.stringToBytes(initialValue).length);
+        + (stringToBytes(finalValue).length - stringToBytes(initialValue).length);
 
     assertThat(hash.getSizeInBytes()).isEqualTo(expectedUpdatedRedisHashSize);
   }
@@ -386,7 +387,7 @@ public class RedisHashTest {
   /******* put if absent *******/
   @Test
   public void putIfAbsentShould_calculateSizeEqualToSizeCalculatedInConstructor_forMultipleUniqueEntries() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String baseField = "field";
     final String baseValue = "value";
 
@@ -397,8 +398,8 @@ public class RedisHashTest {
     RedisHash hash = new RedisHash(Collections.emptyList());
     List<byte[]> data = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      data.add(Coder.stringToBytes((baseField + i)));
-      data.add(Coder.stringToBytes((baseValue + i)));
+      data.add(stringToBytes((baseField + i)));
+      data.add(stringToBytes((baseValue + i)));
     }
 
     hash.hset(region, key, data, true);
@@ -410,7 +411,7 @@ public class RedisHashTest {
 
   @Test
   public void putIfAbsentShould_notChangeSize_whenSameDataIsSetTwice() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String baseField = "field";
     final String baseValue = "value";
 
@@ -421,8 +422,8 @@ public class RedisHashTest {
     RedisHash hash = new RedisHash(Collections.emptyList());
     List<byte[]> data = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      data.add(Coder.stringToBytes((baseField + i)));
-      data.add(Coder.stringToBytes((baseValue + i)));
+      data.add(stringToBytes((baseField + i)));
+      data.add(stringToBytes((baseValue + i)));
     }
 
     hash.hset(region, key, data, true);
@@ -436,7 +437,7 @@ public class RedisHashTest {
 
   @Test
   public void putIfAbsent_shouldNotChangeSize_whenPuttingToExistingFields() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String baseField = "field";
     final String initialBaseValue = "value";
     final String finalBaseValue = "longerValue";
@@ -448,8 +449,8 @@ public class RedisHashTest {
     RedisHash hash = new RedisHash(Collections.emptyList());
     List<byte[]> initialData = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      initialData.add(Coder.stringToBytes((baseField + i)));
-      initialData.add(Coder.stringToBytes((initialBaseValue + i)));
+      initialData.add(stringToBytes((baseField + i)));
+      initialData.add(stringToBytes((initialBaseValue + i)));
     }
 
     hash.hset(region, key, initialData, true);
@@ -458,8 +459,8 @@ public class RedisHashTest {
 
     List<byte[]> finalData = new ArrayList<>();
     for (int i = 0; i < 10_000; i++) {
-      finalData.add(Coder.stringToBytes((baseField + i)));
-      finalData.add(Coder.stringToBytes((finalBaseValue + i)));
+      finalData.add(stringToBytes((baseField + i)));
+      finalData.add(stringToBytes((finalBaseValue + i)));
     }
 
     hash.hset(region, key, finalData, true);
@@ -470,7 +471,7 @@ public class RedisHashTest {
   /******* remove *******/
   @Test
   public void sizeShouldDecrease_whenValueIsRemoved() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String baseField = "field";
     final String baseValue = "value";
     final Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
@@ -479,10 +480,10 @@ public class RedisHashTest {
 
     List<byte[]> data = new ArrayList<>();
     List<byte[]> dataToRemove = new ArrayList<>();
-    byte[] field1 = Coder.stringToBytes((baseField + 1));
-    byte[] value1 = Coder.stringToBytes((baseValue + 1));
-    byte[] field2 = Coder.stringToBytes((baseField + 2));
-    byte[] value2 = Coder.stringToBytes((baseValue + 2));
+    byte[] field1 = stringToBytes((baseField + 1));
+    byte[] value1 = stringToBytes((baseValue + 1));
+    byte[] field2 = stringToBytes((baseField + 2));
+    byte[] value2 = stringToBytes((baseValue + 2));
     data.add(field1);
     data.add(value1);
     data.add(field2);
@@ -502,7 +503,7 @@ public class RedisHashTest {
 
   @Test
   public void dataStoreBytesInUse_shouldReturnToHashOverhead_whenAllFieldsAreRemoved() {
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     final String baseField = "field";
     final String baseValue = "value";
     final Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
@@ -514,8 +515,8 @@ public class RedisHashTest {
 
     List<byte[]> data = new ArrayList<>();
     for (int i = 0; i < 100; i++) {
-      data.add(Coder.stringToBytes((baseField + i)));
-      data.add(Coder.stringToBytes((baseValue + i)));
+      data.add(stringToBytes((baseField + i)));
+      data.add(stringToBytes((baseValue + i)));
     }
 
     hash.hset(region, key, data, false);
@@ -524,7 +525,7 @@ public class RedisHashTest {
 
     for (int i = 0; i < 100; i++) {
       List<byte[]> toRm = new ArrayList<>();
-      toRm.add(Coder.stringToBytes((baseField + i)));
+      toRm.add(stringToBytes((baseField + i)));
       hash.hdel(region, key, toRm);
     }
 
@@ -555,6 +556,6 @@ public class RedisHashTest {
   }
 
   private byte[] toBytes(String str) {
-    return Coder.stringToBytes(str);
+    return stringToBytes(str);
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisKeyJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisKeyJUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.data;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.BeforeClass;
@@ -37,34 +38,34 @@ public class RedisKeyJUnitTest {
 
   @Test
   public void testRoutingId_withHashtags() {
-    RedisKey key = new RedisKey("name{user1000}".getBytes());
+    RedisKey key = new RedisKey(stringToBytes("name{user1000}"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("user1000"));
 
-    key = new RedisKey("{user1000".getBytes());
+    key = new RedisKey(stringToBytes("{user1000"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("{user1000"));
 
-    key = new RedisKey("}user1000{".getBytes());
+    key = new RedisKey(stringToBytes("}user1000{"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("}user1000{"));
 
-    key = new RedisKey("user{}1000".getBytes());
+    key = new RedisKey(stringToBytes("user{}1000"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("user{}1000"));
 
-    key = new RedisKey("user}{1000".getBytes());
+    key = new RedisKey(stringToBytes("user}{1000"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("user}{1000"));
 
-    key = new RedisKey("{user1000}}bar".getBytes());
+    key = new RedisKey(stringToBytes("{user1000}}bar"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("user1000"));
 
-    key = new RedisKey("foo{user1000}{bar}".getBytes());
+    key = new RedisKey(stringToBytes("foo{user1000}{bar}"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("user1000"));
 
-    key = new RedisKey("foo{}{user1000}".getBytes());
+    key = new RedisKey(stringToBytes("foo{}{user1000}"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("foo{}{user1000}"));
 
-    key = new RedisKey("{}{user1000}".getBytes());
+    key = new RedisKey(stringToBytes("{}{user1000}"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("{}{user1000}"));
 
-    key = new RedisKey("foo{{user1000}}bar".getBytes());
+    key = new RedisKey(stringToBytes("foo{{user1000}}bar"));
     assertThat(key.getCrc16()).isEqualTo(CRC16.calculate("{user1000"));
 
     key = new RedisKey(new byte[] {});
@@ -73,7 +74,7 @@ public class RedisKeyJUnitTest {
 
   @Test
   public void testSerialization_withPositiveSignedShortCRC16() throws Exception {
-    RedisKey keyOut = new RedisKey("012345".getBytes());
+    RedisKey keyOut = new RedisKey(stringToBytes("012345"));
     assertThat((short) keyOut.getCrc16()).isPositive();
 
     HeapDataOutputStream out = new HeapDataOutputStream(100);
@@ -86,7 +87,7 @@ public class RedisKeyJUnitTest {
 
   @Test
   public void testSerialization_withNegativeSignedShortCRC16() throws Exception {
-    RedisKey keyOut = new RedisKey("k2".getBytes());
+    RedisKey keyOut = new RedisKey(stringToBytes("k2"));
     assertThat((short) keyOut.getCrc16()).isNegative();
 
     HeapDataOutputStream out = new HeapDataOutputStream(100);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_SET;
 import static org.apache.geode.redis.internal.data.RedisSet.BASE_REDIS_SET_OVERHEAD;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -197,7 +198,7 @@ public class RedisSetTest {
   @Test
   public void should_calculateSize_equalToROS_withSingleMember() {
     Set<byte[]> members = new ObjectOpenCustomHashSet<>(ByteArrays.HASH_STRATEGY);
-    members.add("value".getBytes());
+    members.add(stringToBytes("value"));
     RedisSet set = new RedisSet(members);
 
     int actual = set.getSizeInBytes();
@@ -236,10 +237,10 @@ public class RedisSetTest {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
     when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     String valueString = "value";
 
-    final byte[] value = valueString.getBytes();
+    final byte[] value = stringToBytes(valueString);
     List<byte[]> members = new ArrayList<>();
     members.add(value);
 
@@ -256,13 +257,13 @@ public class RedisSetTest {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
     when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
-    final RedisKey key = new RedisKey("key".getBytes());
+    final RedisKey key = new RedisKey(stringToBytes("key"));
     String baseString = "value";
 
     for (int i = 0; i < 1_000; i++) {
       List<byte[]> members = new ArrayList<>();
       String valueString = baseString + i;
-      final byte[] value = valueString.getBytes();
+      final byte[] value = stringToBytes(valueString);
       members.add(value);
       set.sadd(members, region, key);
 
@@ -281,9 +282,9 @@ public class RedisSetTest {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     final RedisData returnData = mock(RedisData.class);
     when(region.put(any(RedisKey.class), any(RedisData.class))).thenReturn(returnData);
-    final RedisKey key = new RedisKey("key".getBytes());
-    final byte[] value1 = "value1".getBytes();
-    final byte[] value2 = "value2".getBytes();
+    final RedisKey key = new RedisKey(stringToBytes("key"));
+    final byte[] value1 = stringToBytes("value1");
+    final byte[] value2 = stringToBytes("value2");
 
     List<byte[]> members = new ArrayList<>();
     members.add(value1);
@@ -346,14 +347,14 @@ public class RedisSetTest {
   private RedisSet createRedisSetOfSpecifiedSize(int setSize) {
     List<byte[]> arrayList = new ArrayList<>();
     for (int i = 0; i < setSize; i++) {
-      arrayList.add(("abcdefgh" + i).getBytes());
+      arrayList.add(stringToBytes(("abcdefgh" + i)));
     }
     return new RedisSet(arrayList);
   }
 
   private RedisSet createRedisSetWithMemberOfSpecifiedSize(int memberSize) {
     List<byte[]> arrayList = new ArrayList<>();
-    byte[] member = createMemberOfSpecifiedSize("a", memberSize).getBytes();
+    byte[] member = stringToBytes(createMemberOfSpecifiedSize("a", memberSize));
     if (member.length > 0) {
       arrayList.add(member);
     }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.data;
 
 import static java.lang.Math.round;
 import static org.apache.geode.redis.internal.data.RedisSortedSet.BASE_REDIS_SORTED_SET_OVERHEAD;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -125,8 +126,8 @@ public class RedisSortedSetTest {
     RedisSortedSet sortedSet1 = createRedisSortedSet("3.14159", "v1", "2.71828", "v2");
 
     List<byte[]> adds = new ArrayList<>();
-    adds.add("1.61803".getBytes());
-    adds.add("v3".getBytes());
+    adds.add(stringToBytes("1.61803"));
+    adds.add(stringToBytes("v3"));
 
     sortedSet1.zadd(region, null, adds, new ZAddOptions(ZAddOptions.Exists.NONE, false, false));
     assertThat(sortedSet1.hasDelta()).isTrue();
@@ -208,8 +209,8 @@ public class RedisSortedSetTest {
   @Ignore("Redo when we have a defined Sizable strategy")
   public void should_calculateSize_closeToROSSize_ofIndividualInstanceWithSingleValue() {
     List<byte[]> data = new ArrayList<>();
-    data.add("1.0".getBytes());
-    data.add("membernamethatisverylonggggggggg".getBytes());
+    data.add(stringToBytes("1.0"));
+    data.add(stringToBytes("membernamethatisverylonggggggggg"));
 
     RedisSortedSet sortedSet = new RedisSortedSet(data);
 
@@ -251,9 +252,9 @@ public class RedisSortedSetTest {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     RedisKey key = new RedisKey();
     ArrayList<byte[]> membersToRemove = new ArrayList<>();
-    membersToRemove.add(Coder.stringToBytes("nonExisting"));
-    membersToRemove.add(Coder.stringToBytes(member1));
-    membersToRemove.add(Coder.stringToBytes(member3));
+    membersToRemove.add(stringToBytes("nonExisting"));
+    membersToRemove.add(stringToBytes(member1));
+    membersToRemove.add(stringToBytes(member3));
 
     long removed = sortedSet.zrem(region, key, membersToRemove);
 
@@ -267,12 +268,12 @@ public class RedisSortedSetTest {
     RedisSortedSet sortedSet2 = createRedisSortedSet(score2, member2);
     int originalSize = sortedSet.getSizeInBytes();
 
-    byte[] returnValue = sortedSet.memberRemove(Coder.stringToBytes(member1));
+    byte[] returnValue = sortedSet.memberRemove(stringToBytes(member1));
     int removedSize =
-        sortedSet.calculateSizeOfFieldValuePair(Coder.stringToBytes(member1), returnValue);
+        sortedSet.calculateSizeOfFieldValuePair(stringToBytes(member1), returnValue);
 
     assertThat(sortedSet).isEqualTo(sortedSet2);
-    assertThat(returnValue).isEqualTo(Coder.stringToBytes(score1));
+    assertThat(returnValue).isEqualTo(stringToBytes(score1));
     assertThat(sortedSet.getSizeInBytes()).isEqualTo(originalSize - removedSize);
   }
 
@@ -291,7 +292,7 @@ public class RedisSortedSetTest {
     Offset<Integer> offset = Offset.offset((int) round(expected * 0.03));
     assertThat(actual).isCloseTo(expected, offset);
 
-    sortedSet.memberRemove(Coder.stringToBytes(member1));
+    sortedSet.memberRemove(stringToBytes(member1));
     expected = reflectionObjectSizer.sizeof(sortedSet);
     actual = sortedSet.getSizeInBytes();
     offset = Offset.offset((int) round(expected * 0.03));

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
@@ -17,6 +17,7 @@
 package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.data.RedisString.BASE_REDIS_STRING_OVERHEAD;
+import static org.apache.geode.redis.internal.netty.Coder.longToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -146,7 +147,7 @@ public class RedisStringTest {
   @Test
   public void incrErrorsWhenValueOverflows() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = stringToBytes(String.valueOf(Long.MAX_VALUE));
+    byte[] bytes = longToBytes(Long.MAX_VALUE);
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.incr(region, null)).isInstanceOf(ArithmeticException.class);
   }
@@ -172,7 +173,7 @@ public class RedisStringTest {
   @Test
   public void incrbyErrorsWhenValueOverflows() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = stringToBytes(String.valueOf(Long.MAX_VALUE));
+    byte[] bytes = longToBytes(Long.MAX_VALUE);
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.incrby(region, null, 2L))
         .isInstanceOf(ArithmeticException.class);
@@ -216,7 +217,7 @@ public class RedisStringTest {
   @Test
   public void decrThrowsArithmeticExceptionWhenDecrementingMin() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = stringToBytes(String.valueOf(Long.MIN_VALUE));
+    byte[] bytes = longToBytes(Long.MIN_VALUE);
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.decr(region, null)).isInstanceOf(ArithmeticException.class);
   }
@@ -242,7 +243,7 @@ public class RedisStringTest {
   @Test
   public void decrbyThrowsArithmeticExceptionWhenDecrementingMin() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = stringToBytes(String.valueOf(Long.MIN_VALUE));
+    byte[] bytes = longToBytes(Long.MIN_VALUE);
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.decrby(region, null, 2))
         .isInstanceOf(ArithmeticException.class);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisStringTest.java
@@ -17,6 +17,7 @@
 package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.data.RedisString.BASE_REDIS_STRING_OVERHEAD;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -137,7 +138,7 @@ public class RedisStringTest {
   @Test
   public void incrThrowsArithmeticErrorWhenNotALong() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = "10 1".getBytes();
+    byte[] bytes = stringToBytes("10 1");
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.incr(region, null)).isInstanceOf(NumberFormatException.class);
   }
@@ -145,7 +146,7 @@ public class RedisStringTest {
   @Test
   public void incrErrorsWhenValueOverflows() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = String.valueOf(Long.MAX_VALUE).getBytes();
+    byte[] bytes = stringToBytes(String.valueOf(Long.MAX_VALUE));
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.incr(region, null)).isInstanceOf(ArithmeticException.class);
   }
@@ -153,16 +154,16 @@ public class RedisStringTest {
   @Test
   public void incrIncrementsValueAtGivenKey() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = "10".getBytes();
+    byte[] bytes = stringToBytes("10");
     RedisString string = new RedisString(bytes);
     string.incr(region, null);
-    assertThat(string.get()).isEqualTo("11".getBytes());
+    assertThat(string.get()).isEqualTo(stringToBytes("11"));
   }
 
   @Test
   public void incrbyThrowsNumberFormatExceptionWhenNotALong() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = "10 1".getBytes();
+    byte[] bytes = stringToBytes("10 1");
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.incrby(region, null, 2L))
         .isInstanceOf(NumberFormatException.class);
@@ -171,7 +172,7 @@ public class RedisStringTest {
   @Test
   public void incrbyErrorsWhenValueOverflows() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = String.valueOf(Long.MAX_VALUE).getBytes();
+    byte[] bytes = stringToBytes(String.valueOf(Long.MAX_VALUE));
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.incrby(region, null, 2L))
         .isInstanceOf(ArithmeticException.class);
@@ -180,16 +181,16 @@ public class RedisStringTest {
   @Test
   public void incrbyIncrementsValueByGivenLong() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = "10".getBytes();
+    byte[] bytes = stringToBytes("10");
     RedisString string = new RedisString(bytes);
     string.incrby(region, null, 2L);
-    assertThat(string.get()).isEqualTo("12".getBytes());
+    assertThat(string.get()).isEqualTo(stringToBytes("12"));
   }
 
   @Test
   public void incrbyfloatThrowsArithmeticErrorWhenNotADouble() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = "10 1".getBytes();
+    byte[] bytes = stringToBytes("10 1");
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.incrbyfloat(region, null, new BigDecimal("1.1")))
         .isInstanceOf(NumberFormatException.class);
@@ -198,10 +199,10 @@ public class RedisStringTest {
   @Test
   public void incrbyfloatIncrementsValueByGivenFloat() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = "10".getBytes();
+    byte[] bytes = stringToBytes("10");
     RedisString string = new RedisString(bytes);
     string.incrbyfloat(region, null, new BigDecimal("2.20"));
-    assertThat(string.get()).isEqualTo("12.20".getBytes());
+    assertThat(string.get()).isEqualTo(stringToBytes("12.20"));
   }
 
   @Test
@@ -215,7 +216,7 @@ public class RedisStringTest {
   @Test
   public void decrThrowsArithmeticExceptionWhenDecrementingMin() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = String.valueOf(Long.MIN_VALUE).getBytes();
+    byte[] bytes = stringToBytes(String.valueOf(Long.MIN_VALUE));
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.decr(region, null)).isInstanceOf(ArithmeticException.class);
   }
@@ -223,10 +224,10 @@ public class RedisStringTest {
   @Test
   public void decrDecrementsValue() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = "10".getBytes();
+    byte[] bytes = stringToBytes("10");
     RedisString string = new RedisString(bytes);
     string.decr(region, null);
-    assertThat(string.get()).isEqualTo("9".getBytes());
+    assertThat(string.get()).isEqualTo(stringToBytes("9"));
   }
 
   @Test
@@ -241,7 +242,7 @@ public class RedisStringTest {
   @Test
   public void decrbyThrowsArithmeticExceptionWhenDecrementingMin() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = String.valueOf(Long.MIN_VALUE).getBytes();
+    byte[] bytes = stringToBytes(String.valueOf(Long.MIN_VALUE));
     RedisString string = new RedisString(bytes);
     assertThatThrownBy(() -> string.decrby(region, null, 2))
         .isInstanceOf(ArithmeticException.class);
@@ -250,10 +251,10 @@ public class RedisStringTest {
   @Test
   public void decrbyDecrementsValue() {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
-    byte[] bytes = "10".getBytes();
+    byte[] bytes = stringToBytes("10");
     RedisString string = new RedisString(bytes);
     string.decrby(region, null, 2);
-    assertThat(string.get()).isEqualTo("8".getBytes());
+    assertThat(string.get()).isEqualTo(stringToBytes("8"));
   }
 
   @Test
@@ -328,7 +329,7 @@ public class RedisStringTest {
   @Test
   public void should_calculateSize_equalToROSSize_ofLargeStrings() {
     String javaString = makeStringOfSpecifiedSize(10_000);
-    RedisString string = new RedisString(javaString.getBytes());
+    RedisString string = new RedisString(stringToBytes(javaString));
 
     int actual = string.getSizeInBytes();
     int expected = reflectionObjectSizer.sizeof(string);
@@ -341,7 +342,7 @@ public class RedisStringTest {
     String javaString;
     for (int i = 0; i < 512; i += 8) {
       javaString = makeStringOfSpecifiedSize(i);
-      RedisString string = new RedisString(javaString.getBytes());
+      RedisString string = new RedisString(stringToBytes(javaString));
 
       int expected = reflectionObjectSizer.sizeof(string);
       int actual = string.getSizeInBytes();
@@ -355,11 +356,11 @@ public class RedisStringTest {
   public void changingStringValue_toShorterString_shouldDecreaseSizeInBytes() {
     String baseString = "baseString";
     String stringToRemove = "asdf";
-    RedisString string = new RedisString((baseString + stringToRemove).getBytes());
+    RedisString string = new RedisString(stringToBytes((baseString + stringToRemove)));
 
     int initialSize = string.getSizeInBytes();
 
-    string.set(baseString.getBytes());
+    string.set(stringToBytes(baseString));
 
     int finalSize = string.getSizeInBytes();
 
@@ -369,12 +370,12 @@ public class RedisStringTest {
   @Test
   public void changingStringValue_toLongerString_shouldIncreaseSizeInBytes() {
     String baseString = "baseString";
-    RedisString string = new RedisString(baseString.getBytes());
+    RedisString string = new RedisString(stringToBytes(baseString));
 
     int initialSize = string.getSizeInBytes();
 
     String addedString = "asdf";
-    string.set((baseString + addedString).getBytes());
+    string.set(stringToBytes((baseString + addedString)));
 
     int finalSize = string.getSizeInBytes();
 
@@ -384,9 +385,9 @@ public class RedisStringTest {
   @Test
   public void changingStringValue_toEmptyString_shouldDecreaseSizeInBytes_toBaseSize() {
     String baseString = "baseString";
-    RedisString string = new RedisString((baseString + "asdf").getBytes());
+    RedisString string = new RedisString(stringToBytes((baseString + "asdf")));
 
-    string.set("".getBytes());
+    string.set(stringToBytes(""));
 
     int finalSize = string.getSizeInBytes();
 
@@ -400,7 +401,7 @@ public class RedisStringTest {
   // carefully consider that increase before changing the constant.
   @Test
   public void overheadConstants_shouldMatchCalculatedValue() {
-    RedisString redisString = new RedisString("".getBytes());
+    RedisString redisString = new RedisString(stringToBytes(""));
     int calculatedSize = reflectionObjectSizer.sizeof(redisString);
 
     assertThat(BASE_REDIS_STRING_OVERHEAD).isEqualTo(calculatedSize);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/executor/cluster/CRC16JUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/executor/cluster/CRC16JUnitTest.java
@@ -15,10 +15,12 @@
 
 package org.apache.geode.redis.internal.executor.cluster;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import redis.clients.jedis.util.JedisClusterCRC16;
+
 
 public class CRC16JUnitTest {
 
@@ -32,19 +34,19 @@ public class CRC16JUnitTest {
     assertThat(CRC16.calculate(new byte[] {1}, 0, 1))
         .isEqualTo((short) JedisClusterCRC16.getCRC16(data));
 
-    data = "123456789".getBytes();
+    data = stringToBytes("123456789");
     assertThat(CRC16.calculate(data, 0, data.length))
         .isEqualTo((short) JedisClusterCRC16.getCRC16(data));
 
-    data = "---123456789---".getBytes();
+    data = stringToBytes("---123456789---");
     assertThat(CRC16.calculate(data, 3, 12))
         .isEqualTo((short) JedisClusterCRC16.getCRC16(data, 3, 12));
 
-    data = "abcdefghijklmnopqrstuvwxyz".getBytes();
+    data = stringToBytes("abcdefghijklmnopqrstuvwxyz");
     assertThat(CRC16.calculate(data, 0, data.length))
         .isEqualTo((short) JedisClusterCRC16.getCRC16(data));
 
-    data = "user1000".getBytes();
+    data = stringToBytes("user1000");
     assertThat(CRC16.calculate(data, 0, data.length))
         .isEqualTo((short) JedisClusterCRC16.getCRC16(data));
   }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.netty;
+
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
+import static org.apache.geode.redis.internal.netty.Coder.isNegativeInfinity;
+import static org.apache.geode.redis.internal.netty.Coder.isPositiveInfinity;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class CoderTest {
+  @Test
+  @Parameters(method = "stringPairs")
+  public void equalsIgnoreCaseBytes_matchesStringEqualsIgnoreCase(String string1, String string2) {
+    byte[] string1Bytes = stringToBytes(string1);
+    byte[] string2Bytes = stringToBytes(string2);
+    assertThat(equalsIgnoreCaseBytes(string1Bytes, string2Bytes))
+        .as("Comparing equality of " + string1 + " and " + string2)
+        .isEqualTo(string1.equalsIgnoreCase(string2));
+  }
+
+  @Test
+  @Parameters(method = "infinityStrings")
+  public void isInfinity_returnsCorrectly(String string, boolean isPositiveInfinity,
+      boolean isNegativeInfinity) {
+    byte[] bytes = stringToBytes(string);
+    assertThat(isInfinity(bytes)).isEqualTo(isPositiveInfinity || isNegativeInfinity);
+    assertThat(isPositiveInfinity(bytes)).isEqualTo(isPositiveInfinity);
+    assertThat(isNegativeInfinity(bytes)).isEqualTo(isNegativeInfinity);
+  }
+
+  @SuppressWarnings("unused")
+  private Object[] stringPairs() {
+    // string1, string2
+    return new Object[] {
+        new Object[] {"abc", "abc"},
+        new Object[] {"AbC", "abc"},
+        new Object[] {"ABC", "ABC"},
+        new Object[] {"ABC", "abc"},
+        new Object[] {"abc", "acb"},
+        new Object[] {"abc", "xyz"},
+        new Object[] {"abc", "abcd"},
+        new Object[] {"%abc", "%abc"},
+        new Object[] {"%abc", "abc%"},
+        new Object[] {"123abc!@#", "123ABC!@#"},
+        new Object[] {"123abc!@#", "#@!cba321"},
+        new Object[] {"abc", null}
+    };
+  }
+
+  @SuppressWarnings("unused")
+  private Object[] infinityStrings() {
+    // string, isPositiveInfinity, isNegativeInfinity
+    return new Object[] {
+        new Object[] {"inf", true, false},
+        new Object[] {"+inf", true, false},
+        new Object[] {"Infinity", true, false},
+        new Object[] {"+Infinity", true, false},
+        new Object[] {"-inf", false, true},
+        new Object[] {"-Infinity", false, true},
+        new Object[] {"infinite", false, false},
+        new Object[] {"+infinityty", false, false},
+        new Object[] {"+-inf", false, false},
+        new Object[] {"notEvenClose", false, false},
+        new Object[] {"NaN", false, false},
+        new Object[] {null, false, false}
+    };
+  }
+}

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -14,11 +14,13 @@
  */
 package org.apache.geode.redis.internal.netty;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.isNegativeInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.isPositiveInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import junitparams.JUnitParamsRunner;
@@ -36,6 +38,17 @@ public class CoderTest {
     assertThat(equalsIgnoreCaseBytes(string1Bytes, string2Bytes))
         .as("Comparing equality of " + string1 + " and " + string2)
         .isEqualTo(string1.equalsIgnoreCase(string2));
+  }
+
+  @Test
+  @Parameters({"abc", "AbC", "ABC", "%abc", "123abc!@#"})
+  public void toUpperCaseBytes_matchesStringToUpperCase(String string) {
+    byte[] uppercase = toUpperCaseBytes(stringToBytes(string));
+    assertThat(uppercase)
+        .withFailMessage("Comparing toUpperCase for " + string
+            + ".\nExpected: " + bytesToString(uppercase)
+            + "\nActual: " + string.toUpperCase())
+        .isEqualTo(stringToBytes(string.toUpperCase()));
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -41,7 +41,7 @@ public class CoderTest {
   }
 
   @Test
-  @Parameters({"abc", "AbC", "ABC", "%abc", "123abc!@#"})
+  @Parameters({"abc", "AbC", "ABC", "%abc", "123abc!@#", "+inf", "-INF"})
   public void toUpperCaseBytes_matchesStringToUpperCase(String string) {
     byte[] uppercase = toUpperCaseBytes(stringToBytes(string));
     assertThat(uppercase)
@@ -74,6 +74,8 @@ public class CoderTest {
         new Object[] {"abc", "abcd"},
         new Object[] {"%abc", "%abc"},
         new Object[] {"%abc", "abc%"},
+        new Object[] {"+inf", "+INF"},
+        new Object[] {"-INF", "+INF"},
         new Object[] {"123abc!@#", "123ABC!@#"},
         new Object[] {"123abc!@#", "#@!cba321"},
         new Object[] {"abc", null}

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CommandJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CommandJUnitTest.java
@@ -15,10 +15,10 @@
  */
 package org.apache.geode.redis.internal.netty;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,21 +49,21 @@ public class CommandJUnitTest {
         .hasMessageContaining("List of command elements cannot be empty");
 
     List<byte[]> list3 = new ArrayList<byte[]>();
-    list3.add("Garbage".getBytes(StandardCharsets.UTF_8));
+    list3.add(stringToBytes("Garbage"));
 
     Command cmd = new Command(list3);
     assertThat(cmd.getCommandType()).isNotNull();
 
     assertThat(cmd.getCommandType()).isEqualTo(RedisCommandType.UNKNOWN);
     list3.clear();
-    list3.add(RedisCommandType.HEXISTS.toString().getBytes(StandardCharsets.UTF_8));
+    list3.add(stringToBytes(RedisCommandType.HEXISTS.toString()));
     cmd = new Command(list3);
     assertThat(cmd.getCommandType()).isNotNull();
     assertThat(cmd.getCommandType()).isEqualTo(RedisCommandType.HEXISTS);
     assertThat(cmd.getProcessedCommand()).isEqualTo(list3);
     assertThat(cmd.getKey()).isNull();
 
-    list3.add("Arg1".getBytes(StandardCharsets.UTF_8));
+    list3.add(stringToBytes("Arg1"));
     cmd = new Command(list3);
     assertThat(cmd.getKey()).isNotNull();
     assertThat(cmd.getStringKey()).isEqualTo("Arg1");

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplJUnitTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -47,7 +48,8 @@ public class PubSubImplJUnitTest {
     when(deadClient.isDead()).thenReturn(true);
 
     ChannelSubscription subscription =
-        spy(new ChannelSubscription(deadClient, "sally".getBytes(), mockContext, subscriptions));
+        spy(new ChannelSubscription(deadClient, stringToBytes("sally"), mockContext,
+            subscriptions));
     subscription.readyToPublish();
 
     subscriptions.add(subscription);
@@ -55,7 +57,8 @@ public class PubSubImplJUnitTest {
     PubSubImpl subject = new PubSubImpl(subscriptions);
 
     Long numberOfSubscriptions =
-        subject.publishMessageToSubscribers("sally".getBytes(), "message".getBytes());
+        subject.publishMessageToSubscribers(stringToBytes("sally"),
+            stringToBytes("message"));
 
     assertThat(numberOfSubscriptions).isEqualTo(0);
     assertThat(subscriptions.findSubscriptions(deadClient)).isEmpty();

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -28,7 +29,6 @@ import org.junit.Test;
 
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class SubscriptionsJUnitTest {
@@ -44,11 +44,11 @@ public class SubscriptionsJUnitTest {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     subscriptions
-        .add(new ChannelSubscription(client, Coder.stringToBytes("subscriptions"), context,
+        .add(new ChannelSubscription(client, stringToBytes("subscriptions"), context,
             subscriptions));
 
-    assertThat(subscriptions.exists(Coder.stringToBytes("subscriptions"), client)).isTrue();
-    assertThat(subscriptions.exists(Coder.stringToBytes("unknown"), client)).isFalse();
+    assertThat(subscriptions.exists(stringToBytes("subscriptions"), client)).isTrue();
+    assertThat(subscriptions.exists(stringToBytes("unknown"), client)).isFalse();
   }
 
   @Test
@@ -82,7 +82,7 @@ public class SubscriptionsJUnitTest {
     GlobPattern globPattern2 = new GlobPattern("subscriptions");
 
     subscriptions
-        .add(new ChannelSubscription(client, Coder.stringToBytes("subscriptions"), context,
+        .add(new ChannelSubscription(client, stringToBytes("subscriptions"), context,
             subscriptions));
 
     assertThat(subscriptions.exists(globPattern1, client)).isFalse();
@@ -101,12 +101,12 @@ public class SubscriptionsJUnitTest {
     GlobPattern globby = new GlobPattern("sub*s");
 
     subscriptions
-        .add(new ChannelSubscription(client, Coder.stringToBytes("subscriptions"), context,
+        .add(new ChannelSubscription(client, stringToBytes("subscriptions"), context,
             subscriptions));
     subscriptions.add(new PatternSubscription(client, globby, context, subscriptions));
 
     assertThat(subscriptions.exists(globby, client)).isTrue();
-    assertThat(subscriptions.exists(Coder.stringToBytes("subscriptions"), client)).isTrue();
+    assertThat(subscriptions.exists(stringToBytes("subscriptions"), client)).isTrue();
   }
 
 
@@ -132,10 +132,10 @@ public class SubscriptionsJUnitTest {
     Client clientTwo = new Client(mockChannelTwo);
 
     ChannelSubscription subscriptionOne =
-        new ChannelSubscription(clientOne, Coder.stringToBytes("subscriptions"), context,
+        new ChannelSubscription(clientOne, stringToBytes("subscriptions"), context,
             subscriptions);
     ChannelSubscription subscriptionTwo =
-        new ChannelSubscription(clientTwo, Coder.stringToBytes("monkeys"), context, subscriptions);
+        new ChannelSubscription(clientTwo, stringToBytes("monkeys"), context, subscriptions);
 
     subscriptions.add(subscriptionOne);
     subscriptions.add(subscriptionTwo);
@@ -159,10 +159,10 @@ public class SubscriptionsJUnitTest {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     ChannelSubscription subscriptionOne =
-        new ChannelSubscription(clientOne, Coder.stringToBytes("subscriptions"), context,
+        new ChannelSubscription(clientOne, stringToBytes("subscriptions"), context,
             subscriptions);
     ChannelSubscription subscriptionTwo =
-        new ChannelSubscription(clientTwo, Coder.stringToBytes("monkeys"), context, subscriptions);
+        new ChannelSubscription(clientTwo, stringToBytes("monkeys"), context, subscriptions);
 
     subscriptions.add(subscriptionOne);
     subscriptions.add(subscriptionTwo);
@@ -184,13 +184,13 @@ public class SubscriptionsJUnitTest {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     ChannelSubscription channelSubscriberOne =
-        new ChannelSubscription(client, Coder.stringToBytes("subscriptions"), context,
+        new ChannelSubscription(client, stringToBytes("subscriptions"), context,
             subscriptions);
     GlobPattern pattern = new GlobPattern("monkeys");
     PatternSubscription patternSubscriber = new PatternSubscription(client,
         pattern, context, subscriptions);
     ChannelSubscription channelSubscriberTwo =
-        new ChannelSubscription(client, Coder.stringToBytes("monkeys"), context, subscriptions);
+        new ChannelSubscription(client, stringToBytes("monkeys"), context, subscriptions);
 
     subscriptions.add(channelSubscriberOne);
     subscriptions.add(patternSubscriber);
@@ -215,39 +215,39 @@ public class SubscriptionsJUnitTest {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     Subscription subscriptionFoo =
-        new ChannelSubscription(client, Coder.stringToBytes("foo"), context, subject);
+        new ChannelSubscription(client, stringToBytes("foo"), context, subject);
 
     Subscription subscriptionBar =
-        new ChannelSubscription(client, Coder.stringToBytes("bar"), context, subject);
+        new ChannelSubscription(client, stringToBytes("bar"), context, subject);
 
     subject.add(subscriptionFoo);
     subject.add(subscriptionBar);
 
     List<byte[]> result = subject.findChannelNames();
 
-    assertThat(result).containsExactlyInAnyOrder(Coder.stringToBytes("foo"),
-        Coder.stringToBytes("bar"));
+    assertThat(result).containsExactlyInAnyOrder(stringToBytes("foo"),
+        stringToBytes("bar"));
   }
 
   @Test
   public void findChannelNames_shouldReturnOnlyMatchingChannelNames_whenCalledWithPattern() {
     Subscriptions subject = new Subscriptions();
-    byte[] pattern = Coder.stringToBytes("b*");
+    byte[] pattern = stringToBytes("b*");
 
     Channel channel = mock(Channel.class);
     when(channel.closeFuture()).thenReturn(mock(ChannelFuture.class));
     Client client = new Client(channel);
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
-    subject.add(new ChannelSubscription(client, Coder.stringToBytes("foo"), context, subject));
-    subject.add(new ChannelSubscription(client, Coder.stringToBytes("bar"), context, subject));
+    subject.add(new ChannelSubscription(client, stringToBytes("foo"), context, subject));
+    subject.add(new ChannelSubscription(client, stringToBytes("bar"), context, subject));
     subject
-        .add(new ChannelSubscription(client, Coder.stringToBytes("barbarella"), context, subject));
+        .add(new ChannelSubscription(client, stringToBytes("barbarella"), context, subject));
 
     List<byte[]> result = subject.findChannelNames(pattern);
 
-    assertThat(result).containsExactlyInAnyOrder(Coder.stringToBytes("bar"),
-        Coder.stringToBytes("barbarella"));
+    assertThat(result).containsExactlyInAnyOrder(stringToBytes("bar"),
+        stringToBytes("barbarella"));
   }
 
   @Test
@@ -261,7 +261,7 @@ public class SubscriptionsJUnitTest {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     Subscription subscriptionFoo =
-        new ChannelSubscription(client, Coder.stringToBytes("foo"), context, subject);
+        new ChannelSubscription(client, stringToBytes("foo"), context, subject);
 
     Subscription patternSubscriptionBar =
         new PatternSubscription(client, new GlobPattern("bar"), context, subject);
@@ -271,7 +271,7 @@ public class SubscriptionsJUnitTest {
 
     List<byte[]> result = subject.findChannelNames();
 
-    assertThat(result).containsExactlyInAnyOrder(Coder.stringToBytes("foo"));
+    assertThat(result).containsExactlyInAnyOrder(stringToBytes("foo"));
   }
 
 
@@ -286,17 +286,17 @@ public class SubscriptionsJUnitTest {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     Subscription subscriptionFoo1 =
-        new ChannelSubscription(client, Coder.stringToBytes("foo"), context, subject);
+        new ChannelSubscription(client, stringToBytes("foo"), context, subject);
 
     Subscription subscriptionFoo2 =
-        new ChannelSubscription(client, Coder.stringToBytes("foo"), context, subject);
+        new ChannelSubscription(client, stringToBytes("foo"), context, subject);
 
     subject.add(subscriptionFoo1);
     subject.add(subscriptionFoo2);
 
     List<byte[]> result = subject.findChannelNames();
 
-    assertThat(result).containsExactlyInAnyOrder(Coder.stringToBytes("foo"));
+    assertThat(result).containsExactlyInAnyOrder(stringToBytes("foo"));
   }
 
   @Test
@@ -310,16 +310,16 @@ public class SubscriptionsJUnitTest {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
 
     Subscription subscriptionFoo1 =
-        new ChannelSubscription(client, Coder.stringToBytes("foo"), context, subject);
+        new ChannelSubscription(client, stringToBytes("foo"), context, subject);
 
     Subscription subscriptionFoo2 =
-        new ChannelSubscription(client, Coder.stringToBytes("foo"), context, subject);
+        new ChannelSubscription(client, stringToBytes("foo"), context, subject);
 
     subject.add(subscriptionFoo1);
     subject.add(subscriptionFoo2);
 
-    List<byte[]> result = subject.findChannelNames(Coder.stringToBytes("f*"));
+    List<byte[]> result = subject.findChannelNames(stringToBytes("f*"));
 
-    assertThat(result).containsExactlyInAnyOrder(Coder.stringToBytes("foo"));
+    assertThat(result).containsExactlyInAnyOrder(stringToBytes("foo"));
   }
 }


### PR DESCRIPTION
 - Replace uses of new String(byte[]) and String.getBytes() with
 Coder.bytesToString() and Coder.stringToBytes() respectively
 - Change bytesToString() and stringToBytes() to use the CHARSET defined
 in Coder (UTF-8)
 - Throw IllegalStateException if UTF-8 charset is not supported
 - Introduce StringBytesGlossary class to hold commonly-used byte array
 values to reduce the need to create new Strings
 - Replace as many calls to bytesToString() as possible in Executor
 classes with byte array comparisons using StringBytesGlossary values
 - Introduce methods in Coder to allow case-insensitive byte array
 comparisons

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
