### PR TITLE
GEODE-9376: Implement Radish ZREVRANGE command

### DIFF
--- a/geode-apis-compatible-with-redis/build.gradle
+++ b/geode-apis-compatible-with-redis/build.gradle
@@ -65,6 +65,7 @@ dependencies {
   integrationTestImplementation('org.apache.logging.log4j:log4j-core')
   // This only exists for debugging PubSubNativeRedisAcceptanceTest
   integrationTestImplementation('org.buildobjects:jproc:2.6.2')
+  integrationTestImplementation('pl.pragmatists:JUnitParams')
   integrationTestRuntimeOnly(project(':geode-log4j'))
 
   acceptanceTestImplementation(sourceSets.integrationTest.output)

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeNativeRedisAcceptanceTest.java
@@ -14,19 +14,23 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
+import org.junit.ClassRule;
 
-import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Command;
-import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+import org.apache.geode.redis.NativeRedisClusterTestRule;
 
-public class ZRankExecutor extends AbstractZRankExecutor {
+public class ZRevRangeNativeRedisAcceptanceTest extends AbstractZRevRangeIntegrationTest {
+
+  @ClassRule
+  public static NativeRedisClusterTestRule server = new NativeRedisClusterTestRule();
+
   @Override
-  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    return super.executeCommand(command, context);
+  public int getPort() {
+    return server.getExposedPorts().get(0);
   }
 
   @Override
-  public boolean isRev() {
-    return false;
+  public void flushAll() {
+    server.flushAll();
   }
+
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -45,13 +45,13 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   private static final String HITS = "keyspace_hits";
   private static final String MISSES = "keyspace_misses";
-  public static final String STRING_KEY = "string";
-  public static final String STRING_INT_KEY = "int";
-  public static final String SET_KEY = "set";
-  public static final String HASH_KEY = "hash";
-  public static final String SORTED_SET_KEY = "sortedSet";
-  public static final String MAP_KEY_1 = "mapKey1";
-  public static final String MAP_KEY_2 = "mapKey2";
+  private static final String STRING_KEY = "string";
+  private static final String STRING_INT_KEY = "int";
+  private static final String SET_KEY = "set";
+  private static final String HASH_KEY = "hash";
+  private static final String SORTED_SET_KEY = "sortedSet";
+  private static final String MAP_KEY_1 = "mapKey1";
+  private static final String MAP_KEY_2 = "mapKey2";
 
   protected Jedis jedis;
 
@@ -253,6 +253,16 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   }
 
   @Test
+  public void testZrange() {
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zrange(k, 0, 1));
+  }
+
+  @Test
+  public void testZrange_withScores() {
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zrangeWithScores(k, 0, 1));
+  }
+
+  @Test
   public void testZrank() {
     runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, (k, m) -> jedis.zrank(k, m));
   }
@@ -260,6 +270,16 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   @Test
   public void testZrem() {
     runCommandAndAssertNoStatUpdates(SORTED_SET_KEY, (k, v) -> jedis.zrem(k, v));
+  }
+
+  @Test
+  public void testZrevrange() {
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zrevrange(k, 0, 1));
+  }
+
+  @Test
+  public void testZrevrange_withScores() {
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zrevrangeWithScores(k, 0, 1));
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -45,16 +46,12 @@ public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrati
   private static final String MEMBER_BASE_NAME = "member";
   private static final String KEY = "key";
   private JedisCluster jedis;
-  private final List<Double> scores = new ArrayList<>();
+  private static final List<Double> scores =
+      Arrays.asList(Double.NEGATIVE_INFINITY, -10.5, 0.0, 10.5, Double.POSITIVE_INFINITY);
 
   @Before
   public void setUp() {
     jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
-    scores.add(Double.NEGATIVE_INFINITY);
-    scores.add(-10.5);
-    scores.add(0.0);
-    scores.add(10.5);
-    scores.add(Double.POSITIVE_INFINITY);
   }
 
   @After

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeIntegrationTest.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.Tuple;
+
+import org.apache.geode.redis.RedisIntegrationTest;
+
+@RunWith(JUnitParamsRunner.class)
+public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrationTest {
+  private static final String MEMBER_BASE_NAME = "member";
+  private static final String KEY = "key";
+  private JedisCluster jedis;
+  private final List<Double> scores = new ArrayList<>();
+
+  @Before
+  public void setUp() {
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+    scores.add(Double.NEGATIVE_INFINITY);
+    scores.add(-10.5);
+    scores.add(0.0);
+    scores.add(10.5);
+    scores.add(Double.POSITIVE_INFINITY);
+  }
+
+  @After
+  public void tearDown() {
+    flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void shouldError_givenNonIntegerRangeValues() {
+    jedis.zadd(KEY, 1.0, MEMBER_BASE_NAME);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "NOT_AN_INT", "2"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "1", "NOT_AN_INT"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void shouldReturnSyntaxError_givenInvalidWithScoresFlag() {
+    jedis.zadd(KEY, 1.0, MEMBER_BASE_NAME);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "1", "2", "WITSCOREZ"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  @Parameters({"1,0", "25,30", "8,-3", "8,8", "-8,-8", "-30,-25"})
+  @TestCaseName("{method}: start:{0}, end:{1}")
+  public void shouldReturnEmptyCollection_givenInvalidRange(int start, int end) {
+    for (int i = 0; i < scores.size(); i++) {
+      String memberName = MEMBER_BASE_NAME + i;
+      Double score = scores.get(i);
+      jedis.zadd(KEY, score, memberName);
+    }
+    assertThat(jedis.zrange(KEY, start, end)).isEmpty();
+  }
+
+  @Test
+  @Parameters({"0,1", "0,3", "0,6", "2,2", "2,4", "0,-2", "2,-2", "-3,-1", "-6,2"})
+  @TestCaseName("{method}: start:{0}, end:{1}")
+  public void zrevrange_withValidRanges(int start, int end) {
+    List<String> entries = new ArrayList<>();
+    for (int i = 0; i < scores.size(); i++) {
+      String memberName = MEMBER_BASE_NAME + i;
+      entries.add(memberName);
+      Double score = scores.get(i);
+      jedis.zadd(KEY, score, memberName);
+    }
+
+    validateRevrange(start, end, entries);
+  }
+
+  @Test
+  @Parameters({"0,1", "0,3", "0,6", "2,2", "2,4", "0,-2", "2,-2", "-3,-1", "-6,2"})
+  @TestCaseName("{method}: start:{0}, end:{1}")
+  public void zrevrangeWithScores_withValidRanges(int start, int end) {
+    List<Tuple> entries = new ArrayList<>();
+    int numOfEntries = scores.size();
+    for (int i = 0; i < numOfEntries; i++) {
+      String memberName = MEMBER_BASE_NAME + i;
+      Double score = scores.get(i);
+      entries.add(new Tuple(memberName, score));
+      jedis.zadd(KEY, score, memberName);
+    }
+
+    int subListStartIndex = getSubListStartIndex(end, numOfEntries);
+    int subListEndIndex = getSubListEndIndex(start, numOfEntries);
+    List<Tuple> expectedRevrange = entries.subList(subListStartIndex, subListEndIndex);
+    Collections.reverse(expectedRevrange);
+
+    Set<Tuple> revrange = jedis.zrevrangeWithScores(KEY, start, end);
+
+    assertThat(revrange).containsExactlyElementsOf(expectedRevrange);
+  }
+
+  @Test
+  @Parameters({"0,1", "0,3", "0,6", "2,2", "2,4", "0,-2", "2,-2", "-3,-1", "-6,2"})
+  @TestCaseName("{method}: start:{0}, end:{1}")
+  public void zrevrange_withSameScores_shouldOrderLexically(int start, int end) {
+    List<String> entries = new ArrayList<>();
+    for (int i = 5; i > 0; i--) {
+      String memberName = MEMBER_BASE_NAME + i;
+      entries.add(memberName);
+      jedis.zadd(KEY, 0.1, memberName);
+    }
+
+    // Since entries were added in reverse lexicographical order, reverse the list here
+    Collections.reverse(entries);
+
+    validateRevrange(start, end, entries);
+  }
+
+  private int getSubListStartIndex(int end, int numOfEntries) {
+    if (end >= 0) {
+      return Math.max(numOfEntries - end - 1, 0);
+    } else {
+      return Math.min(-end - 1, numOfEntries - 1);
+    }
+  }
+
+  private int getSubListEndIndex(int start, int numOfEntries) {
+    if (start >= 0) {
+      return Math.max(numOfEntries - start, 0);
+    } else {
+      return Math.min(-start, numOfEntries);
+    }
+  }
+
+  private void validateRevrange(int start, int end, List<String> entries) {
+    int subListStartIndex = getSubListStartIndex(end, entries.size());
+    int subListEndIndex = getSubListEndIndex(start, entries.size());
+    List<String> expectedRevrange = entries.subList(subListStartIndex, subListEndIndex);
+    Collections.reverse(expectedRevrange);
+
+    Set<String> revrange = jedis.zrevrange(KEY, start, end);
+
+    assertThat(revrange).containsExactlyElementsOf(expectedRevrange);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeIntegrationTest.java
@@ -14,19 +14,18 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
+import org.junit.ClassRule;
 
-import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Command;
-import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+import org.apache.geode.redis.GeodeRedisServerRule;
 
-public class ZRankExecutor extends AbstractZRankExecutor {
-  @Override
-  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    return super.executeCommand(command, context);
-  }
+public class ZRevRangeIntegrationTest extends AbstractZRevRangeIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
 
   @Override
-  public boolean isRev() {
-    return false;
+  public int getPort() {
+    return server.getPort();
   }
+
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -103,6 +103,7 @@ import org.apache.geode.redis.internal.executor.sortedset.ZIncrByExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRangeExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRankExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRemExecutor;
+import org.apache.geode.redis.internal.executor.sortedset.ZRevRangeExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRevRankExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZScoreExecutor;
 import org.apache.geode.redis.internal.executor.string.AppendExecutor;
@@ -214,6 +215,8 @@ public enum RedisCommandType {
       .and(new MaximumParameterRequirements(5, ERROR_SYNTAX))),
   ZRANK(new ZRankExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
   ZREM(new ZRemExecutor(), SUPPORTED, new MinimumParameterRequirements(3)),
+  ZREVRANGE(new ZRevRangeExecutor(), SUPPORTED, new MinimumParameterRequirements(4)
+      .and(new MaximumParameterRequirements(5, ERROR_SYNTAX))),
   ZREVRANK(new ZRevRankExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
   ZSCORE(new ZScoreExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/IndexibleTreeSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/IndexibleTreeSet.java
@@ -50,7 +50,7 @@ class IndexibleTreeSet<E> extends TreeSet<E> implements OrderStatisticsSet<E> {
   }
 
   @Override
-  public Iterator<E> getIndexRange(int min, int max) {
+  public Iterator<E> getIndexRange(int startIndex, int maxElements, boolean reverseRange) {
     return null;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/OrderStatisticsSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/collections/OrderStatisticsSet.java
@@ -64,9 +64,11 @@ public interface OrderStatisticsSet<T> extends Set<T> {
   /**
    * Returns an iterator over a range of <code>elements</code> between min and max.
    *
-   * @param min the minimum element.
-   * @param max the maximum element.
+   * @param startIndex the index of the element at which to start the iterator.
+   * @param maxElements the maximum number of elements to allow the iterator to iterate over.
+   * @param reverseRange if true, the elements are considered to be ordered from the highest to the
+   *        lowest score
    * @return an Iterator of <code>elements</code>.
    */
-  Iterator<T> getIndexRange(int min, int max);
+  Iterator<T> getIndexRange(int startIndex, int maxElements, boolean reverseRange);
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -19,6 +19,7 @@ package org.apache.geode.redis.internal.data;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.geode.cache.Region;
@@ -76,7 +77,12 @@ class NullRedisSortedSet extends RedisSortedSet {
 
   @Override
   List<byte[]> zrange(int min, int max, boolean withScores) {
-    return null;
+    return Collections.emptyList();
+  }
+
+  @Override
+  List<byte[]> zrevrange(int min, int max, boolean withScores) {
+    return Collections.emptyList();
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -59,7 +59,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   @Override
   public List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores) {
     return stripedExecute(key,
-        () -> getRedisSortedSet(key, false).zrange(min, max, withScores));
+        () -> getRedisSortedSet(key, true).zrange(min, max, withScores));
   }
 
   @Override
@@ -71,6 +71,12 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   public long zrem(RedisKey key, List<byte[]> membersToRemove) {
     return stripedExecute(key,
         () -> getRedisSortedSet(key, false).zrem(getRegion(), key, membersToRemove));
+  }
+
+  @Override
+  public List<byte[]> zrevrange(RedisKey key, int min, int max, boolean withScores) {
+    return stripedExecute(key,
+        () -> getRedisSortedSet(key, true).zrevrange(min, max, withScores));
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeExecutor.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWITHSCORES;
+
+import java.util.List;
+
+import org.apache.geode.redis.internal.executor.AbstractExecutor;
+import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.netty.Command;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+
+public abstract class AbstractZRangeExecutor extends AbstractExecutor {
+
+  @Override
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
+    int min;
+    int max;
+    List<byte[]> commandElements = command.getProcessedCommand();
+
+    try {
+      // We need to be able to accept long arguments to match Redis behaviour, even though
+      // internally int is sufficient, as sorted sets have a maximum size of Integer.MAX_VALUE
+      long longMin = bytesToLong(commandElements.get(2));
+      min = narrowLongToInt(longMin);
+      long longMax = bytesToLong(commandElements.get(3));
+      max = narrowLongToInt(longMax);
+    } catch (NumberFormatException nfe) {
+      return RedisResponse.error(ERROR_NOT_INTEGER);
+    }
+
+    boolean withScores = false;
+
+    if (commandElements.size() == 5) {
+      if (equalsIgnoreCaseBytes(commandElements.get(4), bWITHSCORES)) {
+        withScores = true;
+      } else {
+        return RedisResponse.error(ERROR_SYNTAX);
+      }
+    }
+
+    RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
+
+    List<byte[]> retVal;
+    if (isRev()) {
+      retVal = redisSortedSetCommands.zrevrange(command.getKey(), min, max, withScores);
+    } else {
+      retVal = redisSortedSetCommands.zrange(command.getKey(), min, max, withScores);
+    }
+
+    return RedisResponse.array(retVal);
+  }
+
+  private int narrowLongToInt(long toBeNarrowed) {
+    if (toBeNarrowed > Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
+    } else if (toBeNarrowed < Integer.MIN_VALUE) {
+      return Integer.MIN_VALUE;
+    } else {
+      return (int) toBeNarrowed;
+    }
+  }
+
+  public abstract boolean isRev();
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRankExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRankExecutor.java
@@ -14,19 +14,32 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
+import java.util.List;
 
+import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ZRankExecutor extends AbstractZRankExecutor {
+public abstract class AbstractZRankExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    return super.executeCommand(command, context);
+    RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
+
+    List<byte[]> commandElements = command.getProcessedCommand();
+
+    long rank;
+    if (isRev()) {
+      rank = redisSortedSetCommands.zrevrank(command.getKey(), commandElements.get(2));
+    } else {
+      rank = redisSortedSetCommands.zrank(command.getKey(), commandElements.get(2));
+    }
+
+    if (rank == -1) {
+      return RedisResponse.nil();
+    }
+    return RedisResponse.integer(rank);
   }
 
-  @Override
-  public boolean isRev() {
-    return false;
-  }
+  public abstract boolean isRev();
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -35,6 +35,8 @@ public interface RedisSortedSetCommands {
 
   long zrem(RedisKey key, List<byte[]> membersToRemove);
 
+  List<byte[]> zrevrange(RedisKey key, int min, int max, boolean withScore);
+
   long zrevrank(RedisKey key, byte[] member);
 
   byte[] zscore(RedisKey key, byte[] member);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeExecutor.java
@@ -14,43 +14,21 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToInt;
-import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 
-import java.util.List;
 
-import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ZRangeExecutor extends AbstractExecutor {
+public class ZRangeExecutor extends AbstractZRangeExecutor {
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    boolean withScores = false;
-    int min, max;
-    RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
-    List<byte[]> commandElements = command.getProcessedCommand();
+    return super.executeCommand(command, context);
+  }
 
-    try {
-      min = bytesToInt(commandElements.get(2));
-      max = bytesToInt(commandElements.get(3));
-    } catch (NumberFormatException nfe) {
-      return RedisResponse.error(ERROR_NOT_INTEGER);
-    }
-    if (commandElements.size() == 5) {
-      if (equalsIgnoreCaseBytes(commandElements.get(4), "WITHSCORES".getBytes())) {
-        withScores = true;
-      } else {
-        return RedisResponse.error(ERROR_SYNTAX);
-      }
-    }
-
-    List<byte[]> retVal = redisSortedSetCommands.zrange(command.getKey(), min, max, withScores);
-
-    return RedisResponse.array(retVal);
+  @Override
+  public boolean isRev() {
+    return false;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeExecutor.java
@@ -14,12 +14,11 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ZRankExecutor extends AbstractZRankExecutor {
+public class ZRevRangeExecutor extends AbstractZRangeExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     return super.executeCommand(command, context);
@@ -27,6 +26,6 @@ public class ZRankExecutor extends AbstractZRankExecutor {
 
   @Override
   public boolean isRev() {
-    return false;
+    return true;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRankExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRankExecutor.java
@@ -14,25 +14,19 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import java.util.List;
 
-import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ZRevRankExecutor extends AbstractExecutor {
+public class ZRevRankExecutor extends AbstractZRankExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
+    return super.executeCommand(command, context);
+  }
 
-    List<byte[]> commandElements = command.getProcessedCommand();
-
-    long rank = redisSortedSetCommands.zrevrank(command.getKey(), commandElements.get(2));
-
-    if (rank == -1) {
-      return RedisResponse.nil();
-    }
-    return RedisResponse.integer(rank);
+  @Override
+  public boolean isRev() {
+    return true;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -175,6 +175,10 @@ public class StringBytesGlossary {
   @MakeImmutable
   public static final byte[] bABSTTL = stringToBytes("ABSTTL");
 
+  // AbstractZRangeExecutor
+  @MakeImmutable
+  public static final byte[] bWITHSCORES = stringToBytes("WITHSCORES");
+
   // ********** Constants for Double Infinity comparisons **********
   public static final String P_INF = "+inf";
   public static final String INF = "inf";

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -94,6 +94,7 @@ public class SupportedCommandsJUnitTest {
       "ZRANGE",
       "ZRANK",
       "ZREM",
+      "ZREVRANGE",
       "ZREVRANK",
       "ZSCORE"
   };

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderStatisticsTreeTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderStatisticsTreeTest.java
@@ -582,31 +582,79 @@ public class OrderStatisticsTreeTest {
     }
 
     List<Integer> subSet = new ArrayList<>();
-    Iterator<Integer> subIterator = tree.getIndexRange(0, 9);
+    int maxElements = 10;
+    Iterator<Integer> subIterator = tree.getIndexRange(0, maxElements, false);
     while (subIterator.hasNext()) {
       subSet.add(subIterator.next());
     }
-    assertThat(subSet.size()).isEqualTo(10);
+    assertThat(subSet.size()).isEqualTo(maxElements);
     assertThat(subSet).containsExactly(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
     subSet.clear();
-    subIterator = tree.getIndexRange(95, 110);
+
+    maxElements = 5;
+    subIterator = tree.getIndexRange(95, maxElements, false);
     while (subIterator.hasNext()) {
       subSet.add(subIterator.next());
     }
-    assertThat(subSet.size()).isEqualTo(5);
+    assertThat(subSet.size()).isEqualTo(maxElements);
     assertThat(subSet).containsExactly(95, 96, 97, 98, 99);
 
     subSet.clear();
-    subIterator = tree.getIndexRange(45, 55);
+
+    maxElements = 11;
+    subIterator = tree.getIndexRange(45, maxElements, false);
     while (subIterator.hasNext()) {
       subSet.add(subIterator.next());
     }
-    assertThat(subSet.size()).isEqualTo(11);
+    assertThat(subSet.size()).isEqualTo(maxElements);
     assertThat(subSet).containsExactly(45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55);
 
     subSet.clear();
-    subIterator = tree.getIndexRange(10, 0);
+    subIterator = tree.getIndexRange(10, 0, false);
+    while (subIterator.hasNext()) {
+      subSet.add(subIterator.next());
+    }
+    assertThat(subSet.size()).isEqualTo(0);
+  }
+
+  @Test
+  public void testGetIndexRangeWithReverseRange() {
+    for (int i = 0; i < 100; ++i) {
+      tree.add(i);
+    }
+
+    List<Integer> subSet = new ArrayList<>();
+    int maxElements = 10;
+    Iterator<Integer> subIterator = tree.getIndexRange(99, maxElements, true);
+    while (subIterator.hasNext()) {
+      subSet.add(subIterator.next());
+    }
+    assertThat(subSet.size()).isEqualTo(maxElements);
+    assertThat(subSet).containsExactly(99, 98, 97, 96, 95, 94, 93, 92, 91, 90);
+
+    subSet.clear();
+
+    maxElements = 5;
+    subIterator = tree.getIndexRange(4, maxElements, true);
+    while (subIterator.hasNext()) {
+      subSet.add(subIterator.next());
+    }
+    assertThat(subSet.size()).isEqualTo(maxElements);
+    assertThat(subSet).containsExactly(4, 3, 2, 1, 0);
+
+    subSet.clear();
+
+    maxElements = 11;
+    subIterator = tree.getIndexRange(55, maxElements, true);
+    while (subIterator.hasNext()) {
+      subSet.add(subIterator.next());
+    }
+    assertThat(subSet.size()).isEqualTo(maxElements);
+    assertThat(subSet).containsExactly(55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45);
+
+    subSet.clear();
+    subIterator = tree.getIndexRange(10, 0, true);
     while (subIterator.hasNext()) {
       subSet.add(subIterator.next());
     }


### PR DESCRIPTION
 - Add ZREVRANGE to supported commands
 - Add reverse range iterator implementation to OrderStatisticsTree
 - Introduce AbstractZRangeExecutor class
 - Add tests for ZREVRANGE
 - Add tests for new reverse iterator in OrderStatisticsTree
 - Introduce AbstractZRankExecutor class to reduce code duplication and
 refactor ZRankExecutor and ZRevRankExecutor to use it
 - Fix incorrect implementation of ZRANGE in NullRedisSortedSet
 - Fix ZRANGE not updating stats
 - Add missing hits/misses tests for ZRANGE

Co-authored-by: Donal Evans <doevans@vmware.com>
Co-authored-by: Hale Bales <hbales@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?


### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
