### PR TITLE
GEODE-9371: Change stress-new-test to non-required

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -39,7 +39,6 @@ github:
         contexts:
           - concourse-ci/api-check-test-openjdk11
           - concourse-ci/build
-          - concourse-ci/stress-new-test-openjdk11
           - concourse-ci/unit-test-openjdk11
           - concourse-ci/unit-test-openjdk8
 


### PR DESCRIPTION
Discussion on dev-list decided to change stress-new-test-openjdk11 from required to non-required.