### PR TITLE
GEODE-8282: Improve disk-store dir sizes constraints handling in gfsh

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -774,6 +774,12 @@ public class CliStrings {
       "Critical percentage for disk volume usage.";
   public static final String CREATE_DISK_STORE__ERROR_WHILE_CREATING_REASON_0 =
       "An error occurred while creating the disk store: \"{0}\"";
+  public static final String CREATE_DISK_STORE__DIR_SIZE_TOO_BIG_ERROR =
+      "Directory size (%s) is over the maximum allowed value.";
+  public static final String CREATE_DISK_STORE__DIR_SIZE_IS_NEGATIVE =
+      "Directory size cannot be negative (%s)";
+  public static final String CREATE_DISK_STORE__DIR_SIZE_NOT_A_NUMBER =
+      "Incorrect directory size specified (%s)";
 
   /* create index */
   public static final String CREATE_INDEX = "create index";

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -286,7 +286,7 @@ create disk-store --name=value --dir=value(,value)* [--allow-force-compaction(=v
 <pre class="pre codeblock"><code>--dir=/data/ds1 
 --dir=/data/ds2#5000</code></pre>
 If the specified directory does not exist, the command will create the directory for you.</td>
-<td> </td>
+<td>If the maximum directory size in megabytes is not specified, it will be set to `2147483647` (the value of `Integer.MAX_VALUE`)</td>
 </tr>
 <tr>
 <td><span class="keyword parmname">\-\-allow-force-compaction</span></td>

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateDiskStoreCommand.java
@@ -15,6 +15,10 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static org.apache.geode.management.internal.i18n.CliStrings.CREATE_DISK_STORE__DIR_SIZE_IS_NEGATIVE;
+import static org.apache.geode.management.internal.i18n.CliStrings.CREATE_DISK_STORE__DIR_SIZE_NOT_A_NUMBER;
+import static org.apache.geode.management.internal.i18n.CliStrings.CREATE_DISK_STORE__DIR_SIZE_TOO_BIG_ERROR;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -110,7 +114,9 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
         sizes[i] = Integer.MAX_VALUE;
       } else {
         directories[i] = new File(directoriesAndSizes[i].substring(0, hashPosition));
-        sizes[i] = Integer.parseInt(directoriesAndSizes[i].substring(hashPosition + 1));
+        String dirSizeString = directoriesAndSizes[i].substring(hashPosition + 1);
+        verifyDirSizeConstraints(dirSizeString);
+        sizes[i] = Integer.parseInt(dirSizeString);
       }
     }
     diskStoreAttributes.diskDirs = directories;
@@ -143,6 +149,25 @@ public class CreateDiskStoreCommand extends SingleGfshCommand {
     }
 
     return result;
+  }
+
+  @VisibleForTesting
+  void verifyDirSizeConstraints(String dirSize) {
+    long dirSizeLongValue;
+    try {
+      dirSizeLongValue = Long.parseLong(dirSize);
+    } catch (NumberFormatException exc) {
+      throw new IllegalArgumentException(
+          String.format(CREATE_DISK_STORE__DIR_SIZE_NOT_A_NUMBER, dirSize));
+    }
+    if (dirSizeLongValue > Long.valueOf(Integer.MAX_VALUE)) {
+      throw new IllegalArgumentException(
+          String.format(CREATE_DISK_STORE__DIR_SIZE_TOO_BIG_ERROR, dirSize));
+    }
+    if (dirSizeLongValue < 0) {
+      throw new IllegalArgumentException(
+          String.format(CREATE_DISK_STORE__DIR_SIZE_IS_NEGATIVE, dirSize));
+    }
   }
 
   @VisibleForTesting


### PR DESCRIPTION
`gfsh` handling of wrong disk store directories sizes can be improved. This is the output when trying to use wrong values:

Negative size:
```
gfsh>create disk-store --name=storage --dir=dataStore#-100
 Member   | Status | Message
--------- | ------ | -----------------------------------------------------------------------
theServer | ERROR  |  java.lang.IllegalArgumentException: Dir size cannot be negative : -100

Did not complete waiting for Disk Store MBean proxy creation
```

Using a wrong number string:
```
gfsh>create disk-store --name=storage --dir=dataStore#123ABC
For input string: "123ABC"
```

Using a value bigger than the maximum allowed value which is `2147483647` (`Integer.MAX_VALUE`):
```
gfsh>create disk-store --name=storage --dir=dataStore#2147483648
For input string: "2147483648"
```

This PR improves the user experience in this cases: the user gets a better error message in the case of wrong number strings and values bigger than the maximum, and it fails faster in case of negative values:

```
gfsh>create disk-store --name=storage --dir=dataStore#-100
Directory size cannot be negative (-100)

gfsh>create disk-store --name=storage --dir=dataStore#2147483648
Directory size (2147483648) is over the maximum allowed value.

gfsh>create disk-store --name=storage --dir=dataStore#123ABC
Incorrect directory size specified (123ABC)
```


