### PR TITLE
GEODE-9187: Implement Radish ZREVRANK command

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRankNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRankNativeRedisAcceptanceTest.java
@@ -14,25 +14,22 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import java.util.List;
+import org.junit.ClassRule;
 
-import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Command;
-import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+import org.apache.geode.redis.NativeRedisClusterTestRule;
 
-public class ZRankExecutor extends AbstractExecutor {
+public class ZRevRankNativeRedisAcceptanceTest extends AbstractZRevRankIntegrationTest {
+
+  @ClassRule
+  public static NativeRedisClusterTestRule server = new NativeRedisClusterTestRule();
+
   @Override
-  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
+  public int getPort() {
+    return server.getExposedPorts().get(0);
+  }
 
-    List<byte[]> commandElements = command.getProcessedCommand();
-
-    long rank = redisSortedSetCommands.zrank(command.getKey(), commandElements.get(2));
-
-    if (rank == -1) {
-      return RedisResponse.nil();
-    }
-    return RedisResponse.integer(rank);
+  @Override
+  public void flushAll() {
+    server.flushAll();
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -231,13 +231,18 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   }
 
   @Test
+  public void testZcard() {
+    runCommandAndAssertHitsAndMisses("sortedSet", k -> jedis.zcard(k));
+  }
+
+  @Test
   public void testZIncrBy() {
     runCommandAndAssertNoStatUpdates("key", (k, m) -> jedis.zincrby(k, 100.0, m));
   }
 
   @Test
-  public void testZscore() {
-    runCommandAndAssertHitsAndMisses("sortedSet", (k, v) -> jedis.zscore(k, v));
+  public void testZrank() {
+    runCommandAndAssertHitsAndMisses("sortedSet", (k, m) -> jedis.zrank(k, m));
   }
 
   @Test
@@ -246,13 +251,13 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   }
 
   @Test
-  public void testZcard() {
-    runCommandAndAssertHitsAndMisses("sortedSet", k -> jedis.zcard(k));
+  public void testZrevrank() {
+    runCommandAndAssertHitsAndMisses("sortedSet", (k, m) -> jedis.zrevrank(k, m));
   }
 
   @Test
-  public void testZrank() {
-    runCommandAndAssertHitsAndMisses("sortedSet", (k, m) -> jedis.zrank(k, m));
+  public void testZscore() {
+    runCommandAndAssertHitsAndMisses("sortedSet", (k, v) -> jedis.zscore(k, v));
   }
 
   /************* Set related commands *************/
@@ -403,8 +408,8 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   @Test
   public void testBitpos() {
     Map<String, String> info = RedisTestHelper.getInfo(jedis);
-    Long currentHits = Long.parseLong(info.get(HITS));
-    Long currentMisses = Long.parseLong(info.get(MISSES));
+    long currentHits = Long.parseLong(info.get(HITS));
+    long currentMisses = Long.parseLong(info.get(MISSES));
 
     jedis.bitpos("string", true);
     info = RedisTestHelper.getInfo(jedis);
@@ -422,8 +427,8 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   @Test
   public void testBitop() {
     Map<String, String> info = RedisTestHelper.getInfo(jedis);
-    Long currentHits = Long.parseLong(info.get(HITS));
-    Long currentMisses = Long.parseLong(info.get(MISSES));
+    long currentHits = Long.parseLong(info.get(HITS));
+    long currentMisses = Long.parseLong(info.get(MISSES));
 
     jedis.bitop(BitOP.OR, "dest", "string", "string", "dest");
     info = RedisTestHelper.getInfo(jedis);
@@ -514,8 +519,8 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   /************* Helper Methods *************/
   private void runCommandAndAssertHitsAndMisses(String key, Consumer<String> command) {
     Map<String, String> info = RedisTestHelper.getInfo(jedis);
-    Long currentHits = Long.parseLong(info.get(HITS));
-    Long currentMisses = Long.parseLong(info.get(MISSES));
+    long currentHits = Long.parseLong(info.get(HITS));
+    long currentMisses = Long.parseLong(info.get(MISSES));
 
     command.accept(key);
     info = RedisTestHelper.getInfo(jedis);
@@ -532,8 +537,8 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   private void runCommandAndAssertHitsAndMisses(String key, BiConsumer<String, String> command) {
     Map<String, String> info = RedisTestHelper.getInfo(jedis);
-    Long currentHits = Long.parseLong(info.get(HITS));
-    Long currentMisses = Long.parseLong(info.get(MISSES));
+    long currentHits = Long.parseLong(info.get(HITS));
+    long currentMisses = Long.parseLong(info.get(MISSES));
 
     command.accept(key, "42");
     info = RedisTestHelper.getInfo(jedis);
@@ -551,8 +556,8 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   private void runCommandAndAssertHitsAndMisses(String key1, String key2,
       BiConsumer<String, String> command) {
     Map<String, String> info = RedisTestHelper.getInfo(jedis);
-    Long currentHits = Long.parseLong(info.get(HITS));
-    Long currentMisses = Long.parseLong(info.get(MISSES));
+    long currentHits = Long.parseLong(info.get(HITS));
+    long currentMisses = Long.parseLong(info.get(MISSES));
 
     command.accept(key1, key2);
     info = RedisTestHelper.getInfo(jedis);
@@ -564,8 +569,8 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   private void runDiffCommandAndAssertHitsAndMisses(String key,
       BiConsumer<String, String> command) {
     Map<String, String> info = RedisTestHelper.getInfo(jedis);
-    Long currentHits = Long.parseLong(info.get(HITS));
-    Long currentMisses = Long.parseLong(info.get(MISSES));
+    long currentHits = Long.parseLong(info.get(HITS));
+    long currentMisses = Long.parseLong(info.get(MISSES));
 
     command.accept(key, key);
     info = RedisTestHelper.getInfo(jedis);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRankIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRankIntegrationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Protocol;
+
+import org.apache.geode.redis.RedisIntegrationTest;
+
+public abstract class AbstractZRevRankIntegrationTest implements RedisIntegrationTest {
+  public static final String KEY = "key";
+  public static final String MEMBER = "member";
+
+  private JedisCluster jedis;
+
+  @Before
+  public void setUp() {
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void shouldError_givenWrongNumberOfArguments() {
+    assertExactNumberOfArgs(jedis, Protocol.Command.ZREVRANK, 2);
+  }
+
+  @Test
+  public void shouldReturnNil_givenKeyDoesNotExist() {
+    assertThat(jedis.zrevrank("fakeKey", "fakeMember")).isEqualTo(null);
+  }
+
+  @Test
+  public void shouldReturnNil_givenMemberDoesNotExist() {
+    jedis.zadd(KEY, 1.0, MEMBER);
+    assertThat(jedis.zrevrank(KEY, "fakeMember")).isEqualTo(null);
+  }
+
+  @Test
+  public void shouldReturnReverseRank_givenKeyAndMemberExist() {
+    jedis.zadd(KEY, 1.0, MEMBER);
+    assertThat(jedis.zrevrank(KEY, MEMBER)).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldReturnReverseRankByScore_givenUniqueScoresAndMembers() {
+    Map<String, Double> membersMap = new HashMap<>();
+    List<String> membersInRankOrder = new ArrayList<>();
+    // Add members with scores in increasing rank order, including positive and negative infinity,
+    // and keep track of the rank order in membersInRankOrder
+    String firstMember = MEMBER + membersMap.size();
+    membersMap.put(firstMember, Double.NEGATIVE_INFINITY);
+    membersInRankOrder.add(firstMember);
+
+    for (int i = membersMap.size(); i < 10; ++i) {
+      String memberName = MEMBER + i;
+      membersMap.put(memberName, (double) i);
+      membersInRankOrder.add(memberName);
+    }
+
+    String finalMember = MEMBER + membersMap.size();
+    membersMap.put(finalMember, Double.POSITIVE_INFINITY);
+    membersInRankOrder.add(finalMember);
+
+    jedis.zadd(KEY, membersMap);
+
+    // Assert that revRank returns the expected rank
+    for (int i = 0; i < membersInRankOrder.size(); i++) {
+      String member = membersInRankOrder.get(i);
+      int expectedRevRank = membersInRankOrder.size() - i - 1;
+      assertThat(jedis.zrevrank(KEY, member)).isEqualTo(expectedRevRank);
+    }
+  }
+
+  @Test
+  public void shouldReturnReverseRankByLex_givenMembersWithSameScore() {
+    String firstMember = "aaa";
+    String secondMember = "bbb";
+    String thirdMember = "ccc";
+
+    double score = 1.0;
+    jedis.zadd(KEY, score, firstMember);
+    jedis.zadd(KEY, score, secondMember);
+    jedis.zadd(KEY, score, thirdMember);
+
+    assertThat(jedis.zrevrank(KEY, firstMember)).isEqualTo(2);
+    assertThat(jedis.zrevrank(KEY, secondMember)).isEqualTo(1);
+    assertThat(jedis.zrevrank(KEY, thirdMember)).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldUpdateRank_whenScoreChanges() {
+    String firstMember = "first";
+    String secondMember = "second";
+    String thirdMember = "third";
+
+    jedis.zadd(KEY, 1.0, firstMember);
+    jedis.zadd(KEY, 2.0, secondMember);
+    jedis.zadd(KEY, 3.0, thirdMember);
+
+    assertThat(jedis.zrevrank(KEY, firstMember)).isEqualTo(2);
+    assertThat(jedis.zrevrank(KEY, secondMember)).isEqualTo(1);
+    assertThat(jedis.zrevrank(KEY, thirdMember)).isEqualTo(0);
+
+    jedis.zadd(KEY, 4.0, firstMember);
+
+    assertThat(jedis.zrevrank(KEY, firstMember)).isEqualTo(0);
+    assertThat(jedis.zrevrank(KEY, secondMember)).isEqualTo(2);
+    assertThat(jedis.zrevrank(KEY, thirdMember)).isEqualTo(1);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRankIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRankIntegrationTest.java
@@ -14,25 +14,17 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import java.util.List;
+import org.junit.ClassRule;
 
-import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Command;
-import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+import org.apache.geode.redis.GeodeRedisServerRule;
 
-public class ZRankExecutor extends AbstractExecutor {
+public class ZRevRankIntegrationTest extends AbstractZRevRankIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
   @Override
-  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
-
-    List<byte[]> commandElements = command.getProcessedCommand();
-
-    long rank = redisSortedSetCommands.zrank(command.getKey(), commandElements.get(2));
-
-    if (rank == -1) {
-      return RedisResponse.nil();
-    }
-    return RedisResponse.integer(rank);
+  public int getPort() {
+    return server.getPort();
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -102,6 +102,7 @@ import org.apache.geode.redis.internal.executor.sortedset.ZIncrByExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRangeExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRankExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRemExecutor;
+import org.apache.geode.redis.internal.executor.sortedset.ZRevRankExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZScoreExecutor;
 import org.apache.geode.redis.internal.executor.string.AppendExecutor;
 import org.apache.geode.redis.internal.executor.string.BitCountExecutor;
@@ -211,6 +212,7 @@ public enum RedisCommandType {
       .and(new MaximumParameterRequirements(5, ERROR_SYNTAX))),
   ZRANK(new ZRankExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
   ZREM(new ZRemExecutor(), SUPPORTED, new MinimumParameterRequirements(3)),
+  ZREVRANK(new ZRevRankExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
   ZSCORE(new ZScoreExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
 
   /************* Server *****************/

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -79,7 +79,7 @@ class NullRedisSortedSet extends RedisSortedSet {
   }
 
   private Object zaddIncr(Region<RedisKey, RedisData> region, RedisKey key,
-                          List<byte[]> membersToAdd) {
+      List<byte[]> membersToAdd) {
     // for zadd incr option, only one incrementing element pair is allowed to get here.
     byte[] increment = membersToAdd.get(0);
     byte[] member = membersToAdd.get(1);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -55,19 +55,6 @@ class NullRedisSortedSet extends RedisSortedSet {
     return sortedSet.getSortedSetSize();
   }
 
-  private Object zaddIncr(Region<RedisKey, RedisData> region, RedisKey key,
-      List<byte[]> membersToAdd) {
-    // for zadd incr option, only one incrementing element pair is allowed to get here.
-    byte[] increment = membersToAdd.get(0);
-    byte[] member = membersToAdd.get(1);
-    return zincrby(region, key, increment, member);
-  }
-
-  @Override
-  byte[] zscore(byte[] member) {
-    return null;
-  }
-
   @Override
   byte[] zincrby(Region<RedisKey, RedisData> region, RedisKey key, byte[] increment,
       byte[] member) {
@@ -82,13 +69,20 @@ class NullRedisSortedSet extends RedisSortedSet {
   }
 
   @Override
-  int zrank(byte[] member) {
-    return -1;
+  List<byte[]> zrange(int min, int max, boolean withScores) {
+    return null;
   }
 
   @Override
-  List<byte[]> zrange(int min, int max,
-      boolean withScores) {
+  byte[] zscore(byte[] member) {
     return null;
+  }
+
+  private Object zaddIncr(Region<RedisKey, RedisData> region, RedisKey key,
+                          List<byte[]> membersToAdd) {
+    // for zadd incr option, only one incrementing element pair is allowed to get here.
+    byte[] increment = membersToAdd.get(0);
+    byte[] member = membersToAdd.get(1);
+    return zincrby(region, key, increment, member);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -40,15 +40,8 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
         () -> getRedisSortedSet(key, false).zadd(getRegion(), key, scoresAndMembersToAdd, options));
   }
 
-  @Override
-  public List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores) {
-    return stripedExecute(key,
-        () -> getRedisSortedSet(key, false).zrange(min, max, withScores));
-  }
-
-  @Override
-  public byte[] zscore(RedisKey key, byte[] member) {
-    return stripedExecute(key, () -> getRedisSortedSet(key, true).zscore(member));
+  public long zcard(RedisKey key) {
+    return stripedExecute(key, () -> getRedisSortedSet(key, true).zcard());
   }
 
   @Override
@@ -58,18 +51,29 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
+  public List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores) {
+    return stripedExecute(key,
+        () -> getRedisSortedSet(key, false).zrange(min, max, withScores));
+  }
+
+  @Override
+  public long zrank(RedisKey key, byte[] member) {
+    return stripedExecute(key, () -> getRedisSortedSet(key, true).zrank(member));
+  }
+
+  @Override
   public long zrem(RedisKey key, List<byte[]> membersToRemove) {
     return stripedExecute(key,
         () -> getRedisSortedSet(key, false).zrem(getRegion(), key, membersToRemove));
   }
 
   @Override
-  public long zcard(RedisKey key) {
-    return stripedExecute(key, () -> getRedisSortedSet(key, true).zcard());
+  public long zrevrank(RedisKey key, byte[] member) {
+    return stripedExecute(key, () -> getRedisSortedSet(key, true).zrevrank(member));
   }
 
   @Override
-  public int zrank(RedisKey key, byte[] member) {
-    return stripedExecute(key, () -> getRedisSortedSet(key, true).zrank(member));
+  public byte[] zscore(RedisKey key, byte[] member) {
+    return stripedExecute(key, () -> getRedisSortedSet(key, true).zscore(member));
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -23,15 +23,17 @@ public interface RedisSortedSetCommands {
 
   Object zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options);
 
-  List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores);
-
-  byte[] zscore(RedisKey key, byte[] member);
-
-  int zrank(RedisKey key, byte[] member);
-
-  long zrem(RedisKey key, List<byte[]> membersToRemove);
-
   long zcard(RedisKey key);
 
   byte[] zincrby(RedisKey key, byte[] increment, byte[] member);
+
+  List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores);
+
+  long zrank(RedisKey key, byte[] member);
+
+  long zrem(RedisKey key, List<byte[]> membersToRemove);
+
+  long zrevrank(RedisKey key, byte[] member);
+
+  byte[] zscore(RedisKey key, byte[] member);
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRankExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRankExecutor.java
@@ -21,14 +21,14 @@ import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ZRankExecutor extends AbstractExecutor {
+public class ZRevRankExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
 
     List<byte[]> commandElements = command.getProcessedCommand();
 
-    long rank = redisSortedSetCommands.zrank(command.getKey(), commandElements.get(2));
+    long rank = redisSortedSetCommands.zrevrank(command.getKey(), commandElements.get(2));
 
     if (rank == -1) {
       return RedisResponse.nil();

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -93,6 +93,7 @@ public class SupportedCommandsJUnitTest {
       "ZRANGE",
       "ZRANK",
       "ZREM",
+      "ZREVRANK",
       "ZSCORE"
   };
 


### PR DESCRIPTION
 - Add ZREVRANK to supported commands
 - Arrange RedisSortedSet commands alphabetically in classes
 - Remove redundant zrank implementation in NullRedisSet
 - Add tests for ZREVRANK command

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
