### PR TITLE
GEODE-9050: Bump netty from 4.1.59.Final to 4.1.65.Final

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -205,7 +205,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.59.Final</version>
+        <version>4.1.65.Final</version>
       </dependency>
       <dependency>
         <groupId>io.swagger</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -115,7 +115,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'io.github.resilience4j', name: 'resilience4j-retry', version: '1.7.0')
         api(group: 'io.lettuce', name: 'lettuce-core', version: '6.1.2.RELEASE')
         api(group: 'io.micrometer', name: 'micrometer-core', version: get('micrometer.version'))
-        api(group: 'io.netty', name: 'netty-all', version: '4.1.59.Final')
+        api(group: 'io.netty', name: 'netty-all', version: '4.1.65.Final')
         api(group: 'io.swagger', name: 'swagger-annotations', version: '1.6.2')
         api(group: 'it.unimi.dsi', name: 'fastutil', version: get('fastutil.version'))
         api(group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2')

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1044,7 +1044,7 @@ lib/micrometer-core-1.7.0.jar
 lib/mx4j-3.0.2.jar
 lib/mx4j-remote-3.0.2.jar
 lib/mx4j-tools-3.0.1.jar
-lib/netty-all-4.1.59.Final.jar
+lib/netty-all-4.1.65.Final.jar
 lib/ra.jar
 lib/rmiio-2.1.2.jar
 lib/shiro-cache-1.7.1.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -87,4 +87,4 @@ lucene-queryparser-6.6.6.jar
 lucene-core-6.6.6.jar
 lucene-queries-6.6.6.jar
 geo-0.7.7.jar
-netty-all-4.1.59.Final.jar
+netty-all-4.1.65.Final.jar


### PR DESCRIPTION
confirming that tests still fail with the latest netty (4.1.65.Final)