### PR TITLE
GEODE-9400: Do not use Coder conversion methods in tests

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/ClusterNodes.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/ClusterNodes.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.redis;
 
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -42,9 +41,9 @@ public class ClusterNodes {
       long slotEnd = (long) firstLevel.get(1);
 
       List<Object> primary = (List<Object>) firstLevel.get(2);
-      String primaryIp = bytesToString((byte[]) primary.get(0));
+      String primaryIp = new String((byte[]) primary.get(0));
       long primaryPort = (long) primary.get(1);
-      String primaryGUID = primary.size() > 2 ? bytesToString((byte[]) primary.get(2)) : "";
+      String primaryGUID = primary.size() > 2 ? new String((byte[]) primary.get(2)) : "";
 
       result.addSlot(primaryGUID, primaryIp, primaryPort, slotStart, slotEnd);
     }

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/RenameDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/RenameDUnitTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.redis.internal.executor.key;
 
 
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -120,7 +119,7 @@ public class RenameDUnitTest {
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {
     Random random = new Random();
     String key1 = "{rename}keyz" + random.nextInt();
-    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
+    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     Set<String> keys = new HashSet<>();
     keys.add(key1);
@@ -128,7 +127,7 @@ public class RenameDUnitTest {
     do {
       String key2 = "{rename}key" + random.nextInt();
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(stringToBytes(key2))) == 0) {
+          new RedisKey(key2.getBytes())) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZAddIncrOptionDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZAddIncrOptionDUnitTest.java
@@ -42,7 +42,6 @@ import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
@@ -101,11 +100,11 @@ public class ZAddIncrOptionDUnitTest {
   private void doZAddIncr(int i, double increment, double total, boolean isConcurrentExecution) {
     Object result =
         jedis.sendCommand(sortedSetKey, Protocol.Command.ZADD, sortedSetKey, "INCR",
-            Coder.doubleToString(increment), baseMemberName + i);
+            String.valueOf(increment), baseMemberName + i);
     if (isConcurrentExecution) {
-      assertThat(Coder.bytesToDouble((byte[]) result)).isIn(increment, total);
+      assertThat(Double.parseDouble(new String((byte[]) result))).isIn(increment, total);
     } else {
-      assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(total);
+      assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(total);
     }
   }
 
@@ -193,7 +192,7 @@ public class ZAddIncrOptionDUnitTest {
   }
 
   private static boolean isPrimaryForKey() {
-    int bucketId = getBucketId(new RedisKey(Coder.stringToBytes(sortedSetKey)));
+    int bucketId = getBucketId(new RedisKey(sortedSetKey.getBytes()));
     return isPrimaryForBucket(bucketId);
   }
 

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemDUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -221,7 +220,7 @@ public class ZRemDUnitTest {
   }
 
   private static boolean isPrimaryForKey() {
-    int bucketId = getBucketId(new RedisKey(stringToBytes(sortedSetKey)));
+    int bucketId = getBucketId(new RedisKey(sortedSetKey.getBytes()));
     return isPrimaryForBucket(bucketId);
   }
 

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.session;
 
 
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.net.HttpCookie;
 import java.time.Duration;
@@ -255,7 +254,7 @@ public abstract class SessionDUnitTest {
   protected String getSessionId(String sessionCookie) {
     List<HttpCookie> cookies = HttpCookie.parse(sessionCookie);
     byte[] decodedCookie = Base64.getDecoder().decode(cookies.get(0).getValue());
-    return bytesToString(decodedCookie);
+    return new String(decodedCookie);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.redis.session;
 
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -166,7 +165,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
       return 0;
     }
     ObjectInputStream inputStream;
-    byte[] bytes = redisHash.hget(stringToBytes("maxInactiveInterval"));
+    byte[] bytes = redisHash.hget("maxInactiveInterval".getBytes());
     ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
     try {
       inputStream = new ObjectInputStream(byteStream);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
@@ -15,9 +15,6 @@
 
 package org.apache.geode.redis;
 
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-import static org.apache.geode.redis.internal.netty.Coder.intToBytes;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.function.BiFunction;
@@ -35,7 +32,7 @@ public class RedisCommandArgumentsTestHelper {
   public static void assertExactNumberOfArgs(JedisCluster jedis,
       Protocol.Command command, int numArgs) {
     assertExactNumberOfArgs0(
-        (cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args), command,
+        (cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args), command,
         numArgs);
   }
 
@@ -59,7 +56,7 @@ public class RedisCommandArgumentsTestHelper {
 
   public static void assertAtLeastNArgs(JedisCluster jedis, Protocol.Command command,
       int minNumArgs) {
-    assertAtLeastNArgs0((cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args),
+    assertAtLeastNArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args),
         command,
         minNumArgs);
   }
@@ -87,7 +84,7 @@ public class RedisCommandArgumentsTestHelper {
 
   public static void assertAtMostNArgs(JedisCluster jedis, Protocol.Command command,
       int maxNumArgs) {
-    assertAtMostNArgs0((cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args),
+    assertAtMostNArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args),
         command,
         maxNumArgs);
   }
@@ -112,7 +109,7 @@ public class RedisCommandArgumentsTestHelper {
 
       assertThatThrownBy(() -> runMe.apply(command, args))
           .hasMessageContaining("ERR Unknown subcommand or wrong number of arguments for '"
-              + bytesToString(firstParameter));
+              + new String(firstParameter));
     }
   }
 
@@ -124,7 +121,7 @@ public class RedisCommandArgumentsTestHelper {
     }
 
     for (int i = 0; i < numArgs; i++) {
-      args[i] = intToBytes(i);
+      args[i] = String.valueOf(i).getBytes();
     }
 
     return args;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.redis.internal.executor;
 
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.After;
@@ -45,13 +44,13 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
 
   @Test
   public void givenUnknownCommand_returnsUnknownCommandError() {
-    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("fhqwhgads")))
+    assertThatThrownBy(() -> jedis.sendCommand(() -> "fhqwhgads".getBytes()))
         .hasMessage("ERR unknown command `fhqwhgads`, with args beginning with: ");
   }
 
   @Test
   public void givenUnknownCommand_withArguments_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("fhqwhgads"), "EVERYBODY",
+    assertThatThrownBy(() -> jedis.sendCommand(() -> "fhqwhgads".getBytes(), "EVERYBODY",
         "TO THE LIMIT"))
             .hasMessage(
                 "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, `TO THE LIMIT`, ");
@@ -60,21 +59,21 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
   @Test
   public void givenUnknownCommand_withEmptyStringArgument_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand(() -> stringToBytes("fhqwhgads"), "EVERYBODY", ""))
+        () -> jedis.sendCommand(() -> "fhqwhgads".getBytes(), "EVERYBODY", ""))
             .hasMessage(
                 "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, ``, ");
   }
 
   @Test // HELLO is not a recognized command until Redis 6.0.0
   public void givenHelloCommand_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("HELLO")))
+    assertThatThrownBy(() -> jedis.sendCommand(() -> "HELLO".getBytes()))
         .hasMessage("ERR unknown command `HELLO`, with args beginning with: ");
   }
 
   @Test
   public void givenInternalSMembersCommand_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand(() -> stringToBytes("INTERNALSMEMBERS"), "something",
+        () -> jedis.sendCommand(() -> "INTERNALSMEMBERS".getBytes(), "something",
             "somethingElse"))
                 .hasMessage(
                     "ERR unknown command `INTERNALSMEMBERS`, with args beginning with: `something`, `somethingElse`, ");
@@ -83,7 +82,7 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
   @Test
   public void givenInternalPTTLCommand_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand(() -> stringToBytes("INTERNALPTTL"), "something"))
+        () -> jedis.sendCommand(() -> "INTERNALPTTL".getBytes(), "something"))
             .hasMessage(
                 "ERR unknown command `INTERNALPTTL`, with args beginning with: `something`, ");
   }
@@ -91,7 +90,7 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
   @Test
   public void givenInternalTypeCommand_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand(() -> stringToBytes("INTERNALTYPE"), "something"))
+        () -> jedis.sendCommand(() -> "INTERNALTYPE".getBytes(), "something"))
             .hasMessage(
                 "ERR unknown command `INTERNALTYPE`, with args beginning with: `something`, ");
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -20,8 +20,6 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -232,7 +230,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     scanParams.match("\\p");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
-        jedis.hscan(stringToBytes("a"), stringToBytes("0"), scanParams);
+        jedis.hscan("a".getBytes(), "0".getBytes(), scanParams);
 
     assertThat(result.getResult()).isEmpty();
   }
@@ -287,10 +285,10 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
           "COUNT", "1");
 
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = bytesToString((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
   }
 
   @Test
@@ -308,7 +306,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.hscan(stringToBytes("colors"), stringToBytes(cursor), scanParams);
+      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
@@ -319,17 +317,17 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   @Test
   public void givenMatch_returnsAllMatchingEntries() {
     Map<byte[], byte[]> entryMap = new HashMap<>();
-    byte[] field3 = stringToBytes("3");
-    entryMap.put(stringToBytes("1"), stringToBytes("yellow"));
-    entryMap.put(stringToBytes("12"), stringToBytes("green"));
-    entryMap.put(field3, stringToBytes("grey"));
-    jedis.hmset(stringToBytes("colors"), entryMap);
+    byte[] field3 = "3".getBytes();
+    entryMap.put("1".getBytes(), "yellow".getBytes());
+    entryMap.put("12".getBytes(), "green".getBytes());
+    entryMap.put(field3, "grey".getBytes());
+    jedis.hmset("colors".getBytes(), entryMap);
 
     ScanParams scanParams = new ScanParams();
     scanParams.match("1*");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
-        jedis.hscan(stringToBytes("colors"), stringToBytes("0"), scanParams);
+        jedis.hscan("colors".getBytes(), "0".getBytes(), scanParams);
 
     entryMap.remove(field3);
     assertThat(result.isCompleteIteration()).isTrue();
@@ -357,25 +355,25 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hmset("colors", entryMap);
 
     List<Object> result =
-        (List<Object>) jedis.sendCommand(stringToBytes("colors"), Protocol.Command.HSCAN,
-            stringToBytes("colors"), stringToBytes("0"), stringToBytes("MATCH"),
-            stringToBytes("3*"),
-            stringToBytes("MATCH"), stringToBytes("1*"));
+        (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
+            "colors".getBytes(), "0".getBytes(), "MATCH".getBytes(),
+            "3*".getBytes(),
+            "MATCH".getBytes(), "1*".getBytes());
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
     assertThat((List<Object>) result.get(1)).containsAll(
-        Arrays.asList(stringToBytes("1"), stringToBytes("yellow"),
-            stringToBytes("12"), stringToBytes("green")));
+        Arrays.asList("1".getBytes(), "yellow".getBytes(),
+            "12".getBytes(), "green".getBytes()));
   }
 
   @Test
   public void givenMatchAndCount_returnsAllMatchingKeys() {
     Map<byte[], byte[]> entryMap = new HashMap<>();
-    byte[] field3 = stringToBytes("3");
-    entryMap.put(stringToBytes("1"), stringToBytes("yellow"));
-    entryMap.put(stringToBytes("12"), stringToBytes("green"));
-    entryMap.put(field3, stringToBytes("orange"));
-    jedis.hmset(stringToBytes("colors"), entryMap);
+    byte[] field3 = "3".getBytes();
+    entryMap.put("1".getBytes(), "yellow".getBytes());
+    entryMap.put("12".getBytes(), "green".getBytes());
+    entryMap.put(field3, "orange".getBytes());
+    jedis.hmset("colors".getBytes(), entryMap);
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
@@ -385,7 +383,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.hscan(stringToBytes("colors"), stringToBytes(cursor), scanParams);
+      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
@@ -412,21 +410,21 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     do {
       result =
-          (List<Object>) jedis.sendCommand(stringToBytes("colors"), Protocol.Command.HSCAN,
-              stringToBytes("colors"), stringToBytes(cursor),
-              stringToBytes("COUNT"), stringToBytes("37"),
-              stringToBytes("MATCH"), stringToBytes("3*"), stringToBytes("COUNT"),
-              stringToBytes("2"),
-              stringToBytes("COUNT"), stringToBytes("1"), stringToBytes("MATCH"),
-              stringToBytes("1*"));
+          (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
+              "colors".getBytes(), cursor.getBytes(),
+              "COUNT".getBytes(), "37".getBytes(),
+              "MATCH".getBytes(), "3*".getBytes(), "COUNT".getBytes(),
+              "2".getBytes(),
+              "COUNT".getBytes(), "1".getBytes(), "MATCH".getBytes(),
+              "1*".getBytes());
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = bytesToString((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
-    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
-        stringToBytes("yellow"),
-        stringToBytes("12"), stringToBytes("green"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(),
+        "yellow".getBytes(),
+        "12".getBytes(), "green".getBytes());
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -887,8 +886,8 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
       blob[i] = (byte) i;
     }
 
-    jedis.hset(stringToBytes("key"), blob, blob);
-    Map<byte[], byte[]> result = jedis.hgetAll(stringToBytes("key"));
+    jedis.hset("key".getBytes(), blob, blob);
+    Map<byte[], byte[]> result = jedis.hgetAll("key".getBytes());
 
     assertThat(result.keySet()).containsExactly(blob);
     assertThat(result.values()).containsExactly(blob);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHincrByFloatIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHincrByFloatIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.hash;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.offset;
@@ -113,13 +112,13 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
     String field = "field";
 
     Object response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "1.23");
-    assertThat(bytesToString((byte[]) response)).isEqualTo("1.23");
+    assertThat(new String((byte[]) response)).isEqualTo("1.23");
 
     response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "0.77");
-    assertThat(bytesToString((byte[]) response)).isEqualTo("2");
+    assertThat(new String((byte[]) response)).isEqualTo("2");
 
     response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "-0.1");
-    assertThat(bytesToString((byte[]) response)).isEqualTo("1.9");
+    assertThat(new String((byte[]) response)).isEqualTo("1.9");
   }
 
   @Test
@@ -150,7 +149,7 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
     // Beyond this, native redis produces inconsistent results.
     Object rawResult =
         jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "1");
-    BigDecimal result = new BigDecimal(bytesToString((byte[]) rawResult));
+    BigDecimal result = new BigDecimal(new String((byte[]) rawResult));
 
     assertThat(result.toPlainString()).isEqualTo(biggy.add(BigDecimal.ONE).toPlainString());
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractDelIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractDelIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -110,7 +109,7 @@ public abstract class AbstractDelIntegrationTest implements RedisIntegrationTest
   public void testDel_withBinaryKey() {
     byte[] key = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    jedis.set(key, stringToBytes("foo"));
+    jedis.set(key, "foo".getBytes());
     jedis.del(key);
 
     assertThat(jedis.get(key)).isNull();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
@@ -94,7 +93,7 @@ public abstract class AbstractKeysIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenBinaryValue_withExactMatch_preservesBinaryData() {
     String chineseHashTag = "{子}";
-    byte[] utf8encodedBytes = stringToBytes(chineseHashTag);
+    byte[] utf8encodedBytes = chineseHashTag.getBytes();
     byte[] stringKey =
         new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'};
     byte[] allByteArray = new byte[utf8encodedBytes.length + stringKey.length];
@@ -105,7 +104,7 @@ public abstract class AbstractKeysIntegrationTest implements RedisIntegrationTes
     byte[] combined = buff.array();
 
     jedis.set(combined, combined);
-    assertThat(jedis.keys(stringToBytes("{子}*")))
+    assertThat(jedis.keys("{子}*".getBytes()))
         .containsExactlyInAnyOrder(combined);
   }
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractRenameIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractRenameIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -238,7 +237,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   private List<String> getKeysOnDifferentStripes() {
     String key1 = "{user1}keyz" + new Random().nextInt();
 
-    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
+    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     int iterator = 0;
     String key2;
@@ -246,7 +245,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
       key2 = "{user1}key" + iterator;
       iterator++;
     } while (stripedExecutor.compareStripes(key1RedisKey,
-        new RedisKey(stringToBytes(key2))) == 0);
+        new RedisKey(key2.getBytes())) == 0);
 
     return Arrays.asList(key1, key2);
   }
@@ -254,7 +253,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {
     Random random = new Random();
     String key1 = "{user1}keyz" + random.nextInt();
-    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
+    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     Set<String> keys = new HashSet<>();
     keys.add(key1);
@@ -262,7 +261,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     do {
       String key2 = "{user1}key" + random.nextInt();
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(stringToBytes(key2))) == 0) {
+          new RedisKey(key2.getBytes())) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);
@@ -320,14 +319,14 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     RedisKey key1RedisKey;
     do {
       key1 = "{user1}keyz" + new Random().nextInt();
-      key1RedisKey = new RedisKey(stringToBytes(key1));
+      key1RedisKey = new RedisKey(key1.getBytes());
     } while (stripedExecutor.compareStripes(key1RedisKey, toAvoid) == 0 && keys.add(key1));
 
     do {
       String key2 = "{user1}key" + new Random().nextInt();
 
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(stringToBytes(key2))) == 0) {
+          new RedisKey(key2.getBytes())) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractScanIntegrationTest.java
@@ -18,8 +18,6 @@ package org.apache.geode.redis.internal.executor.key;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -178,12 +176,12 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
           (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, cursor, "COUNT", "2",
               "COUNT", "1");
       allKeysFromScan.addAll((List<byte[]>) result.get(1));
-      cursor = bytesToString((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder(stringToBytes("{user1}a"),
-        stringToBytes("{user1}b"), stringToBytes("{user1}c"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a".getBytes(),
+        "{user1}b".getBytes(), "{user1}c".getBytes());
   }
 
   @Test
@@ -211,8 +209,8 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
         (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, "0", "MATCH", "{user1}b*",
             "MATCH", "{user1}a*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
-    assertThat((List<byte[]>) result.get(1)).containsExactly(stringToBytes("{user1}a"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((List<byte[]>) result.get(1)).containsExactly("{user1}a".getBytes());
   }
 
   @Test
@@ -254,12 +252,12 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
           (List<Object>) jedis.sendCommand("{user1}", Protocol.Command.SCAN, cursor, "COUNT", "37",
               "MATCH", "{user1}b*", "COUNT", "2", "COUNT", "1", "MATCH", "{user1}a*");
       allKeysFromScan.addAll((List<byte[]>) result.get(1));
-      cursor = bytesToString((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder(stringToBytes("{user1}a"),
-        stringToBytes("{user1}aardvark"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a".getBytes(),
+        "{user1}aardvark".getBytes());
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractUnlinkIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractUnlinkIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -110,7 +109,7 @@ public abstract class AbstractUnlinkIntegrationTest implements RedisIntegrationT
   public void testUnlink_withBinaryKey() {
     byte[] key = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    jedis.set(key, stringToBytes("foo"));
+    jedis.set(key, "foo".getBytes());
     jedis.unlink(key);
 
     assertThat(jedis.get(key)).isNull();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import static org.apache.geode.redis.internal.executor.pubsub.AbstractSubscriptionsIntegrationTest.REDIS_CLIENT_TIMEOUT;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -78,7 +77,7 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
   @SuppressWarnings("unchecked")
   public void punsubscribe_whenNonexistent() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.PUNSUBSCRIBE, "Nonexistent"))
-        .containsExactly(stringToBytes("punsubscribe"), stringToBytes("Nonexistent"),
+        .containsExactly("punsubscribe".getBytes(), "Nonexistent".getBytes(),
             0L);
   }
 
@@ -86,14 +85,14 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
   @SuppressWarnings("unchecked")
   public void unsubscribe_whenNoSubscriptionsExist_shouldNotHang() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.UNSUBSCRIBE))
-        .containsExactly(stringToBytes("unsubscribe"), null, 0L);
+        .containsExactly("unsubscribe".getBytes(), null, 0L);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void punsubscribe_whenNoSubscriptionsExist_shouldNotHang() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.PUNSUBSCRIBE))
-        .containsExactly(stringToBytes("punsubscribe"), null, 0L);
+        .containsExactly("punsubscribe".getBytes(), null, 0L);
   }
 
   @Test
@@ -294,17 +293,17 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
     MockBinarySubscriber mockSubscriber = new MockBinarySubscriber();
 
     Runnable runnable = () -> {
-      subscriber.subscribe(mockSubscriber, stringToBytes("salutations"));
+      subscriber.subscribe(mockSubscriber, "salutations".getBytes());
     };
 
     Thread subscriberThread = new Thread(runnable);
     subscriberThread.start();
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
 
-    Long result = publisher.publish(stringToBytes("salutations"), expectedMessage);
+    Long result = publisher.publish("salutations".getBytes(), expectedMessage);
     assertThat(result).isEqualTo(1);
 
-    mockSubscriber.unsubscribe(stringToBytes("salutations"));
+    mockSubscriber.unsubscribe("salutations".getBytes());
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
     waitFor(() -> !subscriberThread.isAlive());
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubCommandsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubCommandsIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLea
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtMostNArgsForSubCommand;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_PUBSUB_SUBCOMMAND;
 import static org.apache.geode.redis.internal.executor.pubsub.AbstractSubscriptionsIntegrationTest.REDIS_CLIENT_TIMEOUT;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -93,15 +92,15 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   public void channels_shouldError_givenTooManyArguments() {
     assertAtMostNArgsForSubCommand(introspector,
         Protocol.Command.PUBSUB,
-        stringToBytes(PUBSUB_CHANNELS),
+        PUBSUB_CHANNELS.getBytes(),
         1);
   }
 
   @Test
   public void channels_shouldNotError_givenMixedCaseArguments() {
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add(stringToBytes("foo"));
-    expectedChannels.add(stringToBytes("bar"));
+    expectedChannels.add("foo".getBytes());
+    expectedChannels.add("bar".getBytes());
 
     executor.submit(() -> subscriber.subscribe(mockSubscriber, "foo", "bar"));
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
@@ -115,8 +114,8 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   @Test
   public void channels_shouldReturnListOfAllChannels_withActiveChannelSubscribers_whenCalledWithoutPattern() {
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add(stringToBytes("foo"));
-    expectedChannels.add(stringToBytes("bar"));
+    expectedChannels.add("foo".getBytes());
+    expectedChannels.add("bar".getBytes());
 
     executor.submit(() -> subscriber.subscribe(mockSubscriber, "foo", "bar"));
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
@@ -163,7 +162,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   @Test
   public void channels_shouldOnlyReturnChannelsWithActiveSubscribers() {
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add(stringToBytes("bar"));
+    expectedChannels.add("bar".getBytes());
 
     executor.submit(() -> subscriber.subscribe(mockSubscriber, "foo", "bar"));
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
@@ -182,7 +181,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
 
     MockSubscriber mockSubscriber2 = new MockSubscriber();
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add(stringToBytes("foo"));
+    expectedChannels.add("foo".getBytes());
 
     executor.submit(() -> subscriber.subscribe(mockSubscriber, "foo"));
     executor.submit(() -> subscriber2.subscribe(mockSubscriber2, "foo"));

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSPopIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSPopIntegrationTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.set;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -257,7 +256,7 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
 
       byte[] inputBuffer = new byte[1024];
       int n = redisSocket.getInputStream().read(inputBuffer);
-      String result = bytesToString(Arrays.copyOfRange(inputBuffer, 0, n));
+      String result = new String(Arrays.copyOfRange(inputBuffer, 0, n));
 
       assertThat(result).isEqualTo("$3\r\none\r\n");
     }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
@@ -18,8 +18,6 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -80,7 +78,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<Object> result =
         (List<Object>) jedis.sendCommand("key!", Protocol.Command.SSCAN, "key!", "0", "a*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
     assertThat((List<Object>) result.get(1)).isEmpty();
   }
 
@@ -201,14 +199,14 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<byte[]> allMembersFromScan = new ArrayList<>();
 
     do {
-      result = jedis.sscan(stringToBytes("a"), stringToBytes(cursor), scanParams);
+      result = jedis.sscan("a".getBytes(), cursor.getBytes(), scanParams);
       allMembersFromScan.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(allMembersFromScan).containsExactlyInAnyOrder(stringToBytes("1"),
-        stringToBytes("2"),
-        stringToBytes("3"));
+    assertThat(allMembersFromScan).containsExactlyInAnyOrder("1".getBytes(),
+        "2".getBytes(),
+        "3".getBytes());
   }
 
   @Test
@@ -226,13 +224,13 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
           (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", cursor, "COUNT", "2",
               "COUNT", "1");
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = bytesToString((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
-    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
-        stringToBytes("12"),
-        stringToBytes("3"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(),
+        "12".getBytes(),
+        "3".getBytes());
   }
 
   @Test
@@ -243,11 +241,11 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     scanParams.match("1*");
 
     ScanResult<byte[]> result =
-        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
+        jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
 
     assertThat(result.isCompleteIteration()).isTrue();
-    assertThat(result.getResult()).containsExactlyInAnyOrder(stringToBytes("1"),
-        stringToBytes("12"));
+    assertThat(result.getResult()).containsExactlyInAnyOrder("1".getBytes(),
+        "12".getBytes());
   }
 
   @Test
@@ -258,9 +256,9 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<Object> result = (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", "0",
         "MATCH", "3*", "MATCH", "1*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
-    assertThat((List<byte[]>) result.get(1)).containsExactlyInAnyOrder(stringToBytes("1"),
-        stringToBytes("12"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((List<byte[]>) result.get(1)).containsExactlyInAnyOrder("1".getBytes(),
+        "12".getBytes());
   }
 
   @Test
@@ -275,13 +273,13 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.sscan(stringToBytes("a"), stringToBytes(cursor), scanParams);
+      result = jedis.sscan("a".getBytes(), cursor.getBytes(), scanParams);
       allMembersFromScan.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(allMembersFromScan).containsExactlyInAnyOrder(stringToBytes("1"),
-        stringToBytes("12"));
+    assertThat(allMembersFromScan).containsExactlyInAnyOrder("1".getBytes(),
+        "12".getBytes());
   }
 
   @Test
@@ -298,12 +296,12 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
           (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", cursor, "COUNT", "37",
               "MATCH", "3*", "COUNT", "2", "COUNT", "1", "MATCH", "1*");
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = bytesToString((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
-    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
-        stringToBytes("12"));
+    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(),
+        "12".getBytes());
   }
 
   @Test
@@ -343,7 +341,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     scanParams.match("\\p");
 
     ScanResult<byte[]> result =
-        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
+        jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
 
     assertThat(result.getResult()).isEmpty();
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSetsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSetsIntegrationTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.set;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -119,8 +118,8 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
       blob[i] = (byte) i;
     }
 
-    jedis.sadd(stringToBytes("key"), blob, blob);
-    Set<byte[]> result = jedis.smembers(stringToBytes("key"));
+    jedis.sadd("key".getBytes(), blob, blob);
+    Set<byte[]> result = jedis.smembers("key".getBytes());
 
     assertThat(result).containsExactly(blob);
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
-import static org.apache.geode.redis.internal.netty.Coder.intToBytes;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -43,16 +41,16 @@ public class SScanIntegrationTest extends AbstractSScanIntegrationTest {
     List<byte[]> memberList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       jedis.sadd("a", String.valueOf(i));
-      memberList.add(intToBytes(i));
+      memberList.add(String.valueOf(i).getBytes());
     }
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(5);
     ScanResult<byte[]> result =
-        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
+        jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
     assertThat(result.isCompleteIteration()).isFalse();
 
-    result = jedis.sscan(stringToBytes("a"), stringToBytes("100"));
+    result = jedis.sscan("a".getBytes(), "100".getBytes());
 
     assertThat(result.getResult()).containsExactlyInAnyOrderElementsOf(memberList);
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZAddIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZAddIntegrationTest.java
@@ -45,7 +45,6 @@ import redis.clients.jedis.params.ZAddParams;
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;
-import org.apache.geode.redis.internal.netty.Coder;
 
 public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
@@ -360,16 +359,16 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     jedis.zadd(SORTED_SET_KEY, initial, member);
 
     Object result = jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, "XX",
-        incrOption, Coder.doubleToString(increment), member);
-    assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(expected);
+        incrOption, String.valueOf(increment), member);
+    assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(expected);
     assertThat(jedis.zscore(SORTED_SET_KEY, member)).isEqualTo(expected);
   }
 
   @Test
   public void zaddIncrOptionAddsANewMemberWithNXOption() {
     Object result = jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, "NX",
-        incrOption, Coder.doubleToString(increment), member);
-    assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(increment);
+        incrOption, String.valueOf(increment), member);
+    assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(increment);
 
     assertThat(jedis.zscore(SORTED_SET_KEY, member)).isEqualTo(increment);
   }
@@ -395,8 +394,8 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void zaddIncrOptionCanIncrementScoreForExistingMemberWithChangeOption() {
     jedis.zadd(SORTED_SET_KEY, initial, member);
     Object result = jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, "CH",
-        incrOption, Coder.doubleToString(increment), member);
-    assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(expected);
+        incrOption, String.valueOf(increment), member);
+    assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(expected);
 
     assertThat(jedis.zscore(SORTED_SET_KEY, member)).isEqualTo(expected);
   }
@@ -406,9 +405,9 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     jedis.zadd(SORTED_SET_KEY, initial, member);
     Object result =
         jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, incrOption,
-            Coder.doubleToString(increment), member);
+            String.valueOf(increment), member);
 
-    assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(expected);
+    assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(expected);
     result = jedis.zscore(SORTED_SET_KEY, member);
     assertThat(result).isEqualTo(expected);
   }
@@ -432,8 +431,8 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   private void doZAddIncr(int i, double increment, double total) {
     Object result =
         jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, incrOption,
-            Coder.doubleToString(increment), member + i);
-    assertThat(Coder.bytesToDouble((byte[]) result)).isIn(increment, total);
+            String.valueOf(increment), member + i);
+    assertThat(Double.parseDouble(new String((byte[]) result))).isIn(increment, total);
   }
 
   @Test
@@ -461,7 +460,7 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     }
     totalIncremented.addAndGet(increment);
     jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, incrOption,
-        Coder.doubleToString(increment), member);
+        String.valueOf(increment), member);
   }
 
   private double getValueWthPrecision(double value) {

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZIncrByIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZIncrByIntegrationTest.java
@@ -18,7 +18,6 @@ package org.apache.geode.redis.internal.executor.sortedset;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -42,8 +41,8 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   JedisCluster jedis;
   final String STRING_KEY = "key";
   final String STRING_MEMBER = "member";
-  final byte[] KEY = stringToBytes(STRING_KEY);
-  final byte[] MEMBER = stringToBytes(STRING_MEMBER);
+  final byte[] KEY = STRING_KEY.getBytes();
+  final byte[] MEMBER = STRING_MEMBER.getBytes();
 
   @Before
   public void setUp() {
@@ -143,7 +142,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void memberShouldBeCreatedWhenItDoesNotExist_withIncrementOfPositiveInfinity() {
     final double increment = POSITIVE_INFINITY;
-    jedis.zadd(KEY, 0.0, stringToBytes("something")); // init the key but not the member
+    jedis.zadd(KEY, 0.0, "something".getBytes()); // init the key but not the member
 
     assertKeyIsCreatedWithIncrementOf(increment);
   }
@@ -151,7 +150,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void memberShouldBeCreatedWhenItDoesNotExist_withIncrementOfNegativeInfinity() {
     final double increment = NEGATIVE_INFINITY;
-    jedis.zadd(KEY, 0.0, stringToBytes("something")); // init the key but not the member
+    jedis.zadd(KEY, 0.0, "something".getBytes()); // init the key but not the member
 
     assertKeyIsCreatedWithIncrementOf(increment);
   }
@@ -227,7 +226,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void shouldCreateNewMember_whenIncrementedMemberDoesNotExist() {
     final double increment = 1.5;
-    jedis.zadd(KEY, increment, stringToBytes("something"));
+    jedis.zadd(KEY, increment, "something".getBytes());
 
     assertThat(jedis.zincrby(KEY, increment, MEMBER)).isEqualTo(increment);
     assertThat(jedis.zscore(KEY, MEMBER)).isEqualTo(increment);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRankIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRankIntegrationTest.java
@@ -38,7 +38,6 @@ import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.data.RedisSortedSet;
-import org.apache.geode.redis.internal.netty.Coder;
 
 public abstract class AbstractZRankIntegrationTest implements RedisIntegrationTest {
   public static final String KEY = "key";
@@ -111,8 +110,8 @@ public abstract class AbstractZRankIntegrationTest implements RedisIntegrationTe
     List<byte[]> memberList = new ArrayList<>();
     for (String memberName : map.keySet()) {
       long rank = jedis.zrank(KEY, memberName);
-      rankMap.put(rank, Coder.stringToBytes(memberName));
-      memberList.add(Coder.stringToBytes(memberName));
+      rankMap.put(rank, memberName.getBytes());
+      memberList.add(memberName.getBytes());
     }
 
     memberList.sort(new ByteArrayComparator());
@@ -233,7 +232,7 @@ public abstract class AbstractZRankIntegrationTest implements RedisIntegrationTe
     Set<String> memberSet = new HashSet<>();
     while (memberSet.size() < ENTRY_COUNT) {
       random.nextBytes(memberNameArray);
-      String memberName = Coder.bytesToString(memberNameArray);
+      String memberName = new String(memberNameArray);
       memberSet.add(memberName);
     }
     return memberSet;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByFloatIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByFloatIntegrationTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.redis.internal.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -152,7 +151,7 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
 
     // Beyond this, native redis produces inconsistent results.
     Object rawResult = jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "1");
-    BigDecimal result = new BigDecimal(bytesToString((byte[]) rawResult));
+    BigDecimal result = new BigDecimal(new String((byte[]) rawResult));
 
     assertThat(result.toPlainString()).isEqualTo(biggy.add(BigDecimal.ONE).toPlainString());
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -96,7 +95,7 @@ public class SubscriptionsIntegrationTest {
 
     new ConcurrentLoopingThreads(ITERATIONS,
         i -> subscriptions.add(new DummySubscription()),
-        i -> subscriptions.findSubscriptions(stringToBytes("channel")))
+        i -> subscriptions.findSubscriptions("channel".getBytes()))
             .run();
 
     assertThat(subscriptions.size()).isEqualTo(ITERATIONS);
@@ -114,7 +113,7 @@ public class SubscriptionsIntegrationTest {
       Client client = new Client(channel);
       clients.add(client);
       subscriptions
-          .add(new ChannelSubscription(client, stringToBytes("channel"), context,
+          .add(new ChannelSubscription(client, "channel".getBytes(), context,
               subscriptions));
     }
 
@@ -139,13 +138,13 @@ public class SubscriptionsIntegrationTest {
 
       clients.add(client);
       subscriptions
-          .add(new ChannelSubscription(client, stringToBytes("channel"), context,
+          .add(new ChannelSubscription(client, "channel".getBytes(), context,
               subscriptions));
     }
 
     new ConcurrentLoopingThreads(1,
-        i -> clients.forEach(c -> subscriptions.remove(stringToBytes("channel"), c)),
-        i -> clients.forEach(c -> subscriptions.remove(stringToBytes("channel"), c)))
+        i -> clients.forEach(c -> subscriptions.remove("channel".getBytes(), c)),
+        i -> clients.forEach(c -> subscriptions.remove("channel".getBytes(), c)))
             .run();
 
     assertThat(subscriptions.size()).isEqualTo(0);


### PR DESCRIPTION
 - Replace uses of Coder conversion methods in DUnit and Integration
 tests with implementations that do not assume knowledge of the way we
 internally handle such conversions.

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [N/A] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
