### PR TITLE
GEODE-9410: User Guide - resolve inconsistencies in gfsh import command description

### DIFF
--- a/geode-docs/configuring/cluster_config/export-import.html.md.erb
+++ b/geode-docs/configuring/cluster_config/export-import.html.md.erb
@@ -21,12 +21,12 @@ limitations under the License.
 
 The cluster configuration service exports and imports configurations created using `gfsh` for an entire <%=vars.product_name_long%> cluster.
 
-The cluster configuration service saves the cluster configuration as you create regions, disk-stores and other objects using `gfsh` commands. You can export this configuration as well as any jar files that contain application files to a zip file and then import this configuration to create a new cluster.
+The cluster configuration service saves the cluster configuration as you create regions, disk-stores and other objects using `gfsh` commands. You can export this configuration as well as any jar files that contain application files to a ZIP archive and then import this configuration to create a new cluster.
 
 ## Exporting a Cluster Configuration
 
 Issue the `gfsh` `export cluster-configuration` command to save the configuration data for your
-cluster in a zip file. This zip file contains subdirectories for cluster-level configurations and a
+cluster in a ZIP archive. This ZIP file contains subdirectories for cluster-level configurations and a
 directory for each group specified in the cluster. The contents of these directories are described
 in [Cluster Configuration Files and Troubleshooting](gfsh_config_troubleshooting.html#concept_ylt_2cb_y4).
 
@@ -44,7 +44,8 @@ See [export cluster-configuration](../../tools_modules/gfsh/command-pages/export
 ## Importing a Cluster Configuration
 
 Use the `gfsh` `import cluster-configuration` command to configure a new cluster based on a configuration exported from another system.
-You can import a cluster configuration only into a new cluster, that is, when:
+You can import a cluster configuration only into a new cluster, or into a running cluster that has not yet been configured and contains no defined regions.
+That is, when:
 
 - There are no running cache servers
 
@@ -63,5 +64,5 @@ To import a cluster configuration, start one or more locators and then run the `
 import cluster-configuration --zip-file-name=/home/username/configs/myClusterConfig.zip
 ```
 
-See [import cluster-configuration](../../tools_modules/gfsh/command-pages/import.html#topic_vnv_grz_ck).
+See [import cluster-configuration](../../tools_modules/gfsh/command-pages/import.html#import-cluster-config).
 

--- a/geode-docs/tools_modules/gfsh/command-pages/import.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/import.html.md.erb
@@ -18,20 +18,18 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-<a id="topic_u55_wkd_2l"></a>
-
 
 You can import an exported cluster configuration to create a new cluster or import data into a region.
 
--   **[import cluster-configuration](#topic_vnv_grz_ck)**
+-   **[import cluster-configuration](#import-cluster-config)**
 
     Import a cluster configuration.
 
--   **[import data](#topic_jw2_2ld_2l)**
+-   **[import data](#import-data)**
 
     Import user data from a file to a region.
 
-## <a id="topic_vnv_grz_ck" class="no-quick-link"></a>import cluster-configuration
+## <a id="import-cluster-config" class="no-quick-link"></a>import cluster-configuration
 
 Imports a previously exported cluster configuration from a ZIP file or an XML file. This command is useful when spinning up a new cluster.
 
@@ -74,7 +72,7 @@ gfsh>import cluster-configuration --zip-file-name=/home/username/myClusterConfig
 Cluster configuration successfully imported
 ```
 
-## <a id="topic_jw2_2ld_2l" class="no-quick-link"></a>import data
+## <a id="import-data" class="no-quick-link"></a>import data
 
 Import user data from a file or files to a region.
 

--- a/geode-docs/tools_modules/gfsh/quick_ref_commands_by_area.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/quick_ref_commands_by_area.html.md.erb
@@ -87,7 +87,7 @@ limitations under the License.
 <td>online</td>
 </tr>
 <tr>
-<td><a href="command-pages/import.html#topic_vnv_grz_ck">import cluster-configuration</a></td>
+<td><a href="command-pages/import.html#import-cluster-config">import cluster-configuration</a></td>
 <td>Import an exported configuration.</td>
 <td>online</td>
 </tr>


### PR DESCRIPTION
Two write-ups on the gfsh import cluster-configuration command seem to differ with regard to whether the operation is allowed on running cache servers.

The operation is allowed, but with restrictions. The correct details are provided in the gfsh import command description.
This PR modifies the corresponding section under Exporting and Importing Cluster Configurations to be consistent with the gfsh write-up.