### PR TITLE
GEODE-9407: Handle exception getting region names

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/util/ManagementUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/util/ManagementUtils.java
@@ -34,11 +34,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
-import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionService;
@@ -51,6 +51,7 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.execute.AbstractExecution;
 import org.apache.geode.internal.classloader.ClassPathLoader;
 import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.DistributedRegionMXBean;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.internal.MBeanJMXAdapter;
@@ -58,6 +59,9 @@ import org.apache.geode.management.internal.exceptions.UserErrorException;
 import org.apache.geode.management.internal.i18n.CliStrings;
 
 public class ManagementUtils {
+
+  private static final Logger logger = LogService.getLogger();
+
   @Immutable
   public static final FileFilter JAR_FILE_FILTER = new CustomFileFilter(".jar");
 
@@ -170,7 +174,9 @@ public class ManagementUtils {
           regionNames.add(subRegion.getFullPath().substring(1));
         }
 
-      } catch (RegionDestroyedException ignored) {
+      } catch (Exception e) {
+        logger.debug("Cannot get subregions of " + rootRegion.getFullPath()
+            + ". Omitting from the set of region names.", e);
         continue;
       }
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/util/ManagementUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/util/ManagementUtils.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.execute.Execution;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.FunctionService;
@@ -162,14 +163,20 @@ public class ManagementUtils {
     Set<Region<?, ?>> rootRegions = cache.rootRegions();
 
     for (Region<?, ?> rootRegion : rootRegions) {
-      regionNames.add(rootRegion.getFullPath().substring(1));
+      try {
+        Set<Region<?, ?>> subRegions = rootRegion.subregions(true);
 
-      Set<Region<?, ?>> subRegions = rootRegion.subregions(true);
+        for (Region<?, ?> subRegion : subRegions) {
+          regionNames.add(subRegion.getFullPath().substring(1));
+        }
 
-      for (Region<?, ?> subRegion : subRegions) {
-        regionNames.add(subRegion.getFullPath().substring(1));
+      } catch (RegionDestroyedException ignored) {
+        continue;
       }
+
+      regionNames.add(rootRegion.getFullPath().substring(1));
     }
+
     return regionNames;
   }
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/util/ManagementUtilsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/util/ManagementUtilsTest.java
@@ -16,16 +16,24 @@
 package org.apache.geode.management.internal.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionDestroyedException;
 
 
 public class ManagementUtilsTest {
@@ -50,5 +58,21 @@ public class ManagementUtilsTest {
     assertThat(filePaths).hasSize(2);
     assertThat(new File(filePaths.get(0))).hasContent("file1-content");
     assertThat(new File(filePaths.get(1))).hasContent("file2-content");
+  }
+
+  @Test
+  public void regionDestroyedWhileGettingRegionNames() {
+    Cache cache = mock(Cache.class);
+
+    Region<?, ?> regionDestroyed = mock(Region.class);
+    Region<?, ?> regionNotDestroyed = mock(Region.class);
+    List<Region<?, ?>> rootRegions = Arrays.asList(regionDestroyed, regionNotDestroyed);
+
+    when(cache.rootRegions()).thenReturn(new HashSet<>(rootRegions));
+    when(regionDestroyed.subregions(anyBoolean())).thenThrow(new RegionDestroyedException("", ""));
+    when(regionDestroyed.getFullPath()).thenReturn("/regionDestroyed");
+    when(regionNotDestroyed.getFullPath()).thenReturn("/regionNotDestroyed");
+
+    assertThat(ManagementUtils.getAllRegionNames(cache)).containsExactly("regionNotDestroyed");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/util/ManagementUtilsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/util/ManagementUtilsTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
@@ -61,7 +62,26 @@ public class ManagementUtilsTest {
   }
 
   @Test
-  public void regionDestroyedWhileGettingRegionNames() {
+  public void getAllRegionNamesWithSubregions() {
+    Cache cache = mock(Cache.class);
+
+    Region<?, ?> regionWithSubregion = mock(Region.class);
+    Region<?, ?> regionWithoutSubregions = mock(Region.class);
+    Region<?, ?> subregion = mock(Region.class);
+    List<Region<?, ?>> rootRegions = Arrays.asList(regionWithSubregion, regionWithoutSubregions);
+
+    when(cache.rootRegions()).thenReturn(new HashSet<>(rootRegions));
+    when(regionWithSubregion.subregions(anyBoolean())).thenReturn(Collections.singleton(subregion));
+    when(regionWithSubregion.getFullPath()).thenReturn("/regionWithSubregion");
+    when(regionWithoutSubregions.getFullPath()).thenReturn("/regionWithoutSubregion");
+    when(subregion.getFullPath()).thenReturn("/subregion");
+
+    assertThat(ManagementUtils.getAllRegionNames(cache))
+        .containsExactlyInAnyOrder("regionWithSubregion", "regionWithoutSubregion", "subregion");
+  }
+
+  @Test
+  public void exceptionGettingSubregions() {
     Cache cache = mock(Cache.class);
 
     Region<?, ?> regionDestroyed = mock(Region.class);


### PR DESCRIPTION
GetMemberInformationFunction may throw RegionDestroyedException if a
hosted region is destroyed while the function is checking the region
names. This exception is logged as an "error" level message which is
confusing to users.

Catch the exception and omit the destroyed region from the list of
hosted region names.
