### PR TITLE
[GEODE-9386] Fix windows builder cleanup

### DIFF
--- a/ci/images/google-windows-geode-builder/packer.json
+++ b/ci/images/google-windows-geode-builder/packer.json
@@ -135,6 +135,9 @@
         "ps -Name java -ErrorAction ignore",
 
         "write-output '>>>>>>>>>> Final cleanup <<<<<<<<<<'",
+        "pushd geode",
+        ".\\gradlew.bat --no-daemon clean",
+        "popd",
         "rm -force -recurse geode"
       ]
     },


### PR DESCRIPTION
* Do './gradlew.bat clean' before C:/geode.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
