### PR TITLE
GEODE-9293: Add cause of error to GemFireIOException messages

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/GemFireIOException.java
+++ b/geode-core/src/main/java/org/apache/geode/GemFireIOException.java
@@ -30,7 +30,9 @@ public class GemFireIOException extends GemFireException {
    * Creates a new <code>GemFireIOException</code>.
    */
   public GemFireIOException(String message, Throwable cause) {
-    super(message, cause);
+    super(message
+        + ((cause != null && cause.getMessage() != null) ? " ( " + cause.getMessage() + " )" : ""),
+        cause);
   }
 
   public GemFireIOException(String message) {

--- a/geode-core/src/test/java/org/apache/geode/GemFireIOExceptionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/GemFireIOExceptionTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+
+import org.junit.Test;
+
+public class GemFireIOExceptionTest {
+
+  @Test
+  public void testExceptionMessageDoesNotIncludeCauseMessageIfCauseIsNull() {
+    GemFireIOException ioe = new GemFireIOException("Dummy GemFireIOException", null);
+
+    assertThat(ioe.getMessage()).isEqualTo("Dummy GemFireIOException");
+  }
+
+  @Test
+  public void testExceptionMessageDoesNotIncludeCauseMessageIfCauseMessageIsNull() {
+    GemFireIOException ioe = new GemFireIOException("Dummy GemFireIOException", new IOException());
+
+    assertThat(ioe.getMessage()).isEqualTo("Dummy GemFireIOException");
+  }
+
+  @Test
+  public void testExceptionMessageIncludesCauseMessage() {
+    GemFireIOException ioe =
+        new GemFireIOException("Dummy GemFireIOException", new IOException("Dummy IOException"));
+
+    assertThat(ioe.getMessage()).isEqualTo("Dummy GemFireIOException ( Dummy IOException )");
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/GemFireCacheImplTest.java
@@ -173,7 +173,7 @@ public class GemFireCacheImplTest {
 
     assertThat(thrown)
         .isInstanceOf(SerializationException.class)
-        .hasMessage("Serialization failed")
+        .hasMessage("Serialization failed ( java.lang.Object )")
         .hasCauseInstanceOf(NotSerializableException.class);
   }
 


### PR DESCRIPTION
**AS A** geode user
**I WANT TO** have more information when an IO exception occurs
**SO THAT** I can understand and fix the root cause of the problem

`GemFireIOException` is used to encapsulate a given `IOException` that happen in the Geode code.
For creating a `GemFireIOException` when a `IOException` is catched, this constructor is used:

```
public GemFireIOException(String message, Throwable cause)  {
    super(message, cause);
}
```

The problem is that the `IOException` message is not part of the `GemFireIOException` message. So when a `GemFireIOException` is logged, the root cause of the problem is not shown.

For example, the following message log message:

```
"Cache initialization for GemFireCache[id = 1081136680; isClosing = false; isShutDownAll = false; created = Fri Jun 19 11:42:29 UTC 2020; server = false; copyOnRead = false; lockLease = 120; lockTimeout = 60] failed because: org.apache.geode.GemFireIOException: While starting cache server CacheServer on port=40404 client subscription config policy=none client subscription config capacity=1 client subscription config overflow directory=."
```

It was logged at `GemFireCacheImpl`:

```
logger.error("Cache initialization for " + toString() + " failed because:", throwable);
```

And the `GemFireIOException` was created in `CacheCreation` in this way:

```
} catch (IOException ex) {
     throw new GemFireIOException(format("While starting cache server %s", impl), ex);
}
```

This PR adds the wrapped exception message to the `GemFireIOException` exception message, so when the exception is catched and logged, the root cause will be known at first sight.