### PR TITLE
GEODE-9295: Reply sent always  while processing LatestLastAccessTimeM…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessageDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessageDistributedTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
+import org.apache.geode.distributed.internal.DistributionManager;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+public class LatestLastAccessTimeMessageDistributedTest implements Serializable {
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Test
+  public void testSendLatestLastAccessTimeMessageToMemberWithNoRegion() {
+    // Start Locator
+    MemberVM locator = cluster.startLocatorVM(0);
+
+    // Start servers
+    int locatorPort = locator.getPort();
+    MemberVM server1 =
+        cluster.startServerVM(1, s -> s.withConnectionToLocator(locatorPort).withRegion(
+            RegionShortcut.PARTITION_REDUNDANT, testName.getMethodName()));
+    cluster.startServerVM(2, s -> s.withConnectionToLocator(locatorPort));
+
+    // Assign buckets to create the BucketRegions
+    server1.invoke(this::assignBucketsToPartitions);
+
+    // Send LastAccessTimeMessage from server1 to server2
+    server1.invoke(this::sendLastAccessTimeMessage);
+  }
+
+  private void assignBucketsToPartitions() {
+    Cache cache = Objects.requireNonNull(ClusterStartupRule.getCache());
+    PartitionedRegion pr = (PartitionedRegion) cache.getRegion(testName.getMethodName());
+    PartitionRegionHelper.assignBucketsToPartitions(pr);
+  }
+
+  private void sendLastAccessTimeMessage() throws InterruptedException {
+    // Get a BucketRegion
+    Cache cache = Objects.requireNonNull(ClusterStartupRule.getCache());
+    PartitionedRegion pr = (PartitionedRegion) cache.getRegion(testName.getMethodName());
+    BucketRegion br = pr.getBucketRegion(0);
+
+    // Get the recipients
+    DistributionManager dm = br.getDistributionManager();
+    Set<InternalDistributedMember> recipients = dm.getOtherNormalDistributionManagerIds();
+
+    // Create and sent the LatestLastAccessTimeMessage
+    LatestLastAccessTimeReplyProcessor replyProcessor =
+        new LatestLastAccessTimeReplyProcessor(dm, recipients);
+    dm.putOutgoing(new LatestLastAccessTimeMessage<>(replyProcessor, recipients, br, (Object) 0));
+
+    // Wait for the reply. Timeout if no reply is received.
+    boolean success = replyProcessor.waitForReplies(getTimeout().toMillis());
+
+    // Assert the wait was successful
+    assertThat(success).isTrue();
+
+    // Assert the latest last accessed time is 0
+    assertThat(replyProcessor.getLatestLastAccessTime()).isEqualTo(0L);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessageTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/LatestLastAccessTimeMessageTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -74,6 +75,16 @@ public class LatestLastAccessTimeMessageTest {
 
     lastAccessTimeMessage.process(dm);
 
+    verify(lastAccessTimeMessage).sendReply(dm, 0);
+  }
+
+  @Test
+  public void replyIsSentEvenIfThereIsAnException() {
+    setupMessage();
+    when(dm.getCache()).thenThrow(new RuntimeException());
+    assertThatThrownBy(() -> {
+      lastAccessTimeMessage.process(dm);
+    }).isExactlyInstanceOf(RuntimeException.class);
     verify(lastAccessTimeMessage).sendReply(dm, 0);
   }
 


### PR DESCRIPTION
…essage

	* Even if there any any exception, a reply will be sent back to the sender so that the sender's threads are not stuck.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
