### PR TITLE
GEODE-9380: Replace sleep()s from Nio.SslEngine replace with yields

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioSslEngine.java
@@ -89,8 +89,7 @@ public class NioSslEngine implements NioFilter {
    * state. It may throw other IOExceptions caused by I/O operations
    */
   public boolean handshake(SocketChannel socketChannel, int timeout,
-      ByteBuffer peerNetData)
-      throws IOException, InterruptedException {
+      ByteBuffer peerNetData) throws IOException {
 
     if (peerNetData.capacity() < engine.getSession().getPacketBufferSize()) {
       throw new IllegalArgumentException(String.format("Provided buffer is too small to perform "
@@ -152,7 +151,7 @@ public class NioSslEngine implements NioFilter {
             // if we're not finished, there's nothing to process and no data was read let's hang out
             // for a little
             if (peerAppData.remaining() == 0 && dataRead == 0 && status == NEED_UNWRAP) {
-              Thread.sleep(10);
+              Thread.yield();
             }
 
             if (engineResult.getStatus() == BUFFER_OVERFLOW) {
@@ -203,7 +202,7 @@ public class NioSslEngine implements NioFilter {
           logger.info("handshake terminated with illegal state due to {}", status);
           throw new IllegalStateException("Unknown SSL Handshake state: " + status);
       }
-      Thread.sleep(10);
+      Thread.yield();
     }
     if (status != FINISHED) {
       logger.info("handshake terminated with exception due to {}", status);

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -443,11 +443,6 @@ public class SocketCreator extends TcpSocketCreatorImpl {
       }
       logger.warn("SSL handshake exception", e);
       throw e;
-    } catch (InterruptedException e) {
-      if (!socketChannel.socket().isClosed()) {
-        socketChannel.close();
-      }
-      throw new IOException("SSL handshake interrupted");
     } finally {
       if (blocking) {
         try {


### PR DESCRIPTION
We noticed a 4-5x increase in the worst-case P2P send latency (most notably sendReplication) in 1.12 vs 1.8. Further analysis showed that the increase in sendReplicationTime is related to how long it takes to create the sender connection. More specifically, all the time spent creating the sender is in the handshake. Experiments with various sleep durations in NioSslEngine.handshake() method showed that this issue can be fixed by replacing both sleeps handshake() method with Thread.yield() calls.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
