### PR TITLE
GEODE-9404: Do not log error message if sender is not configured. 

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXCommitMessage.java
@@ -738,7 +738,8 @@ public class TXCommitMessage extends PooledDistributionMessage
     }
 
     for (EntryEventImpl ee : callbacks) {
-      boolean isLastTransactionEvent = isConfigError || ee.equals(lastTransactionEvent);
+      boolean isLastTransactionEvent = TXLastEventInTransactionUtils
+          .isLastTransactionEvent(isConfigError, lastTransactionEvent, ee);
       try {
         if (ee.getOperation().isDestroy()) {
           ee.getRegion().invokeTXCallbacks(EnumListenerEvent.AFTER_DESTROY, ee, true,
@@ -760,7 +761,8 @@ public class TXCommitMessage extends PooledDistributionMessage
   }
 
   EntryEventImpl getLastTransactionEvent(List<EntryEventImpl> callbacks) {
-    return TXLastEventInTransactionUtils.getLastTransactionEvent(callbacks, dm.getCache());
+    return TXLastEventInTransactionUtils.getLastTransactionEventInGroupedTxForWANSender(callbacks,
+        dm.getCache());
   }
 
   protected void processCacheRuntimeException(CacheRuntimeException problem) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXLastEventInTransactionUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXLastEventInTransactionUtils.java
@@ -20,15 +20,10 @@ import java.util.ServiceConfigurationError;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.logging.log4j.Logger;
-
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.wan.GatewaySender;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
 public class TXLastEventInTransactionUtils {
-  private static final Logger logger = LogService.getLogger();
-
   /**
    * @param callbacks list of events belonging to a transaction
    *
@@ -39,9 +34,8 @@ public class TXLastEventInTransactionUtils {
    *         events belong have different sets of senders that group transactions
    *         then it throws a ServiceConfigurationError exception.
    */
-  public static EntryEventImpl getLastTransactionEvent(List<EntryEventImpl> callbacks,
-      Cache cache)
-      throws ServiceConfigurationError {
+  public static EntryEventImpl getLastTransactionEventInGroupedTxForWANSender(
+      List<EntryEventImpl> callbacks, Cache cache) throws ServiceConfigurationError {
     if (checkNoSendersGroupTransactionEvents(callbacks, cache)) {
       return null;
     }
@@ -77,11 +71,7 @@ public class TXLastEventInTransactionUtils {
       Cache cache) throws ServiceConfigurationError {
     for (String senderId : getSenderIdsForEvents(callbacks)) {
       GatewaySender sender = cache.getGatewaySender(senderId);
-      if (sender == null) {
-        logger.error("No sender found for {}", senderId);
-        throw new ServiceConfigurationError("No information for senderId: " + senderId);
-      }
-      if (sender.mustGroupTransactionEvents()) {
+      if (sender != null && sender.mustGroupTransactionEvents()) {
         return false;
       }
     }
@@ -116,5 +106,10 @@ public class TXLastEventInTransactionUtils {
       throw new ServiceConfigurationError("No information for senderId: " + senderId);
     }
     return sender.mustGroupTransactionEvents();
+  }
+
+  static boolean isLastTransactionEvent(boolean isConfigError,
+      EntryEventImpl lastTransactionEvent, EntryEventImpl entryEvent) {
+    return isConfigError || lastTransactionEvent == null || entryEvent.equals(lastTransactionEvent);
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TXState.java
@@ -245,15 +245,16 @@ public class TXState implements TXStateInterface {
     boolean isConfigError = false;
     EntryEventImpl lastTransactionEvent = null;
     try {
-      lastTransactionEvent =
-          TXLastEventInTransactionUtils.getLastTransactionEvent(getPendingCallbacks(), getCache());
+      lastTransactionEvent = TXLastEventInTransactionUtils
+          .getLastTransactionEventInGroupedTxForWANSender(getPendingCallbacks(), getCache());
     } catch (ServiceConfigurationError ex) {
       logger.error(ex.getMessage());
       isConfigError = true;
     }
 
     for (EntryEventImpl ee : getPendingCallbacks()) {
-      boolean isLastTransactionEvent = isConfigError || ee.equals(lastTransactionEvent);
+      boolean isLastTransactionEvent = TXLastEventInTransactionUtils
+          .isLastTransactionEvent(isConfigError, lastTransactionEvent, ee);
       if (ee.getOperation().isDestroy()) {
         ee.getRegion().invokeTXCallbacks(EnumListenerEvent.AFTER_DESTROY, ee, true,
             isLastTransactionEvent);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -2301,6 +2301,21 @@ public class WANTestBase extends DistributedTestCase {
     }
   }
 
+  public static void doTxPuts(String regionName, int numPuts) {
+    try (
+        IgnoredException ignored = IgnoredException.addIgnoredException(InterruptedException.class);
+        IgnoredException ignored1 =
+            IgnoredException.addIgnoredException(GatewaySenderException.class)) {
+      Region<Object, Object> r = cache.getRegion(SEPARATOR + regionName);
+      assertNotNull(r);
+      for (long i = 0; i < numPuts; i++) {
+        cache.getCacheTransactionManager().begin();
+        r.put(i, "Value_" + i);
+        cache.getCacheTransactionManager().commit();
+      }
+    }
+  }
+
   public static void doPutsSameKey(String regionName, int numPuts, String key) {
     IgnoredException exp1 =
         IgnoredException.addIgnoredException(InterruptedException.class.getName());

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagation_PartitionedRegionDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagation_PartitionedRegionDUnitTest.java
@@ -79,6 +79,40 @@ public class SerialWANPropagation_PartitionedRegionDUnitTest extends WANTestBase
   }
 
   @Test
+  public void testPartitionedSerialPropagationWithTXWhenSendersNotConfiguredOnAllServers() {
+    int lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
+    int nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
+
+    createCacheInVMs(nyPort, vm2, vm3);
+    createReceiverInVMs(vm2, vm3);
+
+    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
+
+    vm4.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
+    vm5.invoke(() -> WANTestBase.createSender("ln", 2, false, 100, 10, false, false, null, true));
+
+    vm4.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+    vm5.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+    vm6.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+    vm7.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", "ln", 1, 100,
+        isOffHeap()));
+
+    vm4.invoke(() -> WANTestBase.startSender("ln"));
+
+    vm2.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
+        isOffHeap()));
+    vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 1, 100,
+        isOffHeap()));
+
+    vm7.invoke(() -> WANTestBase.doTxPuts(getTestMethodName() + "_PR", 1000));
+
+    vm2.invoke(() -> WANTestBase.validateRegionSize(getTestMethodName() + "_PR", 1000));
+  }
+
+  @Test
   public void testBothReplicatedAndPartitionedSerialPropagation() {
 
     Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));


### PR DESCRIPTION

 * This is normal case for serial wan configuration. Error message should not be
    logged when executing transactions.

* Log error message only if some events in a tx configured to group transaction but
others do not have sender configured.

* Should not wait for lastTransactionEvent in a tx if no sender configured or sender
does not set must group transaction.

(cherry picked from commit f0e328ba3eb4a1b2b47bdca5d565b79e88fecdca)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
