### PR TITLE
GEODE-9342: Handle a double reply of "inf" in the same way as Redis

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -280,10 +280,10 @@ public class Coder {
 
   public static String doubleToString(double d) {
     if (d == Double.POSITIVE_INFINITY) {
-      return "Infinity";
+      return "inf";
     }
     if (d == Double.NEGATIVE_INFINITY) {
-      return "-Infinity";
+      return "-inf";
     }
 
     String stringValue = String.valueOf(d);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -14,7 +14,9 @@
  */
 package org.apache.geode.redis.internal.netty;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToDouble;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+import static org.apache.geode.redis.internal.netty.Coder.doubleToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.isNaN;
@@ -63,6 +65,13 @@ public class CoderTest {
     assertThat(isNaN(bytes)).isEqualTo(isNaN);
   }
 
+  @Test
+  @Parameters(method = "infinityReturnStrings")
+  public void doubleToString_processesLikeRedis(String inputString, String expectedString) {
+    byte[] bytes = stringToBytes(inputString);
+    assertThat(doubleToString(bytesToDouble(bytes))).isEqualTo(expectedString);
+  }
+
   @SuppressWarnings("unused")
   private Object[] stringPairs() {
     // string1, string2
@@ -102,4 +111,18 @@ public class CoderTest {
         new Object[] {null, false, false, false}
     };
   }
+
+  @SuppressWarnings("unused")
+  private Object[] infinityReturnStrings() {
+    // string, expectedString
+    return new Object[] {
+        new Object[] {"inf", "inf"},
+        new Object[] {"+inf", "inf"},
+        new Object[] {"Infinity", "inf"},
+        new Object[] {"+Infinity", "inf"},
+        new Object[] {"-inf", "-inf"},
+        new Object[] {"-Infinity", "-inf"},
+    };
+  }
+
 }


### PR DESCRIPTION
Updates Coder.java to convert doubles with the value of Double.POSITIVE_INFINITY as "inf" and Double.NEGATIVE_INFINITY as "-inf". This matches native Redis behavior.