### PR TITLE
GEODE-9421: Remove BatchRemoval NPE logs from JUnit tests

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/cache/asyncqueue/internal/ParallelAsyncEventQueueImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/asyncqueue/internal/ParallelAsyncEventQueueImplTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -50,7 +51,7 @@ public class ParallelAsyncEventQueueImplTest {
 
   @Before
   public void setUp() {
-    cache = mock(InternalCache.class);
+    cache = mock(InternalCache.class, RETURNS_DEEP_STUBS);
     statisticsClock = mock(StatisticsClock.class);
     statsFactory = mock(StatisticsFactory.class);
     attrs = new GatewaySenderAttributes();
@@ -60,6 +61,7 @@ public class ParallelAsyncEventQueueImplTest {
     InternalDistributedSystem system = mock(InternalDistributedSystem.class);
     when(cache.getInternalDistributedSystem()).thenReturn(system);
     when(cache.getDistributedSystem()).thenReturn(system);
+    when(cache.getCancelCriterion().isCancelInProgress()).thenReturn(false);
     ClusterDistributionManager distributionManager = mock(ClusterDistributionManager.class);
     when(system.getDistributionManager()).thenReturn(distributionManager);
     when(distributionManager.getDistributedSystemId()).thenReturn(-1);

--- a/geode-wan/src/test/java/org/apache/geode/cache/wan/internal/parallel/ParallelGatewaySenderImplTest.java
+++ b/geode-wan/src/test/java/org/apache/geode/cache/wan/internal/parallel/ParallelGatewaySenderImplTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -47,7 +48,7 @@ public class ParallelGatewaySenderImplTest {
 
   @Before
   public void setUp() {
-    cache = mock(InternalCache.class);
+    cache = mock(InternalCache.class, RETURNS_DEEP_STUBS);
     statisticsClock = mock(StatisticsClock.class);
     attrs = new GatewaySenderAttributes();
     attrs.setParallel(true);
@@ -55,6 +56,7 @@ public class ParallelGatewaySenderImplTest {
     InternalDistributedSystem system = mock(InternalDistributedSystem.class);
     when(cache.getInternalDistributedSystem()).thenReturn(system);
     when(cache.getDistributedSystem()).thenReturn(system);
+    when(cache.getCancelCriterion().isCancelInProgress()).thenReturn(false);
     ClusterDistributionManager distributionManager = mock(ClusterDistributionManager.class);
     when(system.getDistributionManager()).thenReturn(distributionManager);
     when(distributionManager.getDistributedSystemId()).thenReturn(-1);


### PR DESCRIPTION
ParallelAsyncEventQueueImplTest and ParallelGatewaySenderImplTest classes were mocking InternalRegion
but were not providing an implementation for cache.getCancelCriterion().
This led to a null pointer exception in the BatchRemoval thread code that,
even though it did not affect the tests, provoked that a log message with
a null pointer exception was printed.

The solution consists of adding a response in the mock using when() for the cache.getCancelCriterion() method.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
