### PR TITLE
GEODE-9369: Command to copy region entries from a WAN site to another

### DIFF
--- a/geode-book/master_middleman/source/subnavs/geode-subnav.erb
+++ b/geode-book/master_middleman/source/subnavs/geode-subnav.erb
@@ -2109,6 +2109,7 @@ gfsh</a>
                                     </li>
                                     <li>
                                         <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/gfsh/command-pages/version.html">version</a>
+                                        <a href="/docs/guide/<%=vars.product_version_nodot%>/tools_modules/gfsh/command-pages/wan_copy_region.html">wan-copy region</a>
                                     </li>
                                 </ul>
                             </li>

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
@@ -420,7 +420,7 @@ public class DistributedAckRegionCCEDUnitTest extends DistributedAckRegionDUnitT
       VersionTagHolder holder = new VersionTagHolder(tag);
       ClientProxyMembershipID id = ClientProxyMembershipID
           .getNewProxyMembership(CCRegion.getDistributionManager().getSystem());
-      CCRegion.basicBridgePut("cckey0", "newvalue", null, true, null, id, true, holder, true);
+      CCRegion.basicBridgePut("cckey0", "newvalue", null, true, null, id, holder, true);
       vm0.invoke("check conflation count", () -> {
         // after changed the 3rd try of AUO.doPutOrCreate to be ifOld=false ifNew=false
         // ARM.updateEntry will be called one more time, so there will be 2 conflicted events

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
@@ -420,7 +420,7 @@ public class DistributedAckRegionCCEDUnitTest extends DistributedAckRegionDUnitT
       VersionTagHolder holder = new VersionTagHolder(tag);
       ClientProxyMembershipID id = ClientProxyMembershipID
           .getNewProxyMembership(CCRegion.getDistributionManager().getSystem());
-      CCRegion.basicBridgePut("cckey0", "newvalue", null, true, null, id, true, holder);
+      CCRegion.basicBridgePut("cckey0", "newvalue", null, true, null, id, true, holder, true);
       vm0.invoke("check conflation count", () -> {
         // after changed the 3rd try of AUO.doPutOrCreate to be ifOld=false ifNew=false
         // ARM.updateEntry will be called one more time, so there will be 2 conflicted events

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EnumListenerEvent.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EnumListenerEvent.java
@@ -106,12 +106,17 @@ public abstract class EnumListenerEvent {
   public static final EnumListenerEvent TIMESTAMP_UPDATE = new TIMESTAMP_UPDATE(); // 18
 
   @Immutable
+  public static final EnumListenerEvent AFTER_UPDATE_WITH_GENERATE_CALLBACKS =
+      new AFTER_UPDATE_WITH_GENERATE_CALLBACKS(); // 19
+
+  @Immutable
   private static final EnumListenerEvent[] instances =
       new EnumListenerEvent[] {AFTER_CREATE, AFTER_UPDATE, AFTER_INVALIDATE, AFTER_DESTROY,
           AFTER_REGION_CREATE, AFTER_REGION_INVALIDATE, AFTER_REGION_CLEAR, AFTER_REGION_DESTROY,
           AFTER_REMOTE_REGION_CREATE, AFTER_REMOTE_REGION_DEPARTURE, AFTER_REMOTE_REGION_CRASH,
           AFTER_ROLE_GAIN, AFTER_ROLE_LOSS, AFTER_REGION_LIVE, AFTER_REGISTER_INSTANTIATOR,
-          AFTER_REGISTER_DATASERIALIZER, AFTER_TOMBSTONE_EXPIRATION, TIMESTAMP_UPDATE};
+          AFTER_REGISTER_DATASERIALIZER, AFTER_TOMBSTONE_EXPIRATION, TIMESTAMP_UPDATE,
+          AFTER_UPDATE_WITH_GENERATE_CALLBACKS};
 
   static {
     for (int i = 0; i < instances.length; i++) {
@@ -412,6 +417,21 @@ public abstract class EnumListenerEvent {
     }
   }
 
+  private static class AFTER_UPDATE_WITH_GENERATE_CALLBACKS extends EnumListenerEvent {
+    protected AFTER_UPDATE_WITH_GENERATE_CALLBACKS() {
+      super("AFTER_UPDATE_WITH_GENERATE_CALLBACKS");
+    }
+
+    @Override
+    public void dispatchEvent(CacheEvent event, CacheListener listener) {}
+
+    @Override
+    public byte getEventCode() {
+      return 19;
+    }
+  }
+
+
   /**
    *
    * This method returns the EnumListenerEvent object corresponding to the cCode given.
@@ -435,6 +455,8 @@ public abstract class EnumListenerEvent {
    * <li>15 - AFTER_REGISTER_INSTANTIATOR
    * <li>16 - AFTER_REGISTER_DATASERIALIZER
    * <li>17 - AFTER_TOMBSTONE_EXPIRATION
+   * <li>18 - TIMESTAMP_UPDATE
+   * <li>19 - AFTER_UPDATE_WITH_GENERATE_CALLBACKS
    * </ul>
    *
    * @param eventCode the eventCode corresponding to the EnumListenerEvent object desired

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -5180,7 +5180,8 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
 
   public boolean basicBridgePut(Object key, Object value, byte[] deltaBytes, boolean isObject,
       Object callbackArg, ClientProxyMembershipID memberId, boolean fromClient,
-      EntryEventImpl clientEvent) throws TimeoutException, CacheWriterException {
+      EntryEventImpl clientEvent, boolean generateCallbacks)
+      throws TimeoutException, CacheWriterException {
 
     EventID eventID = clientEvent.getEventId();
     Object theCallbackArg = callbackArg;
@@ -5189,7 +5190,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     @Released
     final EntryEventImpl event = entryEventFactory.create(this, Operation.UPDATE, key,
         null, theCallbackArg, false,
-        memberId.getDistributedMember(), true, eventID);
+        memberId.getDistributedMember(), generateCallbacks, eventID);
 
     try {
       event.setContext(memberId);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -5179,7 +5179,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
   }
 
   public boolean basicBridgePut(Object key, Object value, byte[] deltaBytes, boolean isObject,
-      Object callbackArg, ClientProxyMembershipID memberId, boolean fromClient,
+      Object callbackArg, ClientProxyMembershipID memberId,
       EntryEventImpl clientEvent, boolean generateCallbacks)
       throws TimeoutException, CacheWriterException {
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerStats.java
@@ -992,8 +992,8 @@ public class CacheServerStats implements MessageStats {
     return this.stats.getDouble(loadPerConnectionId);
   }
 
-  public int getProcessBatchRequests() {
-    return this.stats.getInt(processBatchRequestsId);
+  public long getProcessBatchRequests() {
+    return this.stats.getLong(processBatchRequestsId);
   }
 
   public void close() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GatewayReceiverCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/GatewayReceiverCommand.java
@@ -309,7 +309,7 @@ public class GatewayReceiverCommand extends BaseCommand {
                     // attempt to update the entry
                     if (!result) {
                       result = region.basicBridgePut(key, value, null, isObject, callbackArg,
-                          serverConnection.getProxyID(), false, clientEvent, true);
+                          serverConnection.getProxyID(), clientEvent, true);
                     }
                   }
 
@@ -407,12 +407,10 @@ public class GatewayReceiverCommand extends BaseCommand {
                   if (isPdxEvent) {
                     result = addPdxType(crHelper, key, value);
                   } else {
-                    boolean generateCallbacks = true;
-                    if (actionType == GatewaySenderEventImpl.UPDATE_ACTION_NO_GENERATE_CALLBACKS) {
-                      generateCallbacks = false;
-                    }
+                    boolean generateCallbacks =
+                        actionType != GatewaySenderEventImpl.UPDATE_ACTION_NO_GENERATE_CALLBACKS;
                     result = region.basicBridgePut(key, value, null, isObject, callbackArg,
-                        serverConnection.getProxyID(), false, clientEvent, generateCallbacks);
+                        serverConnection.getProxyID(), clientEvent, generateCallbacks);
                   }
                   if (result || clientEvent.isConcurrencyConflict()) {
                     serverConnection.setModificationInfo(true, regionName, key);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put70.java
@@ -379,7 +379,7 @@ public class Put70 extends BaseCommand {
               serverConnection.getProxyID(), true, clientEvent, true);
         } else {
           result = region.basicBridgePut(key, value, delta, isObject, callbackArg,
-              serverConnection.getProxyID(), true, clientEvent, true);
+              serverConnection.getProxyID(), clientEvent, true);
         }
         if (clientMessage.isRetry() && clientEvent.isConcurrencyConflict()
             && clientEvent.getVersionTag() != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put70.java
@@ -379,7 +379,7 @@ public class Put70 extends BaseCommand {
               serverConnection.getProxyID(), true, clientEvent, true);
         } else {
           result = region.basicBridgePut(key, value, delta, isObject, callbackArg,
-              serverConnection.getProxyID(), true, clientEvent);
+              serverConnection.getProxyID(), true, clientEvent, true);
         }
         if (clientMessage.isRetry() && clientEvent.isConcurrencyConflict()
             && clientEvent.getVersionTag() != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventCallbackDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventCallbackDispatcher.java
@@ -23,6 +23,9 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.cache.asyncqueue.AsyncEventListener;
+import org.apache.geode.cache.client.internal.Connection;
+import org.apache.geode.cache.client.internal.ExecutablePool;
+import org.apache.geode.cache.wan.GatewayQueueEvent;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -183,5 +186,12 @@ public class GatewaySenderEventCallbackDispatcher implements GatewaySenderEventD
   @Override
   public void shutDownAckReaderConnection() {
     // no op
+  }
+
+  @Override
+  public void sendBatch(List<GatewayQueueEvent> events, Connection connection,
+      ExecutablePool senderPool, int batchId, boolean removeFromQueueOnException)
+      throws BatchException70 {
+    throw new UnsupportedOperationException();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventCallbackDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventCallbackDispatcher.java
@@ -189,7 +189,7 @@ public class GatewaySenderEventCallbackDispatcher implements GatewaySenderEventD
   }
 
   @Override
-  public void sendBatch(List<GatewayQueueEvent> events, Connection connection,
+  public void sendBatch(List<GatewayQueueEvent<?, ?>> events, Connection connection,
       ExecutablePool senderPool, int batchId, boolean removeFromQueueOnException)
       throws BatchException70 {
     throw new UnsupportedOperationException();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventCallbackDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventCallbackDispatcher.java
@@ -190,8 +190,7 @@ public class GatewaySenderEventCallbackDispatcher implements GatewaySenderEventD
 
   @Override
   public void sendBatch(List<GatewayQueueEvent<?, ?>> events, Connection connection,
-      ExecutablePool senderPool, int batchId, boolean removeFromQueueOnException)
-      throws BatchException70 {
+      ExecutablePool senderPool, int batchId, boolean removeFromQueueOnException) {
     throw new UnsupportedOperationException();
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventDispatcher.java
@@ -36,7 +36,8 @@ public interface GatewaySenderEventDispatcher {
 
   void shutDownAckReaderConnection();
 
-  void sendBatch(List<GatewayQueueEvent> events, Connection connection, ExecutablePool senderPool,
+  void sendBatch(List<GatewayQueueEvent<?, ?>> events, Connection connection,
+      ExecutablePool senderPool,
       int batchId, boolean removeFromQueueOnException)
       throws BatchException70;
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventDispatcher.java
@@ -16,6 +16,10 @@ package org.apache.geode.internal.cache.wan;
 
 import java.util.List;
 
+import org.apache.geode.cache.client.internal.Connection;
+import org.apache.geode.cache.client.internal.ExecutablePool;
+import org.apache.geode.cache.wan.GatewayQueueEvent;
+
 /**
  * @since GemFire 7.0
  *
@@ -31,4 +35,8 @@ public interface GatewaySenderEventDispatcher {
   void stop();
 
   void shutDownAckReaderConnection();
+
+  void sendBatch(List<GatewayQueueEvent> events, Connection connection, ExecutablePool senderPool,
+      int batchId, boolean removeFromQueueOnException)
+      throws BatchException70;
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderEventImpl.java
@@ -196,6 +196,8 @@ public class GatewaySenderEventImpl
 
   private static final int VERSION_ACTION = 3;
 
+  public static final int UPDATE_ACTION_NO_GENERATE_CALLBACKS = 4;
+
   private static final int INVALIDATE_ACTION = 5;
   /**
    * Static constants for Operation detail of EntryEvent.
@@ -310,7 +312,7 @@ public class GatewaySenderEventImpl
 
     // Initialize the action and number of parts (called after _callbackArgument
     // is set above)
-    initializeAction(this.operation);
+    initializeAction(this.operation, event);
 
     // initialize the operation detail
     initializeOperationDetail(event.getOperation());
@@ -1021,7 +1023,7 @@ public class GatewaySenderEventImpl
    *
    * @param operation The operation from which to initialize this event's action and number of parts
    */
-  protected void initializeAction(EnumListenerEvent operation) {
+  protected void initializeAction(EnumListenerEvent operation, EntryEventImpl event) {
     if (operation == EnumListenerEvent.AFTER_CREATE) {
       // Initialize after create action
       action = CREATE_ACTION;
@@ -1064,6 +1066,13 @@ public class GatewaySenderEventImpl
       // Initialize number of parts
       // Since there is no value, there is one less part
       numberOfParts = (callbackArgument == null) ? 7 : 8;
+    } else if (operation == EnumListenerEvent.AFTER_UPDATE_WITH_GENERATE_CALLBACKS) {
+      if (event.isGenerateCallbacks()) {
+        action = UPDATE_ACTION;
+      } else {
+        action = UPDATE_ACTION_NO_GENERATE_CALLBACKS;
+      }
+      numberOfParts = (this.callbackArgument == null) ? 8 : 9;
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -1459,11 +1459,11 @@ public class CliStrings {
   public static final String WAN_COPY_REGION__MSG__EXECUTION__FAILED =
       "Execution failed. Error: {0}";
   public static final String WAN_COPY_REGION__MSG__NO__CONNECTION__POOL =
-      "No connection pool available towards receiver";
+      "No connection pool available to receiver";
   public static final String WAN_COPY_REGION__MSG__COMMAND__NOT__SUPPORTED__AT__REMOTE__SITE =
       "Command not supported at remote site.";
   public static final String WAN_COPY_REGION__MSG__NO__CONNECTION =
-      "No connection available towards receiver after having copied {0} entries";
+      "No connection available to receiver after having copied {0} entries";
   public static final String WAN_COPY_REGION__MSG__ERROR__AFTER__HAVING__COPIED =
       "Error ({0}) in operation after having copied {1} entries";
   public static final String WAN_COPY_REGION__MSG__CANCELED__BEFORE__HAVING__COPIED =

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -1426,6 +1426,51 @@ public class CliStrings {
   public static final String EXPORT_DATA__SUCCESS__MESSAGE =
       "Data successfully exported from region : {0} to file : {1} on host : {2}";
 
+  /* 'replicate region' command */
+  public static final String WAN_COPY_REGION = "wan-copy region";
+  public static final String WAN_COPY_REGION__HELP =
+      "Copy a region with a senderId via WAN replication";
+  public static final String WAN_COPY_REGION__REGION = "region";
+  public static final String WAN_COPY_REGION__REGION__HELP =
+      "Region from which data will be exported.";
+  public static final String WAN_COPY_REGION__SENDERID = "sender-id";
+  public static final String WAN_COPY_REGION__SENDERID__HELP =
+      "senderId to use to copy the region.";
+  public static final String WAN_COPY_REGION__MAXRATE = "max-rate";
+  public static final String WAN_COPY_REGION__MAXRATE__HELP =
+      "maximum rate for copying in events per second.";
+  public static final String WAN_COPY_REGION__BATCHSIZE = "batch-size";
+  public static final String WAN_COPY_REGION__BATCHSIZE__HELP =
+      "size for batches of events to be copied.";
+  public static final String WAN_COPY_REGION__CANCEL = "cancel";
+  public static final String WAN_COPY_REGION__CANCEL__HELP =
+      "cancel an ongoing wan-copy region command";
+  public static final String WAN_COPY_REGION__MSG__REGION__NOT__FOUND = "Region {0} not found";
+  public static final String WAN_COPY_REGION__MSG__REGION__NOT__USING_SENDER =
+      "Region {0} is not configured to use sender {1}";
+  public static final String WAN_COPY_REGION__MSG__SENDER__NOT__FOUND = "Sender {0} not found";
+  public static final String WAN_COPY_REGION__MSG__SENDER__SERIAL__AND__NOT__PRIMARY =
+      "Sender {0} is serial and not primary. 0 entries copied.";
+  public static final String WAN_COPY_REGION__MSG__SENDER__NOT__RUNNING =
+      "Sender {0} is not running";
+  public static final String WAN_COPY_REGION__MSG__EXECUTION__CANCELED = "Execution canceled";
+  public static final String WAN_COPY_REGION__MSG__EXECUTION__FAILED =
+      "Execution failed. Error: {0}";
+  public static final String WAN_COPY_REGION__MSG__ENTRIES__COPIED = "Entries copied: {0}";
+  public static final String WAN_COPY_REGION__MSG__NO__CONNECTION__POOL =
+      "No connection pool available towards receiver";
+  public static final String WAN_COPY_REGION__MSG__COMMAND__NOT__SUPPORTED__AT__REMOTE__SITE =
+      "Command not supported at remote site.";
+  public static final String WAN_COPY_REGION__MSG__NO__CONNECTION =
+      "No connection available towards receiver after having copied {0} entries";
+  public static final String WAN_COPY_REGION__MSG__ERROR__AFTER__HAVING__COPIED =
+      "Error ({0}) in operation after having copied {1} entries";
+  public static final String WAN_COPY_REGION__MSG__CANCELED__AFTER__HAVING__COPIED =
+      "Operation canceled after having copied {0} entries";
+  public static final String WAN_COPY_REGION__MSG__COPIED__ENTRIES = "Entries copied: {0}";
+  public static final String WAN_COPY_REGION__MSG__NO__RUNNING__COMMAND =
+      "No running command to be canceled for region {0} and sender {1}";
+
   /* export logs command */
   public static final String EXPORT_LOGS = "export logs";
   public static final String EXPORT_LOGS__HELP = "Export the log files for a member or members.";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -1454,9 +1454,10 @@ public class CliStrings {
   public static final String WAN_COPY_REGION__MSG__SENDER__NOT__RUNNING =
       "Sender {0} is not running";
   public static final String WAN_COPY_REGION__MSG__EXECUTION__CANCELED = "Execution canceled";
+  public static final String WAN_COPY_REGION__MSG__EXECUTIONS__CANCELED =
+      "Executions canceled: {0}";
   public static final String WAN_COPY_REGION__MSG__EXECUTION__FAILED =
       "Execution failed. Error: {0}";
-  public static final String WAN_COPY_REGION__MSG__ENTRIES__COPIED = "Entries copied: {0}";
   public static final String WAN_COPY_REGION__MSG__NO__CONNECTION__POOL =
       "No connection pool available towards receiver";
   public static final String WAN_COPY_REGION__MSG__COMMAND__NOT__SUPPORTED__AT__REMOTE__SITE =
@@ -1465,11 +1466,14 @@ public class CliStrings {
       "No connection available towards receiver after having copied {0} entries";
   public static final String WAN_COPY_REGION__MSG__ERROR__AFTER__HAVING__COPIED =
       "Error ({0}) in operation after having copied {1} entries";
-  public static final String WAN_COPY_REGION__MSG__CANCELED__AFTER__HAVING__COPIED =
-      "Operation canceled after having copied {0} entries";
+  public static final String WAN_COPY_REGION__MSG__CANCELED__BEFORE__HAVING__COPIED =
+      "Operation canceled before having copied all entries";
   public static final String WAN_COPY_REGION__MSG__COPIED__ENTRIES = "Entries copied: {0}";
   public static final String WAN_COPY_REGION__MSG__NO__RUNNING__COMMAND =
       "No running command to be canceled for region {0} and sender {1}";
+  public static final String WAN_COPY_REGION__MSG__ALREADY__RUNNING__COMMAND =
+      "There is already a command running for region {0} and sender {1}";
+
 
   /* export logs command */
   public static final String EXPORT_LOGS = "export logs";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -1438,10 +1438,10 @@ public class CliStrings {
       "Sender Id to use to copy the region.";
   public static final String WAN_COPY_REGION__MAXRATE = "max-rate";
   public static final String WAN_COPY_REGION__MAXRATE__HELP =
-      "Maximum rate for copying in events per second.";
+      "Maximum rate for copying in entries per second.";
   public static final String WAN_COPY_REGION__BATCHSIZE = "batch-size";
   public static final String WAN_COPY_REGION__BATCHSIZE__HELP =
-      "Size for batches of events to be copied.";
+      "Number of entries to be copied in each batch.";
   public static final String WAN_COPY_REGION__CANCEL = "cancel";
   public static final String WAN_COPY_REGION__CANCEL__HELP =
       "Cancel an ongoing wan-copy region command";

--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -1426,7 +1426,7 @@ public class CliStrings {
   public static final String EXPORT_DATA__SUCCESS__MESSAGE =
       "Data successfully exported from region : {0} to file : {1} on host : {2}";
 
-  /* 'replicate region' command */
+  /* 'wan-copy region' command */
   public static final String WAN_COPY_REGION = "wan-copy region";
   public static final String WAN_COPY_REGION__HELP =
       "Copy a region with a senderId via WAN replication";
@@ -1435,16 +1435,16 @@ public class CliStrings {
       "Region from which data will be exported.";
   public static final String WAN_COPY_REGION__SENDERID = "sender-id";
   public static final String WAN_COPY_REGION__SENDERID__HELP =
-      "senderId to use to copy the region.";
+      "Sender Id to use to copy the region.";
   public static final String WAN_COPY_REGION__MAXRATE = "max-rate";
   public static final String WAN_COPY_REGION__MAXRATE__HELP =
-      "maximum rate for copying in events per second.";
+      "Maximum rate for copying in events per second.";
   public static final String WAN_COPY_REGION__BATCHSIZE = "batch-size";
   public static final String WAN_COPY_REGION__BATCHSIZE__HELP =
-      "size for batches of events to be copied.";
+      "Size for batches of events to be copied.";
   public static final String WAN_COPY_REGION__CANCEL = "cancel";
   public static final String WAN_COPY_REGION__CANCEL__HELP =
-      "cancel an ongoing wan-copy region command";
+      "Cancel an ongoing wan-copy region command";
   public static final String WAN_COPY_REGION__MSG__REGION__NOT__FOUND = "Region {0} not found";
   public static final String WAN_COPY_REGION__MSG__REGION__NOT__USING_SENDER =
       "Region {0} is not configured to use sender {1}";

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EnumListenerEventJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EnumListenerEventJUnitTest.java
@@ -47,7 +47,8 @@ public class EnumListenerEventJUnitTest {
     // extra non-existent code checks as a markers so that this test will
     // fail if further events are added (0th or +1 codes) without updating this test
     checkAndAssert(18, EnumListenerEvent.TIMESTAMP_UPDATE);
-    checkAndAssert(19, null);
+    checkAndAssert(19, EnumListenerEvent.AFTER_UPDATE_WITH_GENERATE_CALLBACKS);
+    checkAndAssert(20, null);
   }
 
   // check that the code and object both match

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put70Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put70Test.java
@@ -138,7 +138,7 @@ public class Put70Test {
     when(keyPart.getStringOrObject()).thenReturn(KEY);
 
     when(localRegion.basicBridgePut(eq(KEY), eq(VALUE), eq(null), eq(true), eq(CALLBACK_ARG),
-        any(), eq(true), any())).thenReturn(true);
+        any(), eq(true), any(), eq(true))).thenReturn(true);
 
     when(message.getNumberOfParts()).thenReturn(8);
     when(message.getPart(eq(0))).thenReturn(regionNamePart);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put70Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put70Test.java
@@ -138,7 +138,7 @@ public class Put70Test {
     when(keyPart.getStringOrObject()).thenReturn(KEY);
 
     when(localRegion.basicBridgePut(eq(KEY), eq(VALUE), eq(null), eq(true), eq(CALLBACK_ARG),
-        any(), eq(true), any(), eq(true))).thenReturn(true);
+        any(), any(), eq(true))).thenReturn(true);
 
     when(message.getNumberOfParts()).thenReturn(8);
     when(message.getPart(eq(0))).thenReturn(regionNamePart);

--- a/geode-docs/tools_modules/gfsh/command-pages/wan_copy_region.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/wan_copy_region.html.md.erb
@@ -37,7 +37,7 @@ The main uses of this command are:
 -   Adding a new WAN site to a <%=vars.product_name%> system in which the data in the new WAN site needs to be initially loaded from
     an existing WAN site.
 
-The execution of a currently running instance of this command my be stopped by using
+The execution of a currently running instance of this command may be stopped by using
 this same command with the `--cancel` option.
 
 **Requirements:**
@@ -76,7 +76,7 @@ table th:nth-of-type(3) {
 | &#8209;&#8209;sender-id| <em>Required</em>. The gateway sender to be used to copy the region entries. | |
 | &#8209;&#8209;max-rate| The maximum copy rate in entries per second. If the sender is parallel, the maximum rate limit is applied to each server hosting buckets for the region to be copied. | 0 (unlimited) |
 | &#8209;&#8209;batch-size| The size of the batches, in number of entries, to be used to copy the region entries. | 1000 |
-| &#8209;&#8209;cancel| Cancel a running `wan-copy region` command for the specified sender and region. |  |
+| &#8209;&#8209;cancel| Cancel a running `wan-copy region` command for the specified sender and region. If the `sender-id` and `region` passed are both "*", then all running `wan-copy region` commands will be canceled. |  |
 
 <span class="tablecap">Table 1. Copy Region Parameters</span>
 
@@ -89,6 +89,10 @@ wan-copy region --region=myRegion--sender-id=mySender --max-rate=1000 --batch-si
 
 ``` pre
 wan-copy region --region=/overload --sender-id=sender1 --cancel
+```
+
+``` pre
+wan-copy region --region=* --sender-id=* --cancel
 ```
 
 **Sample Output:**
@@ -173,5 +177,16 @@ gfsh> wan-copy region --region=/region1 --sender-id=sender1 --cancel
     server-sender2 | ERROR  | No running command to be canceled for region /region1 and sender sender1
     server-sender  | ERROR  | No running command to be canceled for region /region1 and sender sender1
     server-sender3 | ERROR  | No running command to be canceled for region /region1 and sender sender1
+```
+
+Example of cancel of all running `wan-copy region` commands:
+
+``` pre
+gfsh> wan-copy region --region=* --sender-id=* --cancel
+        Member     | Status | Message
+    -------------- | ------ | ------------------------------------------------------------------------------------
+    server-sender2 | OK     | Executions canceled: [(myRegion,mySender1), (myRegion,mySender)]
+    server-sender  | OK     | Executions canceled: [(myRegion,mySender1), (myRegion,mySender)]
+    server-sender3 | OK     | Executions canceled: [(myRegion,mySender1), (myRegion,mySender)]
 ```
 

--- a/geode-docs/tools_modules/gfsh/command-pages/wan_copy_region.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/wan_copy_region.html.md.erb
@@ -37,11 +37,11 @@ The main uses of this command are:
 -   Recovery of a WAN site after a disaster in which the failed site needs to be put into service again with
     the data from another WAN site.
 
--   Adding a new WAN site to a Geode system in which the data in the new WAN site needs to be initially loaded from
+-   Adding a new WAN site to a <%=vars.product_name%> system in which the data in the new WAN site needs to be initially loaded from
     an existing WAN site.
 
 The execution of a currently running instance of this command my be stopped by using
-this same command with the --cancel option.
+this same command with the `--cancel` option.
 
 **Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
 

--- a/geode-docs/tools_modules/gfsh/command-pages/wan_copy_region.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/wan_copy_region.html.md.erb
@@ -1,0 +1,171 @@
+---
+title:  wan-copy region
+---
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+Copy the entries of a region in a WAN site onto the same region in another WAN site, using a gateway sender.
+
+This command requires that a gateway sender is configured and running on the source WAN site and that a gateway
+receiver is configured and running on the remote WAN site.
+The command also requires that the remote WAN site has the region onto which the data will be copied already created.
+Callbacks (cache listeners, replication to other WAN sites) will not be executed in the remote WAN site for the entries copied.
+
+This command copies region entries from a WAN site to another by putting them in batches of configurable
+size that are sent to the remote site by the selected gateway sender.
+
+The command allows to specify a maximum copy rate in order not to stress excessively the sending or receiving WAN sites.
+This rate is configured in entries per second.
+
+The main uses of this command are:
+
+-   Recovery of a WAN site after a disaster in which the failed site needs to be put into service again with
+    the data from another WAN site.
+
+-   Adding a new WAN site to a Geode system in which the data in the new WAN site needs to be initially loaded from
+    an existing WAN site.
+
+The execution of a currently running instance of this command my be stopped by using
+this same command with the --cancel option.
+
+**Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
+
+**Syntax:**
+
+``` pre
+wan-copy region --region=value --sender-id=value [--max-rate=value] [--batch-size=value] [--cancel(=value)?]
+```
+
+<a id="wan_copy_region_command_params"></a>
+<style>
+table th:first-of-type {
+    width: 20%;
+}
+table th:nth-of-type(2) {
+    width: 60%;
+}
+table th:nth-of-type(3) {
+    width: 20%;
+}
+</style>
+
+| Name | Description | Default Value |
+|------|-------------|---------------|
+| &#8209;&#8209;region| <em>Required</em>. The region for which the data is to be copied. | |
+| &#8209;&#8209;sender-id| <em>Required</em>. The gateway sender to be used to copy the region entries. | |
+| &#8209;&#8209;max-rate| The maximum copy rate in entries per second. If the sender is parallel, the maximum rate limit is applied to each server hosting buckets for the region to be copied. | 0 (unlimited) |
+| &#8209;&#8209;bath-size| The size of the batches to be used to copy the region entries. | 1000 |
+| &#8209;&#8209;cancel| If specified without a value or if true, it will cancel a running `wan-copy region` command for the passed sender and region. | false |
+
+<span class="tablecap">Table 1. Copy Region Parameters</span>
+
+
+**Example Commands:**
+
+``` pre
+wan-copy region --region=myRegion--sender-id=mySender --max-rate=1000 --batch-size=100
+```
+
+``` pre
+wan-copy region --region=/overload --sender-id=sender1 --cancel
+```
+
+**Sample Output:**
+
+``` pre
+gfsh>wan-copy region --region=/overload --sender-id=myParallelSender --max-rate=100 --batch-size=100
+        Member     | Status | Message
+    -------------- | ------ | -----------------------
+    server-sender  | OK     | Entries copied: 333
+    server-sender3 | OK     | Entries copied: 334
+    server-sender2 | OK     | Entries copied: 333
+
+```
+
+``` pre
+gfsh>wan-copy region --region=/overload --sender-id=mySerialSender --max-rate=100 --batch-size=100
+        Member     | Status | Message
+    -------------- | ------ | ----------------------------------------------------------------------
+    server-sender2 | OK     | Sender mySerialSender is serial and not primary. 0 entries copied.
+    server-sender3 | OK     | Sender mySerialSender is serial and not primary. 0 entries copied.
+    server-sender  | OK     | Entries copied: 1000
+```
+
+
+``` pre
+gfsh>wan-copy region --region=/overload --sender-id=sender1 --cancel
+        Member     | Status | Message
+    -------------- | ------ | ------------------
+    server-sender2 | OK     | Execution canceled
+    server-sender  | OK     | Execution canceled
+    server-sender3 | OK     | Execution canceled
+```
+
+``` pre
+gfsh>wan-copy region --region=myRegion --sender-id=myParallelSender --max-rate=100 --batch-size=10
+        Member     | Status | Message
+    -------------- | ------ | ------------------------------------------------------
+    server-sender2 | OK     | Operation canceled after having copied 10 entries
+    server-sender  | OK     | Operation canceled after having copied 10 entries
+    server-sender3 | OK     | Operation canceled after having copied 10 entries
+```
+
+``` pre
+gfsh>wan-copy region --region=myRegion --sender-id=myParallelSender --max-rate=100 --batch-size=10
+        Member     | Status | Message
+    -------------- | ------ | ----------------------------------------------------------------------
+    server-sender2 | OK     | Sender mySerialSender is serial and not primary. 0 entries copied.
+    server-sender3 | OK     | Sender mySerialSender is serial and not primary. 0 entries copied.
+    server-sender  | OK     | Operation canceled after having copied 4 entries
+```
+
+**Error Messages:**
+
+Example of `wan-copy region` with an invalid region:
+
+``` pre
+gfsh> wan-copy region --region=/regionX --sender-id=sender1
+        Member     | Status | Message
+    -------------- | ------ | -------------------------
+    server-sender  | ERROR  | Region /regionX not found
+    server-sender2 | ERROR  | Region /regionX not found
+    server-sender3 | ERROR  | Region /regionX not found
+```
+
+Example of `wan-copy region` with an stopped gateway sender:
+
+``` pre
+gfsh> wan-copy region --region=/region1 --sender-id=sender1
+        Member     | Status | Message
+    -------------- | ------ | -----------------------------
+    server-sender  | ERROR  | Sender sender1 is not running
+    server-sender2 | ERROR  | Sender sender1 is not running
+    server-sender3 | ERROR  | Sender sender1 is not running
+```
+
+Example of cancel of `wan-copy region` when no command is running:
+
+``` pre
+gfsh> wan-copy region --region=/region1 --sender-id=sender1 --cancel
+        Member     | Status | Message
+    -------------- | ------ | ------------------------------------------------------------------------------------
+    server-sender2 | ERROR  | No running command to be canceled for region /region1 and sender sender1
+    server-sender  | ERROR  | No running command to be canceled for region /region1 and sender sender1
+    server-sender3 | ERROR  | No running command to be canceled for region /region1 and sender sender1
+```
+

--- a/geode-docs/tools_modules/gfsh/command-pages/wan_copy_region.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/wan_copy_region.html.md.erb
@@ -21,16 +21,13 @@ limitations under the License.
 
 Copy the entries of a region in a WAN site onto the same region in another WAN site, using a gateway sender.
 
-This command requires that a gateway sender is configured and running on the source WAN site and that a gateway
-receiver is configured and running on the remote WAN site.
-The command also requires that the remote WAN site has the region onto which the data will be copied already created.
-Callbacks (cache listeners, replication to other WAN sites) will not be executed in the remote WAN site for the entries copied.
-
 This command copies region entries from a WAN site to another by putting them in batches of configurable
-size that are sent to the remote site by the selected gateway sender.
+size that are sent to the remote site by the selected gateway sender. Batch size is specified as number of entries per batch.
 
-The command allows to specify a maximum copy rate in order not to stress excessively the sending or receiving WAN sites.
+The command allows you to specify a maximum copy rate in order not to stress excessively the sending or receiving WAN sites.
 This rate is configured in entries per second.
+
+Callbacks (cache listeners, replication to other WAN sites) will not be executed in the remote WAN site for the entries copied.
 
 The main uses of this command are:
 
@@ -43,12 +40,21 @@ The main uses of this command are:
 The execution of a currently running instance of this command my be stopped by using
 this same command with the `--cancel` option.
 
+**Requirements:**
+
+The `wan-copy region` command requires that
+
+- a gateway sender is configured and running on the source WAN site
+- a gateway receiver is configured and running on the remote WAN site
+- the region onto which the data will be copied has already been created on the remote WAN site
+
 **Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
 
 **Syntax:**
 
 ``` pre
-wan-copy region --region=value --sender-id=value [--max-rate=value] [--batch-size=value] [--cancel(=value)?]
+wan-copy region --region=value --sender-id=value [--max-rate=value] [--batch-size=value]
+  [--cancel]
 ```
 
 <a id="wan_copy_region_command_params"></a>
@@ -69,8 +75,8 @@ table th:nth-of-type(3) {
 | &#8209;&#8209;region| <em>Required</em>. The region for which the data is to be copied. | |
 | &#8209;&#8209;sender-id| <em>Required</em>. The gateway sender to be used to copy the region entries. | |
 | &#8209;&#8209;max-rate| The maximum copy rate in entries per second. If the sender is parallel, the maximum rate limit is applied to each server hosting buckets for the region to be copied. | 0 (unlimited) |
-| &#8209;&#8209;bath-size| The size of the batches to be used to copy the region entries. | 1000 |
-| &#8209;&#8209;cancel| If specified without a value or if true, it will cancel a running `wan-copy region` command for the passed sender and region. | false |
+| &#8209;&#8209;batch-size| The size of the batches, in number of entries, to be used to copy the region entries. | 1000 |
+| &#8209;&#8209;cancel| Cancel a running `wan-copy region` command for the specified sender and region. |  |
 
 <span class="tablecap">Table 1. Copy Region Parameters</span>
 
@@ -147,7 +153,7 @@ gfsh> wan-copy region --region=/regionX --sender-id=sender1
     server-sender3 | ERROR  | Region /regionX not found
 ```
 
-Example of `wan-copy region` with an stopped gateway sender:
+Example of `wan-copy region` with a stopped gateway sender:
 
 ``` pre
 gfsh> wan-copy region --region=/region1 --sender-id=sender1

--- a/geode-docs/tools_modules/gfsh/gfsh_command_index.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/gfsh_command_index.html.md.erb
@@ -161,7 +161,7 @@ This section provides help and usage information on all `gfsh` commands, listed 
 
     Remove an entry from a region.
 
--   **[restore redunadancy](../../tools_modules/gfsh/command-pages/restore.html)**
+-   **[restore redundancy](../../tools_modules/gfsh/command-pages/restore.html)**
 
     Restore redundancy to partitioned regions and optionally reassign which members host the primary copies.
 
@@ -221,4 +221,7 @@ This section provides help and usage information on all `gfsh` commands, listed 
 
     Display product version information.
 
+-   **[wan-copy region](../../tools_modules/gfsh/command-pages/wan_copy_region.html)**
+
+    Copy the data of a region from a WAN site to the same region on another WAN site by using a gateway sender.
 

--- a/geode-docs/tools_modules/gfsh/quick_ref_commands_by_area.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/quick_ref_commands_by_area.html.md.erb
@@ -112,6 +112,7 @@ limitations under the License.
 | [put](command-pages/put.html)                                                               | Add or update a region entry.                                   | online       |
 | [query](command-pages/query.html)                                                      | Run queries against <%=vars.product_name%> regions. | online       |
 | [remove](command-pages/remove.html)                                                        | Remove an entry from a region.                                  | online       |
+| [wan-copy region ](command-pages/wan_copy_region.html) | Copy the entries of a region in a WAN site onto the same region in another WAN site, using a gateway sender.  | online       |
 
 ## <a id="topic_1B47A0E110124EB6BF08A467EB510412" class="no-quick-link"></a>Deployment Commands
 

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
@@ -603,7 +603,7 @@ public class GfshParserAutoCompletionIntegrationTest {
   public void testCompletionOffersMandatoryOptionsInAlphabeticalOrderForWanCopyRegionWithSpace() {
     String buffer = "wan-copy region ";
     CommandCandidate candidate = gfshParserRule.complete(buffer);
-    assertThat(candidate.getCandidates()).hasSize(1);
+    assertThat(candidate.getCandidates()).hasSize(2);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--region");
   }
 

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
@@ -413,7 +413,7 @@ public class GfshParserAutoCompletionIntegrationTest {
     String hintArgument = "data";
     String hintsProvided = gfshParserRule.getCommandManager().obtainHint(hintArgument);
     String[] hintsProvidedArray = hintsProvided.split(lineSeparator());
-    assertThat(hintsProvidedArray.length).isEqualTo(17);
+    assertThat(hintsProvidedArray.length).isEqualTo(18);
     assertThat(hintsProvidedArray[0])
         .isEqualTo("User data as stored in regions of the Geode distributed system.");
   }
@@ -594,6 +594,22 @@ public class GfshParserAutoCompletionIntegrationTest {
   @Test
   public void testCompletionOffersTheFirstMandatoryOptionInAlphabeticalOrderForRemoveWithDash() {
     String buffer = "remove --";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(1);
+    assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "region");
+  }
+
+  @Test
+  public void testCompletionOffersMandatoryOptionsInAlphabeticalOrderForWanCopyRegionWithSpace() {
+    String buffer = "wan-copy region ";
+    CommandCandidate candidate = gfshParserRule.complete(buffer);
+    assertThat(candidate.getCandidates()).hasSize(1);
+    assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--region");
+  }
+
+  @Test
+  public void testCompletionOffersTheFirstMandatoryOptionInAlphabeticalOrderForWanCopyRegionWithDash() {
+    String buffer = "wan-copy region --";
     CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(1);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "region");

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
@@ -605,6 +605,7 @@ public class GfshParserAutoCompletionIntegrationTest {
     CommandCandidate candidate = gfshParserRule.complete(buffer);
     assertThat(candidate.getCandidates()).hasSize(2);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--region");
+    assertThat(candidate.getCandidate(1)).isEqualTo(buffer + "--sender-id");
   }
 
   @Test

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
@@ -413,7 +413,7 @@ public class GfshParserAutoCompletionIntegrationTest {
     String hintArgument = "data";
     String hintsProvided = gfshParserRule.getCommandManager().obtainHint(hintArgument);
     String[] hintsProvidedArray = hintsProvided.split(lineSeparator());
-    assertThat(hintsProvidedArray.length).isEqualTo(18);
+    assertThat(hintsProvidedArray).hasSize(18);
     assertThat(hintsProvidedArray[0])
         .isEqualTo("User data as stored in regions of the Geode distributed system.");
   }
@@ -423,7 +423,7 @@ public class GfshParserAutoCompletionIntegrationTest {
     String hintArgument = "";
     String hintsProvided = gfshParserRule.getCommandManager().obtainHint(hintArgument);
     String[] hintsProvidedArray = hintsProvided.split(lineSeparator());
-    assertThat(hintsProvidedArray.length).isEqualTo(21);
+    assertThat(hintsProvidedArray).hasSize(21);
     assertThat(hintsProvidedArray[0]).isEqualTo(
         "Hints are available for the following topics. Use \"hint <topic-name>\" for a specific hint.");
   }
@@ -433,7 +433,7 @@ public class GfshParserAutoCompletionIntegrationTest {
     String hintArgument = "fortytwo";
     String hintsProvided = gfshParserRule.getCommandManager().obtainHint(hintArgument);
     String[] hintsProvidedArray = hintsProvided.split(lineSeparator());
-    assertThat(hintsProvidedArray.length).isEqualTo(1);
+    assertThat(hintsProvidedArray).hasSize(1);
     assertThat(hintsProvidedArray[0]).isEqualTo(
         "Unknown topic: " + hintArgument + ". Use hint to view the list of available topics.");
   }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CommandAvailabilityIndicator.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CommandAvailabilityIndicator.java
@@ -50,6 +50,7 @@ public class CommandAvailabilityIndicator extends GfshCommand {
       CliStrings.STOP_GATEWAYRECEIVER, CliStrings.LIST_GATEWAY, CliStrings.STATUS_GATEWAYSENDER,
       CliStrings.STATUS_GATEWAYRECEIVER, CliStrings.LOAD_BALANCE_GATEWAYSENDER,
       CliStrings.DESTROY_GATEWAYSENDER, AlterAsyncEventQueueCommand.COMMAND_NAME,
+      CliStrings.WAN_COPY_REGION,
       DestroyAsyncEventQueueCommand.DESTROY_ASYNC_EVENT_QUEUE,
       DestroyGatewayReceiverCommand.DESTROY_GATEWAYRECEIVER,
       CreateJndiBindingCommand.CREATE_JNDIBINDING, DestroyJndiBindingCommand.DESTROY_JNDIBINDING,

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommand.java
@@ -42,7 +42,7 @@ public class WanCopyRegionCommand extends GfshCommand {
       @CliOption(key = CliStrings.WAN_COPY_REGION__REGION, mandatory = true,
           optionContext = ConverterHint.REGION_PATH,
           help = CliStrings.WAN_COPY_REGION__REGION__HELP) String regionName,
-      @CliOption(key = CliStrings.WAN_COPY_REGION__SENDERID,
+      @CliOption(key = CliStrings.WAN_COPY_REGION__SENDERID, mandatory = true,
           optionContext = ConverterHint.GATEWAY_SENDER_ID,
           help = CliStrings.WAN_COPY_REGION__SENDERID__HELP) String senderId,
       @CliOption(key = CliStrings.WAN_COPY_REGION__MAXRATE,
@@ -60,12 +60,13 @@ public class WanCopyRegionCommand extends GfshCommand {
     final Object[] args = {regionName, senderId, isCancel, maxRate, batchSize};
     ResultCollector<?, ?> resultCollector =
         executeFunction(wanCopyRegionFunction, args, getAllNormalMembers());
+    @SuppressWarnings("unchecked")
     final List<CliFunctionResult> cliFunctionResults =
-        getCliFunctionResults((List) resultCollector.getResult());
+        getCliFunctionResults((List<CliFunctionResult>) resultCollector.getResult());
     return ResultModel.createMemberStatusResult(cliFunctionResults, false, false);
   }
 
-  private List<CliFunctionResult> getCliFunctionResults(List resultsObjects) {
+  private List<CliFunctionResult> getCliFunctionResults(List<CliFunctionResult> resultsObjects) {
     final List<CliFunctionResult> cliFunctionResults = new ArrayList<>();
     for (Object r : resultsObjects) {
       if (r instanceof FunctionInvocationTargetException) {

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommand.java
@@ -58,9 +58,10 @@ public class WanCopyRegionCommand extends GfshCommand {
 
     authorize(Resource.DATA, Operation.WRITE, regionName);
     final Object[] args = {regionName, senderId, isCancel, maxRate, batchSize};
-    ResultCollector<?, ?> rc =
+    ResultCollector<?, ?> resultCollector =
         executeFunction(wanCopyRegionFunction, args, getAllNormalMembers());
-    final List<CliFunctionResult> cliFunctionResults = getCliFunctionResults((List) rc.getResult());
+    final List<CliFunctionResult> cliFunctionResults =
+        getCliFunctionResults((List) resultCollector.getResult());
     return ResultModel.createMemberStatusResult(cliFunctionResults, false, false);
   }
 

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommand.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliOption;
+
+import org.apache.geode.cache.execute.FunctionInvocationTargetException;
+import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.management.cli.CliMetaData;
+import org.apache.geode.management.cli.ConverterHint;
+import org.apache.geode.management.cli.GfshCommand;
+import org.apache.geode.management.internal.cli.functions.WanCopyRegionFunction;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
+import org.apache.geode.management.internal.functions.CliFunctionResult;
+import org.apache.geode.management.internal.i18n.CliStrings;
+import org.apache.geode.security.ResourcePermission.Operation;
+import org.apache.geode.security.ResourcePermission.Resource;
+
+public class WanCopyRegionCommand extends GfshCommand {
+  private final WanCopyRegionFunction wanCopyRegionFunction = new WanCopyRegionFunction();
+
+  @CliCommand(value = CliStrings.WAN_COPY_REGION, help = CliStrings.WAN_COPY_REGION__HELP)
+  @CliMetaData(relatedTopic = {CliStrings.TOPIC_GEODE_DATA, CliStrings.TOPIC_GEODE_REGION})
+  public ResultModel wanCopyRegion(
+      @CliOption(key = CliStrings.WAN_COPY_REGION__REGION, mandatory = true,
+          optionContext = ConverterHint.REGION_PATH,
+          help = CliStrings.WAN_COPY_REGION__REGION__HELP) String regionName,
+      @CliOption(key = CliStrings.WAN_COPY_REGION__SENDERID,
+          optionContext = ConverterHint.GATEWAY_SENDER_ID,
+          help = CliStrings.WAN_COPY_REGION__SENDERID__HELP) String senderId,
+      @CliOption(key = CliStrings.WAN_COPY_REGION__MAXRATE,
+          unspecifiedDefaultValue = "0",
+          help = CliStrings.WAN_COPY_REGION__MAXRATE__HELP) long maxRate,
+      @CliOption(key = CliStrings.WAN_COPY_REGION__BATCHSIZE,
+          unspecifiedDefaultValue = "1000",
+          help = CliStrings.WAN_COPY_REGION__BATCHSIZE__HELP) int batchSize,
+      @CliOption(key = CliStrings.WAN_COPY_REGION__CANCEL,
+          unspecifiedDefaultValue = "false",
+          specifiedDefaultValue = "true",
+          help = CliStrings.WAN_COPY_REGION__CANCEL__HELP) boolean isCancel) {
+
+    authorize(Resource.DATA, Operation.WRITE, regionName);
+    final Object[] args = {regionName, senderId, isCancel, maxRate, batchSize};
+    ResultCollector<?, ?> rc =
+        executeFunction(wanCopyRegionFunction, args, getAllNormalMembers());
+    final List<CliFunctionResult> cliFunctionResults = getCliFunctionResults((List) rc.getResult());
+    return ResultModel.createMemberStatusResult(cliFunctionResults, false, false);
+  }
+
+  private List<CliFunctionResult> getCliFunctionResults(List resultsObjects) {
+    final List<CliFunctionResult> cliFunctionResults = new ArrayList<>();
+    for (Object r : resultsObjects) {
+      if (r instanceof FunctionInvocationTargetException) {
+        CliFunctionResult errorResult =
+            new CliFunctionResult(((FunctionInvocationTargetException) r).getMemberId().getName(),
+                CliFunctionResult.StatusState.ERROR,
+                ((FunctionInvocationTargetException) r).getMessage());
+        cliFunctionResults.add(errorResult);
+      } else {
+        cliFunctionResults.add((CliFunctionResult) r);
+      }
+    }
+    return cliFunctionResults;
+  }
+}

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction.java
@@ -1,0 +1,480 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.functions;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.Declarable;
+import org.apache.geode.cache.EntryDestroyedException;
+import org.apache.geode.cache.Operation;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.AllConnectionsInUseException;
+import org.apache.geode.cache.client.NoAvailableServersException;
+import org.apache.geode.cache.client.ServerConnectivityException;
+import org.apache.geode.cache.client.internal.Connection;
+import org.apache.geode.cache.client.internal.PoolImpl;
+import org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException;
+import org.apache.geode.cache.client.internal.pooling.PooledConnection;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.wan.GatewayQueueEvent;
+import org.apache.geode.cache.wan.GatewaySender;
+import org.apache.geode.internal.cache.BucketRegion;
+import org.apache.geode.internal.cache.DefaultEntryEventFactory;
+import org.apache.geode.internal.cache.EntryEventImpl;
+import org.apache.geode.internal.cache.EntrySnapshot;
+import org.apache.geode.internal.cache.EnumListenerEvent;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalRegion;
+import org.apache.geode.internal.cache.NonTXEntry;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
+import org.apache.geode.internal.cache.wan.BatchException70;
+import org.apache.geode.internal.cache.wan.GatewaySenderEventDispatcher;
+import org.apache.geode.internal.cache.wan.GatewaySenderEventImpl;
+import org.apache.geode.internal.cache.wan.InternalGatewaySender;
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.logging.internal.executors.LoggingExecutors;
+import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.management.cli.CliFunction;
+import org.apache.geode.management.internal.functions.CliFunctionResult;
+import org.apache.geode.management.internal.i18n.CliStrings;
+
+/**
+ * Class for copying via WAN the contents of a region
+ * It must be executed in all members of the Geode cluster that host the region
+ * to be copied. (called with onServers() or withMembers() passing the list
+ * of all members hosting the region).
+ * It also offers the possibility to cancel an ongoing execution of this function.
+ * The copying itself is executed in a new thread with a known name
+ * (parameterized with the regionName and senderId) in order to allow
+ * to cancel ongoing invocations by interrupting that thread.
+ *
+ * It accepts the following arguments in an array of objects
+ * 0: regionName (String)
+ * 1: senderId (String)
+ * 2: isCancel (Boolean): If true, it indicates that an ongoing execution of this
+ * function for the given region and senderId must be stopped. Otherwise,
+ * it indicates that the region must be copied.
+ * 3: maxRate (Long) maximum copy rate in entries per second. In the case of
+ * parallel gateway senders, the maxRate is per server hosting the region.
+ * 4: batchSize (Integer): the size of the batches. Region entries are copied in batches of the
+ * passed size. After each batch is sent, the function checks if the command
+ * must be canceled and also sleeps for some time if necessary to adjust the
+ * copy rate to the one passed as argument.
+ */
+public class WanCopyRegionFunction extends CliFunction<Object[]> implements Declarable {
+  private static final Logger logger = LogService.getLogger();
+  private static final long serialVersionUID = 1L;
+
+  public static final String ID = WanCopyRegionFunction.class.getName();
+
+  private static final int MAX_BATCH_SEND_RETRIES = 1;
+
+  private Clock clock = Clock.systemDefaultZone();
+  private ThreadSleeper threadSleeper = new ThreadSleeper();
+
+  static class ThreadSleeper implements Serializable {
+    void millis(long millis) throws InterruptedException {
+      Thread.sleep(millis);
+    }
+  }
+
+  @VisibleForTesting
+  public void setClock(Clock clock) {
+    this.clock = clock;
+  }
+
+  @VisibleForTesting
+  public void setThreadSleeper(ThreadSleeper ts) {
+    this.threadSleeper = ts;
+  }
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public boolean hasResult() {
+    return true;
+  }
+
+  @Override
+  public boolean isHA() {
+    return false;
+  }
+
+  @Override
+  public CliFunctionResult executeFunction(FunctionContext<Object[]> context) {
+    final Object[] args = context.getArguments();
+    if (args.length < 5) {
+      throw new IllegalStateException(
+          "Arguments length does not match required length.");
+    }
+    final String regionName = (String) args[0];
+    final String senderId = (String) args[1];
+    final boolean isCancel = (Boolean) args[2];
+    long maxRate = (Long) args[3];
+    int batchSize = (Integer) args[4];
+
+    final InternalCache cache = (InternalCache) context.getCache();
+
+    if (isCancel) {
+      return cancelWanCopyRegion(context, regionName, senderId);
+    }
+
+    final Region region = cache.getRegion(regionName);
+    if (region == null) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__REGION__NOT__FOUND, regionName));
+    }
+
+    GatewaySender sender = cache.getGatewaySender(senderId);
+    if (sender == null) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__SENDER__NOT__FOUND, senderId));
+    }
+
+    if (!region.getAttributes().getGatewaySenderIds().contains(sender.getId())) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__REGION__NOT__USING_SENDER, regionName,
+              senderId));
+    }
+
+    if (!sender.isRunning()) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__SENDER__NOT__RUNNING, senderId));
+    }
+
+    if (!sender.isParallel() && !((InternalGatewaySender) sender).isPrimary()) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.OK,
+          CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__SENDER__SERIAL__AND__NOT__PRIMARY,
+              senderId));
+    }
+
+    try {
+      return executeWanCopyRegionFunctionInNewThread(context, region, regionName, sender, maxRate,
+          batchSize);
+    } catch (InterruptedException e) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          CliStrings.WAN_COPY_REGION__MSG__EXECUTION__CANCELED);
+    } catch (ExecutionException e) {
+      Writer buffer = new StringWriter();
+      PrintWriter pw = new PrintWriter(buffer);
+      e.printStackTrace(pw);
+      logger.error("Exception when running wan-copy region command: {}", buffer.toString());
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__EXECUTION__FAILED, e.getMessage()));
+    }
+  }
+
+  private CliFunctionResult executeWanCopyRegionFunctionInNewThread(
+      FunctionContext<Object[]> context,
+      Region region, String regionName, GatewaySender sender, long maxRate, int batchSize)
+      throws InterruptedException, ExecutionException {
+    ExecutorService executor = LoggingExecutors
+        .newSingleThreadExecutor(getFunctionThreadName(regionName,
+            sender.getId()), true);
+    Callable<CliFunctionResult> callable =
+        new wanCopyRegionCallable(context, region, sender, maxRate, batchSize);
+    Future<CliFunctionResult> future = executor.submit(callable);
+    return future.get();
+  }
+
+  class wanCopyRegionCallable implements Callable<CliFunctionResult> {
+    private final FunctionContext<Object[]> context;
+    private final Region region;
+    private final GatewaySender sender;
+    private final long maxRate;
+    private final int batchSize;
+
+    public wanCopyRegionCallable(final FunctionContext<Object[]> context, final Region region,
+        final GatewaySender sender, final long maxRate,
+        final int batchSize) {
+      this.context = context;
+      this.region = region;
+      this.sender = sender;
+      this.maxRate = maxRate;
+      this.batchSize = batchSize;
+    }
+
+    @Override
+    public CliFunctionResult call() throws Exception {
+      return wanCopyRegion(context, region, sender, maxRate, batchSize);
+    }
+  }
+
+  @VisibleForTesting
+  CliFunctionResult wanCopyRegion(FunctionContext<Object[]> context, Region region,
+      GatewaySender sender, long maxRate, int batchSize) {
+    Connection connection = null;
+    PoolImpl senderPool = null;
+    int copiedEntries = 0;
+
+    try {
+      final long startTime = clock.millis();
+      int batchId = 0;
+      final InternalCache cache = (InternalCache) context.getCache();
+      GatewaySenderEventDispatcher dispatcher =
+          ((AbstractGatewaySender) sender).getEventProcessor().getDispatcher();
+      Iterator<?> entriesIter = getEntries(region, sender).iterator();
+      while (entriesIter.hasNext()) {
+        List<GatewayQueueEvent> batch =
+            createBatch((InternalRegion) region, sender, batchSize, cache, entriesIter);
+        if (batch.size() == 0) {
+          continue;
+        }
+        if (senderPool == null) {
+          senderPool = ((AbstractGatewaySender) sender).getProxy();
+          if (senderPool == null) {
+            return new CliFunctionResult(context.getMemberName(),
+                CliFunctionResult.StatusState.ERROR,
+                CliStrings.WAN_COPY_REGION__MSG__NO__CONNECTION__POOL);
+          }
+          connection = senderPool.acquireConnection();
+          if (connection.getWanSiteVersion() < KnownVersion.GEODE_1_15_0.ordinal()) {
+            return new CliFunctionResult(context.getMemberName(),
+                CliFunctionResult.StatusState.ERROR,
+                CliStrings.WAN_COPY_REGION__MSG__COMMAND__NOT__SUPPORTED__AT__REMOTE__SITE);
+          }
+        }
+        int retries = 0;
+        while (true) {
+          try {
+            dispatcher.sendBatch(batch, connection, senderPool, batchId++, true);
+            copiedEntries += batch.size();
+            break;
+          } catch (BatchException70 e) {
+            return new CliFunctionResult(context.getMemberName(),
+                CliFunctionResult.StatusState.ERROR,
+                CliStrings.format(
+                    CliStrings.WAN_COPY_REGION__MSG__ERROR__AFTER__HAVING__COPIED,
+                    e.getMessage(), copiedEntries));
+          } catch (ConnectionDestroyedException | ServerConnectivityException e) {
+            ((PooledConnection) connection).setShouldDestroy();
+            senderPool.returnConnection(connection);
+            connection = null;
+            if (retries++ >= MAX_BATCH_SEND_RETRIES) {
+              return new CliFunctionResult(context.getMemberName(),
+                  CliFunctionResult.StatusState.ERROR,
+                  CliStrings.format(
+                      CliStrings.WAN_COPY_REGION__MSG__ERROR__AFTER__HAVING__COPIED,
+                      "Connection error", copiedEntries));
+            }
+            logger.error("Exception {} in sendBatch. Retrying", e.getClass().getName());
+            try {
+              connection = senderPool.acquireConnection();
+            } catch (NoAvailableServersException | AllConnectionsInUseException e1) {
+              return new CliFunctionResult(context.getMemberName(),
+                  CliFunctionResult.StatusState.ERROR,
+                  CliStrings.format(
+                      CliStrings.WAN_COPY_REGION__MSG__NO__CONNECTION,
+                      copiedEntries));
+            }
+          }
+        }
+        try {
+          doPostSendBatchActions(startTime, copiedEntries, maxRate);
+        } catch (InterruptedException e) {
+          return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.OK,
+              CliStrings.format(
+                  CliStrings.WAN_COPY_REGION__MSG__CANCELED__AFTER__HAVING__COPIED,
+                  copiedEntries));
+        }
+      }
+    } finally {
+      if (senderPool != null && connection != null) {
+        ((PooledConnection) connection).setShouldDestroy();
+        senderPool.returnConnection(connection);
+      }
+    }
+
+    if (region.isDestroyed()) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+          CliStrings.format(
+              CliStrings.WAN_COPY_REGION__MSG__ERROR__AFTER__HAVING__COPIED,
+              "Region destroyed",
+              copiedEntries));
+    }
+
+    return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.OK,
+        CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__COPIED__ENTRIES,
+            copiedEntries));
+  }
+
+  List<GatewayQueueEvent> createBatch(InternalRegion region, GatewaySender sender,
+      int batchSize, InternalCache cache, Iterator<?> iter) {
+    int batchIndex = 0;
+    List<GatewayQueueEvent> batch = new ArrayList<>();
+    while (iter.hasNext() && batchIndex < batchSize) {
+      GatewayQueueEvent event =
+          createGatewaySenderEvent(cache, region, sender, (Region.Entry) iter.next());
+      if (event != null) {
+        batch.add(event);
+        batchIndex++;
+      }
+    }
+    return batch;
+  }
+
+  Set<?> getEntries(Region region, GatewaySender sender) {
+    if (region instanceof PartitionedRegion && sender.isParallel()) {
+      return ((PartitionedRegion) region).getDataStore().getAllLocalBucketRegions()
+          .stream()
+          .flatMap(br -> ((Set<?>) br.entrySet()).stream()).collect(Collectors.toSet());
+    }
+    return region.entrySet();
+  }
+
+  @VisibleForTesting
+  GatewayQueueEvent createGatewaySenderEvent(InternalCache cache,
+      InternalRegion region, GatewaySender sender, Region.Entry entry) {
+    final EntryEventImpl event;
+    if (region instanceof PartitionedRegion) {
+      event = createEventForPartitionedRegion(sender, cache, region, entry);
+    } else {
+      event = createEventForReplicatedRegion(cache, region, entry);
+    }
+    if (event == null) {
+      return null;
+    }
+    try {
+      return new GatewaySenderEventImpl(EnumListenerEvent.AFTER_UPDATE_WITH_GENERATE_CALLBACKS,
+          event, null, true);
+    } catch (IOException e) {
+      e.printStackTrace();
+      return null;
+    }
+  }
+
+  final CliFunctionResult cancelWanCopyRegion(FunctionContext<Object[]> context,
+      String regionName, String senderId) {
+    boolean found = false;
+    String threadBaseName = getFunctionThreadName(regionName, senderId);
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      if (t.getName().startsWith(threadBaseName)) {
+        found = true;
+        t.interrupt();
+      }
+    }
+    if (found) {
+      return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.OK,
+          CliStrings.WAN_COPY_REGION__MSG__EXECUTION__CANCELED);
+    }
+    return new CliFunctionResult(context.getMemberName(), CliFunctionResult.StatusState.ERROR,
+        CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__NO__RUNNING__COMMAND,
+            regionName, senderId));
+  }
+
+  public static String getFunctionThreadName(String regionName, String senderId) {
+    return "wanCopyRegionFunctionThread_" + regionName + "_" + senderId;
+  }
+
+  /**
+   * It runs the actions to be done after a batch has been
+   * sent: throw an interrupted exception if the operation was canceled and
+   * adjust the rate of copying by sleeping if necessary.
+   *
+   * @param startTime time at which the entries started to be copied
+   * @param copiedEntries number of entries copied so far
+   * @param maxRate maximum copying rate
+   */
+  void doPostSendBatchActions(long startTime, int copiedEntries, long maxRate)
+      throws InterruptedException {
+    if (Thread.currentThread().isInterrupted()) {
+      throw new InterruptedException();
+    }
+    long sleepMs = getTimeToSleep(startTime, copiedEntries, maxRate);
+    if (sleepMs > 0) {
+      logger.info("{}: Sleeping for {} ms to accommodate to requested maxRate",
+          this.getClass().getName(), sleepMs);
+      threadSleeper.millis(sleepMs);
+    }
+  }
+
+  @VisibleForTesting
+  long getTimeToSleep(long startTime, int copiedEntries, long maxRate) {
+    if (maxRate == 0) {
+      return 0;
+    }
+    final long elapsedMs = clock.millis() - startTime;
+    if (elapsedMs != 0 && (copiedEntries * 1000.0) / (double) elapsedMs <= maxRate) {
+      return 0;
+    }
+    final long targetElapsedMs = (copiedEntries * 1000L) / maxRate;
+    return targetElapsedMs - elapsedMs;
+  }
+
+  private EntryEventImpl createEventForReplicatedRegion(InternalCache cache, InternalRegion region,
+      Region.Entry entry) {
+    return createEvent(cache, region, entry);
+  }
+
+  private EntryEventImpl createEventForPartitionedRegion(GatewaySender sender, InternalCache cache,
+      InternalRegion region,
+      Region.Entry entry) {
+    EntryEventImpl event = createEvent(cache, region, entry);
+    if (event == null) {
+      return null;
+    }
+    BucketRegion bucketRegion = ((PartitionedRegion) event.getRegion()).getDataStore()
+        .getLocalBucketById(event.getKeyInfo().getBucketId());
+    if (bucketRegion != null && !bucketRegion.getBucketAdvisor().isPrimary()
+        && sender.isParallel()) {
+      return null;
+    }
+    if (bucketRegion != null) {
+      bucketRegion.handleWANEvent(event);
+    }
+    return event;
+  }
+
+  private EntryEventImpl createEvent(InternalCache cache, InternalRegion region,
+      Region.Entry entry) {
+    EntryEventImpl event;
+    try {
+      event = new DefaultEntryEventFactory().create(region, Operation.UPDATE,
+          entry.getKey(),
+          entry.getValue(), null, false,
+          (cache).getInternalDistributedSystem().getDistributedMember(), false);
+    } catch (EntryDestroyedException e) {
+      return null;
+    }
+    if (entry instanceof NonTXEntry) {
+      event.setVersionTag(((NonTXEntry) entry).getRegionEntry().getVersionStamp().asVersionTag());
+    } else {
+      event.setVersionTag(((EntrySnapshot) entry).getVersionTag());
+    }
+    event.setNewEventId(cache.getInternalDistributedSystem());
+    return event;
+  }
+}

--- a/geode-gfsh/src/main/resources/META-INF/services/org.springframework.shell.core.CommandMarker
+++ b/geode-gfsh/src/main/resources/META-INF/services/org.springframework.shell.core.CommandMarker
@@ -82,6 +82,7 @@ org.apache.geode.management.internal.cli.commands.QueryCommand
 org.apache.geode.management.internal.cli.commands.RebalanceCommand
 org.apache.geode.management.internal.cli.commands.RedundancyCommand
 org.apache.geode.management.internal.cli.commands.RemoveCommand
+org.apache.geode.management.internal.cli.commands.WanCopyRegionCommand
 org.apache.geode.management.internal.cli.commands.RestoreRedundancyCommand
 org.apache.geode.management.internal.cli.commands.ResumeAsyncEventQueueDispatcherCommand
 org.apache.geode.management.internal.cli.commands.ResumeGatewaySenderCommand

--- a/geode-gfsh/src/main/resources/org/apache/geode/gfsh/internal/management/sanctioned-geode-gfsh-serializables.txt
+++ b/geode-gfsh/src/main/resources/org/apache/geode/gfsh/internal/management/sanctioned-geode-gfsh-serializables.txt
@@ -100,6 +100,8 @@ org/apache/geode/management/internal/cli/functions/SizeExportLogsFunction,true,1
 org/apache/geode/management/internal/cli/functions/UndeployFunction,true,1
 org/apache/geode/management/internal/cli/functions/UnregisterFunction,true,1
 org/apache/geode/management/internal/cli/functions/UserFunctionExecution,true,1
+org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction,true,1,clock:java/time/Clock,threadSleeper:org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction$ThreadSleeper
+org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction$ThreadSleeper,false
 org/apache/geode/management/internal/cli/result/Align,false
 org/apache/geode/management/internal/cli/result/CommandResultException,true,1
 org/apache/geode/management/internal/cli/result/TooManyColumnsException,true,4703710831740034363

--- a/geode-gfsh/src/main/resources/org/apache/geode/gfsh/internal/management/sanctioned-geode-gfsh-serializables.txt
+++ b/geode-gfsh/src/main/resources/org/apache/geode/gfsh/internal/management/sanctioned-geode-gfsh-serializables.txt
@@ -100,7 +100,7 @@ org/apache/geode/management/internal/cli/functions/SizeExportLogsFunction,true,1
 org/apache/geode/management/internal/cli/functions/UndeployFunction,true,1
 org/apache/geode/management/internal/cli/functions/UnregisterFunction,true,1
 org/apache/geode/management/internal/cli/functions/UserFunctionExecution,true,1
-org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction,true,1,clock:java/time/Clock,threadSleeper:org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction$ThreadSleeper
+org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction,true,1,batchId:int,clock:java/time/Clock,threadSleeper:org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction$ThreadSleeper
 org/apache/geode/management/internal/cli/functions/WanCopyRegionFunction$ThreadSleeper,false
 org/apache/geode/management/internal/cli/result/Align,false
 org/apache/geode/management/internal/cli/result/CommandResultException,true,1

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandTest.java
@@ -30,14 +30,14 @@ public class WanCopyRegionCommandTest {
   @Test
   public void gfshParserReturnsNullIfMandatoryOptionsNotSpecified() {
     assertThat(gfsh.parse("wan-copy region")).isNull();
-    assertThat(gfsh.parse("wan-copy region --senderId=ln")).isNull();
-    assertThat(gfsh.parse("wan-copy region --batchSize=10")).isNull();
+    assertThat(gfsh.parse("wan-copy region --region=myregion")).isNull();
+    assertThat(gfsh.parse("wan-copy region --sender-id=ln")).isNull();
+    assertThat(gfsh.parse("wan-copy region --batch-size=10")).isNull();
   }
 
   @Test
   public void verifyDefaultValues() {
-    GfshParseResult result = gfsh.parse("wan-copy region --region=myregion");
-    assertThat(result.getParamValueAsString(CliStrings.WAN_COPY_REGION__SENDERID)).isNull();
+    GfshParseResult result = gfsh.parse("wan-copy region --region=myregion --sender-id=ln");
     assertThat(result.getParamValueAsString(CliStrings.WAN_COPY_REGION__MAXRATE)).isEqualTo("0");
     assertThat(result.getParamValueAsString(CliStrings.WAN_COPY_REGION__BATCHSIZE))
         .isEqualTo("1000");

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.apache.geode.management.internal.cli.GfshParseResult;
+import org.apache.geode.management.internal.i18n.CliStrings;
+import org.apache.geode.test.junit.rules.GfshParserRule;
+
+public class WanCopyRegionCommandTest {
+  @ClassRule
+  public static GfshParserRule gfsh = new GfshParserRule();
+
+  @Test
+  public void gfshParserReturnsNullIfMandatoryOptionsNotSpecified() {
+    assertThat(gfsh.parse("wan-copy region")).isNull();
+    assertThat(gfsh.parse("wan-copy region --senderId=ln")).isNull();
+    assertThat(gfsh.parse("wan-copy region --batchSize=10")).isNull();
+  }
+
+  @Test
+  public void verifyDefaultValues() {
+    GfshParseResult result = gfsh.parse("wan-copy region --region=myregion");
+    assertThat(result.getParamValueAsString(CliStrings.WAN_COPY_REGION__SENDERID)).isNull();
+    assertThat(result.getParamValueAsString(CliStrings.WAN_COPY_REGION__MAXRATE)).isEqualTo("0");
+    assertThat(result.getParamValueAsString(CliStrings.WAN_COPY_REGION__BATCHSIZE))
+        .isEqualTo("1000");
+    assertThat(result.getParamValueAsString(CliStrings.WAN_COPY_REGION__CANCEL))
+        .isEqualTo("false");
+  }
+}

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionTest.java
@@ -1,0 +1,559 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.functions;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.NoAvailableServersException;
+import org.apache.geode.cache.client.ServerConnectivityException;
+import org.apache.geode.cache.client.internal.Connection;
+import org.apache.geode.cache.client.internal.PoolImpl;
+import org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException;
+import org.apache.geode.cache.client.internal.pooling.PooledConnection;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.wan.GatewayQueueEvent;
+import org.apache.geode.cache.wan.GatewaySender;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.InternalRegion;
+import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
+import org.apache.geode.internal.cache.wan.BatchException70;
+import org.apache.geode.internal.cache.wan.GatewaySenderEventDispatcher;
+import org.apache.geode.internal.cache.wan.InternalGatewaySender;
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.management.internal.functions.CliFunctionResult;
+
+public class WanCopyRegionFunctionTest {
+
+  private WanCopyRegionFunction rrf;
+  private long startTime;
+  private final int entries = 25;
+  private Clock clockMock;
+  private WanCopyRegionFunction.ThreadSleeper threadSleeperMock;
+  private InternalCache internalCacheMock;
+  private GatewaySender gatewaySenderMock;
+  private PoolImpl poolMock;
+  private Connection connectionMock;
+  private GatewaySenderEventDispatcher dispatcherMock;
+
+  @SuppressWarnings("unchecked")
+  private final FunctionContext<Object[]> contextMock = mock(FunctionContext.class);
+
+  @SuppressWarnings("unchecked")
+  private final Region<Object, Object> regionMock = mock(InternalRegion.class, RETURNS_DEEP_STUBS);
+
+  @SuppressWarnings("unchecked")
+  private final Region.Entry<String, String> entryMock = mock(Region.Entry.class);
+
+  @SuppressWarnings("unchecked")
+  private final Region.Entry<String, String> entryMock2 = mock(Region.Entry.class);
+
+  @Before
+  public void setUp() throws InterruptedException {
+    clockMock = mock(Clock.class);
+    threadSleeperMock = mock(WanCopyRegionFunction.ThreadSleeper.class);
+    doNothing().when(threadSleeperMock).millis(anyLong());
+    internalCacheMock = mock(InternalCache.class);
+    gatewaySenderMock = mock(AbstractGatewaySender.class, RETURNS_DEEP_STUBS);
+    when(gatewaySenderMock.getId()).thenReturn("mySender");
+    poolMock = mock(PoolImpl.class);
+    connectionMock = mock(PooledConnection.class);
+    when(connectionMock.getWanSiteVersion()).thenReturn(KnownVersion.GEODE_1_15_0.ordinal());
+    dispatcherMock = mock(GatewaySenderEventDispatcher.class);
+    rrf = new WanCopyRegionFunction();
+    rrf.setClock(clockMock);
+    rrf.setThreadSleeper(threadSleeperMock);
+    startTime = System.currentTimeMillis();
+  }
+
+  @Test
+  public void doPostSendBatchActions_DoNotSleepIfGetTimeToSleepIsZero()
+      throws InterruptedException {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    doReturn(0L).when(rrfSpy).getTimeToSleep(anyLong(), anyInt(), anyLong());
+    rrfSpy.doPostSendBatchActions(startTime, entries, 1L);
+    verify(threadSleeperMock, never()).millis(anyLong());
+  }
+
+  @Test
+  public void doPostSendBatchActions_SleepIfGetTimeToSleepIsNotZero()
+      throws InterruptedException {
+    long expectedMsToSleep = 1100L;
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    doReturn(expectedMsToSleep).when(rrfSpy).getTimeToSleep(anyLong(), anyInt(), anyLong());
+    rrfSpy.doPostSendBatchActions(startTime, entries, 1L);
+    verify(threadSleeperMock, times(1)).millis(expectedMsToSleep);
+  }
+
+  @Test
+  public void doPostSendBatchActions_ThrowInterruptedIfInterrupted() {
+    long maxRate = 100;
+    Thread.currentThread().interrupt();
+    assertThatThrownBy(
+        () -> rrf.doPostSendBatchActions(startTime, entries, maxRate))
+            .isInstanceOf(InterruptedException.class);
+  }
+
+  @Test
+  public void executeFunction_verifyErrorWhenRegionNotFound() {
+    Object[] options = new Object[] {"myRegion", "mySender", false, 1L, 10};
+    when(internalCacheMock.getRegion(any())).thenReturn(null);
+    when(contextMock.getArguments()).thenReturn(options);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    CliFunctionResult result = rrf.executeFunction(contextMock);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage()).isEqualTo("Region myRegion not found");
+  }
+
+  @Test
+  public void executeFunction_verifyErrorWhenSenderNotFound() {
+    Object[] options = new Object[] {"myRegion", "mySender", false, 1L, 10};
+    when(internalCacheMock.getRegion(any())).thenReturn(regionMock);
+    when(internalCacheMock.getGatewaySender(any())).thenReturn(null);
+    when(contextMock.getArguments()).thenReturn(options);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    CliFunctionResult result = rrf.executeFunction(contextMock);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage()).isEqualTo("Sender mySender not found");
+  }
+
+  @Test
+  public void executeFunction_verifyErrorWhenSenderIsNotRunning() {
+    Object[] options = new Object[] {"myRegion", "mySender", false, 1L, 10};
+    when(gatewaySenderMock.isRunning()).thenReturn(false);
+    when(regionMock.getAttributes().getGatewaySenderIds().contains(anyString())).thenReturn(true);
+    when(internalCacheMock.getRegion(any())).thenReturn(regionMock);
+    when(internalCacheMock.getGatewaySender(any())).thenReturn(gatewaySenderMock);
+    when(contextMock.getArguments()).thenReturn(options);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    CliFunctionResult result = rrf.executeFunction(contextMock);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage()).isEqualTo("Sender mySender is not running");
+  }
+
+  @Test
+  public void executeFunction_verifySuccessWhenSenderIsSerialAndSenderIsNotPrimary() {
+    Object[] options = new Object[] {"myRegion", "mySender", false, 1L, 10};
+    when(gatewaySenderMock.isRunning()).thenReturn(true);
+    when(regionMock.getAttributes().getGatewaySenderIds().contains(anyString())).thenReturn(true);
+    when(gatewaySenderMock.isParallel()).thenReturn(false);
+    when(((InternalGatewaySender) gatewaySenderMock).isPrimary()).thenReturn(false);
+    when(internalCacheMock.getRegion(any())).thenReturn(regionMock);
+    when(internalCacheMock.getGatewaySender(any())).thenReturn(gatewaySenderMock);
+    when(contextMock.getArguments()).thenReturn(options);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    CliFunctionResult result = rrf.executeFunction(contextMock);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Sender mySender is serial and not primary. 0 entries copied.");
+  }
+
+  @Test
+  public void wanCopyRegion_verifyErrorWhenRemoteSiteDoesNotSupportCommand() {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    PooledConnection oldWanSiteConn = mock(PooledConnection.class);
+    when(oldWanSiteConn.getWanSiteVersion()).thenReturn(KnownVersion.GEODE_1_14_0.ordinal());
+    when(oldWanSiteConn.setShouldDestroy()).thenReturn(true);
+    when(poolMock.acquireConnection()).thenReturn(oldWanSiteConn);
+
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Command not supported at remote site.");
+  }
+
+
+  @Test
+  public void wanCopyRegion_verifyErrorWhenNoPoolAvailableAndEntriesInRegion() {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(null);
+    when(poolMock.acquireConnection()).thenThrow(NoAvailableServersException.class)
+        .thenThrow(NoAvailableServersException.class);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("No connection pool available towards receiver");
+  }
+
+  @Test
+  public void wanCopyRegion_verifySuccessWhenNoPoolAvailableAndNoEntriesInRegion() {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(null);
+    when(poolMock.acquireConnection()).thenThrow(NoAvailableServersException.class)
+        .thenThrow(NoAvailableServersException.class);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    doReturn(new HashSet<>()).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Entries copied: 0");
+  }
+
+  @Test
+  public void wanCopyRegion_verifyErrorWhenSenderNotConfiguredWithForRegion() {
+    Object[] options = new Object[] {"myRegion", "mySender", false, 1L, 10};
+    Set<String> senders = new HashSet<>();
+    senders.add("notMySender");
+    when(gatewaySenderMock.isParallel()).thenReturn(true);
+    when(internalCacheMock.getRegion(any())).thenReturn(regionMock);
+    when(regionMock.getAttributes().getGatewaySenderIds()).thenReturn(senders);
+    when(internalCacheMock.getGatewaySender(any())).thenReturn(gatewaySenderMock);
+    when(contextMock.getArguments()).thenReturn(options);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+
+    CliFunctionResult result = rrf.executeFunction(contextMock);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Region myRegion is not configured to use sender mySender");
+  }
+
+  @Test
+  public void wanCopyRegion_verifyErrorWhenNoConnectionAvailableAtStartAndEntriesInRegion() {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenThrow(NoAvailableServersException.class)
+        .thenThrow(NoAvailableServersException.class);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+
+    assertThatThrownBy(
+        () -> rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10))
+            .isInstanceOf(NoAvailableServersException.class);
+  }
+
+  @Test
+  public void wanCopyRegion_verifySuccessWhenNoConnectionAvailableAtStartAndNoEntriesInRegion() {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenThrow(NoAvailableServersException.class)
+        .thenThrow(NoAvailableServersException.class);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    doReturn(new HashSet<>()).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Entries copied: 0");
+  }
+
+  @Test
+  public void wanCopyRegion_verifyErrorWhenNoConnectionAvailableAfterCopyingSomeEntries()
+      throws BatchException70 {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenReturn(connectionMock)
+        .thenThrow(NoAvailableServersException.class);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    entries.add(entryMock2);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy)
+        .createGatewaySenderEvent(any(), any(),
+            any(), any());
+    doNothing().doThrow(ConnectionDestroyedException.class).doNothing().when(dispatcherMock)
+        .sendBatch(anyList(), any(), any(), anyInt(), anyBoolean());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 1);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("No connection available towards receiver after having copied 1 entries");
+  }
+
+  @Test
+  public void wanCopyRegion_verifySuccess() throws BatchException70 {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenReturn(connectionMock).thenReturn(connectionMock);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+    doNothing().when(dispatcherMock).sendBatch(anyList(), any(), any(), anyInt(), anyBoolean());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Entries copied: 1");
+  }
+
+  @Test
+  public void wanCopyRegion_verifySuccessWithRetryWhenConnectionDestroyed()
+      throws BatchException70 {
+
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    ConnectionDestroyedException exceptionWhenSendingBatch =
+        new ConnectionDestroyedException("My connection exception", new Exception());
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenReturn(connectionMock).thenReturn(connectionMock);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+    doThrow(exceptionWhenSendingBatch).doNothing().when(dispatcherMock).sendBatch(anyList(), any(),
+        any(), anyInt(), anyBoolean());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Entries copied: 1");
+  }
+
+  @Test
+  public void wanCopyRegion_verifyErrorWhenConnectionDestroyedTwice() throws BatchException70 {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    ConnectionDestroyedException exceptionWhenSendingBatch =
+        new ConnectionDestroyedException("My connection exception", new Exception());
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenReturn(connectionMock).thenReturn(connectionMock);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+    doThrow(exceptionWhenSendingBatch).when(dispatcherMock).sendBatch(anyList(), any(), any(),
+        anyInt(), anyBoolean());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Error (Connection error) in operation after having copied 0 entries");
+  }
+
+  @Test
+  public void wanCopyRegion_verifySuccessWithRetryWhenServerConnectivityException()
+      throws BatchException70 {
+
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    ServerConnectivityException exceptionWhenSendingBatch =
+        new ServerConnectivityException("My connection exception", new Exception());
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenReturn(connectionMock).thenReturn(connectionMock);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+    doThrow(exceptionWhenSendingBatch).doNothing().when(dispatcherMock).sendBatch(anyList(), any(),
+        any(), anyInt(), anyBoolean());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.OK.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Entries copied: 1");
+  }
+
+  @Test
+  public void wanCopyRegion_verifyErrorWhenServerConnectivityExceptionTwice()
+      throws BatchException70 {
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    ServerConnectivityException exceptionWhenSendingBatch =
+        new ServerConnectivityException("My connection exception", new Exception());
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenReturn(connectionMock).thenReturn(connectionMock);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+    doThrow(exceptionWhenSendingBatch).when(dispatcherMock).sendBatch(anyList(), any(), any(),
+        anyInt(), anyBoolean());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Error (Connection error) in operation after having copied 0 entries");
+  }
+
+  @Test
+  public void wanCopyRegion_verifyErrorWhenBatchExceptionWhileSendingBatch()
+      throws BatchException70 {
+
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    BatchException70 exceptionWhenSendingBatch =
+        new BatchException70("My batch exception", new Exception(), 0, 0);
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenReturn(connectionMock);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+    doThrow(exceptionWhenSendingBatch).when(dispatcherMock).sendBatch(anyList(), any(), any(),
+        anyInt(), anyBoolean());
+
+    CliFunctionResult result =
+        rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10);
+    assertThat(result.getStatus()).isEqualTo(CliFunctionResult.StatusState.ERROR.toString());
+    assertThat(result.getStatusMessage())
+        .isEqualTo("Error (My batch exception) in operation after having copied 0 entries");
+  }
+
+  @Test
+  public void wanCopyRegion_verifyExceptionThrownWhenExceptionWhileSendingBatch()
+      throws BatchException70 {
+
+    WanCopyRegionFunction rrfSpy = spy(rrf);
+    RuntimeException exceptionWhenSendingBatch =
+        new RuntimeException("Exception when sending batch");
+    when(((AbstractGatewaySender) gatewaySenderMock).getProxy()).thenReturn(poolMock);
+    when(poolMock.acquireConnection()).thenReturn(connectionMock);
+    when(contextMock.getCache()).thenReturn(internalCacheMock);
+    when(((AbstractGatewaySender) gatewaySenderMock).getEventProcessor().getDispatcher())
+        .thenReturn(dispatcherMock);
+    Set<Region.Entry<String, String>> entries = new HashSet<>();
+    entries.add(entryMock);
+    doReturn(mock(GatewayQueueEvent.class)).when(rrfSpy).createGatewaySenderEvent(any(), any(),
+        any(), any());
+    doThrow(exceptionWhenSendingBatch).when(dispatcherMock).sendBatch(anyList(), any(), any(),
+        anyInt(), anyBoolean());
+    doReturn(entries).when(rrfSpy).getEntries(regionMock, gatewaySenderMock);
+
+    assertThatThrownBy(
+        () -> rrfSpy.wanCopyRegion(contextMock, regionMock, gatewaySenderMock, 1, 10))
+            .isInstanceOf(RuntimeException.class);
+  }
+
+  @Test
+  public void getTimeToSleep_ReturnZeroWhenMaxRateIsZero() {
+    assertThat(rrf.getTimeToSleep(startTime, 1, 0)).isEqualTo(0);
+  }
+
+  @Test
+  public void getTimeToSleep_ReturnZeroWhenCopiedEntriesIsZero() {
+    assertThat(rrf.getTimeToSleep(startTime, 0, 1)).isEqualTo(0);
+  }
+
+  @Test
+  public void getTimeToSleep_ReturnZeroWhenBelowMaxRate() {
+    long elapsedTime = 2000L;
+    when(clockMock.millis()).thenReturn(startTime + elapsedTime);
+    assertThat(rrf.getTimeToSleep(startTime, 1, 1)).isEqualTo(0);
+  }
+
+  @Test
+  public void getTimeToSleep_ReturnZeroWhenOnMaxRate() {
+    long elapsedTime = 1000L;
+    when(clockMock.millis()).thenReturn(startTime + elapsedTime);
+    assertThat(rrf.getTimeToSleep(startTime, 1, 1)).isEqualTo(0);
+  }
+
+  @Test
+  public void getTimeToSleep_ReturnZeroWhenAboveMaxRate_value1() {
+    long elapsedTime = 1000L;
+    when(clockMock.millis()).thenReturn(startTime + elapsedTime);
+    assertThat(rrf.getTimeToSleep(startTime, 2, 1)).isEqualTo(1000);
+  }
+
+  @Test
+  public void getTimeToSleep_ReturnZeroWhenAboveMaxRate_value2() {
+    long elapsedTime = 1000L;
+    when(clockMock.millis()).thenReturn(startTime + elapsedTime);
+    assertThat(rrf.getTimeToSleep(startTime, 4, 1)).isEqualTo(3000);
+  }
+
+  @Test
+  public void getTimeToSleep_ReturnZeroWhenAboveMaxRate_value3() {
+    long elapsedTime = 2000L;
+    when(clockMock.millis()).thenReturn(startTime + elapsedTime);
+    assertThat(rrf.getTimeToSleep(startTime, 4, 1)).isEqualTo(2000);
+  }
+}

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionTest.java
@@ -120,12 +120,11 @@ public class WanCopyRegionFunctionTest {
   }
 
   @Test
-  public void doPostSendBatchActions_ThrowInterruptedIfInterruptedTimeToSleepNotZero()
-      throws InterruptedException {
+  public void doPostSendBatchActions_ThrowInterruptedIfInterruptedTimeToSleepNotZero() {
     long maxRate = 1;
     long elapsedTime = 20L;
-    when(clockMock.millis()).thenAnswer((Answer) invocation -> {
-      Thread.currentThread().sleep(1000L);
+    when(clockMock.millis()).thenAnswer((Answer<?>) invocation -> {
+      Thread.sleep(1000L);
       return startTime + elapsedTime;
     });
     Thread.currentThread().interrupt();

--- a/geode-gfsh/src/test/resources/expected-pom.xml
+++ b/geode-gfsh/src/test/resources/expected-pom.xml
@@ -16,11 +16,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-  <!-- This module was also published with a richer model, Gradle metadata,  -->
-  <!-- which should be used instead. Do not delete the following line which  -->
-  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-  <!-- that they should prefer consuming it instead. -->
-  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.geode</groupId>
   <artifactId>geode-gfsh</artifactId>

--- a/geode-gfsh/src/test/resources/expected-pom.xml
+++ b/geode-gfsh/src/test/resources/expected-pom.xml
@@ -16,6 +16,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
+  <!-- This module was also published with a richer model, Gradle metadata,  -->
+  <!-- which should be used instead. Do not delete the following line which  -->
+  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
+  <!-- that they should prefer consuming it instead. -->
+  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.geode</groupId>
   <artifactId>geode-gfsh</artifactId>

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -1339,13 +1339,13 @@ public class WANTestBase extends DistributedTestCase {
     assertEquals(creates, gatewayReceiverStats.getCreateRequest());
   }
 
-  public static List<Integer> getReceiverStats() {
+  public static List<Long> getReceiverStats() {
     Set<GatewayReceiver> gatewayReceivers = cache.getGatewayReceivers();
     GatewayReceiver receiver = gatewayReceivers.iterator().next();
     CacheServerStats stats = ((CacheServerImpl) receiver.getServer()).getAcceptor().getStats();
     assertTrue(stats instanceof GatewayReceiverStats);
     GatewayReceiverStats gatewayReceiverStats = (GatewayReceiverStats) stats;
-    ArrayList<Integer> statsList = new ArrayList<>();
+    ArrayList<Long> statsList = new ArrayList<>();
     statsList.add(gatewayReceiverStats.getEventsReceived());
     statsList.add(gatewayReceiverStats.getEventsRetried());
     statsList.add(gatewayReceiverStats.getProcessBatchRequests());

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -434,7 +434,7 @@ public class WANTestBase extends DistributedTestCase {
       }
 
       fact.setOffHeap(offHeap);
-      Region r = fact.create(regionName);
+      Region<Object, Object> r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -462,7 +462,7 @@ public class WANTestBase extends DistributedTestCase {
       }
 
       fact.setOffHeap(offHeap);
-      Region r = fact.create(regionName);
+      Region<Object, Object> r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -481,7 +481,7 @@ public class WANTestBase extends DistributedTestCase {
       }
     }
 
-    Region r = fact.create(regionName);
+    Region<Object, Object> r = fact.create(regionName);
     assertNotNull(r);
   }
 
@@ -497,7 +497,7 @@ public class WANTestBase extends DistributedTestCase {
     }
 
     fact.setOffHeap(offHeap);
-    Region r = fact.create(regionName);
+    Region<Object, Object> r = fact.create(regionName);
     assertNotNull(r);
   }
 
@@ -516,7 +516,7 @@ public class WANTestBase extends DistributedTestCase {
       }
 
       fact.setOffHeap(offHeap);
-      Region r = fact.create(regionName);
+      Region<Object, Object> r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp1.remove();
@@ -539,7 +539,7 @@ public class WANTestBase extends DistributedTestCase {
 
       fact.setOffHeap(offHeap);
       fact.addAsyncEventQueueId(asyncChannelId);
-      Region r = fact.create(regionName);
+      Region<Object, Object> r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -567,7 +567,7 @@ public class WANTestBase extends DistributedTestCase {
     fact.setScope(scope);
     fact.setOffHeap(offHeap);
     fact.setStatisticsEnabled(statisticsEnabled);
-    Region r = fact.create(regionName);
+    Region<Object, Object> r = fact.create(regionName);
     assertNotNull(r);
   }
 
@@ -635,7 +635,7 @@ public class WANTestBase extends DistributedTestCase {
       fact.setPartitionAttributes(pfact.create());
       fact.setOffHeap(offHeap);
       fact.setStatisticsEnabled(statisticsEnabled);
-      Region r = fact.create(regionName);
+      Region<Object, Object> r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -664,7 +664,7 @@ public class WANTestBase extends DistributedTestCase {
       pfact.setRedundantCopies(redundantCopies);
       pfact.setRecoveryDelay(0);
       fact.setPartitionAttributes(pfact.create());
-      Region r = fact.create(regionName);
+      Region<Object, Object> r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -694,7 +694,7 @@ public class WANTestBase extends DistributedTestCase {
       pfact.setRecoveryDelay(0);
       pfact.setColocatedWith(colocatedWith);
       fact.setPartitionAttributes(pfact.create());
-      Region r = fact.create(regionName);
+      Region<Object, Object> r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -703,14 +703,14 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void addSenderThroughAttributesMutator(String regionName, String senderIds) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     AttributesMutator mutator = r.getAttributesMutator();
     mutator.addGatewaySenderId(senderIds);
   }
 
   public static void addAsyncEventQueueThroughAttributesMutator(String regionName, String queueId) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     AttributesMutator mutator = r.getAttributesMutator();
     mutator.addAsyncEventQueueId(queueId);
@@ -730,7 +730,7 @@ public class WANTestBase extends DistributedTestCase {
     pfact.setTotalNumBuckets(totalNumBuckets);
     pfact.setRedundantCopies(redundantCopies);
     fact.setPartitionAttributes(pfact.create());
-    Region r = fact.create(regionName);
+    Region<Object, Object> r = fact.create(regionName);
     assertNotNull(r);
   }
 
@@ -755,7 +755,7 @@ public class WANTestBase extends DistributedTestCase {
     pfact.setColocatedWith(colocatedWith);
     fact.setPartitionAttributes(pfact.create());
     fact.setOffHeap(offHeap);
-    Region r = fact.create(regionName);
+    Region<Object, Object> r = fact.create(regionName);
     assertNotNull(r);
   }
 
@@ -781,7 +781,7 @@ public class WANTestBase extends DistributedTestCase {
       pfact.setRedundantCopies(redundantCopies);
       fact.setPartitionAttributes(pfact.create());
       fact.setOffHeap(offHeap);
-      Region r = fact.create(regionName);
+      Region<Object, Object> r = fact.create(regionName);
       assertNotNull(r);
     } finally {
       exp.remove();
@@ -870,7 +870,7 @@ public class WANTestBase extends DistributedTestCase {
     pfact.setRedundantCopies(redundantCopies);
     fact.setPartitionAttributes(pfact.create());
     fact.setOffHeap(offHeap);
-    Region r = fact.create(regionName);
+    Region<Object, Object> r = fact.create(regionName);
     assertNotNull(r);
 
     pfact.setColocatedWith(r.getName());
@@ -898,7 +898,7 @@ public class WANTestBase extends DistributedTestCase {
     pfact.setRedundantCopies(redundantCopies);
     fact.setPartitionAttributes(pfact.create());
     fact.setOffHeap(offHeap);
-    Region r = fact.create(regionName);
+    Region<Object, Object> r = fact.create(regionName);
     assertNotNull(r);
 
     fact = cache.createRegionFactory(RegionShortcut.PARTITION);
@@ -1620,7 +1620,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   private void addCacheListenerOnRegion(String regionName) {
-    Region region = cache.getRegion(regionName);
+    Region<Object, Object> region = cache.getRegion(regionName);
     AttributesMutator mutator = region.getAttributesMutator();
     listener1 = new QueueListener();
     mutator.addCacheListener(listener1);
@@ -2216,33 +2216,19 @@ public class WANTestBase extends DistributedTestCase {
     return port;
   }
 
-  public static void createClientWithLocator(int port0, String host, String regionName,
+  public static void createClientWithLocatorAndRegion(int port0, String host, String regionName,
       ClientRegionShortcut regionType) {
     ClientCache cache = new ClientCacheFactory().addPoolLocator(host, port0).create();
 
-    Region region =
+    Region<Object, Object> region =
         cache.createClientRegionFactory(regionType)
             .create(regionName);
 
     assertNotNull(region);
   }
 
-  public static void createClientWithLocatorAndRegions(int port0, String host,
-      ClientRegionShortcut regionType, List<String> regions) {
-    ClientCache cache = new ClientCacheFactory().addPoolLocator(host, port0).create();
-
-    for (String regionName : regions) {
-      Region region =
-          cache.createClientRegionFactory(regionType)
-              .create(regionName);
-
-      assertNotNull(region);
-    }
-  }
-
-
-  public static void createClientWithLocator(int port0, String host, String regionName) {
-    createClientWithLocator(port0, host);
+  public static void createClientWithLocatorAndRegion(int port0, String host, String regionName) {
+    createClientWithLocatorAndRegion(port0, host);
 
     RegionFactory factory = cache.createRegionFactory(RegionShortcut.LOCAL);
     factory.setPoolName("pool");
@@ -2253,7 +2239,7 @@ public class WANTestBase extends DistributedTestCase {
     logger.info("Distributed Region " + regionName + " created Successfully :" + region.toString());
   }
 
-  public static void createClientWithLocator(final int port0, final String host) {
+  public static void createClientWithLocatorAndRegion(final int port0, final String host) {
     WANTestBase test = new WANTestBase();
     Properties props = test.getDistributedSystemProperties();
     props.setProperty(MCAST_PORT, "0");
@@ -2315,7 +2301,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp2 =
         IgnoredException.addIgnoredException(GatewaySenderException.class.getName());
     try {
-      Region r = cache.getRegion(SEPARATOR + regionName);
+      Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       for (long i = 1; i <= numPuts; i++) {
         txMgr.begin();
@@ -2335,7 +2321,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp2 =
         IgnoredException.addIgnoredException(GatewaySenderException.class.getName());
     try {
-      Region r = cache.getRegion(SEPARATOR + regionName);
+      Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       for (long i = 0; i < numPuts; i++) {
         r.put(i, value);
@@ -2352,7 +2338,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp2 =
         IgnoredException.addIgnoredException(GatewaySenderException.class.getName());
     try {
-      Region r = cache.getRegion(SEPARATOR + regionName);
+      Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       for (long i = 0; i < numPuts; i++) {
         r.put(i, "Value_" + i);
@@ -2384,7 +2370,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp2 =
         IgnoredException.addIgnoredException(GatewaySenderException.class.getName());
     try {
-      Region r = cache.getRegion(SEPARATOR + regionName);
+      Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       for (long i = 0; i < numPuts; i++) {
         r.put(key, "Value_" + i);
@@ -2397,7 +2383,7 @@ public class WANTestBase extends DistributedTestCase {
 
 
   public static void doPutsAfter300(String regionName, int numPuts) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (long i = 300; i < numPuts; i++) {
       r.put(i, "Value_" + i);
@@ -2405,7 +2391,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void doPutsFrom(String regionName, int from, int numPuts) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (long i = from; i < numPuts; i++) {
       r.put(i, "Value_" + i);
@@ -2413,7 +2399,8 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void doClientPutsFrom(String regionName, int from, int numPuts) {
-    Region r = ClientCacheFactory.getAnyInstance().getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r =
+        ClientCacheFactory.getAnyInstance().getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (long i = from; i < numPuts; i++) {
       r.put(i, "Value_" + i);
@@ -2421,7 +2408,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void doDestroys(String regionName, int keyNum) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (long i = 0; i < keyNum; i++) {
       r.destroy(i);
@@ -2429,7 +2416,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void doPutAll(String regionName, int numPuts, int size) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (long i = 0; i < numPuts; i++) {
       Map putAllMap = new HashMap();
@@ -2443,7 +2430,7 @@ public class WANTestBase extends DistributedTestCase {
 
 
   public static void doPutsWithKeyAsString(String regionName, int numPuts) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (long i = 0; i < numPuts; i++) {
       r.put("Object_" + i, "Value_" + i);
@@ -2451,7 +2438,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void putGivenKeyValue(String regionName, Map keyValues) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (Object key : keyValues.keySet()) {
       r.put(key, keyValues.get(key));
@@ -2489,7 +2476,7 @@ public class WANTestBase extends DistributedTestCase {
 
   public static void doPutsInsideTransactions(String regionName, Map keyValues,
       int eventsPerTransaction) {
-    Region r = cache.getRegion(Region.SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(Region.SEPARATOR + regionName);
     assertNotNull(r);
     int eventInTransaction = 0;
     CacheTransactionManager cacheTransactionManager = cache.getCacheTransactionManager();
@@ -2513,7 +2500,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void destroyRegion(String regionName, final int min) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     await().until(() -> r.size() > min);
     r.destroyRegion();
@@ -2523,7 +2510,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp =
         IgnoredException.addIgnoredException(PRLocallyDestroyedException.class.getName());
     try {
-      Region r = cache.getRegion(SEPARATOR + regionName);
+      Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       r.localDestroyRegion();
     } finally {
@@ -2776,7 +2763,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void doPutsPDXSerializable(String regionName, int numPuts) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (int i = 0; i < numPuts; i++) {
       r.put("Key_" + i, new SimpleClass(i, (byte) i));
@@ -2784,7 +2771,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void doPutsPDXSerializable2(String regionName, int numPuts) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     for (int i = 0; i < numPuts; i++) {
       r.put("Key_" + i, new SimpleClass1(false, (short) i, "" + i, i, "" + i, "" + i, i, i));
@@ -2793,7 +2780,7 @@ public class WANTestBase extends DistributedTestCase {
 
 
   public static void doTxPuts(String regionName) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     CacheTransactionManager mgr = cache.getCacheTransactionManager();
 
@@ -2806,7 +2793,7 @@ public class WANTestBase extends DistributedTestCase {
 
   public static void doTxPutsWithRetryIfError(String regionName, final long putsPerTransaction,
       final long transactions, long offset) {
-    Region r = cache.getRegion(Region.SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(Region.SEPARATOR + regionName);
     assertNotNull(r);
 
     long keyOffset = offset * ((putsPerTransaction + (10 * transactions)) * 100);
@@ -2851,7 +2838,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp =
         IgnoredException.addIgnoredException(CacheClosedException.class.getName());
     try {
-      Region r = cache.getRegion(SEPARATOR + regionName);
+      Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       for (long i = start; i < numPuts; i++) {
         r.put(i, i);
@@ -2954,7 +2941,7 @@ public class WANTestBase extends DistributedTestCase {
       }
     });
 
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
 
     List<Callable<Object>> tasks = new ArrayList<Callable<Object>>();
@@ -2981,7 +2968,7 @@ public class WANTestBase extends DistributedTestCase {
     IgnoredException exp1 =
         IgnoredException.addIgnoredException(CacheClosedException.class.getName());
     try {
-      final Region r = cache.getRegion(SEPARATOR + regionName);
+      final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
       assertNotNull(r);
       if (regionSize != r.keySet().size()) {
         await()
@@ -2996,11 +2983,10 @@ public class WANTestBase extends DistributedTestCase {
     }
   }
 
-  public ArrayList getKeys(String regionName) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+  public List<Object> getKeys(String regionName) {
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
-    return new ArrayList(r.keySet());
-
+    return new ArrayList<>(r.keySet());
   }
 
   public void checkEqualRegionData(String regionName, VM vm1, VM vm2) {
@@ -3015,13 +3001,13 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static Object getValueForEntry(long key, String regionName) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     return r.get(key);
   }
 
   public static long getTimestampForEntry(long key, String regionName) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     if (r.getEntry(key) == null) {
       return 0;
@@ -3098,7 +3084,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void validateRegionSize_PDX(String regionName, final int regionSize) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     await().untilAsserted(() -> {
       assertEquals("Expected region entries: " + regionSize + " but actual entries: "
@@ -3117,7 +3103,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void validateRegionSizeOnly_PDX(String regionName, final int regionSize) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     await()
         .untilAsserted(
@@ -3152,7 +3138,7 @@ public class WANTestBase extends DistributedTestCase {
    *
    */
   public static void validateRegionSizeRemainsSame(String regionName, final int regionSizeLimit) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     WaitCriterion wc = new WaitCriterion() {
       final int MIN_VERIFICATION_RUNS = 20;
@@ -3190,19 +3176,19 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static String getRegionFullPath(String regionName) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     return r.getFullPath();
   }
 
   public static Integer getRegionSize(String regionName) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     return r.keySet().size();
   }
 
   public static void validateRegionContents(String regionName, final Map keyValues) {
-    final Region r = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     await().untilAsserted(() -> {
       boolean matchFlag = true;
@@ -3220,7 +3206,7 @@ public class WANTestBase extends DistributedTestCase {
 
 
   public static void doHeavyPuts(String regionName, int numPuts) {
-    Region r = cache.getRegion(SEPARATOR + regionName);
+    Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     // GatewaySender.DEFAULT_BATCH_SIZE * OBJECT_SIZE should be more than MAXIMUM_QUEUE_MEMORY
     // to guarantee overflow
@@ -3230,7 +3216,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void addCacheListenerAndDestroyRegion(String regionName) {
-    final Region region = cache.getRegion(SEPARATOR + regionName);
+    final Region<Object, Object> region = cache.getRegion(SEPARATOR + regionName);
     assertNotNull(region);
     CacheListenerAdapter cl = new CacheListenerAdapter() {
       @Override
@@ -3726,7 +3712,7 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void removeSenderFromTheRegion(String senderId, String regionName) {
-    Region region = cache.getRegion(regionName);
+    Region<Object, Object> region = cache.getRegion(regionName);
     assertNotNull(region);
     region.getAttributesMutator().removeGatewaySenderId(senderId);
   }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -2227,6 +2227,19 @@ public class WANTestBase extends DistributedTestCase {
     assertNotNull(region);
   }
 
+  public static void createClientWithLocatorAndRegions(int port0, String host,
+      ClientRegionShortcut regionType, List<String> regions) {
+    ClientCache cache = new ClientCacheFactory().addPoolLocator(host, port0).create();
+
+    for (String regionName : regions) {
+      Region region =
+          cache.createClientRegionFactory(regionType)
+              .create(regionName);
+
+      assertNotNull(region);
+    }
+  }
+
 
   public static void createClientWithLocator(int port0, String host, String regionName) {
     createClientWithLocator(port0, host);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationClientServerDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationClientServerDUnitTest.java
@@ -38,7 +38,7 @@ public class ParallelWANPropagationClientServerDUnitTest extends WANTestBase {
     vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
         isOffHeap()));
 
-    vm4.invoke(() -> WANTestBase.createClientWithLocator(nyPort, "localhost",
+    vm4.invoke(() -> WANTestBase.createClientWithLocatorAndRegion(nyPort, "localhost",
         getTestMethodName() + "_PR"));
     vm4.invoke(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 100));
 
@@ -51,7 +51,7 @@ public class ParallelWANPropagationClientServerDUnitTest extends WANTestBase {
     vm6.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
         isOffHeap()));
 
-    vm7.invoke(() -> WANTestBase.createClientWithLocator(lnPort, "localhost",
+    vm7.invoke(() -> WANTestBase.createClientWithLocatorAndRegion(lnPort, "localhost",
         getTestMethodName() + "_PR"));
 
     startSenderInVMsAsync("ln", vm5, vm6);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
@@ -993,7 +993,7 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
     checkEqualRegionData(regionName, serversInA.get(0), serverInB);
 
     // Check that wanCopyRegionBatchSize is correctly used by the command
-    int receivedBatches = serverInB.invoke(() -> WANTestBase.getReceiverStats().get(2));
+    long receivedBatches = serverInB.invoke(() -> WANTestBase.getReceiverStats().get(2));
     if (isPartitionedRegion && isParallelGatewaySender) {
       assertThat(receivedBatches).isEqualTo(6);
     } else {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
@@ -1,0 +1,1153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
+import static org.apache.geode.distributed.ConfigurationProperties.REMOTE_LOCATORS;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION__BATCHSIZE;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION__CANCEL;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION__MAXRATE;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION__MSG__CANCELED__AFTER__HAVING__COPIED;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION__MSG__EXECUTION__CANCELED;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION__MSG__NO__RUNNING__COMMAND;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION__REGION;
+import static org.apache.geode.management.internal.i18n.CliStrings.WAN_COPY_REGION__SENDERID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.FutureTask;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import org.assertj.core.api.Condition;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.Scope;
+import org.apache.geode.cache.client.ClientCacheFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.wan.GatewaySender;
+import org.apache.geode.internal.cache.wan.InternalGatewaySender;
+import org.apache.geode.internal.cache.wan.WANTestBase;
+import org.apache.geode.logging.internal.executors.LoggingExecutors;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
+import org.apache.geode.management.internal.i18n.CliStrings;
+import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.junit.assertions.CommandResultAssert;
+import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.LocatorLauncherStartupRule;
+
+@Category({WanTest.class})
+public class WanCopyRegionCommandDUnitTest extends WANTestBase {
+
+  private static final long serialVersionUID = 1L;
+
+  private enum Gateway {
+    SENDER, RECEIVER
+  }
+
+  public WanCopyRegionCommandDUnitTest() {
+    super();
+  }
+
+  @Test
+  public void testUnsuccessfulExecution_RegionNotFound() throws Exception {
+    List<VM> serversInA = Arrays.asList(vm5, vm6, vm7);
+    VM serverInB = vm3;
+    VM serverInC = vm4;
+    VM client = vm8;
+    String senderIdInA = "B";
+    String senderIdInB = "C";
+
+    Integer senderLocatorPort = create3WanSitesAndClient(true, vm0,
+        vm1, vm2, serversInA, serverInB, serverInC, client,
+        senderIdInA, senderIdInB);
+
+    int wanCopyRegionBatchSize = 20;
+    String regionName = "foo";
+
+    // Execute wan-copy region command
+    GfshCommandRule gfsh = new GfshCommandRule();
+    gfsh.connectAndVerify(senderLocatorPort, GfshCommandRule.PortType.locator);
+    String commandString = new CommandStringBuilder(WAN_COPY_REGION)
+        .addOption(WAN_COPY_REGION__REGION, regionName)
+        .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+        .addOption(WAN_COPY_REGION__BATCHSIZE, String.valueOf(wanCopyRegionBatchSize))
+        .getCommandString();
+
+    // Check command status and output
+    CommandResultAssert command =
+        verifyStatusIsError(gfsh.executeAndAssertThat(commandString));
+    String message =
+        CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__REGION__NOT__FOUND,
+            Region.SEPARATOR + regionName);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .containsExactly(message, message, message);
+  }
+
+  @Test
+  public void testUnsuccessfulExecution_SenderNotFound() throws Exception {
+    List<VM> serversInA = Arrays.asList(vm5, vm6, vm7);
+    VM serverInB = vm3;
+    VM serverInC = vm4;
+    VM client = vm8;
+    String senderIdInA = "B";
+    String senderIdInB = "C";
+
+    Integer senderLocatorPort = create3WanSitesAndClient(true, vm0,
+        vm1, vm2, serversInA, serverInB, serverInC, client,
+        senderIdInA, senderIdInB);
+
+    int wanCopyRegionBatchSize = 20;
+    String regionName = getRegionName(true);
+
+    // Execute wan-copy region command
+    GfshCommandRule gfsh = new GfshCommandRule();
+    gfsh.connectAndVerify(senderLocatorPort, GfshCommandRule.PortType.locator);
+    String commandString = new CommandStringBuilder(WAN_COPY_REGION)
+        .addOption(WAN_COPY_REGION__REGION, regionName)
+        .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+        .addOption(WAN_COPY_REGION__BATCHSIZE, String.valueOf(wanCopyRegionBatchSize))
+        .getCommandString();
+
+    // Check command status and output
+    CommandResultAssert command =
+        verifyStatusIsError(gfsh.executeAndAssertThat(commandString));
+    String message =
+        CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__SENDER__NOT__FOUND, senderIdInA);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .containsExactly(message, message, message);
+  }
+
+  @Test
+  public void testUnsuccessfulExecutionWithPartitionedRegionAndParallelSender_ExceptionAtReceiver()
+      throws Exception {
+    testUnsuccessfulExecution_ExceptionAtReceiver(true, true);
+  }
+
+  public void testUnsuccessfulExecution_ExceptionAtReceiver(
+      boolean isPartitionedRegion, boolean isParallelGatewaySender) throws Exception {
+    List<VM> serversInA = Arrays.asList(vm5, vm6, vm7);
+    VM serverInB = vm3;
+    VM serverInC = vm4;
+    VM client = vm8;
+    String senderIdInA = "B";
+    String senderIdInB = "C";
+
+    Integer senderLocatorPort = create3WanSitesAndClient(isPartitionedRegion, vm0,
+        vm1, vm2, serversInA, serverInB, serverInC, client,
+        senderIdInA, senderIdInB);
+
+    String regionName = getRegionName(true);
+    int wanCopyRegionBatchSize = 20;
+
+    int entries = 20;
+    // Put entries
+    client.invoke(() -> WANTestBase.doClientPutsFrom(regionName, 0, entries));
+
+    // Check that entries are put in the region
+    for (VM member : serversInA) {
+      member.invoke(() -> WANTestBase.validateRegionSize(regionName, entries));
+    }
+
+    // destroy region to provoke the exception
+    serverInB.invoke(() -> destroyRegion(regionName));
+
+    // Create senders and receivers with replication as follows: "A" -> "B" -> "C"
+    createSenders(isParallelGatewaySender, serversInA, serverInB,
+        senderIdInA, senderIdInB);
+    createReceivers(serverInB, serverInC);
+
+    // Execute wan-copy region command
+    GfshCommandRule gfsh = new GfshCommandRule();
+    gfsh.connectAndVerify(senderLocatorPort, GfshCommandRule.PortType.locator);
+    String commandString = new CommandStringBuilder(WAN_COPY_REGION)
+        .addOption(WAN_COPY_REGION__REGION, regionName)
+        .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+        .addOption(WAN_COPY_REGION__BATCHSIZE, String.valueOf(wanCopyRegionBatchSize))
+        .getCommandString();
+
+    // Check command status and output
+    if (isParallelGatewaySender) {
+      CommandResultAssert command =
+          verifyStatusIsError(gfsh.executeAndAssertThat(commandString));
+      Condition<String> exceptionError =
+          new Condition<>(s -> s.startsWith("Error ("), "Error");
+      command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+          .asList().haveExactly(3, exceptionError);
+    } else {
+      CommandResultAssert command =
+          verifyStatusIsErrorInOneServer(gfsh.executeAndAssertThat(commandString));
+      Condition<String> exceptionError =
+          new Condition<>(s -> s.startsWith("Error ("), "Error");
+      Condition<String> senderNotPrimary = new Condition<>(
+          s -> s.equals(CliStrings
+              .format(CliStrings.WAN_COPY_REGION__MSG__SENDER__SERIAL__AND__NOT__PRIMARY,
+                  senderIdInA)),
+          "sender not primary");
+      command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+          .asList().haveExactly(1, exceptionError).haveExactly(2, senderNotPrimary);
+    }
+  }
+
+  @Test
+  public void testSuccessfulExecution_WithReplicatedRegionAndSerialGatewaySender()
+      throws Exception {
+    testSuccessfulExecution(false, false);
+  }
+
+  @Test
+  public void testSuccessfulExecution_WithPartitionedRegionAndSerialGatewaySender()
+      throws Exception {
+    testSuccessfulExecution(true, false);
+  }
+
+  @Test
+  public void testSuccessfulExecution_WithPartitionedRegionAndParallelGatewaySender()
+      throws Exception {
+    testSuccessfulExecution(true, true);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWhileRunningOpsOnRegion_WithReplicatedRegionAndSerialGatewaySender()
+      throws Exception {
+    testSuccessfulExecutionWhileRunningOpsOnRegion(false, false);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWhileRunningOpsOnRegion_WithPartitionedRegionAndSerialGatewaySender()
+      throws Exception {
+    testSuccessfulExecutionWhileRunningOpsOnRegion(true, false);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWhileRunningOpsOnRegion_WithPartitionedRegionAndParallelGatewaySender()
+      throws Exception {
+    testSuccessfulExecutionWhileRunningOpsOnRegion(true, true);
+  }
+
+  @Test
+  public void testSuccessfulCancelExecution_WithReplicatedRegionAndSerialGatewaySender()
+      throws Exception {
+    testSuccessfulCancelExecution(false, false);
+  }
+
+  @Test
+  public void testSuccessfulCancelExecution_WithPartitionedRegionAndSerialGatewaySender()
+      throws Exception {
+    testSuccessfulCancelExecution(true, false);
+  }
+
+  @Test
+  public void testSuccessfulCancelExecution_WithPartitionedRegionAndParallelGatewaySender()
+      throws Exception {
+    testSuccessfulCancelExecution(true, true);
+  }
+
+  @Test
+  public void testUnsuccessfulCancelExecution_WithReplicatedRegionAndSerialGatewaySender()
+      throws Exception {
+    testUnsuccessfulCancelExecution(false, false);
+  }
+
+  @Test
+  public void testUnsuccessfulCancelExecution_WithPartitionedRegionAndSerialGatewaySender()
+      throws Exception {
+    testUnsuccessfulCancelExecution(true, false);
+  }
+
+  @Test
+  public void testUnsuccessfulCancelExecution_WithPartitionedRegionAndParallelGatewaySender()
+      throws Exception {
+    testUnsuccessfulCancelExecution(true, true);
+  }
+
+  @Test
+  public void testUnsuccessfulExecutionWithPartitionedRegionDueToParallelSenderWentDown()
+      throws Exception {
+    addIgnoredExceptionsForSenderInUseWentDown();
+    testSenderOrReceiverGoesDownDuringExecution(true, true, Gateway.SENDER, false);
+  }
+
+  @Test
+  public void testUnsuccessfulExecutionWithPartitionedRegionDueToSerialPrimarySenderWentDown()
+      throws Exception {
+    addIgnoredExceptionsForSenderInUseWentDown();
+    testSenderOrReceiverGoesDownDuringExecution(false, true, Gateway.SENDER, true);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWithPartitionedRegionDueToSerialSecondarySenderWentDown()
+      throws Exception {
+    testSenderOrReceiverGoesDownDuringExecution(false, true, Gateway.SENDER, false);
+  }
+
+  @Test
+  public void testUnsuccessfulExecutionWithReplicatedRegionDueToSerialPrimarySenderWentDown()
+      throws Exception {
+    addIgnoredExceptionsForSenderInUseWentDown();
+    testSenderOrReceiverGoesDownDuringExecution(false, false, Gateway.SENDER, true);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWithReplicatedRegionDueToSerialSecondarySenderWentDown()
+      throws Exception {
+    testSenderOrReceiverGoesDownDuringExecution(false, false, Gateway.SENDER, false);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWithPartitionedRegionAndParallelSenderDueToReceiverWentDown()
+      throws Exception {
+    addIgnoredExceptionsForReceiverConnectedToSenderInUseWentDown();
+    testSenderOrReceiverGoesDownDuringExecution(true, true, Gateway.RECEIVER, false);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWithPartitionedRegionAndSerialSenderDueToReceiverConnectedToPrimarySenderWentDown()
+      throws Exception {
+    addIgnoredExceptionsForReceiverConnectedToSenderInUseWentDown();
+    testSenderOrReceiverGoesDownDuringExecution(false, true, Gateway.RECEIVER, true);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWithPartitionedRegionAndSerialSenderDueToReceiverNotConnectedToPrimarySenderWentDown()
+      throws Exception {
+    testSenderOrReceiverGoesDownDuringExecution(false, true, Gateway.RECEIVER, false);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWithReplicatedRegionAndSerialSenderDueToReceiverConnectedToPrimarySenderWentDown()
+      throws Exception {
+    addIgnoredExceptionsForReceiverConnectedToSenderInUseWentDown();
+    testSenderOrReceiverGoesDownDuringExecution(false, false, Gateway.RECEIVER, true);
+  }
+
+  @Test
+  public void testSuccessfulExecutionWithReplicatedRegionAndSerialSenderDueToReceiverNotConnectedToPrimarySenderWentDown()
+      throws Exception {
+    testSenderOrReceiverGoesDownDuringExecution(false, false, Gateway.RECEIVER, false);
+  }
+
+  private void addIgnoredExceptionsForSenderInUseWentDown() {
+    IgnoredException.addIgnoredException(
+        "Exception org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException in sendBatch. Retrying");
+    IgnoredException.addIgnoredException(
+        "Exception org.apache.geode.cache.client.ServerConnectivityException in sendBatch. Retrying");
+    IgnoredException.addIgnoredException("DistributedSystemDisconnectedException");
+
+    IgnoredException.addIgnoredException(
+        "Exception when running wan-copy region command: java.util.concurrent.ExecutionException: org.apache.geode.distributed.PoolCancelledException");
+    IgnoredException.addIgnoredException(
+        "Exception when running wan-copy region command: java.util.concurrent.ExecutionException: org.apache.geode.cache.EntryDestroyedException");
+  }
+
+  private void addIgnoredExceptionsForReceiverConnectedToSenderInUseWentDown() {
+    IgnoredException.addIgnoredException(
+        "Exception org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException in sendBatch. Retrying");
+    IgnoredException.addIgnoredException(
+        "Exception org.apache.geode.cache.client.ServerConnectivityException in sendBatch. Retrying");
+    IgnoredException.addIgnoredException("DistributedSystemDisconnectedException");
+  }
+
+  private int create2WanSitesAndClient(VM locatorInA, List<VM> serversInA, String senderIdInA,
+      VM locatorInB, List<VM> serversInB, VM client, boolean usePartitionedRegion,
+      String regionName) {
+    // Create locators
+    Integer locatorBPort = locatorInB.invoke(() -> WANTestBase.createFirstLocatorWithDSId(2));
+    Integer locatorAPort = locatorInA.invoke(() -> {
+      Properties props = getDistributedSystemProperties();
+      props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + 1);
+      props.setProperty(REMOTE_LOCATORS, "localhost[" + locatorBPort + "]");
+      LocatorLauncherStartupRule launcherStartupRule =
+          new LocatorLauncherStartupRule().withProperties(props);
+      launcherStartupRule.start();
+      return launcherStartupRule.getLauncher().getPort();
+    });
+
+    // Create servers and regions
+    createServersAndRegions(locatorBPort, serversInB, usePartitionedRegion, regionName, null);
+    createServersAndRegions(locatorAPort, serversInA, usePartitionedRegion, regionName,
+        senderIdInA);
+
+    // Create client
+    client.invoke(() -> WANTestBase.createClientWithLocator(locatorAPort, "localhost",
+        regionName, ClientRegionShortcut.PROXY));
+
+    return locatorAPort;
+  }
+
+  /**
+   * This test creates two sites A & B, each one containing 3 servers.
+   * A region is created in both sites, and populated in site A.
+   * After that replication is configured from site A to site B.
+   * WanCopyRegionFunction is called, and while it is running, a sender in site A
+   * or a receiver in site B are killed.
+   */
+  public void testSenderOrReceiverGoesDownDuringExecution(boolean useParallel,
+      boolean usePartitionedRegion, Gateway gwToBeStopped, boolean stopPrimarySender)
+      throws Exception {
+
+    final int wanCopyRegionBatchSize = 10;
+    final int entries;
+    if (!useParallel && !usePartitionedRegion && stopPrimarySender) {
+      entries = 2500;
+    } else {
+      entries = 1000;
+    }
+
+    final String regionName = getRegionName(usePartitionedRegion);
+
+    // Site A
+    VM locatorInA = vm0;
+    VM server1InA = vm1;
+    VM server2InA = vm2;
+    VM server3InA = vm3;
+    List<VM> serversInA = Arrays.asList(server1InA, server2InA, server3InA);
+    final String senderIdInA = "B";
+
+    // Site B
+    VM locatorInB = vm4;
+    VM server1InB = vm5;
+    VM server2InB = vm6;
+    VM server3InB = vm7;
+    List<VM> serversInB = Arrays.asList(server1InB, server2InB, server3InB);
+    VM client = vm8;
+
+    int locatorAPort = create2WanSitesAndClient(locatorInA, serversInA, senderIdInA, locatorInB,
+        serversInB, client, usePartitionedRegion, regionName);
+
+    // Put entries
+    client.invoke(() -> WANTestBase.doClientPutsFrom(regionName, 0, entries));
+    for (VM member : serversInA) {
+      member.invoke(() -> WANTestBase.validateRegionSize(regionName, entries));
+    }
+
+    // Create senders and receivers with replication as follows: "A" -> "B"
+    if (useParallel) {
+      createReceiverInVMs(server1InB, server2InB, server3InB);
+      createSenders(useParallel, serversInA, null, senderIdInA, null);
+    } else {
+      // Senders will connect to receiver in server1InB
+      server1InB.invoke(WANTestBase::createReceiver);
+      createSenders(useParallel, serversInA, null, senderIdInA, null);
+      createReceiverInVMs(server2InB, server3InB);
+    }
+
+    CountDownLatch wanCopyCommandStartLatch = new CountDownLatch(1);
+
+    FutureTask<CommandResultAssert> wanCopyCommandFuture =
+        new FutureTask<>(() -> {
+          String command = new CommandStringBuilder(WAN_COPY_REGION)
+              .addOption(WAN_COPY_REGION__REGION, regionName)
+              .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+              .addOption(WAN_COPY_REGION__BATCHSIZE, String.valueOf(wanCopyRegionBatchSize))
+              .addOption(WAN_COPY_REGION__MAXRATE, "50")
+              .getCommandString();
+          GfshCommandRule gfsh = new GfshCommandRule();
+          try {
+            gfsh.connectAndVerify(locatorAPort, GfshCommandRule.PortType.locator);
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
+          wanCopyCommandStartLatch.countDown();
+          return gfsh.executeAndAssertThat(command);
+        });
+    LoggingExecutors.newSingleThreadExecutor(getTestMethodName(), true)
+        .submit(wanCopyCommandFuture);
+
+    // Wait for the wan-copy command to start
+    wanCopyCommandStartLatch.await();
+    Thread.sleep(1000);
+
+    // Stop sender or receiver and verify result
+    if (gwToBeStopped == Gateway.SENDER) {
+      stopSenderAndVerifyResult(useParallel, stopPrimarySender, server2InA, serversInA, senderIdInA,
+          wanCopyCommandFuture);
+    } else if (gwToBeStopped == Gateway.RECEIVER) {
+      stopReceiverAndVerifyResult(useParallel, stopPrimarySender, entries, regionName, server1InB,
+          server2InB, server3InB, wanCopyCommandFuture);
+    }
+  }
+
+  private void stopReceiverAndVerifyResult(boolean useParallel, boolean stopPrimarySender,
+      int entries, String regionName, VM server1InB, VM server2InB, VM server3InB,
+      FutureTask<CommandResultAssert> commandFuture)
+      throws InterruptedException, java.util.concurrent.ExecutionException {
+    // if parallel sender: stop any receiver
+    // if serial sender: stop receiver connected to primary or secondary
+    if (useParallel) {
+      server2InB.invoke(() -> cache.close());
+    } else {
+      // Region type has no influence on which server should be stopped
+      if (stopPrimarySender) {
+        // Stop the first server which had an available receiver
+        server1InB.invoke(() -> cache.close());
+      } else {
+        server3InB.invoke(() -> cache.close());
+      }
+    }
+
+    CommandResultAssert result = commandFuture.get();
+    // Verify result
+    if (useParallel) {
+      verifyResultOfStoppingReceiverWhenUsingParallelSender(result);
+    } else {
+      verifyResultOfStoppingReceiverWhenUsingSerialSender(result);
+      server2InB.invoke(() -> WANTestBase.validateRegionSize(regionName, entries));
+    }
+  }
+
+  private void stopSenderAndVerifyResult(boolean useParallel, boolean stopPrimarySender,
+      VM server2InA, List<VM> serversInA, String senderIdInA,
+      FutureTask<CommandResultAssert> wanCopyCommandFuture)
+      throws InterruptedException, java.util.concurrent.ExecutionException {
+    // If parallel: stop any server
+    // If serial: stop primary or secondary
+    if (useParallel) {
+      server2InA.invoke(() -> WANTestBase.killSender(senderIdInA));
+    } else {
+      for (VM server : serversInA) {
+        boolean senderWasStopped = server.invoke(() -> {
+          GatewaySender sender = cache.getGatewaySender(senderIdInA);
+          if (((InternalGatewaySender) sender).isPrimary() == stopPrimarySender) {
+            WANTestBase.killSender();
+            return true;
+          }
+          return false;
+        });
+        if (senderWasStopped) {
+          break;
+        }
+      }
+    }
+
+    CommandResultAssert result = wanCopyCommandFuture.get();
+    // Verify result
+    if (useParallel) {
+      verifyResultOfStoppingParallelSender(result);
+    } else {
+      if (stopPrimarySender) {
+        verifyResultOfStoppingPrimarySerialSender(result);
+      } else {
+        verifyResultStoppingSecondarySerialSender(result);
+      }
+    }
+  }
+
+  public void verifyResultOfStoppingReceiverWhenUsingSerialSender(
+      CommandResultAssert command) {
+    verifyStatusIsOk(command);
+    Condition<String> haveEntriesCopied =
+        new Condition<>(s -> s.startsWith("Entries copied: "), "Entries copied");
+    Condition<String> senderNotPrimary = new Condition<>(
+        s -> s.equals("Sender B is serial and not primary. 0 entries copied."),
+        "sender not primary");
+
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .asList().haveExactly(1, haveEntriesCopied).haveExactly(2, senderNotPrimary);
+  }
+
+  public void verifyResultOfStoppingReceiverWhenUsingParallelSender(
+      CommandResultAssert command) {
+    verifyStatusIsOk(command);
+    Condition<String> haveEntriesCopied =
+        new Condition<>(s -> s.startsWith("Entries copied: "), "Entries copied");
+
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .asList().haveExactly(3, haveEntriesCopied);
+  }
+
+  public void verifyResultOfStoppingParallelSender(CommandResultAssert command) {
+    verifyStatusIsErrorInOneServer(command);
+    Condition<String> startsWithError = new Condition<>(
+        s -> (s.startsWith("Execution failed. Error:")
+            || s.startsWith("Error (Unknown error sending batch)")
+            || s.startsWith("Error (Region destroyed)")
+            || s.startsWith("MemberResponse got memberDeparted event for")),
+        "execution error");
+    Condition<String> haveEntriesCopied =
+        new Condition<>(s -> s.startsWith("Entries copied:"), "Entries copied");
+
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .asList().haveExactly(1, startsWithError).haveExactly(2, haveEntriesCopied);
+  }
+
+  public void verifyResultOfStoppingPrimarySerialSender(
+      CommandResultAssert command) {
+    verifyStatusIsErrorInOneServer(command);
+
+    Condition<String> startsWithError = new Condition<>(
+        s -> (s.startsWith("Execution failed. Error:")
+            || s.startsWith("Error (Unknown error sending batch)")
+            || s.startsWith("No connection available towards receiver after having copied")
+            || s.startsWith("Error (Region destroyed)")
+            || s.startsWith("MemberResponse got memberDeparted event for")),
+        "execution error");
+
+    Condition<String> senderNotPrimary = new Condition<>(
+        s -> s.equals("Sender B is serial and not primary. 0 entries copied."),
+        "sender not primary");
+
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .asList().haveExactly(1, startsWithError).haveExactly(2, senderNotPrimary);
+  }
+
+  public void verifyResultStoppingSecondarySerialSender(
+      CommandResultAssert command) {
+    command.statusIsSuccess();
+    command.hasTableSection().hasColumns().hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Member")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Status")
+        .containsExactlyInAnyOrder("OK", "OK", "OK");
+
+    Condition<String> haveEntriesCopied =
+        new Condition<>(s -> s.startsWith("Entries copied:"), "Entries copied");
+    Condition<String> senderNotPrimary = new Condition<>(
+        s -> s.equals("Sender B is serial and not primary. 0 entries copied."),
+        "sender not primary");
+
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .asList().haveExactly(1, haveEntriesCopied).haveExactly(2, senderNotPrimary);
+  }
+
+  /**
+   * Scenario with 3 WAN sites: "A", "B" and "C".
+   * Initially, no replication is configured between sites.
+   * Several entries are put in WAN site "A".
+   *
+   * The following gateway senders are created and started:
+   * - In "A" site: to replicate region entries to "B" site. Sender called "B".
+   * - In "B" site: to replicate region entries to "C" site. Sender called "C".
+   * (Replication is as follows: A -> B -> C)
+   *
+   * The "wan-copy region" command is run from "A" site passing sender "B".
+   *
+   * It must be verified that the entries are copied to site "B".
+   * It must also be verified that the entries are not transitively
+   * copied to "C" even though replication is configured from "B" to "C"
+   * because with this command generateCallbacks is set to false in the
+   * events generated.
+   *
+   */
+  public void testSuccessfulExecution(boolean isPartitionedRegion,
+      boolean isParallelGatewaySender) throws Exception {
+    List<VM> serversInA = Arrays.asList(vm5, vm6, vm7);
+    VM serverInB = vm3;
+    VM serverInC = vm4;
+    VM client = vm8;
+    String senderIdInA = "B";
+    String senderIdInB = "C";
+
+    Integer senderLocatorPort = create3WanSitesAndClient(isPartitionedRegion, vm0,
+        vm1, vm2, serversInA, serverInB, serverInC, client,
+        senderIdInA, senderIdInB);
+
+    int wanCopyRegionBatchSize = 20;
+    int entries = 100;
+    String regionName = getRegionName(isPartitionedRegion);
+    // Put entries
+    client.invoke(() -> WANTestBase.doClientPutsFrom(regionName, 0, entries + 1));
+    // remove an entry to make sure that replication works well even when removes.
+    client.invoke(() -> removeEntry(regionName, entries));
+
+    // Check that entries are put in the region
+    for (VM member : serversInA) {
+      member.invoke(() -> WANTestBase.validateRegionSize(regionName, entries));
+    }
+
+    // Check that entries are not copied to "B" nor "C"
+    serverInB.invoke(() -> WANTestBase.validateRegionSize(regionName, 0));
+    serverInC.invoke(() -> WANTestBase.validateRegionSize(regionName, 0));
+
+    // Create senders and receivers with replication as follows: "A" -> "B" -> "C"
+    createSenders(isParallelGatewaySender, serversInA, serverInB,
+        senderIdInA, senderIdInB);
+    createReceivers(serverInB, serverInC);
+
+    // Check that entries are not copied to "B" nor "C"
+    serverInB.invoke(() -> WANTestBase.validateRegionSize(regionName, 0));
+    serverInC.invoke(() -> WANTestBase.validateRegionSize(regionName, 0));
+
+    // Execute wan-copy region command
+    GfshCommandRule gfsh = new GfshCommandRule();
+    gfsh.connectAndVerify(senderLocatorPort, GfshCommandRule.PortType.locator);
+    String commandString = new CommandStringBuilder(WAN_COPY_REGION)
+        .addOption(WAN_COPY_REGION__REGION, regionName)
+        .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+        .addOption(WAN_COPY_REGION__BATCHSIZE, String.valueOf(wanCopyRegionBatchSize))
+        .getCommandString();
+
+    // Check command status and output
+    CommandResultAssert command =
+        verifyStatusIsOk(gfsh.executeAndAssertThat(commandString));
+    if (isPartitionedRegion && isParallelGatewaySender) {
+      String msg1 = CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__COPIED__ENTRIES, 33);
+      String msg2 = CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__COPIED__ENTRIES, 34);
+      command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+          .containsExactlyInAnyOrder(msg1, msg1, msg2);
+    } else {
+      String msg1 = CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__COPIED__ENTRIES, 100);
+      String msg2 = CliStrings
+          .format(CliStrings.WAN_COPY_REGION__MSG__SENDER__SERIAL__AND__NOT__PRIMARY, senderIdInA);
+      command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+          .containsExactlyInAnyOrder(msg1, msg2, msg2);
+    }
+
+    // Check that entries are copied in "B"
+    serverInB.invoke(() -> WANTestBase.validateRegionSize(regionName, entries));
+
+    // Check that the region's data is the same in sites "A" and "B"
+    checkEqualRegionData(regionName, serversInA.get(0), serverInB);
+
+    // Check that wanCopyRegionBatchSize is correctly used by the command
+    int receivedBatches = serverInB.invoke(() -> WANTestBase.getReceiverStats().get(2));
+    if (isPartitionedRegion && isParallelGatewaySender) {
+      assertThat(receivedBatches).isEqualTo(6);
+    } else {
+      assertThat(receivedBatches).isEqualTo(5);
+    }
+
+    // Check that entries are not copied in "C" (generateCallbacks is false)
+    serverInC.invoke(() -> WANTestBase.validateRegionSize(regionName, 0));
+  }
+
+  /**
+   * Scenario with 2 WAN sites: "A" and "B".
+   * Initially, no replication is configured between sites.
+   * Several entries are put in WAN site "A".
+   *
+   * The following gateway senders are created and started:
+   * - In "A" site: to replicate region entries to "B" site. Sender called "B".
+   * (Replication is as follows: A -> B)
+   *
+   * The "wan-copy region" command is run from "A" site passing sender "B".
+   * Simultaneously, random operations for entries with the same
+   * keys as the one previously put are run.
+   *
+   * When the command finishes and the puts finish it
+   * must be verified that the entries in the region in site "A"
+   * are the same as the ones in region in site "B"..
+   */
+  public void testSuccessfulExecutionWhileRunningOpsOnRegion(
+      boolean isPartitionedRegion,
+      boolean isParallelGatewaySender) throws Exception {
+    List<VM> serversInA = Arrays.asList(vm5, vm6, vm7);
+    VM serverInB = vm3;
+    VM serverInC = vm4;
+    VM client = vm8;
+    String senderIdInA = "B";
+    String senderIdInB = "C";
+
+    Integer senderLocatorPort = create3WanSitesAndClient(isPartitionedRegion, vm0,
+        vm1, vm2, serversInA, serverInB, serverInC, client,
+        senderIdInA, senderIdInB);
+
+    int wanCopyRegionBatchSize = 20;
+    int entries = 1000;
+    Set<Long> keySet = LongStream.range(0L, entries).boxed().collect(Collectors.toSet());
+    String regionName = getRegionName(isPartitionedRegion);
+    // Put entries
+    client.invoke(() -> WANTestBase.doClientPutsFrom(regionName, 0, entries));
+
+    // Check that entries are put in the region
+    for (VM member : serversInA) {
+      member.invoke(() -> WANTestBase.validateRegionSize(regionName, entries));
+    }
+
+    // Create senders and receivers with replication as follows: "A" -> "B" -> "C"
+    createSenders(isParallelGatewaySender, serversInA, serverInB,
+        senderIdInA, senderIdInB);
+    createReceivers(serverInB, serverInC);
+
+    // Execute wan-copy region command
+    GfshCommandRule gfsh = new GfshCommandRule();
+    gfsh.connectAndVerify(senderLocatorPort, GfshCommandRule.PortType.locator);
+    String command = new CommandStringBuilder(WAN_COPY_REGION)
+        .addOption(WAN_COPY_REGION__REGION, regionName)
+        .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+        .addOption(WAN_COPY_REGION__BATCHSIZE, String.valueOf(wanCopyRegionBatchSize))
+        .getCommandString();
+
+    // While the command is running, send some random operations over the same keys
+    AsyncInvocation<Object> asyncOps1 =
+        client.invokeAsync(() -> sendRandomOpsFromClient(regionName, keySet, 10));
+    AsyncInvocation<Object> asyncOps2 =
+        client.invokeAsync(() -> sendRandomOpsFromClient(regionName, keySet, 10));
+    AsyncInvocation<Object> asyncOps3 =
+        client.invokeAsync(() -> sendRandomOpsFromClient(regionName, keySet, 10));
+
+    // Check command status and output
+    verifyStatusIsOk(gfsh.executeAndAssertThat(command));
+
+    // Wait for random operations to finish
+    asyncOps1.await();
+    asyncOps2.await();
+    asyncOps3.await();
+
+    // Wait for entries to be replicated (replication queues empty)
+    for (VM server : serversInA) {
+      server.invoke(() -> getSenderStats(senderIdInA, 0));
+    }
+
+    // Check that the region's data is the same in sites "A" and "B"
+    checkEqualRegionData(regionName, serversInA.get(0), serverInB);
+  }
+
+  /**
+   * Cancel is executed when no wan-copy region command is running.
+   */
+  public void testUnsuccessfulCancelExecution(boolean isPartitionedRegion,
+      boolean isParallelGatewaySender) throws Exception {
+    List<VM> serversInA = Arrays.asList(vm5, vm6, vm7);
+    VM serverInB = vm3;
+    VM serverInC = vm4;
+    VM client = vm8;
+    String senderIdInA = "B";
+    String senderIdInB = "C";
+
+    Integer senderLocatorPort = create3WanSitesAndClient(isPartitionedRegion, vm0,
+        vm1, vm2, serversInA, serverInB, serverInC, client,
+        senderIdInA, senderIdInB);
+
+    String regionName = getRegionName(isPartitionedRegion);
+
+    // Create senders and receivers with replication as follows: "A" -> "B" -> "C"
+    createSenders(isParallelGatewaySender, serversInA, serverInB,
+        senderIdInA, senderIdInB);
+    createReceivers(serverInB, serverInC);
+
+    // Execute cancel wan-copy region command
+    GfshCommandRule gfsh = new GfshCommandRule();
+    gfsh.connectAndVerify(senderLocatorPort, GfshCommandRule.PortType.locator);
+    String cancelCommand = new CommandStringBuilder(WAN_COPY_REGION)
+        .addOption(WAN_COPY_REGION__REGION, regionName)
+        .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+        .addOption(WAN_COPY_REGION__CANCEL)
+        .getCommandString();
+    CommandResultAssert cancelCommandResult =
+        verifyStatusIsError(gfsh.executeAndAssertThat(cancelCommand));
+    String msg1 = CliStrings.format(WAN_COPY_REGION__MSG__NO__RUNNING__COMMAND,
+        Region.SEPARATOR + regionName, senderIdInA);
+    cancelCommandResult.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .containsExactlyInAnyOrder(msg1, msg1, msg1);
+  }
+
+  /**
+   * Scenario with 3 WAN sites: "A", "B" and "C".
+   * Initially, no replication is configured between sites.
+   * Several entries are put in WAN site "A".
+   *
+   * The following gateway senders are created and started:
+   * - In "A" site: to replicate region entries to "B" site. Sender called "B".
+   * - In "B" site: to replicate region entries to "C" site. Sender called "C".
+   * (Replication is as follows: A -> B -> C)
+   *
+   * The "wan-copy region" command is run from "A" site passing sender "B"
+   * in a different thread. The maxRate is set to a very low value so that there is
+   * time to cancel it before it finishes.
+   *
+   * The "wan-copy region" command with the cancel option
+   * is run from "A" site passing sender "B".
+   *
+   * It must be verified that the command is canceled.
+   * Also, the output of the command must show
+   * the number of entries copied before the command was canceled.
+   */
+  public void testSuccessfulCancelExecution(boolean isPartitionedRegion,
+      boolean isParallelGatewaySender) throws Exception {
+    List<VM> serversInA = Arrays.asList(vm5, vm6, vm7);
+    VM serverInB = vm3;
+    VM serverInC = vm4;
+    VM client = vm8;
+    String senderIdInA = "B";
+    String senderIdInB = "C";
+
+    Integer senderLocatorPort = create3WanSitesAndClient(isPartitionedRegion, vm0,
+        vm1, vm2, serversInA, serverInB, serverInC, client,
+        senderIdInA, senderIdInB);
+
+    int wanCopyRegionBatchSize = 20;
+    int entries = 100;
+    String regionName = getRegionName(isPartitionedRegion);
+    // Put entries
+    client.invoke(() -> WANTestBase.doClientPutsFrom(regionName, 0, entries));
+
+    // Create senders and receivers with replication as follows: "A" -> "B" -> "C"
+    createSenders(isParallelGatewaySender, serversInA, serverInB,
+        senderIdInA, senderIdInB);
+    createReceivers(serverInB, serverInC);
+
+    CountDownLatch wanCopyCommandStartLatch = new CountDownLatch(1);
+
+    // Execute wan-copy region command to be canceled in an independent thread
+    FutureTask<CommandResultAssert> wanCopyCommandFuture =
+        new FutureTask<>(() -> {
+          String command = new CommandStringBuilder(WAN_COPY_REGION)
+              .addOption(WAN_COPY_REGION__REGION, regionName)
+              .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+              .addOption(WAN_COPY_REGION__BATCHSIZE, String.valueOf(wanCopyRegionBatchSize))
+              .addOption(WAN_COPY_REGION__MAXRATE, String.valueOf(1))
+              .getCommandString();
+          GfshCommandRule gfsh = new GfshCommandRule();
+          try {
+            gfsh.connectAndVerify(senderLocatorPort, GfshCommandRule.PortType.locator);
+          } catch (Exception e) {
+            e.printStackTrace();
+          }
+          wanCopyCommandStartLatch.countDown();
+          return gfsh.executeAndAssertThat(command).statusIsSuccess();
+        });
+    LoggingExecutors.newSingleThreadExecutor(getTestMethodName(), true)
+        .submit(wanCopyCommandFuture);
+
+    // Wait for the wan-copy command to start
+    wanCopyCommandStartLatch.await();
+    Thread.sleep(1000);
+
+    // Cancel wan-copy region command
+    GfshCommandRule gfsh = new GfshCommandRule();
+    gfsh.connectAndVerify(senderLocatorPort, GfshCommandRule.PortType.locator);
+    String cancelCommand = new CommandStringBuilder(WAN_COPY_REGION)
+        .addOption(WAN_COPY_REGION__REGION, regionName)
+        .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
+        .addOption(WAN_COPY_REGION__CANCEL)
+        .getCommandString();
+    CommandResultAssert cancelCommandResult =
+        gfsh.executeAndAssertThat(cancelCommand);
+
+    if (isPartitionedRegion && isParallelGatewaySender) {
+      verifyStatusIsOk(cancelCommandResult);
+      cancelCommandResult.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+          .containsExactlyInAnyOrder(WAN_COPY_REGION__MSG__EXECUTION__CANCELED,
+              WAN_COPY_REGION__MSG__EXECUTION__CANCELED,
+              WAN_COPY_REGION__MSG__EXECUTION__CANCELED);
+    } else {
+      verifyStatusIsOkInOneServer(cancelCommandResult);
+      String msg1 = CliStrings.format(WAN_COPY_REGION__MSG__NO__RUNNING__COMMAND,
+          Region.SEPARATOR + regionName, senderIdInA);
+      cancelCommandResult.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+          .containsExactlyInAnyOrder(msg1, msg1, WAN_COPY_REGION__MSG__EXECUTION__CANCELED);
+    }
+
+    // Check wan-copy region command output
+    CommandResultAssert wanCopyCommandResult = wanCopyCommandFuture.get();
+    verifyStatusIsOk(wanCopyCommandResult);
+    if (isPartitionedRegion && isParallelGatewaySender) {
+      String msg = CliStrings.format(WAN_COPY_REGION__MSG__CANCELED__AFTER__HAVING__COPIED,
+          wanCopyRegionBatchSize);
+      wanCopyCommandResult.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+          .containsExactly(msg, msg, msg);
+    } else {
+      String msg1 =
+          CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__CANCELED__AFTER__HAVING__COPIED,
+              wanCopyRegionBatchSize);
+      String msg2 = CliStrings
+          .format(CliStrings.WAN_COPY_REGION__MSG__SENDER__SERIAL__AND__NOT__PRIMARY, senderIdInA);
+      wanCopyCommandResult.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+          .containsExactlyInAnyOrder(msg1, msg2, msg2);
+    }
+  }
+
+  private void createSenders(boolean isParallelGatewaySender, List<VM> serversInA,
+      VM serverInB, String senderIdInA, String senderIdInB) {
+    if (serverInB != null && senderIdInB != null) {
+      serverInB.invoke(() -> WANTestBase.createSender(senderIdInB, 3,
+          isParallelGatewaySender, 100, 10, false,
+          false, null, false));
+    }
+    for (VM server : serversInA) {
+      server.invoke(() -> WANTestBase.createSender(senderIdInA, 2, isParallelGatewaySender,
+          100, 10, false,
+          false, null, true));
+    }
+    startSenderInVMsAsync(senderIdInA, serversInA.toArray(new VM[0]));
+  }
+
+  private void createReceivers(VM serverInB, VM serverInC) {
+    createReceiverInVMs(serverInB);
+    createReceiverInVMs(serverInC);
+  }
+
+  private Integer create3WanSitesAndClient(boolean isPartitionedRegion, VM locatorSender,
+      VM locatorSenderReceiver, VM locatorReceiver, List<VM> serversInA, VM serverInB,
+      VM serverInC, VM client, String senderIdInA, String senderIdInB) {
+    // Create locators
+    Integer receiverLocatorPort =
+        locatorReceiver.invoke(() -> WANTestBase.createFirstLocatorWithDSId(3));
+    Integer senderReceiverLocatorPort = locatorSenderReceiver
+        .invoke(() -> WANTestBase.createFirstRemoteLocator(2, receiverLocatorPort));
+    Integer senderLocatorPort = locatorSender.invoke(() -> {
+      Properties props = getDistributedSystemProperties();
+      props.setProperty(DISTRIBUTED_SYSTEM_ID, "" + 1);
+      props.setProperty(REMOTE_LOCATORS, "localhost[" + senderReceiverLocatorPort + "]");
+      LocatorLauncherStartupRule launcherStartupRule =
+          new LocatorLauncherStartupRule().withProperties(props);
+      launcherStartupRule.start();
+      return launcherStartupRule.getLauncher().getPort();
+    });
+
+    // Create servers
+    serverInB.invoke(() -> WANTestBase.createServer(senderReceiverLocatorPort));
+    serverInC.invoke(() -> WANTestBase.createServer(receiverLocatorPort));
+    for (VM server : serversInA) {
+      server.invoke(() -> WANTestBase.createServer(senderLocatorPort));
+    }
+
+    // Create region in servers
+    final String regionName = getRegionName(isPartitionedRegion);
+    if (isPartitionedRegion) {
+      for (VM server : serversInA) {
+        server
+            .invoke(() -> WANTestBase.createPartitionedRegion(regionName, senderIdInA, 1, 100,
+                isOffHeap(), RegionShortcut.PARTITION, true));
+      }
+      serverInB.invoke(
+          () -> WANTestBase.createPartitionedRegion(regionName, senderIdInB, 0, 100,
+              isOffHeap(), RegionShortcut.PARTITION, true));
+      serverInC.invoke(() -> WANTestBase.createPartitionedRegion(regionName, null, 0, 100,
+          isOffHeap(), RegionShortcut.PARTITION, true));
+    } else {
+      for (VM server : serversInA) {
+        server.invoke(() -> WANTestBase.createReplicatedRegion(regionName, senderIdInA,
+            Scope.GLOBAL, DataPolicy.REPLICATE,
+            isOffHeap(), true));
+      }
+      serverInB
+          .invoke(() -> WANTestBase.createReplicatedRegion(regionName, senderIdInB,
+              Scope.GLOBAL, DataPolicy.REPLICATE,
+              isOffHeap(), true));
+      serverInC.invoke(() -> WANTestBase.createReplicatedRegion(regionName, null,
+          Scope.GLOBAL, DataPolicy.REPLICATE, isOffHeap(), true));
+    }
+
+    // Create client
+    client.invoke(() -> WANTestBase.createClientWithLocator(senderLocatorPort, "localhost",
+        regionName, ClientRegionShortcut.PROXY));
+
+    return senderLocatorPort;
+  }
+
+  private String getRegionName(boolean isPartitionedRegion) {
+    return getTestMethodName() + (isPartitionedRegion ? "_PR" : "RR");
+  }
+
+  public static void removeEntry(String regionName, long key) {
+    Region r = ClientCacheFactory.getAnyInstance().getRegion(SEPARATOR + regionName);
+    assertNotNull(r);
+    r.remove(key);
+  }
+
+  public void sendRandomOpsFromClient(String regionName, Set<Long> keySet, int iterations) {
+    Region r = ClientCacheFactory.getAnyInstance().getRegion(SEPARATOR + regionName);
+    assertNotNull(r);
+    int min = 0;
+    int max = 1000;
+    for (int i = 0; i < iterations; i++) {
+      for (Long key : keySet) {
+        long longKey = key.longValue();
+        int value = (int) (Math.random() * (max - min + 1) + min);
+        if (value < 50) {
+          r.remove(longKey);
+        } else {
+          r.put(longKey, value);
+        }
+      }
+    }
+  }
+
+  public CommandResultAssert verifyStatusIsOk(CommandResultAssert command) {
+    command.statusIsSuccess();
+    command.hasTableSection().hasColumns().hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Member")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Status")
+        .containsExactly("OK", "OK", "OK");
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .hasSize(3);
+    return command;
+  }
+
+  public CommandResultAssert verifyStatusIsError(CommandResultAssert command) {
+    command.statusIsError();
+    command.hasTableSection().hasColumns().hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Member")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Status")
+        .containsExactly("ERROR", "ERROR", "ERROR");
+    return command;
+  }
+
+  public CommandResultAssert verifyStatusIsErrorInOneServer(
+      CommandResultAssert command) {
+    command.statusIsError();
+    command.hasTableSection().hasColumns().hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Member")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Status")
+        .containsExactlyInAnyOrder("OK", "OK", "ERROR");
+    return command;
+  }
+
+  public CommandResultAssert verifyStatusIsOkInOneServer(
+      CommandResultAssert command) {
+    command.statusIsError();
+    command.hasTableSection().hasColumns().hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Member")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
+        .hasSize(3);
+    command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Status")
+        .containsExactlyInAnyOrder("OK", "ERROR", "ERROR");
+    return command;
+  }
+
+  public void createServersAndRegions(int locatorPort, List<VM> servers,
+      boolean usePartitionedRegion, String regionName, String senderId) {
+
+    for (VM server : servers) {
+      server.invoke(() -> WANTestBase.createServer(locatorPort));
+      if (usePartitionedRegion) {
+        server
+            .invoke(() -> WANTestBase.createPartitionedRegion(regionName, senderId, 1, 100,
+                isOffHeap(), RegionShortcut.PARTITION, true));
+      } else {
+        server.invoke(() -> WANTestBase.createReplicatedRegion(regionName, senderId,
+            Scope.GLOBAL, DataPolicy.REPLICATE,
+            isOffHeap(), true));
+      }
+    }
+  }
+}

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
@@ -389,6 +389,15 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
     testDetectOngoingExecution(true, true);
   }
 
+  private void addIgnoredExceptionsForClosingAfterCancelCommand() {
+    IgnoredException.addIgnoredException(
+        "Error closing the connection used to wan-copy region entries");
+    IgnoredException.addIgnoredException(
+        "Exception org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException in sendBatch. Retrying");
+    IgnoredException.addIgnoredException(
+        "Exception org.apache.geode.cache.client.ServerConnectivityException in sendBatch. Retrying");
+  }
+
   private void addIgnoredExceptionsForSenderInUseWentDown() {
     IgnoredException.addIgnoredException(
         "Exception org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException in sendBatch. Retrying");
@@ -638,7 +647,6 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
   public void testDetectOngoingExecution(boolean useParallel,
       boolean usePartitionedRegion)
       throws Exception {
-
     final int wanCopyRegionBatchSize = 10;
     final int entries = 1000;
 
@@ -748,6 +756,7 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
         .getCommandString();
     gfsh1.executeAndAssertThat(commandString1);
     wanCopyCommandFuture.get();
+    addIgnoredExceptionsForClosingAfterCancelCommand();
   }
 
   private void stopReceiverAndVerifyResult(boolean useParallel, boolean stopPrimarySender,
@@ -1228,6 +1237,7 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
           .containsExactlyInAnyOrder(WAN_COPY_REGION__MSG__CANCELED__BEFORE__HAVING__COPIED, msg1,
               msg1);
     }
+    addIgnoredExceptionsForClosingAfterCancelCommand();
   }
 
   private void createSenders(boolean isParallelGatewaySender, List<VM> serversInA,

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
@@ -623,14 +623,14 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
 
     // cancel command
     GfshCommandRule gfsh1 = new GfshCommandRule();
-    gfsh.connectAndVerify(locatorAPort, GfshCommandRule.PortType.locator);
+    gfsh1.connectAndVerify(locatorAPort, GfshCommandRule.PortType.locator);
     String commandString1 = new CommandStringBuilder(WAN_COPY_REGION)
         .addOption(WAN_COPY_REGION__REGION, regionName)
         .addOption(WAN_COPY_REGION__SENDERID, senderIdInA)
         .addOption(WAN_COPY_REGION__BATCHSIZE, String.valueOf(wanCopyRegionBatchSize))
         .addOption(WAN_COPY_REGION__CANCEL)
         .getCommandString();
-    gfsh.executeAndAssertThat(commandString1);
+    gfsh1.executeAndAssertThat(commandString1);
     wanCopyCommandFuture.get();
   }
 
@@ -1201,19 +1201,19 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
   }
 
   public static void removeEntry(String regionName, long key) {
-    Region r = ClientCacheFactory.getAnyInstance().getRegion(SEPARATOR + regionName);
+    Region<?, ?> r = ClientCacheFactory.getAnyInstance().getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     r.remove(key);
   }
 
   public void sendRandomOpsFromClient(String regionName, Set<Long> keySet, int iterations) {
-    Region r = ClientCacheFactory.getAnyInstance().getRegion(SEPARATOR + regionName);
+    Region<Long, Integer> r = ClientCacheFactory.getAnyInstance().getRegion(SEPARATOR + regionName);
     assertNotNull(r);
     int min = 0;
     int max = 1000;
     for (int i = 0; i < iterations; i++) {
       for (Long key : keySet) {
-        long longKey = key.longValue();
+        long longKey = key;
         int value = (int) (Math.random() * (max - min + 1) + min);
         if (value < 50) {
           r.remove(longKey);
@@ -1261,7 +1261,7 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
     return command;
   }
 
-  public CommandResultAssert verifyStatusIsOkInOneServer(
+  public void verifyStatusIsOkInOneServer(
       CommandResultAssert command) {
     command.statusIsError();
     command.hasTableSection().hasColumns().hasSize(3);
@@ -1271,7 +1271,6 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
         .hasSize(3);
     command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Status")
         .containsExactlyInAnyOrder("OK", "ERROR", "ERROR");
-    return command;
   }
 
   public void createServersAndRegions(int locatorPort, List<VM> servers,

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/WanCopyRegionCommandDUnitTest.java
@@ -716,20 +716,18 @@ public class WanCopyRegionCommandDUnitTest extends WANTestBase {
         .getCommandString();
 
     // Check command status and output
+    Condition<String> exceptionError = new Condition<>(
+        s -> s.equals(CliStrings.format(CliStrings.WAN_COPY_REGION__MSG__ALREADY__RUNNING__COMMAND,
+            Region.SEPARATOR + regionName, senderIdInA)),
+        "already running");
     if (useParallel) {
       CommandResultAssert command =
           verifyStatusIsError(gfsh.executeAndAssertThat(commandString));
-      Condition<String> exceptionError =
-          new Condition<>(s -> s.startsWith("There is already a command running for"),
-              "Already running command");
       command.hasTableSection(ResultModel.MEMBER_STATUS_SECTION).hasColumn("Message")
           .asList().haveExactly(3, exceptionError);
     } else {
       CommandResultAssert command =
           verifyStatusIsErrorInOneServer(gfsh.executeAndAssertThat(commandString));
-      Condition<String> exceptionError =
-          new Condition<>(s -> s.startsWith("There is already a command running for"),
-              "Already running command");
       Condition<String> senderNotPrimary = new Condition<>(
           s -> s.equals(CliStrings
               .format(CliStrings.WAN_COPY_REGION__MSG__SENDER__SERIAL__AND__NOT__PRIMARY,

--- a/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderEventRemoteDispatcher.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderEventRemoteDispatcher.java
@@ -32,8 +32,11 @@ import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.client.ServerConnectivityException;
 import org.apache.geode.cache.client.ServerOperationException;
 import org.apache.geode.cache.client.internal.Connection;
+import org.apache.geode.cache.client.internal.ExecutablePool;
 import org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException;
+import org.apache.geode.cache.wan.GatewayQueueEvent;
 import org.apache.geode.cache.wan.GatewaySender;
+import org.apache.geode.cache.wan.internal.client.locator.GatewaySenderBatchOp;
 import org.apache.geode.cache.wan.internal.client.locator.SenderProxy;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.distributed.internal.ServerLocationAndMemberId;
@@ -976,6 +979,23 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
       return t instanceof IOException
           || t instanceof ConnectionDestroyedException
           || t instanceof GemFireSecurityException;
+    }
+  }
+
+  @Override
+  public void sendBatch(List<GatewayQueueEvent> events, Connection connection,
+      ExecutablePool senderPool, int batchId, boolean removeFromQueueOnException)
+      throws BatchException70 {
+    GatewaySenderBatchOp.executeOn(connection, senderPool, events, batchId,
+        removeFromQueueOnException, false);
+    GatewaySenderEventRemoteDispatcher.GatewayAck ack =
+        (GatewaySenderEventRemoteDispatcher.GatewayAck) GatewaySenderBatchOp.executeOn(connection,
+            senderPool);
+    if (ack == null) {
+      throw new BatchException70("Unknown error sending batch", null, 0, batchId);
+    }
+    if (ack.getBatchException() != null) {
+      throw ack.getBatchException();
     }
   }
 }

--- a/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderEventRemoteDispatcher.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderEventRemoteDispatcher.java
@@ -983,7 +983,7 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
   }
 
   @Override
-  public void sendBatch(List<GatewayQueueEvent> events, Connection connection,
+  public void sendBatch(List<GatewayQueueEvent<?, ?>> events, Connection connection,
       ExecutablePool senderPool, int batchId, boolean removeFromQueueOnException)
       throws BatchException70 {
     GatewaySenderBatchOp.executeOn(connection, senderPool, events, batchId,

--- a/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/client/locator/GatewaySenderBatchOp.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/client/locator/GatewaySenderBatchOp.java
@@ -95,10 +95,12 @@ public class GatewaySenderBatchOp {
           byte posDupByte = (byte) (event.getPossibleDuplicate() ? 0x01 : 0x00);
           getMessage().addBytesPart(new byte[] {posDupByte});
         }
-        if (action >= 0 && action <= 3) {
+        if (action >= 0 && action <= GatewaySenderEventImpl.UPDATE_ACTION_NO_GENERATE_CALLBACKS) {
           // 0 = create
           // 1 = update
           // 2 = destroy
+          // 3 = update timestamp
+          // 4 = update passing generatecallbacks
           String regionName = event.getRegionPath();
           EventID eventId = event.getEventId();
           Object key = event.getKey();
@@ -110,7 +112,7 @@ public class GatewaySenderBatchOp {
           getMessage().addObjPart(eventId);
           // Add key
           getMessage().addStringOrObjPart(key);
-          if (action < 2 /* it is 0 or 1 */) {
+          if (action < 2 || action == GatewaySenderEventImpl.UPDATE_ACTION_NO_GENERATE_CALLBACKS) {
             byte[] value = event.getSerializedValue();
             byte valueIsObject = event.getValueIsObject();;
             // Add value (which is already a serialized byte[])


### PR DESCRIPTION
The command has been implemented as proposed in
https://cwiki.apache.org/confluence/display/GEODE/Geode+Command+to+replicate+region+data+from+one+site+to+another+connected+via+WAN
with some modifications with respect to the initial proposal.

The command will get the entries of a region
in a WAN site and will put them in batches
that will be sent by a gateway sender to a remote
WAN site.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
