### PR TITLE
Revert "GEODE-9400: Do not use Coder conversion methods in tests (#66…

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/ClusterNodes.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/ClusterNodes.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,9 +42,9 @@ public class ClusterNodes {
       long slotEnd = (long) firstLevel.get(1);
 
       List<Object> primary = (List<Object>) firstLevel.get(2);
-      String primaryIp = new String((byte[]) primary.get(0));
+      String primaryIp = bytesToString((byte[]) primary.get(0));
       long primaryPort = (long) primary.get(1);
-      String primaryGUID = primary.size() > 2 ? new String((byte[]) primary.get(2)) : "";
+      String primaryGUID = primary.size() > 2 ? bytesToString((byte[]) primary.get(2)) : "";
 
       result.addSlot(primaryGUID, primaryIp, primaryPort, slotStart, slotEnd);
     }

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/RenameDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/key/RenameDUnitTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.executor.key;
 
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -119,7 +120,7 @@ public class RenameDUnitTest {
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {
     Random random = new Random();
     String key1 = "{rename}keyz" + random.nextInt();
-    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
+    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     Set<String> keys = new HashSet<>();
     keys.add(key1);
@@ -127,7 +128,7 @@ public class RenameDUnitTest {
     do {
       String key2 = "{rename}key" + random.nextInt();
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(key2.getBytes())) == 0) {
+          new RedisKey(stringToBytes(key2))) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZAddIncrOptionDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZAddIncrOptionDUnitTest.java
@@ -42,6 +42,7 @@ import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
@@ -100,11 +101,11 @@ public class ZAddIncrOptionDUnitTest {
   private void doZAddIncr(int i, double increment, double total, boolean isConcurrentExecution) {
     Object result =
         jedis.sendCommand(sortedSetKey, Protocol.Command.ZADD, sortedSetKey, "INCR",
-            String.valueOf(increment), baseMemberName + i);
+            Coder.doubleToString(increment), baseMemberName + i);
     if (isConcurrentExecution) {
-      assertThat(Double.parseDouble(new String((byte[]) result))).isIn(increment, total);
+      assertThat(Coder.bytesToDouble((byte[]) result)).isIn(increment, total);
     } else {
-      assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(total);
+      assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(total);
     }
   }
 
@@ -192,7 +193,7 @@ public class ZAddIncrOptionDUnitTest {
   }
 
   private static boolean isPrimaryForKey() {
-    int bucketId = getBucketId(new RedisKey(sortedSetKey.getBytes()));
+    int bucketId = getBucketId(new RedisKey(Coder.stringToBytes(sortedSetKey)));
     return isPrimaryForBucket(bucketId);
   }
 

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -220,7 +221,7 @@ public class ZRemDUnitTest {
   }
 
   private static boolean isPrimaryForKey() {
-    int bucketId = getBucketId(new RedisKey(sortedSetKey.getBytes()));
+    int bucketId = getBucketId(new RedisKey(stringToBytes(sortedSetKey)));
     return isPrimaryForBucket(bucketId);
   }
 

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionDUnitTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.session;
 
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.net.HttpCookie;
 import java.time.Duration;
@@ -254,7 +255,7 @@ public abstract class SessionDUnitTest {
   protected String getSessionId(String sessionCookie) {
     List<HttpCookie> cookies = HttpCookie.parse(sessionCookie);
     byte[] decodedCookie = Base64.getDecoder().decode(cookies.get(0).getValue());
-    return new String(decodedCookie);
+    return bytesToString(decodedCookie);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionExpirationDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.session;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayInputStream;
@@ -165,7 +166,7 @@ public class SessionExpirationDUnitTest extends SessionDUnitTest {
       return 0;
     }
     ObjectInputStream inputStream;
-    byte[] bytes = redisHash.hget("maxInactiveInterval".getBytes());
+    byte[] bytes = redisHash.hget(stringToBytes("maxInactiveInterval"));
     ByteArrayInputStream byteStream = new ByteArrayInputStream(bytes);
     try {
       inputStream = new ObjectInputStream(byteStream);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
@@ -15,6 +15,9 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.intToBytes;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.function.BiFunction;
@@ -32,7 +35,7 @@ public class RedisCommandArgumentsTestHelper {
   public static void assertExactNumberOfArgs(JedisCluster jedis,
       Protocol.Command command, int numArgs) {
     assertExactNumberOfArgs0(
-        (cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args), command,
+        (cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args), command,
         numArgs);
   }
 
@@ -56,7 +59,7 @@ public class RedisCommandArgumentsTestHelper {
 
   public static void assertAtLeastNArgs(JedisCluster jedis, Protocol.Command command,
       int minNumArgs) {
-    assertAtLeastNArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args),
+    assertAtLeastNArgs0((cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args),
         command,
         minNumArgs);
   }
@@ -84,7 +87,7 @@ public class RedisCommandArgumentsTestHelper {
 
   public static void assertAtMostNArgs(JedisCluster jedis, Protocol.Command command,
       int maxNumArgs) {
-    assertAtMostNArgs0((cmd, args) -> jedis.sendCommand("key".getBytes(), cmd, args),
+    assertAtMostNArgs0((cmd, args) -> jedis.sendCommand(stringToBytes("key"), cmd, args),
         command,
         maxNumArgs);
   }
@@ -109,7 +112,7 @@ public class RedisCommandArgumentsTestHelper {
 
       assertThatThrownBy(() -> runMe.apply(command, args))
           .hasMessageContaining("ERR Unknown subcommand or wrong number of arguments for '"
-              + new String(firstParameter));
+              + bytesToString(firstParameter));
     }
   }
 
@@ -121,7 +124,7 @@ public class RedisCommandArgumentsTestHelper {
     }
 
     for (int i = 0; i < numArgs; i++) {
-      args[i] = String.valueOf(i).getBytes();
+      args[i] = intToBytes(i);
     }
 
     return args;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractUnknownIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.executor;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.After;
@@ -44,13 +45,13 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
 
   @Test
   public void givenUnknownCommand_returnsUnknownCommandError() {
-    assertThatThrownBy(() -> jedis.sendCommand(() -> "fhqwhgads".getBytes()))
+    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("fhqwhgads")))
         .hasMessage("ERR unknown command `fhqwhgads`, with args beginning with: ");
   }
 
   @Test
   public void givenUnknownCommand_withArguments_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand(() -> "fhqwhgads".getBytes(), "EVERYBODY",
+    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("fhqwhgads"), "EVERYBODY",
         "TO THE LIMIT"))
             .hasMessage(
                 "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, `TO THE LIMIT`, ");
@@ -59,21 +60,21 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
   @Test
   public void givenUnknownCommand_withEmptyStringArgument_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand(() -> "fhqwhgads".getBytes(), "EVERYBODY", ""))
+        () -> jedis.sendCommand(() -> stringToBytes("fhqwhgads"), "EVERYBODY", ""))
             .hasMessage(
                 "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, ``, ");
   }
 
   @Test // HELLO is not a recognized command until Redis 6.0.0
   public void givenHelloCommand_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(() -> jedis.sendCommand(() -> "HELLO".getBytes()))
+    assertThatThrownBy(() -> jedis.sendCommand(() -> stringToBytes("HELLO")))
         .hasMessage("ERR unknown command `HELLO`, with args beginning with: ");
   }
 
   @Test
   public void givenInternalSMembersCommand_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand(() -> "INTERNALSMEMBERS".getBytes(), "something",
+        () -> jedis.sendCommand(() -> stringToBytes("INTERNALSMEMBERS"), "something",
             "somethingElse"))
                 .hasMessage(
                     "ERR unknown command `INTERNALSMEMBERS`, with args beginning with: `something`, `somethingElse`, ");
@@ -82,7 +83,7 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
   @Test
   public void givenInternalPTTLCommand_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand(() -> "INTERNALPTTL".getBytes(), "something"))
+        () -> jedis.sendCommand(() -> stringToBytes("INTERNALPTTL"), "something"))
             .hasMessage(
                 "ERR unknown command `INTERNALPTTL`, with args beginning with: `something`, ");
   }
@@ -90,7 +91,7 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
   @Test
   public void givenInternalTypeCommand_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand(() -> "INTERNALTYPE".getBytes(), "something"))
+        () -> jedis.sendCommand(() -> stringToBytes("INTERNALTYPE"), "something"))
             .hasMessage(
                 "ERR unknown command `INTERNALTYPE`, with args beginning with: `something`, ");
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -20,6 +20,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -230,7 +232,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     scanParams.match("\\p");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
-        jedis.hscan("a".getBytes(), "0".getBytes(), scanParams);
+        jedis.hscan(stringToBytes("a"), stringToBytes("0"), scanParams);
 
     assertThat(result.getResult()).isEmpty();
   }
@@ -285,10 +287,10 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
           "COUNT", "1");
 
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
   }
 
   @Test
@@ -306,7 +308,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.hscan(stringToBytes("colors"), stringToBytes(cursor), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
@@ -317,17 +319,17 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   @Test
   public void givenMatch_returnsAllMatchingEntries() {
     Map<byte[], byte[]> entryMap = new HashMap<>();
-    byte[] field3 = "3".getBytes();
-    entryMap.put("1".getBytes(), "yellow".getBytes());
-    entryMap.put("12".getBytes(), "green".getBytes());
-    entryMap.put(field3, "grey".getBytes());
-    jedis.hmset("colors".getBytes(), entryMap);
+    byte[] field3 = stringToBytes("3");
+    entryMap.put(stringToBytes("1"), stringToBytes("yellow"));
+    entryMap.put(stringToBytes("12"), stringToBytes("green"));
+    entryMap.put(field3, stringToBytes("grey"));
+    jedis.hmset(stringToBytes("colors"), entryMap);
 
     ScanParams scanParams = new ScanParams();
     scanParams.match("1*");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
-        jedis.hscan("colors".getBytes(), "0".getBytes(), scanParams);
+        jedis.hscan(stringToBytes("colors"), stringToBytes("0"), scanParams);
 
     entryMap.remove(field3);
     assertThat(result.isCompleteIteration()).isTrue();
@@ -355,25 +357,25 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hmset("colors", entryMap);
 
     List<Object> result =
-        (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
-            "colors".getBytes(), "0".getBytes(), "MATCH".getBytes(),
-            "3*".getBytes(),
-            "MATCH".getBytes(), "1*".getBytes());
+        (List<Object>) jedis.sendCommand(stringToBytes("colors"), Protocol.Command.HSCAN,
+            stringToBytes("colors"), stringToBytes("0"), stringToBytes("MATCH"),
+            stringToBytes("3*"),
+            stringToBytes("MATCH"), stringToBytes("1*"));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
     assertThat((List<Object>) result.get(1)).containsAll(
-        Arrays.asList("1".getBytes(), "yellow".getBytes(),
-            "12".getBytes(), "green".getBytes()));
+        Arrays.asList(stringToBytes("1"), stringToBytes("yellow"),
+            stringToBytes("12"), stringToBytes("green")));
   }
 
   @Test
   public void givenMatchAndCount_returnsAllMatchingKeys() {
     Map<byte[], byte[]> entryMap = new HashMap<>();
-    byte[] field3 = "3".getBytes();
-    entryMap.put("1".getBytes(), "yellow".getBytes());
-    entryMap.put("12".getBytes(), "green".getBytes());
-    entryMap.put(field3, "orange".getBytes());
-    jedis.hmset("colors".getBytes(), entryMap);
+    byte[] field3 = stringToBytes("3");
+    entryMap.put(stringToBytes("1"), stringToBytes("yellow"));
+    entryMap.put(stringToBytes("12"), stringToBytes("green"));
+    entryMap.put(field3, stringToBytes("orange"));
+    jedis.hmset(stringToBytes("colors"), entryMap);
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
@@ -383,7 +385,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.hscan(stringToBytes("colors"), stringToBytes(cursor), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
@@ -410,21 +412,21 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     do {
       result =
-          (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
-              "colors".getBytes(), cursor.getBytes(),
-              "COUNT".getBytes(), "37".getBytes(),
-              "MATCH".getBytes(), "3*".getBytes(), "COUNT".getBytes(),
-              "2".getBytes(),
-              "COUNT".getBytes(), "1".getBytes(), "MATCH".getBytes(),
-              "1*".getBytes());
+          (List<Object>) jedis.sendCommand(stringToBytes("colors"), Protocol.Command.HSCAN,
+              stringToBytes("colors"), stringToBytes(cursor),
+              stringToBytes("COUNT"), stringToBytes("37"),
+              stringToBytes("MATCH"), stringToBytes("3*"), stringToBytes("COUNT"),
+              stringToBytes("2"),
+              stringToBytes("COUNT"), stringToBytes("1"), stringToBytes("MATCH"),
+              stringToBytes("1*"));
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(),
-        "yellow".getBytes(),
-        "12".getBytes(), "green".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("yellow"),
+        stringToBytes("12"), stringToBytes("green"));
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHashesIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.executor.hash;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -886,8 +887,8 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
       blob[i] = (byte) i;
     }
 
-    jedis.hset("key".getBytes(), blob, blob);
-    Map<byte[], byte[]> result = jedis.hgetAll("key".getBytes());
+    jedis.hset(stringToBytes("key"), blob, blob);
+    Map<byte[], byte[]> result = jedis.hgetAll(stringToBytes("key"));
 
     assertThat(result.keySet()).containsExactly(blob);
     assertThat(result.values()).containsExactly(blob);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHincrByFloatIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHincrByFloatIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.hash;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.offset;
@@ -112,13 +113,13 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
     String field = "field";
 
     Object response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "1.23");
-    assertThat(new String((byte[]) response)).isEqualTo("1.23");
+    assertThat(bytesToString((byte[]) response)).isEqualTo("1.23");
 
     response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "0.77");
-    assertThat(new String((byte[]) response)).isEqualTo("2");
+    assertThat(bytesToString((byte[]) response)).isEqualTo("2");
 
     response = jedis.sendCommand(key, Protocol.Command.HINCRBYFLOAT, key, field, "-0.1");
-    assertThat(new String((byte[]) response)).isEqualTo("1.9");
+    assertThat(bytesToString((byte[]) response)).isEqualTo("1.9");
   }
 
   @Test
@@ -149,7 +150,7 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
     // Beyond this, native redis produces inconsistent results.
     Object rawResult =
         jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "1");
-    BigDecimal result = new BigDecimal(new String((byte[]) rawResult));
+    BigDecimal result = new BigDecimal(bytesToString((byte[]) rawResult));
 
     assertThat(result.toPlainString()).isEqualTo(biggy.add(BigDecimal.ONE).toPlainString());
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractDelIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractDelIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -109,7 +110,7 @@ public abstract class AbstractDelIntegrationTest implements RedisIntegrationTest
   public void testDel_withBinaryKey() {
     byte[] key = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    jedis.set(key, "foo".getBytes());
+    jedis.set(key, stringToBytes("foo"));
     jedis.del(key);
 
     assertThat(jedis.get(key)).isNull();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractKeysIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
@@ -93,7 +94,7 @@ public abstract class AbstractKeysIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenBinaryValue_withExactMatch_preservesBinaryData() {
     String chineseHashTag = "{子}";
-    byte[] utf8encodedBytes = chineseHashTag.getBytes();
+    byte[] utf8encodedBytes = stringToBytes(chineseHashTag);
     byte[] stringKey =
         new byte[] {(byte) 0xac, (byte) 0xed, 0, 4, 0, 5, 's', 't', 'r', 'i', 'n', 'g', '1'};
     byte[] allByteArray = new byte[utf8encodedBytes.length + stringKey.length];
@@ -104,7 +105,7 @@ public abstract class AbstractKeysIntegrationTest implements RedisIntegrationTes
     byte[] combined = buff.array();
 
     jedis.set(combined, combined);
-    assertThat(jedis.keys("{子}*".getBytes()))
+    assertThat(jedis.keys(stringToBytes("{子}*")))
         .containsExactlyInAnyOrder(combined);
   }
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractRenameIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractRenameIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -237,7 +238,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   private List<String> getKeysOnDifferentStripes() {
     String key1 = "{user1}keyz" + new Random().nextInt();
 
-    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
+    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     int iterator = 0;
     String key2;
@@ -245,7 +246,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
       key2 = "{user1}key" + iterator;
       iterator++;
     } while (stripedExecutor.compareStripes(key1RedisKey,
-        new RedisKey(key2.getBytes())) == 0);
+        new RedisKey(stringToBytes(key2))) == 0);
 
     return Arrays.asList(key1, key2);
   }
@@ -253,7 +254,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {
     Random random = new Random();
     String key1 = "{user1}keyz" + random.nextInt();
-    RedisKey key1RedisKey = new RedisKey(key1.getBytes());
+    RedisKey key1RedisKey = new RedisKey(stringToBytes(key1));
     StripedExecutor stripedExecutor = new SynchronizedStripedExecutor();
     Set<String> keys = new HashSet<>();
     keys.add(key1);
@@ -261,7 +262,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     do {
       String key2 = "{user1}key" + random.nextInt();
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(key2.getBytes())) == 0) {
+          new RedisKey(stringToBytes(key2))) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);
@@ -319,14 +320,14 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     RedisKey key1RedisKey;
     do {
       key1 = "{user1}keyz" + new Random().nextInt();
-      key1RedisKey = new RedisKey(key1.getBytes());
+      key1RedisKey = new RedisKey(stringToBytes(key1));
     } while (stripedExecutor.compareStripes(key1RedisKey, toAvoid) == 0 && keys.add(key1));
 
     do {
       String key2 = "{user1}key" + new Random().nextInt();
 
       if (stripedExecutor.compareStripes(key1RedisKey,
-          new RedisKey(key2.getBytes())) == 0) {
+          new RedisKey(stringToBytes(key2))) == 0) {
         keys.add(key2);
       }
     } while (keys.size() < numKeysNeeded);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractScanIntegrationTest.java
@@ -18,6 +18,8 @@ package org.apache.geode.redis.internal.executor.key;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -176,12 +178,12 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
           (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, cursor, "COUNT", "2",
               "COUNT", "1");
       allKeysFromScan.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a".getBytes(),
-        "{user1}b".getBytes(), "{user1}c".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder(stringToBytes("{user1}a"),
+        stringToBytes("{user1}b"), stringToBytes("{user1}c"));
   }
 
   @Test
@@ -209,8 +211,8 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
         (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, "0", "MATCH", "{user1}b*",
             "MATCH", "{user1}a*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat((List<byte[]>) result.get(1)).containsExactly("{user1}a".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat((List<byte[]>) result.get(1)).containsExactly(stringToBytes("{user1}a"));
   }
 
   @Test
@@ -252,12 +254,12 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
           (List<Object>) jedis.sendCommand("{user1}", Protocol.Command.SCAN, cursor, "COUNT", "37",
               "MATCH", "{user1}b*", "COUNT", "2", "COUNT", "1", "MATCH", "{user1}a*");
       allKeysFromScan.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a".getBytes(),
-        "{user1}aardvark".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder(stringToBytes("{user1}a"),
+        stringToBytes("{user1}aardvark"));
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractUnlinkIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/AbstractUnlinkIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -109,7 +110,7 @@ public abstract class AbstractUnlinkIntegrationTest implements RedisIntegrationT
   public void testUnlink_withBinaryKey() {
     byte[] key = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
-    jedis.set(key, "foo".getBytes());
+    jedis.set(key, stringToBytes("foo"));
     jedis.unlink(key);
 
     assertThat(jedis.get(key)).isNull();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import static org.apache.geode.redis.internal.executor.pubsub.AbstractSubscriptionsIntegrationTest.REDIS_CLIENT_TIMEOUT;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -77,7 +78,7 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
   @SuppressWarnings("unchecked")
   public void punsubscribe_whenNonexistent() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.PUNSUBSCRIBE, "Nonexistent"))
-        .containsExactly("punsubscribe".getBytes(), "Nonexistent".getBytes(),
+        .containsExactly(stringToBytes("punsubscribe"), stringToBytes("Nonexistent"),
             0L);
   }
 
@@ -85,14 +86,14 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
   @SuppressWarnings("unchecked")
   public void unsubscribe_whenNoSubscriptionsExist_shouldNotHang() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.UNSUBSCRIBE))
-        .containsExactly("unsubscribe".getBytes(), null, 0L);
+        .containsExactly(stringToBytes("unsubscribe"), null, 0L);
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void punsubscribe_whenNoSubscriptionsExist_shouldNotHang() {
     assertThat((List<Object>) subscriber.sendCommand(Protocol.Command.PUNSUBSCRIBE))
-        .containsExactly("punsubscribe".getBytes(), null, 0L);
+        .containsExactly(stringToBytes("punsubscribe"), null, 0L);
   }
 
   @Test
@@ -293,17 +294,17 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
     MockBinarySubscriber mockSubscriber = new MockBinarySubscriber();
 
     Runnable runnable = () -> {
-      subscriber.subscribe(mockSubscriber, "salutations".getBytes());
+      subscriber.subscribe(mockSubscriber, stringToBytes("salutations"));
     };
 
     Thread subscriberThread = new Thread(runnable);
     subscriberThread.start();
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);
 
-    Long result = publisher.publish("salutations".getBytes(), expectedMessage);
+    Long result = publisher.publish(stringToBytes("salutations"), expectedMessage);
     assertThat(result).isEqualTo(1);
 
-    mockSubscriber.unsubscribe("salutations".getBytes());
+    mockSubscriber.unsubscribe(stringToBytes("salutations"));
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 0);
     waitFor(() -> !subscriberThread.isAlive());
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubCommandsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractSubCommandsIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLea
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtMostNArgsForSubCommand;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_PUBSUB_SUBCOMMAND;
 import static org.apache.geode.redis.internal.executor.pubsub.AbstractSubscriptionsIntegrationTest.REDIS_CLIENT_TIMEOUT;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -92,15 +93,15 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   public void channels_shouldError_givenTooManyArguments() {
     assertAtMostNArgsForSubCommand(introspector,
         Protocol.Command.PUBSUB,
-        PUBSUB_CHANNELS.getBytes(),
+        stringToBytes(PUBSUB_CHANNELS),
         1);
   }
 
   @Test
   public void channels_shouldNotError_givenMixedCaseArguments() {
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add("foo".getBytes());
-    expectedChannels.add("bar".getBytes());
+    expectedChannels.add(stringToBytes("foo"));
+    expectedChannels.add(stringToBytes("bar"));
 
     executor.submit(() -> subscriber.subscribe(mockSubscriber, "foo", "bar"));
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
@@ -114,8 +115,8 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   @Test
   public void channels_shouldReturnListOfAllChannels_withActiveChannelSubscribers_whenCalledWithoutPattern() {
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add("foo".getBytes());
-    expectedChannels.add("bar".getBytes());
+    expectedChannels.add(stringToBytes("foo"));
+    expectedChannels.add(stringToBytes("bar"));
 
     executor.submit(() -> subscriber.subscribe(mockSubscriber, "foo", "bar"));
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
@@ -162,7 +163,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   @Test
   public void channels_shouldOnlyReturnChannelsWithActiveSubscribers() {
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add("bar".getBytes());
+    expectedChannels.add(stringToBytes("bar"));
 
     executor.submit(() -> subscriber.subscribe(mockSubscriber, "foo", "bar"));
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
@@ -181,7 +182,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
 
     MockSubscriber mockSubscriber2 = new MockSubscriber();
     List<byte[]> expectedChannels = new ArrayList<>();
-    expectedChannels.add("foo".getBytes());
+    expectedChannels.add(stringToBytes("foo"));
 
     executor.submit(() -> subscriber.subscribe(mockSubscriber, "foo"));
     executor.submit(() -> subscriber2.subscribe(mockSubscriber2, "foo"));

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSPopIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSPopIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.executor.set;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -256,7 +257,7 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
 
       byte[] inputBuffer = new byte[1024];
       int n = redisSocket.getInputStream().read(inputBuffer);
-      String result = new String(Arrays.copyOfRange(inputBuffer, 0, n));
+      String result = bytesToString(Arrays.copyOfRange(inputBuffer, 0, n));
 
       assertThat(result).isEqualTo("$3\r\none\r\n");
     }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSScanIntegrationTest.java
@@ -18,6 +18,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -78,7 +80,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<Object> result =
         (List<Object>) jedis.sendCommand("key!", Protocol.Command.SSCAN, "key!", "0", "a*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
     assertThat((List<Object>) result.get(1)).isEmpty();
   }
 
@@ -199,14 +201,14 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<byte[]> allMembersFromScan = new ArrayList<>();
 
     do {
-      result = jedis.sscan("a".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.sscan(stringToBytes("a"), stringToBytes(cursor), scanParams);
       allMembersFromScan.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(allMembersFromScan).containsExactlyInAnyOrder("1".getBytes(),
-        "2".getBytes(),
-        "3".getBytes());
+    assertThat(allMembersFromScan).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("2"),
+        stringToBytes("3"));
   }
 
   @Test
@@ -224,13 +226,13 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
           (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", cursor, "COUNT", "2",
               "COUNT", "1");
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(),
-        "12".getBytes(),
-        "3".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"),
+        stringToBytes("3"));
   }
 
   @Test
@@ -241,11 +243,11 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     scanParams.match("1*");
 
     ScanResult<byte[]> result =
-        jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
+        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
 
     assertThat(result.isCompleteIteration()).isTrue();
-    assertThat(result.getResult()).containsExactlyInAnyOrder("1".getBytes(),
-        "12".getBytes());
+    assertThat(result.getResult()).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"));
   }
 
   @Test
@@ -256,9 +258,9 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     List<Object> result = (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", "0",
         "MATCH", "3*", "MATCH", "1*");
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat((List<byte[]>) result.get(1)).containsExactlyInAnyOrder("1".getBytes(),
-        "12".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat((List<byte[]>) result.get(1)).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"));
   }
 
   @Test
@@ -273,13 +275,13 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     String cursor = "0";
 
     do {
-      result = jedis.sscan("a".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.sscan(stringToBytes("a"), stringToBytes(cursor), scanParams);
       allMembersFromScan.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(allMembersFromScan).containsExactlyInAnyOrder("1".getBytes(),
-        "12".getBytes());
+    assertThat(allMembersFromScan).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"));
   }
 
   @Test
@@ -296,12 +298,12 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
           (List<Object>) jedis.sendCommand("a", Protocol.Command.SSCAN, "a", cursor, "COUNT", "37",
               "MATCH", "3*", "COUNT", "2", "COUNT", "1", "MATCH", "1*");
       allEntries.addAll((List<byte[]>) result.get(1));
-      cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+      cursor = bytesToString((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), stringToBytes("0")));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(),
-        "12".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(stringToBytes("0"));
+    assertThat(allEntries).containsExactlyInAnyOrder(stringToBytes("1"),
+        stringToBytes("12"));
   }
 
   @Test
@@ -341,7 +343,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     scanParams.match("\\p");
 
     ScanResult<byte[]> result =
-        jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
+        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
 
     assertThat(result.getResult()).isEmpty();
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSetsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/AbstractSetsIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.executor.set;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -118,8 +119,8 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
       blob[i] = (byte) i;
     }
 
-    jedis.sadd("key".getBytes(), blob, blob);
-    Set<byte[]> result = jedis.smembers("key".getBytes());
+    jedis.sadd(stringToBytes("key"), blob, blob);
+    Set<byte[]> result = jedis.smembers(stringToBytes("key"));
 
     assertThat(result).containsExactly(blob);
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/set/SScanIntegrationTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
+import static org.apache.geode.redis.internal.netty.Coder.intToBytes;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -41,16 +43,16 @@ public class SScanIntegrationTest extends AbstractSScanIntegrationTest {
     List<byte[]> memberList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
       jedis.sadd("a", String.valueOf(i));
-      memberList.add(String.valueOf(i).getBytes());
+      memberList.add(intToBytes(i));
     }
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(5);
     ScanResult<byte[]> result =
-        jedis.sscan("a".getBytes(), "0".getBytes(), scanParams);
+        jedis.sscan(stringToBytes("a"), stringToBytes("0"), scanParams);
     assertThat(result.isCompleteIteration()).isFalse();
 
-    result = jedis.sscan("a".getBytes(), "100".getBytes());
+    result = jedis.sscan(stringToBytes("a"), stringToBytes("100"));
 
     assertThat(result.getResult()).containsExactlyInAnyOrderElementsOf(memberList);
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZAddIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZAddIntegrationTest.java
@@ -45,6 +45,7 @@ import redis.clients.jedis.params.ZAddParams;
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;
+import org.apache.geode.redis.internal.netty.Coder;
 
 public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
@@ -359,16 +360,16 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     jedis.zadd(SORTED_SET_KEY, initial, member);
 
     Object result = jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, "XX",
-        incrOption, String.valueOf(increment), member);
-    assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(expected);
+        incrOption, Coder.doubleToString(increment), member);
+    assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(expected);
     assertThat(jedis.zscore(SORTED_SET_KEY, member)).isEqualTo(expected);
   }
 
   @Test
   public void zaddIncrOptionAddsANewMemberWithNXOption() {
     Object result = jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, "NX",
-        incrOption, String.valueOf(increment), member);
-    assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(increment);
+        incrOption, Coder.doubleToString(increment), member);
+    assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(increment);
 
     assertThat(jedis.zscore(SORTED_SET_KEY, member)).isEqualTo(increment);
   }
@@ -394,8 +395,8 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void zaddIncrOptionCanIncrementScoreForExistingMemberWithChangeOption() {
     jedis.zadd(SORTED_SET_KEY, initial, member);
     Object result = jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, "CH",
-        incrOption, String.valueOf(increment), member);
-    assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(expected);
+        incrOption, Coder.doubleToString(increment), member);
+    assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(expected);
 
     assertThat(jedis.zscore(SORTED_SET_KEY, member)).isEqualTo(expected);
   }
@@ -405,9 +406,9 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     jedis.zadd(SORTED_SET_KEY, initial, member);
     Object result =
         jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, incrOption,
-            String.valueOf(increment), member);
+            Coder.doubleToString(increment), member);
 
-    assertThat(Double.parseDouble(new String((byte[]) result))).isEqualTo(expected);
+    assertThat(Coder.bytesToDouble((byte[]) result)).isEqualTo(expected);
     result = jedis.zscore(SORTED_SET_KEY, member);
     assertThat(result).isEqualTo(expected);
   }
@@ -431,8 +432,8 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   private void doZAddIncr(int i, double increment, double total) {
     Object result =
         jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, incrOption,
-            String.valueOf(increment), member + i);
-    assertThat(Double.parseDouble(new String((byte[]) result))).isIn(increment, total);
+            Coder.doubleToString(increment), member + i);
+    assertThat(Coder.bytesToDouble((byte[]) result)).isIn(increment, total);
   }
 
   @Test
@@ -460,7 +461,7 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     }
     totalIncremented.addAndGet(increment);
     jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, SORTED_SET_KEY, incrOption,
-        String.valueOf(increment), member);
+        Coder.doubleToString(increment), member);
   }
 
   private double getValueWthPrecision(double value) {

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZIncrByIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZIncrByIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.executor.sortedset;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,8 +42,8 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   JedisCluster jedis;
   final String STRING_KEY = "key";
   final String STRING_MEMBER = "member";
-  final byte[] KEY = STRING_KEY.getBytes();
-  final byte[] MEMBER = STRING_MEMBER.getBytes();
+  final byte[] KEY = stringToBytes(STRING_KEY);
+  final byte[] MEMBER = stringToBytes(STRING_MEMBER);
 
   @Before
   public void setUp() {
@@ -142,7 +143,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void memberShouldBeCreatedWhenItDoesNotExist_withIncrementOfPositiveInfinity() {
     final double increment = POSITIVE_INFINITY;
-    jedis.zadd(KEY, 0.0, "something".getBytes()); // init the key but not the member
+    jedis.zadd(KEY, 0.0, stringToBytes("something")); // init the key but not the member
 
     assertKeyIsCreatedWithIncrementOf(increment);
   }
@@ -150,7 +151,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void memberShouldBeCreatedWhenItDoesNotExist_withIncrementOfNegativeInfinity() {
     final double increment = NEGATIVE_INFINITY;
-    jedis.zadd(KEY, 0.0, "something".getBytes()); // init the key but not the member
+    jedis.zadd(KEY, 0.0, stringToBytes("something")); // init the key but not the member
 
     assertKeyIsCreatedWithIncrementOf(increment);
   }
@@ -226,7 +227,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
   @Test
   public void shouldCreateNewMember_whenIncrementedMemberDoesNotExist() {
     final double increment = 1.5;
-    jedis.zadd(KEY, increment, "something".getBytes());
+    jedis.zadd(KEY, increment, stringToBytes("something"));
 
     assertThat(jedis.zincrby(KEY, increment, MEMBER)).isEqualTo(increment);
     assertThat(jedis.zscore(KEY, MEMBER)).isEqualTo(increment);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRankIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRankIntegrationTest.java
@@ -38,6 +38,7 @@ import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.data.RedisSortedSet;
+import org.apache.geode.redis.internal.netty.Coder;
 
 public abstract class AbstractZRankIntegrationTest implements RedisIntegrationTest {
   public static final String KEY = "key";
@@ -110,8 +111,8 @@ public abstract class AbstractZRankIntegrationTest implements RedisIntegrationTe
     List<byte[]> memberList = new ArrayList<>();
     for (String memberName : map.keySet()) {
       long rank = jedis.zrank(KEY, memberName);
-      rankMap.put(rank, memberName.getBytes());
-      memberList.add(memberName.getBytes());
+      rankMap.put(rank, Coder.stringToBytes(memberName));
+      memberList.add(Coder.stringToBytes(memberName));
     }
 
     memberList.sort(new ByteArrayComparator());
@@ -232,7 +233,7 @@ public abstract class AbstractZRankIntegrationTest implements RedisIntegrationTe
     Set<String> memberSet = new HashSet<>();
     while (memberSet.size() < ENTRY_COUNT) {
       random.nextBytes(memberNameArray);
-      String memberName = new String(memberNameArray);
+      String memberName = Coder.bytesToString(memberNameArray);
       memberSet.add(memberName);
     }
     return memberSet;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByFloatIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/string/AbstractIncrByFloatIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -151,7 +152,7 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
 
     // Beyond this, native redis produces inconsistent results.
     Object rawResult = jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "1");
-    BigDecimal result = new BigDecimal(new String((byte[]) rawResult));
+    BigDecimal result = new BigDecimal(bytesToString((byte[]) rawResult));
 
     assertThat(result.toPlainString()).isEqualTo(biggy.add(BigDecimal.ONE).toPlainString());
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/pubsub/SubscriptionsIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -95,7 +96,7 @@ public class SubscriptionsIntegrationTest {
 
     new ConcurrentLoopingThreads(ITERATIONS,
         i -> subscriptions.add(new DummySubscription()),
-        i -> subscriptions.findSubscriptions("channel".getBytes()))
+        i -> subscriptions.findSubscriptions(stringToBytes("channel")))
             .run();
 
     assertThat(subscriptions.size()).isEqualTo(ITERATIONS);
@@ -113,7 +114,7 @@ public class SubscriptionsIntegrationTest {
       Client client = new Client(channel);
       clients.add(client);
       subscriptions
-          .add(new ChannelSubscription(client, "channel".getBytes(), context,
+          .add(new ChannelSubscription(client, stringToBytes("channel"), context,
               subscriptions));
     }
 
@@ -138,13 +139,13 @@ public class SubscriptionsIntegrationTest {
 
       clients.add(client);
       subscriptions
-          .add(new ChannelSubscription(client, "channel".getBytes(), context,
+          .add(new ChannelSubscription(client, stringToBytes("channel"), context,
               subscriptions));
     }
 
     new ConcurrentLoopingThreads(1,
-        i -> clients.forEach(c -> subscriptions.remove("channel".getBytes(), c)),
-        i -> clients.forEach(c -> subscriptions.remove("channel".getBytes(), c)))
+        i -> clients.forEach(c -> subscriptions.remove(stringToBytes("channel"), c)),
+        i -> clients.forEach(c -> subscriptions.remove(stringToBytes("channel"), c)))
             .run();
 
     assertThat(subscriptions.size()).isEqualTo(0);


### PR DESCRIPTION
…43)"

This reverts commit 396f213bc64c6aba655cd064d6d96aeca2f44413.

Windows integration tests on JDK8 are failing as a result of this change, so it's being reverted while the cause of this is investigated:

=-=-=-=-=-=-=-=-=-=-=-=-=-=-=  Test Results URI =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
http://files.apachegeode-ci.info/builds/apache-develop-main/1.15.0-build.0335/test-results/integrationTest/1624655667/
=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

Test report artifacts from this job are available at:

http://files.apachegeode-ci.info/builds/apache-develop-main/1.15.0-build.0335/test-artifacts/1624655667/windows-integrationtestfiles-openjdk8-1.15.0-build.0335.tgz

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
