### PR TITLE
GEODE-9340: move benchmark baseline

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -17,7 +17,7 @@
 
 benchmarks:
   baseline_branch: ''
-  baseline_version: '1.13.3'
+  baseline_version: '217be41f087072026ea3b411b89107700edfb5f7'
   benchmark_branch: ((geode-build-branch))
   flavors:
   - title: 'base'


### PR DESCRIPTION
The new baseline is the commit that caused a slight performance
regression in our most sensitive tests. There is a negligible
performance difference between the previous baseline of 1.13.3 and the
commit before the commit that caused the regression (commit with SHA
217be41f087072026ea3b411b89107700edfb5f7). This means that moving the
baseline will not ignore a bunch of other performance changes.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
