### PR TITLE
GEODE-9182: Implement Radish ZCOUNT command

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZCountNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZCountNativeRedisAcceptanceTest.java
@@ -12,30 +12,24 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import java.util.List;
+import org.junit.ClassRule;
 
-import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.NativeRedisClusterTestRule;
 
-public interface RedisSortedSetCommands {
+public class ZCountNativeRedisAcceptanceTest extends AbstractZCountIntegrationTest {
 
-  Object zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options);
+  @ClassRule
+  public static NativeRedisClusterTestRule server = new NativeRedisClusterTestRule();
 
-  long zcard(RedisKey key);
+  @Override
+  public int getPort() {
+    return server.getExposedPorts().get(0);
+  }
 
-  long zcount(RedisKey key, SortedSetRangeOptions rangeOptions);
-
-  byte[] zincrby(RedisKey key, byte[] increment, byte[] member);
-
-  List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores);
-
-  long zrank(RedisKey key, byte[] member);
-
-  long zrem(RedisKey key, List<byte[]> membersToRemove);
-
-  long zrevrank(RedisKey key, byte[] member);
-
-  byte[] zscore(RedisKey key, byte[] member);
+  @Override
+  public void flushAll() {
+    server.flushAll();
+  }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -244,8 +244,7 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   @Test
   public void testZcount() {
-    runCountCommandAndAssertHitsAndMisses(SORTED_SET_KEY,
-        (k, min, max) -> jedis.zcount(k, min, max));
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zcount(k, "-inf", "inf"));
   }
 
   @Test
@@ -560,25 +559,6 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses));
 
     command.accept("missed", "42");
-    info = RedisTestHelper.getInfo(jedis);
-
-    assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
-    assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses + 1));
-  }
-
-  private void runCountCommandAndAssertHitsAndMisses(String key,
-      TriConsumer<String, String, String> command) {
-    Map<String, String> info = RedisTestHelper.getInfo(jedis);
-    long currentHits = Long.parseLong(info.get(HITS));
-    long currentMisses = Long.parseLong(info.get(MISSES));
-
-    command.accept(key, "-inf", "+inf");
-    info = RedisTestHelper.getInfo(jedis);
-
-    assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
-    assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses));
-
-    command.accept("missed", "-inf", "+inf");
     info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -45,6 +45,13 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   private static final String HITS = "keyspace_hits";
   private static final String MISSES = "keyspace_misses";
+  public static final String STRING_KEY = "string";
+  public static final String STRING_INT_KEY = "int";
+  public static final String SET_KEY = "set";
+  public static final String HASH_KEY = "hash";
+  public static final String SORTED_SET_KEY = "sortedSet";
+  public static final String MAP_KEY_1 = "mapKey1";
+  public static final String MAP_KEY_2 = "mapKey2";
 
   protected Jedis jedis;
 
@@ -59,12 +66,12 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   public void setup() {
     jedis = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
 
-    jedis.set("string", "yarn");
-    jedis.set("int", "5");
-    jedis.sadd("set", "cotton");
-    jedis.hset("hash", "green", "eggs");
-    jedis.zadd("sortedSet", -2.0, "almonds");
-    jedis.mset("mapKey1", "fox", "mapKey2", "box");
+    jedis.set(STRING_KEY, "yarn");
+    jedis.set(STRING_INT_KEY, "5");
+    jedis.sadd(SET_KEY, "cotton");
+    jedis.hset(HASH_KEY, "green", "eggs");
+    jedis.zadd(SORTED_SET_KEY, -2.0, "almonds");
+    jedis.mset(MAP_KEY_1, "fox", MAP_KEY_2, "box");
   }
 
   @After
@@ -85,154 +92,160 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   @Test
   public void testExists() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.exists(k));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.exists(k));
   }
 
   @Test
   public void testType() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.type(k));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.type(k));
   }
 
   @Test
   public void testTtl() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.ttl(k));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.ttl(k));
   }
 
   @Test
   public void testPttl() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.pttl(k));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.pttl(k));
   }
 
   @Test
   public void testRename() {
-    runCommandAndAssertNoStatUpdates("string", (k, v) -> jedis.rename(k, v));
+    runCommandAndAssertNoStatUpdates(STRING_KEY, (k, v) -> jedis.rename(k, v));
   }
 
   @Test
   public void testDel() {
-    runCommandAndAssertNoStatUpdates("string", k -> jedis.del(k));
+    runCommandAndAssertNoStatUpdates(STRING_KEY, k -> jedis.del(k));
   }
 
   @Test
   public void testExpire() {
-    runCommandAndAssertNoStatUpdates("hash", (k) -> jedis.expire(k, 5L));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k) -> jedis.expire(k, 5L));
   }
 
   @Test
   public void testPassiveExpiration() {
-    runCommandAndAssertNoStatUpdates("hash", (k) -> {
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k) -> {
       jedis.expire(k, 1L);
       GeodeAwaitility.await().atMost(Duration.ofMinutes(PassiveExpirationManager.INTERVAL * 2))
-          .until(() -> jedis.keys("hash").isEmpty());
+          .until(() -> jedis.keys(HASH_KEY).isEmpty());
     });
   }
 
   @Test
   public void testExpireAt() {
-    runCommandAndAssertNoStatUpdates("hash", (k) -> jedis.expireAt(k, 2145916800));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k) -> jedis.expireAt(k, 2145916800));
   }
 
   @Test
   public void testPExpire() {
-    runCommandAndAssertNoStatUpdates("hash", (k) -> jedis.pexpire(k, 1024));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k) -> jedis.pexpire(k, 1024));
   }
 
   @Test
   public void testPExpireAt() {
-    runCommandAndAssertNoStatUpdates("hash", (k) -> jedis.pexpireAt(k, 1608247597));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k) -> jedis.pexpireAt(k, 1608247597));
   }
 
   @Test
   public void testPersist() {
-    runCommandAndAssertNoStatUpdates("hash", (k) -> jedis.persist(k));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k) -> jedis.persist(k));
   }
 
   @Test
   public void testDump() {
-    runCommandAndAssertHitsAndMisses("hash", (k) -> jedis.dump(k));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, (k) -> jedis.dump(k));
   }
 
   @Test
   public void testRestore() {
-    byte[] data = jedis.dump("hash");
+    byte[] data = jedis.dump(HASH_KEY);
     runCommandAndAssertNoStatUpdates("hash-2", (k) -> jedis.restore(k, 0L, data));
   }
 
   /************* String related commands *************/
   @Test
   public void testGet() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.get(k));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.get(k));
   }
 
   @Test
   public void testAppend() {
-    runCommandAndAssertNoStatUpdates("string", (k, v) -> jedis.append(k, v));
+    runCommandAndAssertNoStatUpdates(STRING_KEY, (k, v) -> jedis.append(k, v));
   }
 
   @Test
   public void testSet() {
-    runCommandAndAssertNoStatUpdates("string", (k, v) -> jedis.set(k, v));
+    runCommandAndAssertNoStatUpdates(STRING_KEY, (k, v) -> jedis.set(k, v));
   }
 
   @Test
   public void testSet_wrongType() {
-    runCommandAndAssertNoStatUpdates("set", (k, v) -> jedis.set(k, v));
+    runCommandAndAssertNoStatUpdates(SET_KEY, (k, v) -> jedis.set(k, v));
   }
 
   @Test
   public void testStrlen() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.strlen(k));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.strlen(k));
   }
 
   @Test
   public void testDecr() {
-    runCommandAndAssertNoStatUpdates("int", k -> jedis.decr(k));
+    runCommandAndAssertNoStatUpdates(STRING_INT_KEY, k -> jedis.decr(k));
   }
 
   @Test
   public void testDecrby() {
-    runCommandAndAssertNoStatUpdates("int", k -> jedis.decrBy(k, 1));
+    runCommandAndAssertNoStatUpdates(STRING_INT_KEY, k -> jedis.decrBy(k, 1));
   }
 
   @Test
   public void testGetrange() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.getrange(k, 1L, 2L));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.getrange(k, 1L, 2L));
   }
 
   @Test
   public void testIncr() {
-    runCommandAndAssertNoStatUpdates("int", k -> jedis.incr(k));
+    runCommandAndAssertNoStatUpdates(STRING_INT_KEY, k -> jedis.incr(k));
   }
 
   @Test
   public void testIncrby() {
-    runCommandAndAssertNoStatUpdates("int", k -> jedis.incrBy(k, 1L));
+    runCommandAndAssertNoStatUpdates(STRING_INT_KEY, k -> jedis.incrBy(k, 1L));
   }
 
   @Test
   public void testIncrbyfloat() {
-    runCommandAndAssertNoStatUpdates("int", k -> jedis.incrByFloat(k, 1.0));
+    runCommandAndAssertNoStatUpdates(STRING_INT_KEY, k -> jedis.incrByFloat(k, 1.0));
   }
 
   @Test
   public void testMget() {
-    runCommandAndAssertHitsAndMisses("mapKey1", "mapKey2", (k1, k2) -> jedis.mget(k1, k2));
+    runCommandAndAssertHitsAndMisses(MAP_KEY_1, MAP_KEY_2, (k1, k2) -> jedis.mget(k1, k2));
   }
 
   @Test
   public void testSetnx() {
-    runCommandAndAssertNoStatUpdates("string", (k, v) -> jedis.setnx(k, v));
+    runCommandAndAssertNoStatUpdates(STRING_KEY, (k, v) -> jedis.setnx(k, v));
   }
 
   /************* SortedSet related commands *************/
   @Test
   public void testZadd() {
-    runCommandAndAssertNoStatUpdates("sortedSet", (k, v) -> jedis.zadd(k, 1.0, v));
+    runCommandAndAssertNoStatUpdates(SORTED_SET_KEY, (k, v) -> jedis.zadd(k, 1.0, v));
   }
 
   @Test
   public void testZcard() {
-    runCommandAndAssertHitsAndMisses("sortedSet", k -> jedis.zcard(k));
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zcard(k));
+  }
+
+  @Test
+  public void testZcount() {
+    runCountCommandAndAssertHitsAndMisses(SORTED_SET_KEY,
+        (k, min, max) -> jedis.zcount(k, min, max));
   }
 
   @Test
@@ -242,49 +255,49 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   @Test
   public void testZrank() {
-    runCommandAndAssertHitsAndMisses("sortedSet", (k, m) -> jedis.zrank(k, m));
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, (k, m) -> jedis.zrank(k, m));
   }
 
   @Test
   public void testZrem() {
-    runCommandAndAssertNoStatUpdates("sortedSet", (k, v) -> jedis.zrem(k, v));
+    runCommandAndAssertNoStatUpdates(SORTED_SET_KEY, (k, v) -> jedis.zrem(k, v));
   }
 
   @Test
   public void testZrevrank() {
-    runCommandAndAssertHitsAndMisses("sortedSet", (k, m) -> jedis.zrevrank(k, m));
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, (k, m) -> jedis.zrevrank(k, m));
   }
 
   @Test
   public void testZscore() {
-    runCommandAndAssertHitsAndMisses("sortedSet", (k, v) -> jedis.zscore(k, v));
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, (k, v) -> jedis.zscore(k, v));
   }
 
   /************* Set related commands *************/
   @Test
   public void testSadd() {
-    runCommandAndAssertNoStatUpdates("set", (k, v) -> jedis.sadd(k, v));
+    runCommandAndAssertNoStatUpdates(SET_KEY, (k, v) -> jedis.sadd(k, v));
   }
 
   @Test
   public void testSrem() {
-    runCommandAndAssertNoStatUpdates("set", (k, v) -> jedis.srem(k, v));
+    runCommandAndAssertNoStatUpdates(SET_KEY, (k, v) -> jedis.srem(k, v));
   }
 
   @Test
   public void testSmembers() {
-    runCommandAndAssertHitsAndMisses("set", k -> jedis.smembers(k));
+    runCommandAndAssertHitsAndMisses(SET_KEY, k -> jedis.smembers(k));
   }
 
   /************* Hash related commands *************/
   @Test
   public void testHset() {
-    runCommandAndAssertNoStatUpdates("hash", (k, v, s) -> jedis.hset(k, v, s));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k, v, s) -> jedis.hset(k, v, s));
   }
 
   @Test
   public void testHgetall() {
-    runCommandAndAssertHitsAndMisses("hash", k -> jedis.hgetAll(k));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, k -> jedis.hgetAll(k));
   }
 
   @Test
@@ -298,62 +311,62 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   @Test
   public void testHdel() {
-    runCommandAndAssertNoStatUpdates("hash", (k, v) -> jedis.hdel(k, v));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k, v) -> jedis.hdel(k, v));
   }
 
   @Test
   public void testHget() {
-    runCommandAndAssertHitsAndMisses("hash", (k, v) -> jedis.hget(k, v));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, (k, v) -> jedis.hget(k, v));
   }
 
   @Test
   public void testHkeys() {
-    runCommandAndAssertHitsAndMisses("hash", k -> jedis.hkeys(k));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, k -> jedis.hkeys(k));
   }
 
   @Test
   public void testHlen() {
-    runCommandAndAssertHitsAndMisses("hash", k -> jedis.hlen(k));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, k -> jedis.hlen(k));
   }
 
   @Test
   public void testHvals() {
-    runCommandAndAssertHitsAndMisses("hash", k -> jedis.hvals(k));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, k -> jedis.hvals(k));
   }
 
   @Test
   public void testHmget() {
-    runCommandAndAssertHitsAndMisses("hash", (k, v) -> jedis.hmget(k, v));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, (k, v) -> jedis.hmget(k, v));
   }
 
   @Test
   public void testHexists() {
-    runCommandAndAssertHitsAndMisses("hash", (k, v) -> jedis.hexists(k, v));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, (k, v) -> jedis.hexists(k, v));
   }
 
   @Test
   public void testHstrlen() {
-    runCommandAndAssertHitsAndMisses("hash", (k, v) -> jedis.hstrlen(k, v));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, (k, v) -> jedis.hstrlen(k, v));
   }
 
   @Test
   public void testHscan() {
-    runCommandAndAssertHitsAndMisses("hash", (k, v) -> jedis.hscan(k, v));
+    runCommandAndAssertHitsAndMisses(HASH_KEY, (k, v) -> jedis.hscan(k, v));
   }
 
   @Test
   public void testHincrby() {
-    runCommandAndAssertNoStatUpdates("hash", (k, f) -> jedis.hincrBy(k, f, 1L));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k, f) -> jedis.hincrBy(k, f, 1L));
   }
 
   @Test
   public void testHincrbyfloat() {
-    runCommandAndAssertNoStatUpdates("hash", (k, f) -> jedis.hincrByFloat(k, f, 1.0));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k, f) -> jedis.hincrByFloat(k, f, 1.0));
   }
 
   @Test
   public void testHsetnx() {
-    runCommandAndAssertNoStatUpdates("hash", (k, f, v) -> jedis.hsetnx(k, f, v));
+    runCommandAndAssertNoStatUpdates(HASH_KEY, (k, f, v) -> jedis.hsetnx(k, f, v));
   }
 
   /**********************************************
@@ -368,41 +381,41 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   @Test
   public void testUnlink() {
-    runCommandAndAssertNoStatUpdates("string", k -> jedis.unlink(k));
+    runCommandAndAssertNoStatUpdates(STRING_KEY, k -> jedis.unlink(k));
   }
 
   /************* String related commands *************/
   @Test
   public void testGetset() {
-    runCommandAndAssertHitsAndMisses("string", (k, v) -> jedis.getSet(k, v));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, (k, v) -> jedis.getSet(k, v));
   }
 
   @Test
   public void testMset() {
-    runCommandAndAssertNoStatUpdates("mapKey1", (k, v) -> jedis.mset(k, v));
+    runCommandAndAssertNoStatUpdates(MAP_KEY_1, (k, v) -> jedis.mset(k, v));
   }
 
   // todo updates stats when it shouldn't. not implemented in the function executor
   @Ignore
   @Test
   public void testMsetnx() {
-    runCommandAndAssertNoStatUpdates("mapKey1", (k, v) -> jedis.msetnx(k, v));
+    runCommandAndAssertNoStatUpdates(MAP_KEY_1, (k, v) -> jedis.msetnx(k, v));
   }
 
   @Test
   public void testSetex() {
-    runCommandAndAssertNoStatUpdates("string", (k, v) -> jedis.setex(k, 200L, v));
+    runCommandAndAssertNoStatUpdates(STRING_KEY, (k, v) -> jedis.setex(k, 200L, v));
   }
 
   @Test
   public void testSetrange() {
-    runCommandAndAssertNoStatUpdates("string", (k, v) -> jedis.setrange(k, 1L, v));
+    runCommandAndAssertNoStatUpdates(STRING_KEY, (k, v) -> jedis.setrange(k, 1L, v));
   }
 
   /************* Bit related commands *************/
   @Test
   public void testBitcount() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.bitcount(k));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.bitcount(k));
   }
 
   @Test
@@ -411,7 +424,7 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
     long currentHits = Long.parseLong(info.get(HITS));
     long currentMisses = Long.parseLong(info.get(MISSES));
 
-    jedis.bitpos("string", true);
+    jedis.bitpos(STRING_KEY, true);
     info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
@@ -430,13 +443,13 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
     long currentHits = Long.parseLong(info.get(HITS));
     long currentMisses = Long.parseLong(info.get(MISSES));
 
-    jedis.bitop(BitOP.OR, "dest", "string", "string", "dest");
+    jedis.bitop(BitOP.OR, "dest", STRING_KEY, STRING_KEY, "dest");
     info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 2));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses + 1));
 
-    jedis.bitop(BitOP.OR, "dest", "string", "missed");
+    jedis.bitop(BitOP.OR, "dest", STRING_KEY, "missed");
     info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 2 + 1));
@@ -445,12 +458,12 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   @Test
   public void testGetbit() {
-    runCommandAndAssertHitsAndMisses("string", k -> jedis.getbit(k, 1));
+    runCommandAndAssertHitsAndMisses(STRING_KEY, k -> jedis.getbit(k, 1));
   }
 
   @Test
   public void testSetbit() {
-    runCommandAndAssertNoStatUpdates("int", (k, v) -> jedis.setbit(k, 0L, "1"));
+    runCommandAndAssertNoStatUpdates(STRING_INT_KEY, (k, v) -> jedis.setbit(k, 0L, "1"));
   }
 
   /************* Set related commands *************/
@@ -458,62 +471,62 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   // or not. In Redis 6.x SPOP does not update any stats.
   @Test
   public void testSpop() {
-    runCommandAndAssertNoStatUpdates("set", k -> jedis.spop(k));
+    runCommandAndAssertNoStatUpdates(SET_KEY, k -> jedis.spop(k));
   }
 
   @Test
   public void testSismember() {
-    runCommandAndAssertHitsAndMisses("set", (k, v) -> jedis.sismember(k, v));
+    runCommandAndAssertHitsAndMisses(SET_KEY, (k, v) -> jedis.sismember(k, v));
   }
 
   @Test
   public void testSrandmember() {
-    runCommandAndAssertHitsAndMisses("set", k -> jedis.srandmember(k));
+    runCommandAndAssertHitsAndMisses(SET_KEY, k -> jedis.srandmember(k));
   }
 
   @Test
   public void testScard() {
-    runCommandAndAssertHitsAndMisses("set", k -> jedis.scard(k));
+    runCommandAndAssertHitsAndMisses(SET_KEY, k -> jedis.scard(k));
   }
 
   @Test
   public void testSscan() {
-    runCommandAndAssertHitsAndMisses("set", (k, v) -> jedis.sscan(k, v));
+    runCommandAndAssertHitsAndMisses(SET_KEY, (k, v) -> jedis.sscan(k, v));
   }
 
   @Test
   public void testSdiff() {
-    runDiffCommandAndAssertHitsAndMisses("set", (k, v) -> jedis.sdiff(k, v));
+    runDiffCommandAndAssertHitsAndMisses(SET_KEY, (k, v) -> jedis.sdiff(k, v));
   }
 
   @Test
   public void testSdiffstore() {
-    runDiffStoreCommandAndAssertNoStatUpdates("set", (k, v, s) -> jedis.sdiffstore(k, v, s));
+    runDiffStoreCommandAndAssertNoStatUpdates(SET_KEY, (k, v, s) -> jedis.sdiffstore(k, v, s));
   }
 
   @Test
   public void testSinter() {
-    runDiffCommandAndAssertHitsAndMisses("set", (k, v) -> jedis.sinter(k, v));
+    runDiffCommandAndAssertHitsAndMisses(SET_KEY, (k, v) -> jedis.sinter(k, v));
   }
 
   @Test
   public void testSinterstore() {
-    runDiffStoreCommandAndAssertNoStatUpdates("set", (k, v, s) -> jedis.sinterstore(k, v, s));
+    runDiffStoreCommandAndAssertNoStatUpdates(SET_KEY, (k, v, s) -> jedis.sinterstore(k, v, s));
   }
 
   @Test
   public void testSunion() {
-    runDiffCommandAndAssertHitsAndMisses("set", (k, v) -> jedis.sunion(k, v));
+    runDiffCommandAndAssertHitsAndMisses(SET_KEY, (k, v) -> jedis.sunion(k, v));
   }
 
   @Test
   public void testSunionstore() {
-    runDiffStoreCommandAndAssertNoStatUpdates("set", (k, v, s) -> jedis.sunionstore(k, v, s));
+    runDiffStoreCommandAndAssertNoStatUpdates(SET_KEY, (k, v, s) -> jedis.sunionstore(k, v, s));
   }
 
   @Test
   public void testSmove() {
-    runCommandAndAssertNoStatUpdates("set", (k, d, m) -> jedis.smove(k, d, m));
+    runCommandAndAssertNoStatUpdates(SET_KEY, (k, d, m) -> jedis.smove(k, d, m));
   }
 
   /************* Helper Methods *************/
@@ -547,6 +560,25 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses));
 
     command.accept("missed", "42");
+    info = RedisTestHelper.getInfo(jedis);
+
+    assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
+    assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses + 1));
+  }
+
+  private void runCountCommandAndAssertHitsAndMisses(String key,
+      TriConsumer<String, String, String> command) {
+    Map<String, String> info = RedisTestHelper.getInfo(jedis);
+    long currentHits = Long.parseLong(info.get(HITS));
+    long currentMisses = Long.parseLong(info.get(MISSES));
+
+    command.accept(key, "-inf", "+inf");
+    info = RedisTestHelper.getInfo(jedis);
+
+    assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
+    assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses));
+
+    command.accept("missed", "-inf", "+inf");
     info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZCountIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZCountIntegrationTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_MIN_MAX_NOT_A_FLOAT;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Protocol;
+
+import org.apache.geode.redis.RedisIntegrationTest;
+
+public abstract class AbstractZCountIntegrationTest implements RedisIntegrationTest {
+  public static final String KEY = "key";
+  private JedisCluster jedis;
+
+  @Before
+  public void setUp() {
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void shouldError_givenWrongNumberOfArguments() {
+    assertExactNumberOfArgs(jedis, Protocol.Command.ZCOUNT, 3);
+  }
+
+  @Test
+  public void shouldError_givenInvalidMinOrMax() {
+    assertThatThrownBy(() -> jedis.zcount("fakeKey", "notANumber", "1"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zcount("fakeKey", "1", "notANumber"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zcount("fakeKey", "notANumber", "notANumber"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zcount("fakeKey", "((", "1"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zcount("fakeKey", "1", "(("))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zcount("fakeKey", "(a", "(b"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+  }
+
+  @Test
+  public void shouldReturnZero_givenNonExistentKey() {
+    assertThat(jedis.zcount("fakeKey", "-inf", "inf")).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldReturnZero_givenMinGreaterThanMax() {
+    jedis.zadd(KEY, 1, "member");
+
+    // Count +inf <= score <= -inf
+    assertThat(jedis.zcount(KEY, "+inf", "-inf")).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldReturnCount_givenRangeIncludingScore() {
+    jedis.zadd(KEY, 1, "member");
+
+    // Count -inf <= score <= +inf
+    assertThat(jedis.zcount(KEY, "-inf", "inf")).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldReturnZero_givenRangeExcludingScore() {
+    int score = 1;
+    jedis.zadd(KEY, score, "member");
+
+    // Count 2 <= score <= 3
+    assertThat(jedis.zcount(KEY, score + 1, score + 2)).isEqualTo(0);
+  }
+
+  @Test
+  public void shouldReturnCount_givenMinAndMaxEqualToScore() {
+    int score = 1;
+    jedis.zadd(KEY, score, "member");
+
+    // Count 1 <= score <= 1
+    assertThat(jedis.zcount(KEY, score, score)).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldReturnCount_givenMultipleMembersWithDifferentScores() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("member1", -10.0);
+    map.put("member2", 1.0);
+    map.put("member3", 10.0);
+
+    jedis.zadd(KEY, map);
+
+    // Count -5 <= score <= 15
+    assertThat(jedis.zcount(KEY, "-5", "15")).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldReturnCount_givenMultipleMembersWithTheSameScoreAndMinAndMaxEqualToScore() {
+    Map<String, Double> map = new HashMap<>();
+    double score = 1;
+    map.put("member1", score);
+    map.put("member2", score);
+    map.put("member3", score);
+
+    jedis.zadd(KEY, map);
+
+    // Count 1 <= score <= 1
+    assertThat(jedis.zcount(KEY, score, score)).isEqualTo(map.size());
+  }
+
+  @Test
+  public void shouldReturnCount_givenExclusiveMin() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("member1", Double.NEGATIVE_INFINITY);
+    map.put("member2", 1.0);
+    map.put("member3", Double.POSITIVE_INFINITY);
+
+    jedis.zadd(KEY, map);
+
+    // Count -inf < score <= +inf
+    assertThat(jedis.zcount(KEY, "(-inf", "+inf")).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldReturnCount_givenExclusiveMax() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("member1", Double.NEGATIVE_INFINITY);
+    map.put("member2", 1.0);
+    map.put("member3", Double.POSITIVE_INFINITY);
+
+    jedis.zadd(KEY, map);
+
+    // Count -inf <= score < +inf
+    assertThat(jedis.zcount(KEY, "-inf", "(+inf")).isEqualTo(2);
+  }
+
+  @Test
+  public void shouldReturnCount_givenExclusiveMinAndMax() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("member1", Double.NEGATIVE_INFINITY);
+    map.put("member2", 1.0);
+    map.put("member3", Double.POSITIVE_INFINITY);
+
+    jedis.zadd(KEY, map);
+
+    // Count -inf < score < +inf
+    assertThat(jedis.zcount(KEY, "(-inf", "(+inf")).isEqualTo(1);
+  }
+
+  @Test
+  public void shouldReturnZero_givenExclusiveMinAndMaxEqualToScore() {
+    double score = 1;
+    jedis.zadd(KEY, score, "member");
+
+    String scoreExclusive = "(" + score;
+    assertThat(jedis.zcount(KEY, scoreExclusive, scoreExclusive)).isEqualTo(0);
+  }
+
+  @Test
+  // Using only "(" as either the min or the max is equivalent to "(0"
+  public void shouldReturnCount_givenLeftParenOnlyForMinOrMax() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("slightlyLessThanZero", -0.01);
+    map.put("zero", 0.0);
+    map.put("slightlyMoreThanZero", 0.01);
+
+    jedis.zadd(KEY, map);
+
+    // Count 0 < score <= inf
+    assertThat(jedis.zcount(KEY, "(", "inf")).isEqualTo(1);
+
+    // Count -inf <= score < 0
+    assertThat(jedis.zcount(KEY, "-inf", "(")).isEqualTo(1);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZCountIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZCountIntegrationTest.java
@@ -12,30 +12,19 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import java.util.List;
+import org.junit.ClassRule;
 
-import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.GeodeRedisServerRule;
 
-public interface RedisSortedSetCommands {
+public class ZCountIntegrationTest extends AbstractZCountIntegrationTest {
 
-  Object zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options);
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
 
-  long zcard(RedisKey key);
-
-  long zcount(RedisKey key, SortedSetRangeOptions rangeOptions);
-
-  byte[] zincrby(RedisKey key, byte[] increment, byte[] member);
-
-  List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores);
-
-  long zrank(RedisKey key, byte[] member);
-
-  long zrem(RedisKey key, List<byte[]> membersToRemove);
-
-  long zrevrank(RedisKey key, byte[] member);
-
-  byte[] zscore(RedisKey key, byte[] member);
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -98,6 +98,7 @@ import org.apache.geode.redis.internal.executor.set.SUnionExecutor;
 import org.apache.geode.redis.internal.executor.set.SUnionStoreExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZCardExecutor;
+import org.apache.geode.redis.internal.executor.sortedset.ZCountExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZIncrByExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRangeExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRankExecutor;
@@ -207,6 +208,7 @@ public enum RedisCommandType {
 
   ZADD(new ZAddExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),
   ZCARD(new ZCardExecutor(), SUPPORTED, new ExactParameterRequirements(2)),
+  ZCOUNT(new ZCountExecutor(), SUPPORTED, new ExactParameterRequirements(4)),
   ZINCRBY(new ZIncrByExecutor(), SUPPORTED, new ExactParameterRequirements(4)),
   ZRANGE(new ZRangeExecutor(), SUPPORTED, new MinimumParameterRequirements(4)
       .and(new MaximumParameterRequirements(5, ERROR_SYNTAX))),

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -45,6 +45,7 @@ public class RedisConstants {
   public static final String ERROR_SYNTAX = "syntax error";
   public static final String ERROR_INVALID_EXPIRE_TIME = "invalid expire time in set";
   public static final String ERROR_NOT_A_VALID_FLOAT = "value is not a valid float";
+  public static final String ERROR_MIN_MAX_NOT_A_FLOAT = "min or max is not a float";
   public static final String ERROR_OOM_COMMAND_NOT_ALLOWED =
       "command not allowed when used memory > 'maxmemory'";
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/OrderStatisticsSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/OrderStatisticsSet.java
@@ -53,20 +53,20 @@ public interface OrderStatisticsSet<T> extends Set<T> {
   T get(int index);
 
   /**
-   * Returns the index of <code>element</code> in the sorted set.
+   * Returns the index of <code>element</code> in the sorted set. If the element is not present in
+   * the set, returns the index it would have if it was present
    *
    * @param element the query element.
-   * @return the index of the query element or -1 if there is no such element
-   *         in this set.
+   * @return the index of the query element.
    */
   int indexOf(T element);
 
   /**
-   * Returns a range of <code>elements</code> between min and max.
+   * Returns an iterator over a range of <code>elements</code> between min and max.
    *
    * @param min the minimum element.
    * @param max the maximum element.
-   * @return an ArrayList of <code>elements</code>.
+   * @return an Iterator of <code>elements</code>.
    */
   Iterator<T> getIndexRange(int min, int max);
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/OrderStatisticsSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/OrderStatisticsSet.java
@@ -54,7 +54,7 @@ public interface OrderStatisticsSet<T> extends Set<T> {
 
   /**
    * Returns the index of <code>element</code> in the sorted set. If the element is not present in
-   * the set, returns the index it would have if it was present
+   * the set, returns the index it would have if it were present.
    *
    * @param element the query element.
    * @return the index of the query element.

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/OrderStatisticsTree.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/OrderStatisticsTree.java
@@ -262,19 +262,7 @@ public class OrderStatisticsTree<E extends Comparable<? super E>>
 
   @Override
   public E get(int index) {
-    checkIndex(index);
-    Node<E> node = root;
-
-    while (true) {
-      if (index > node.count) {
-        index -= node.count + 1;
-        node = node.right;
-      } else if (index < node.count) {
-        node = node.left;
-      } else {
-        return node.key;
-      }
-    }
+    return getNode(index).key;
   }
 
   @Override
@@ -291,14 +279,16 @@ public class OrderStatisticsTree<E extends Comparable<? super E>>
     while (true) {
       if ((cmp = element.compareTo(node.key)) < 0) {
         if (node.left == null) {
-          return -1;
+          return rank;
         }
 
         rank -= (node.count - node.left.count);
         node = node.left;
       } else if (cmp > 0) {
         if (node.right == null) {
-          return -1;
+          // Add 1 because if the element we're testing is greater than the current node but not
+          // present in the set, its rank would be one higher if it were present
+          return rank + 1;
         }
 
         rank += 1 + node.right.count;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.executor.sortedset.SortedSetRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
 
 class NullRedisSortedSet extends RedisSortedSet {
@@ -53,6 +54,11 @@ class NullRedisSortedSet extends RedisSortedSet {
     region.create(key, sortedSet);
 
     return sortedSet.getSortedSetSize();
+  }
+
+  @Override
+  long zcount(SortedSetRangeOptions rangeOptions) {
+    return 0;
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -493,6 +493,15 @@ public class RedisSortedSet extends AbstractRedisData {
       this.score = score;
     }
 
+    public int compareTo(AbstractOrderedSetEntry o) {
+      int comparison = score.compareTo(o.score);
+      if (comparison == 0) {
+        // Scores equal, try lexical ordering
+        return compareMembers(member, o.member);
+      }
+      return comparison;
+    }
+
     public byte[] getScoreBytes() {
       return scoreBytes;
     }
@@ -500,6 +509,8 @@ public class RedisSortedSet extends AbstractRedisData {
     public byte[] getMember() {
       return member;
     }
+
+    public abstract int compareMembers(byte[] array1, byte[] array2);
   }
 
   // Entry used to store data in the scoreSet
@@ -510,13 +521,8 @@ public class RedisSortedSet extends AbstractRedisData {
     }
 
     @Override
-    public int compareTo(AbstractOrderedSetEntry o) {
-      int comparison = score.compareTo(o.score);
-      if (comparison == 0) {
-        // Scores equal, try lexical ordering
-        return javaImplementationOfAnsiCMemCmp(member, o.member);
-      }
-      return comparison;
+    public int compareMembers(byte[] array1, byte[] array2) {
+      return javaImplementationOfAnsiCMemCmp(array1, array2);
     }
   }
 
@@ -529,13 +535,8 @@ public class RedisSortedSet extends AbstractRedisData {
     }
 
     @Override
-    public int compareTo(AbstractOrderedSetEntry o) {
-      int comparison = score.compareTo(o.score);
-      if (comparison == 0) {
-        // Scores equal, use the bLEAST_MEMBER_NAME or bGREATEST_MEMBER_NAME values
-        comparison = checkDummyMemberNames(member, o.member);
-      }
-      return comparison;
+    public int compareMembers(byte[] array1, byte[] array2) {
+      return checkDummyMemberNames(array1, array2);
     }
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -265,13 +265,13 @@ public class RedisSortedSet extends AbstractRedisData {
   long zcount(SortedSetRangeOptions rangeOptions) {
     OrderedSetEntry minEntry =
         new OrderedSetEntry(rangeOptions.getMinDouble(), rangeOptions.isMinExclusive(), true);
-    long minRank = scoreSet.indexOf(minEntry);
+    long minIndex = scoreSet.indexOf(minEntry);
 
     OrderedSetEntry maxEntry =
         new OrderedSetEntry(rangeOptions.getMaxDouble(), rangeOptions.isMaxExclusive(), false);
-    long maxRank = scoreSet.indexOf(maxEntry);
+    long maxIndex = scoreSet.indexOf(maxEntry);
 
-    return maxRank - minRank;
+    return maxIndex - minIndex;
   }
 
   byte[] zincrby(Region<RedisKey, RedisData> region, RedisKey key, byte[] increment,
@@ -435,12 +435,11 @@ public class RedisSortedSet extends AbstractRedisData {
   // in StringBytesGlossary and user-supplied member names which may be equal in content but have
   // a different memory address.
   private static int checkDummyMemberNames(byte[] array1, byte[] array2) {
-    if ((array1 == bLEAST_MEMBER_NAME && array2 == bLEAST_MEMBER_NAME)
-        || (array1 == bGREATEST_MEMBER_NAME && array2 == bGREATEST_MEMBER_NAME)) {
-      throw new IllegalStateException(
-          "Arrays cannot both be least member name or greatest member name");
-    }
     if (array2 == bLEAST_MEMBER_NAME || array1 == bGREATEST_MEMBER_NAME) {
+      if (array1 == bLEAST_MEMBER_NAME || array2 == bGREATEST_MEMBER_NAME) {
+        throw new IllegalStateException(
+            "Arrays cannot both be least member name or greatest member name");
+      }
       return 1; // array2 < array1
     } else if (array1 == bLEAST_MEMBER_NAME || array2 == bGREATEST_MEMBER_NAME) {
       return -1; // array1 < array2

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -514,7 +514,7 @@ public class RedisSortedSet extends AbstractRedisData {
         // For use in (this <= other) and (this > other) comparisons
         this.member = bLEAST_MEMBER_NAME;
       }
-      this.scoreBytes = new byte[] {};
+      this.scoreBytes = null;
       this.score = score;
     }
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -20,6 +20,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_F
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SORTED_SET;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToDouble;
 import static org.apache.geode.redis.internal.netty.Coder.doubleToBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGREATEST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEAST_MEMBER_NAME;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -46,6 +48,7 @@ import org.apache.geode.redis.internal.collections.OrderStatisticsTree;
 import org.apache.geode.redis.internal.delta.AddsDeltaInfo;
 import org.apache.geode.redis.internal.delta.DeltaInfo;
 import org.apache.geode.redis.internal.delta.RemsDeltaInfo;
+import org.apache.geode.redis.internal.executor.sortedset.SortedSetRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
 
 public class RedisSortedSet extends AbstractRedisData {
@@ -259,6 +262,18 @@ public class RedisSortedSet extends AbstractRedisData {
     return members.size();
   }
 
+  long zcount(SortedSetRangeOptions rangeOptions) {
+    OrderedSetEntry minEntry =
+        new OrderedSetEntry(rangeOptions.getMinDouble(), rangeOptions.isMinExclusive(), true);
+    long minRank = scoreSet.indexOf(minEntry);
+
+    OrderedSetEntry maxEntry =
+        new OrderedSetEntry(rangeOptions.getMaxDouble(), rangeOptions.isMaxExclusive(), false);
+    long maxRank = scoreSet.indexOf(maxEntry);
+
+    return maxRank - minRank;
+  }
+
   byte[] zincrby(Region<RedisKey, RedisData> region, RedisKey key, byte[] increment,
       byte[] member) {
     byte[] byteScore = null;
@@ -289,7 +304,7 @@ public class RedisSortedSet extends AbstractRedisData {
   }
 
   List<byte[]> zrange(int min, int max, boolean withScores) {
-    ArrayList<byte[]> result = new ArrayList<>();
+    List<byte[]> result = new ArrayList<>();
     int start = getBoundedStartIndex(min, getSortedSetSize());
     int end = getBoundedEndIndex(max, getSortedSetSize());
     if (start > end || start == getSortedSetSize()) {
@@ -362,7 +377,7 @@ public class RedisSortedSet extends AbstractRedisData {
   }
 
   private int getBoundedStartIndex(int index, int size) {
-    if (index >= 0L) {
+    if (index >= 0) {
       return Math.min(index, size);
     } else {
       return Math.max(index + size, 0);
@@ -370,7 +385,7 @@ public class RedisSortedSet extends AbstractRedisData {
   }
 
   private int getBoundedEndIndex(long index, int size) {
-    if (index >= 0L) {
+    if (index >= 0) {
       return (int) Math.min(index, size);
     } else {
       return (int) Math.max(index + size, -1);
@@ -414,6 +429,28 @@ public class RedisSortedSet extends AbstractRedisData {
     }
   }
 
+  // Comparison to allow the use of bLEAST_MEMBER_NAME and bGREATEST_MEMBER_NAME to always be less
+  // than or greater than respectively any other byte array representing a member name. The use of
+  // "==" is important as it allows us to differentiate between the constant byte arrays defined
+  // in StringBytesGlossary and user-supplied member names which may be equal in content but have
+  // a different memory address.
+  private static int checkDummyMemberNames(byte[] array1, byte[] array2) {
+    if ((array1 == bLEAST_MEMBER_NAME && array2 == bLEAST_MEMBER_NAME)
+        || (array1 == bGREATEST_MEMBER_NAME && array2 == bGREATEST_MEMBER_NAME)) {
+      throw new IllegalStateException(
+          "Arrays cannot both be least member name or greatest member name");
+    }
+    if (array2 == bLEAST_MEMBER_NAME || array1 == bGREATEST_MEMBER_NAME) {
+      return 1; // array2 < array1
+    } else if (array1 == bLEAST_MEMBER_NAME || array2 == bGREATEST_MEMBER_NAME) {
+      return -1; // array1 < array2
+    } else {
+      // Neither of the input arrays are using bLEAST_MEMBER_NAME or bGREATEST_MEMBER_NAME, so real
+      // lexicographical comparison is needed
+      return 0;
+    }
+  }
+
   @VisibleForTesting
   public static int javaImplementationOfAnsiCMemCmp(byte[] array1, byte[] array2) {
     int shortestLength = Math.min(array1.length, array2.length);
@@ -451,8 +488,12 @@ public class RedisSortedSet extends AbstractRedisData {
     public int compareTo(OrderedSetEntry o) {
       int comparison = score.compareTo(o.score);
       if (comparison == 0) {
-        // Scores equal, try lexical ordering
-        return javaImplementationOfAnsiCMemCmp(member, o.member);
+        // Scores equal, try lexical ordering, but first check if the entry is using the
+        // bLEAST_MEMBER_NAME or bGREATEST_MEMBER_NAME values
+        comparison = checkDummyMemberNames(member, o.member);
+        if (comparison == 0) {
+          return javaImplementationOfAnsiCMemCmp(member, o.member);
+        }
       }
       return comparison;
     }
@@ -461,6 +502,20 @@ public class RedisSortedSet extends AbstractRedisData {
       this.member = member;
       this.scoreBytes = score;
       this.score = processByteArrayAsDouble(score);
+    }
+
+    // Dummy entry used to find the rank of an element with the given score for inclusive or
+    // exclusive ranges
+    OrderedSetEntry(double score, boolean isExclusive, boolean isMinimum) {
+      if (isExclusive && isMinimum || !isExclusive && !isMinimum) {
+        // For use in (this < other) and (this >= other) comparisons
+        this.member = bGREATEST_MEMBER_NAME;
+      } else {
+        // For use in (this <= other) and (this > other) comparisons
+        this.member = bLEAST_MEMBER_NAME;
+      }
+      this.scoreBytes = new byte[] {};
+      this.score = score;
     }
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommands;
+import org.apache.geode.redis.internal.executor.sortedset.SortedSetRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
 
 public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFunctionExecutor
@@ -42,6 +43,11 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
 
   public long zcard(RedisKey key) {
     return stripedExecute(key, () -> getRedisSortedSet(key, true).zcard());
+  }
+
+  @Override
+  public long zcount(RedisKey key, SortedSetRangeOptions rangeOptions) {
+    return stripedExecute(key, () -> getRedisSortedSet(key, true).zcount(rangeOptions));
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetRangeOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetRangeOptions.java
@@ -12,30 +12,34 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import java.util.List;
+public class SortedSetRangeOptions {
+  private final double minDouble;
+  private final boolean minExclusive;
+  private final double maxDouble;
+  private final boolean maxExclusive;
 
-import org.apache.geode.redis.internal.data.RedisKey;
+  public SortedSetRangeOptions(double min, boolean minExclusive, double max, boolean maxExclusive) {
+    this.minDouble = min;
+    this.minExclusive = minExclusive;
+    this.maxDouble = max;
+    this.maxExclusive = maxExclusive;
+  }
 
-public interface RedisSortedSetCommands {
+  public double getMinDouble() {
+    return minDouble;
+  }
 
-  Object zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options);
+  public boolean isMinExclusive() {
+    return minExclusive;
+  }
 
-  long zcard(RedisKey key);
+  public double getMaxDouble() {
+    return maxDouble;
+  }
 
-  long zcount(RedisKey key, SortedSetRangeOptions rangeOptions);
-
-  byte[] zincrby(RedisKey key, byte[] increment, byte[] member);
-
-  List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores);
-
-  long zrank(RedisKey key, byte[] member);
-
-  long zrem(RedisKey key, List<byte[]> membersToRemove);
-
-  long zrevrank(RedisKey key, byte[] member);
-
-  byte[] zscore(RedisKey key, byte[] member);
+  public boolean isMaxExclusive() {
+    return maxExclusive;
+  }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZCountExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZCountExecutor.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_MIN_MAX_NOT_A_FLOAT;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToDouble;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEFT_PAREN;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.geode.redis.internal.executor.AbstractExecutor;
+import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.netty.Command;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+
+public class ZCountExecutor extends AbstractExecutor {
+  @Override
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
+    RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
+
+    List<byte[]> commandElements = command.getProcessedCommand();
+
+    SortedSetRangeOptions rangeOptions;
+
+    try {
+      byte[] minBytes = commandElements.get(2);
+      byte[] maxBytes = commandElements.get(3);
+      rangeOptions = parseRangeArguments(minBytes, maxBytes);
+    } catch (NumberFormatException ex) {
+      return RedisResponse.error(ERROR_MIN_MAX_NOT_A_FLOAT);
+    }
+
+    // If the range is empty (min > max or min == max and both are exclusive), return early
+    if (rangeOptions.getMinDouble() > rangeOptions.getMaxDouble() ||
+        (rangeOptions.getMinDouble() == rangeOptions.getMaxDouble())
+            && rangeOptions.isMinExclusive() && rangeOptions.isMaxExclusive()) {
+      return RedisResponse.integer(0);
+    }
+
+    long count = redisSortedSetCommands.zcount(command.getKey(), rangeOptions);
+
+    return RedisResponse.integer(count);
+  }
+
+  SortedSetRangeOptions parseRangeArguments(byte[] minBytes, byte[] maxBytes) {
+    boolean minExclusive = false;
+    double minDouble;
+    if (minBytes[0] == bLEFT_PAREN) {
+      // A value of "(" is equivalent to "(0"
+      if (minBytes.length == 1) {
+        minDouble = 0;
+      } else {
+        minDouble =
+            bytesToDouble(Arrays.copyOfRange(minBytes, 1, minBytes.length));
+      }
+      minExclusive = true;
+    } else {
+      minDouble = bytesToDouble(minBytes);
+    }
+
+    boolean maxExclusive = false;
+    double maxDouble;
+    if (maxBytes[0] == bLEFT_PAREN) {
+      // A value of "(" is equivalent to "(0"
+      if (maxBytes.length == 1) {
+        maxDouble = 0;
+      } else {
+        maxDouble =
+            bytesToDouble(Arrays.copyOfRange(maxBytes, 1, maxBytes.length));
+      }
+      maxExclusive = true;
+    } else {
+      maxDouble = bytesToDouble(maxBytes);
+    }
+    return new SortedSetRangeOptions(minDouble, minExclusive, maxDouble, maxExclusive);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.netty;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 
 import org.apache.geode.annotations.internal.MakeImmutable;
+import org.apache.geode.redis.internal.data.RedisSortedSet;
 
 /**
  * Important note
@@ -219,6 +220,9 @@ public class StringBytesGlossary {
 
   public static final byte bLOWERCASE_Z = 122; // z
 
+  public static final byte bLEFT_PAREN = 40; // (
+
+
   public static final String PING_RESPONSE = "PONG";
 
   @MakeImmutable
@@ -229,4 +233,17 @@ public class StringBytesGlossary {
 
   @MakeImmutable
   public static final byte[] bRADISH_DUMP_HEADER = stringToBytes("RADISH");
+
+  /**
+   * These member names will always be evaluated to be "greater than" or "less than" any other when
+   * using the {@link RedisSortedSet.OrderedSetEntry#compareTo(RedisSortedSet.OrderedSetEntry)}
+   * method, so the rank of an entry using these names will be less than or greater than all other
+   * members with the same score.
+   * These values should always be compared using {@code ==} rather than {@code Array.equals()} so
+   * that we can differentiate between the use of these constants and a value potentially entered by
+   * the user, which while equal in content, will not share the same memory address.
+   */
+  public static final byte[] bGREATEST_MEMBER_NAME = new byte[] {-1};
+
+  public static final byte[] bLEAST_MEMBER_NAME = new byte[] {-2};
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -90,6 +90,7 @@ public class SupportedCommandsJUnitTest {
       "ZADD",
       "ZINCRBY",
       "ZCARD",
+      "ZCOUNT",
       "ZRANGE",
       "ZRANK",
       "ZREM",

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderStatisticsTreeTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderStatisticsTreeTest.java
@@ -203,7 +203,7 @@ public class OrderStatisticsTreeTest {
 
     // Test values smaller than the lowest entry and greater than the largest entry
     assertThat(tree.indexOf(-1)).isEqualTo(0);
-    assertThat(tree.indexOf(1 + entries * stepSize)).isEqualTo(tree.size());
+    assertThat(tree.indexOf(entries * stepSize)).isEqualTo(tree.size());
 
     for (int i = 0; i < entries * stepSize; ++i) {
       assertThat(tree.indexOf(i)).isEqualTo((i + stepSize - 1) / stepSize);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderStatisticsTreeTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderStatisticsTreeTest.java
@@ -34,6 +34,7 @@ import java.util.Collection;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
 import java.util.TreeSet;
@@ -193,16 +194,19 @@ public class OrderStatisticsTreeTest {
 
   @Test
   public void testIndexOf() {
-    for (int i = 100; i < 200; ++i) {
-      assertThat(tree.add(i)).isTrue();
+    int stepSize = 10;
+    int entries = 20;
+    // All entries are multiple of 10, from 0 to 190
+    for (int i = 0; i < entries; ++i) {
+      assertThat(tree.add(i * stepSize)).isTrue();
     }
 
-    for (int i = 100; i < 200; ++i) {
-      assertThat(tree.indexOf(i)).isEqualTo(i - 100);
-    }
+    // Test values smaller than the lowest entry and greater than the largest entry
+    assertThat(tree.indexOf(-1)).isEqualTo(0);
+    assertThat(tree.indexOf(1 + entries * stepSize)).isEqualTo(tree.size());
 
-    for (int i = 200; i < 250; ++i) {
-      assertThat(tree.indexOf(i)).isEqualTo(-1);
+    for (int i = 0; i < entries * stepSize; ++i) {
+      assertThat(tree.indexOf(i)).isEqualTo((i + stepSize - 1) / stepSize);
     }
   }
 
@@ -577,7 +581,7 @@ public class OrderStatisticsTreeTest {
       tree.add(i);
     }
 
-    ArrayList<Integer> subSet = new ArrayList<>();
+    List<Integer> subSet = new ArrayList<>();
     Iterator<Integer> subIterator = tree.getIndexRange(0, 9);
     while (subIterator.hasNext()) {
       subSet.add(subIterator.next());

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderedStatisticTreeQuickCheckTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderedStatisticTreeQuickCheckTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Iterator;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import com.pholser.junit.quickcheck.Property;
 import com.pholser.junit.quickcheck.generator.InRange;
@@ -63,6 +64,23 @@ public class OrderedStatisticTreeQuickCheckTest {
     Long element = expected.get(elementIndex);
 
     assertThat(list.indexOf(element)).isEqualTo(expected.indexOf(element));
+  }
+
+  @Property
+  public void indexOfForElementsThatAreNotPresentReturnExpectedIndex(
+      @Size(min = 5, max = 500) Set<Long> insertData) {
+    // Add only 1/5 of the data
+    int subsetSize = insertData.size() / 5;
+    Set<Long> subset = insertData.stream().limit(subsetSize).collect(Collectors.toSet());
+    expected.addAll(subset);
+    list.addAll(subset);
+
+    insertData.removeAll(subset);
+
+    // Confirm that the index of elements not present in the set is as expected
+    for (Long element : insertData) {
+      assertThat(list.indexOf(element)).isEqualTo(expected.indexOf(element));
+    }
   }
 
   @Property

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -18,10 +18,13 @@ package org.apache.geode.redis.internal.data;
 
 import static java.lang.Math.round;
 import static org.apache.geode.redis.internal.data.RedisSortedSet.BASE_REDIS_SORTED_SET_OVERHEAD;
+import static org.apache.geode.redis.internal.netty.Coder.doubleToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGREATEST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEAST_MEMBER_NAME;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.in;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -58,6 +61,16 @@ import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisSortedSetTest {
   private final ReflectionObjectSizer reflectionObjectSizer = ReflectionObjectSizer.getInstance();
+
+  private final String member1 = "member1";
+  private final String member2 = "member2";
+  private final String score1 = "5.55555";
+  private final String score2 = "209030.31";
+  private final RedisSortedSet rangeSortedSet =
+      createRedisSortedSet(
+          "1.0", member1, "1.1", member2, "1.2", "member3", "1.3", "member4",
+          "1.4", "member5", "1.5", "member6", "1.6", "member7", "1.7", "member8",
+          "1.8", "member9", "1.9", "member10", "2.0", "member11", "2.1", "member12");
 
   @BeforeClass
   public static void beforeClass() {
@@ -243,11 +256,6 @@ public class RedisSortedSetTest {
     assertThat(actual).isCloseTo(expected, offset);
   }
 
-  private final String member1 = "member1";
-  private final String member2 = "member2";
-  private final String score1 = "5.55555";
-  private final String score2 = "209030.31";
-
   @Test
   public void zremCanRemoveMembersToBeRemoved() {
     String member3 = "member3";
@@ -303,12 +311,6 @@ public class RedisSortedSetTest {
     offset = Offset.offset((int) round(expected * 0.03));
     assertThat(actual).isCloseTo(expected, offset);
   }
-
-  RedisSortedSet rangeSortedSet =
-      createRedisSortedSet(
-          "1.0", member1, "1.1", member2, "1.2", "member3", "1.3", "member4",
-          "1.4", "member5", "1.5", "member6", "1.6", "member7", "1.7", "member8",
-          "1.8", "member9", "1.9", "member10", "2.0", "member11", "2.1", "member12");
 
   @Test
   public void zrange_ShouldReturnEmptyList_GivenInvalidRanges() {
@@ -385,6 +387,121 @@ public class RedisSortedSetTest {
         "member3".getBytes(), "member4".getBytes(), "member5".getBytes(),
         "member6".getBytes(), "member7".getBytes(), "member8".getBytes(),
         "member9".getBytes(), "member10".getBytes(), "member11".getBytes(), "member12".getBytes());
+  }
+
+  @Test
+  public void orderedSetEntryCompareTo_returnsCorrectly_givenDifferentScores() {
+    byte[] memberName = stringToBytes("member");
+
+    RedisSortedSet.OrderedSetEntry negativeInf =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(Double.NEGATIVE_INFINITY));
+    RedisSortedSet.OrderedSetEntry negativeOne =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(-1.0));
+    RedisSortedSet.OrderedSetEntry zero =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(0.0));
+    RedisSortedSet.OrderedSetEntry one =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(1.0));
+    RedisSortedSet.OrderedSetEntry positiveInf =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(Double.POSITIVE_INFINITY));
+
+    assertThat(negativeInf.compareTo(negativeOne)).isEqualTo(-1);
+    assertThat(negativeOne.compareTo(zero)).isEqualTo(-1);
+    assertThat(zero.compareTo(one)).isEqualTo(-1);
+    assertThat(one.compareTo(positiveInf)).isEqualTo(-1);
+
+    assertThat(positiveInf.compareTo(one)).isEqualTo(1);
+    assertThat(one.compareTo(zero)).isEqualTo(1);
+    assertThat(zero.compareTo(negativeOne)).isEqualTo(1);
+    assertThat(negativeOne.compareTo(negativeInf)).isEqualTo(1);
+  }
+
+  @Test
+  public void orderedSetEntryCompareTo_throws_givenBothArraysAreGreatestOrLeastMemberNameAndScoresAreEqual() {
+    byte[] score = doubleToBytes(1.0);
+
+    RedisSortedSet.OrderedSetEntry greatest1 =
+        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME, score);
+    RedisSortedSet.OrderedSetEntry greatest2 =
+        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME, score);
+
+    // noinspection ResultOfMethodCallIgnored
+    assertThatThrownBy(() -> greatest1.compareTo(greatest2))
+        .isInstanceOf(IllegalStateException.class);
+
+    RedisSortedSet.OrderedSetEntry least1 =
+        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME, score);
+    RedisSortedSet.OrderedSetEntry least2 =
+        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME, score);
+
+    // noinspection ResultOfMethodCallIgnored
+    assertThatThrownBy(() -> least1.compareTo(least2)).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  public void orderedSetEntryCompareTo_handlesDummyMemberNames_givenScoresAreEqual() {
+    byte[] score = doubleToBytes(1.0);
+
+    RedisSortedSet.OrderedSetEntry greatest =
+        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME, score);
+    RedisSortedSet.OrderedSetEntry least =
+        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME, score);
+    RedisSortedSet.OrderedSetEntry middle =
+        new RedisSortedSet.OrderedSetEntry(stringToBytes("middle"), score);
+
+    // greatest > least
+    assertThat(greatest.compareTo(least)).isEqualTo(1);
+    // least < greatest
+    assertThat(least.compareTo(greatest)).isEqualTo(-1);
+    // greatest > middle
+    assertThat(greatest.compareTo(middle)).isEqualTo(1);
+    // middle < greatest
+    assertThat(middle.compareTo(greatest)).isEqualTo(-1);
+    // least < middle
+    assertThat(least.compareTo(middle)).isEqualTo(-1);
+    // middle > least
+    assertThat(middle.compareTo(least)).isEqualTo(1);
+  }
+
+  @Test
+  public void orderedSetEntryCompareTo_handlesDummyMemberNameEquivalents_givenScoresAreEqual() {
+    byte[] score = doubleToBytes(1.0);
+
+    RedisSortedSet.OrderedSetEntry greatest =
+        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME, score);
+    RedisSortedSet.OrderedSetEntry greatestEquivalent =
+        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME.clone(), score);
+
+    RedisSortedSet.OrderedSetEntry least =
+        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME, score);
+    RedisSortedSet.OrderedSetEntry leastEquivalent =
+        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME.clone(), score);
+
+    // bGREATEST_MEMBER_NAME > an array with contents equal to bGREATEST_MEMBER_NAME
+    assertThat(greatest.compareTo(greatestEquivalent)).isEqualTo(1);
+
+    // an array with contents equal to bGREATEST_MEMBER_NAME < bGREATEST_MEMBER_NAME
+    assertThat(greatestEquivalent.compareTo(greatest)).isEqualTo(-1);
+
+    // bLEAST_MEMBER_NAME < an array with contents equal to bLEAST_MEMBER_NAME
+    assertThat(least.compareTo(leastEquivalent)).isEqualTo(-1);
+
+    // an array with contents equal to bLEAST_MEMBER_NAME > bLEAST_MEMBER_NAME
+    assertThat(leastEquivalent.compareTo(least)).isEqualTo(1);
+  }
+
+  @Test
+  public void dummyOrderedSetEntryConstructor_setsAppropriateMemberName() {
+    RedisSortedSet.OrderedSetEntry entry = new RedisSortedSet.OrderedSetEntry(1, false, false);
+    assertThat(entry.getMember()).isSameAs(bGREATEST_MEMBER_NAME);
+
+    entry = new RedisSortedSet.OrderedSetEntry(1, true, false);
+    assertThat(entry.getMember()).isSameAs(bLEAST_MEMBER_NAME);
+
+    entry = new RedisSortedSet.OrderedSetEntry(1, false, true);
+    assertThat(entry.getMember()).isSameAs(bLEAST_MEMBER_NAME);
+
+    entry = new RedisSortedSet.OrderedSetEntry(1, true, true);
+    assertThat(entry.getMember()).isSameAs(bGREATEST_MEMBER_NAME);
   }
 
   private RedisSortedSet createRedisSortedSet(String... membersAndScores) {

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -393,15 +393,15 @@ public class RedisSortedSetTest {
   public void orderedSetEntryCompareTo_returnsCorrectly_givenDifferentScores() {
     byte[] memberName = stringToBytes("member");
 
-    RedisSortedSet.OrderedSetEntry negativeInf =
+    RedisSortedSet.AbstractOrderedSetEntry negativeInf =
         new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(Double.NEGATIVE_INFINITY));
-    RedisSortedSet.OrderedSetEntry negativeOne =
+    RedisSortedSet.AbstractOrderedSetEntry negativeOne =
         new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(-1.0));
-    RedisSortedSet.OrderedSetEntry zero =
+    RedisSortedSet.AbstractOrderedSetEntry zero =
         new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(0.0));
-    RedisSortedSet.OrderedSetEntry one =
+    RedisSortedSet.AbstractOrderedSetEntry one =
         new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(1.0));
-    RedisSortedSet.OrderedSetEntry positiveInf =
+    RedisSortedSet.AbstractOrderedSetEntry positiveInf =
         new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(Double.POSITIVE_INFINITY));
 
     assertThat(negativeInf.compareTo(negativeOne)).isEqualTo(-1);
@@ -416,37 +416,37 @@ public class RedisSortedSetTest {
   }
 
   @Test
-  public void orderedSetEntryCompareTo_throws_givenBothArraysAreGreatestOrLeastMemberNameAndScoresAreEqual() {
-    byte[] score = doubleToBytes(1.0);
+  public void dummyOrderedSetEntryCompareTo_throws_givenBothArraysAreGreatestOrLeastMemberNameAndScoresAreEqual() {
+    double score = 1.0;
 
-    RedisSortedSet.OrderedSetEntry greatest1 =
-        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME, score);
-    RedisSortedSet.OrderedSetEntry greatest2 =
-        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME, score);
+    RedisSortedSet.AbstractOrderedSetEntry greatest1 =
+        new RedisSortedSet.DummyOrderedSetEntry(score, true, true);
+    RedisSortedSet.AbstractOrderedSetEntry greatest2 =
+        new RedisSortedSet.DummyOrderedSetEntry(score, false, false);
 
     // noinspection ResultOfMethodCallIgnored
     assertThatThrownBy(() -> greatest1.compareTo(greatest2))
         .isInstanceOf(IllegalStateException.class);
 
-    RedisSortedSet.OrderedSetEntry least1 =
-        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME, score);
-    RedisSortedSet.OrderedSetEntry least2 =
-        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME, score);
+    RedisSortedSet.AbstractOrderedSetEntry least1 =
+        new RedisSortedSet.DummyOrderedSetEntry(score, false, true);
+    RedisSortedSet.AbstractOrderedSetEntry least2 =
+        new RedisSortedSet.DummyOrderedSetEntry(score, true, false);
 
     // noinspection ResultOfMethodCallIgnored
     assertThatThrownBy(() -> least1.compareTo(least2)).isInstanceOf(IllegalStateException.class);
   }
 
   @Test
-  public void orderedSetEntryCompareTo_handlesDummyMemberNames_givenScoresAreEqual() {
-    byte[] score = doubleToBytes(1.0);
+  public void dummyOrderedSetEntryCompareTo_handlesDummyMemberNames_givenScoresAreEqual() {
+    double score = 1.0;
 
-    RedisSortedSet.OrderedSetEntry greatest =
-        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME, score);
-    RedisSortedSet.OrderedSetEntry least =
-        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME, score);
-    RedisSortedSet.OrderedSetEntry middle =
-        new RedisSortedSet.OrderedSetEntry(stringToBytes("middle"), score);
+    RedisSortedSet.AbstractOrderedSetEntry greatest =
+        new RedisSortedSet.DummyOrderedSetEntry(score, true, true);
+    RedisSortedSet.AbstractOrderedSetEntry least =
+        new RedisSortedSet.DummyOrderedSetEntry(score, true, false);
+    RedisSortedSet.AbstractOrderedSetEntry middle =
+        new RedisSortedSet.OrderedSetEntry(stringToBytes("middle"), doubleToBytes(score));
 
     // greatest > least
     assertThat(greatest.compareTo(least)).isEqualTo(1);
@@ -454,53 +454,45 @@ public class RedisSortedSetTest {
     assertThat(least.compareTo(greatest)).isEqualTo(-1);
     // greatest > middle
     assertThat(greatest.compareTo(middle)).isEqualTo(1);
-    // middle < greatest
-    assertThat(middle.compareTo(greatest)).isEqualTo(-1);
     // least < middle
     assertThat(least.compareTo(middle)).isEqualTo(-1);
-    // middle > least
-    assertThat(middle.compareTo(least)).isEqualTo(1);
   }
 
   @Test
-  public void orderedSetEntryCompareTo_handlesDummyMemberNameEquivalents_givenScoresAreEqual() {
-    byte[] score = doubleToBytes(1.0);
+  public void dummyOrderedSetEntryCompareTo_handlesDummyMemberNameEquivalents_givenScoresAreEqual() {
+    double score = 1.0;
+    byte[] scoreBytes = doubleToBytes(score);
 
-    RedisSortedSet.OrderedSetEntry greatest =
-        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME, score);
-    RedisSortedSet.OrderedSetEntry greatestEquivalent =
-        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME.clone(), score);
+    RedisSortedSet.AbstractOrderedSetEntry greatest =
+        new RedisSortedSet.DummyOrderedSetEntry(score, true, true);
+    RedisSortedSet.AbstractOrderedSetEntry greatestEquivalent =
+        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME.clone(), scoreBytes);
 
-    RedisSortedSet.OrderedSetEntry least =
-        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME, score);
-    RedisSortedSet.OrderedSetEntry leastEquivalent =
-        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME.clone(), score);
+    RedisSortedSet.AbstractOrderedSetEntry least =
+        new RedisSortedSet.DummyOrderedSetEntry(score, true, false);
+    RedisSortedSet.AbstractOrderedSetEntry leastEquivalent =
+        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME.clone(), scoreBytes);
 
     // bGREATEST_MEMBER_NAME > an array with contents equal to bGREATEST_MEMBER_NAME
     assertThat(greatest.compareTo(greatestEquivalent)).isEqualTo(1);
 
-    // an array with contents equal to bGREATEST_MEMBER_NAME < bGREATEST_MEMBER_NAME
-    assertThat(greatestEquivalent.compareTo(greatest)).isEqualTo(-1);
-
     // bLEAST_MEMBER_NAME < an array with contents equal to bLEAST_MEMBER_NAME
     assertThat(least.compareTo(leastEquivalent)).isEqualTo(-1);
-
-    // an array with contents equal to bLEAST_MEMBER_NAME > bLEAST_MEMBER_NAME
-    assertThat(leastEquivalent.compareTo(least)).isEqualTo(1);
   }
 
   @Test
   public void dummyOrderedSetEntryConstructor_setsAppropriateMemberName() {
-    RedisSortedSet.OrderedSetEntry entry = new RedisSortedSet.OrderedSetEntry(1, false, false);
+    RedisSortedSet.AbstractOrderedSetEntry entry =
+        new RedisSortedSet.DummyOrderedSetEntry(1, false, false);
     assertThat(entry.getMember()).isSameAs(bGREATEST_MEMBER_NAME);
 
-    entry = new RedisSortedSet.OrderedSetEntry(1, true, false);
+    entry = new RedisSortedSet.DummyOrderedSetEntry(1, true, false);
     assertThat(entry.getMember()).isSameAs(bLEAST_MEMBER_NAME);
 
-    entry = new RedisSortedSet.OrderedSetEntry(1, false, true);
+    entry = new RedisSortedSet.DummyOrderedSetEntry(1, false, true);
     assertThat(entry.getMember()).isSameAs(bLEAST_MEMBER_NAME);
 
-    entry = new RedisSortedSet.OrderedSetEntry(1, true, true);
+    entry = new RedisSortedSet.DummyOrderedSetEntry(1, true, true);
     assertThat(entry.getMember()).isSameAs(bGREATEST_MEMBER_NAME);
   }
 


### PR DESCRIPTION
 - Add ZCOUNT to supported commands
 - Modify OrderStatisticsTree.indexOf() to return the index of elements that are
 not present in the collection instead of -1, to make the behaviour of
 OrderStatisticsTree and IndexibleTreeSet match
 - Add constants to the StringBytesGlossary to support parsing Redis
 range values and doing more comparisons on String member names
 - Replace hardcoded Strings with constants in
 AbstractHitsMissesIntegrationTest
 - Fix an inaccurate Javadoc introduced by a previous commit
 - Small code clean-ups in code related to ZRANGE
 - Add tests for ZCOUNT and new behaviour in OrderStatisticsTree

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
