### PR TITLE
GEODE-9424: Accept Long arguments for Redis commands

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/SpopParameterRequirements.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/ParameterRequirements/SpopParameterRequirements.java
@@ -16,7 +16,7 @@
 package org.apache.geode.redis.internal.ParameterRequirements;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToInt;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
@@ -26,7 +26,7 @@ public class SpopParameterRequirements implements ParameterRequirements {
   public void checkParameters(Command command, ExecutionHandlerContext context) {
     if (command.getProcessedCommand().size() == 3) {
       try {
-        bytesToInt(command.getProcessedCommand().get(2));
+        bytesToLong(command.getProcessedCommand().get(2));
       } catch (NumberFormatException nex) {
         throw new RedisParametersMismatchException(ERROR_NOT_INTEGER);
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -19,8 +19,10 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_HASH;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
 
@@ -37,7 +39,6 @@ import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -87,7 +88,7 @@ public class HScanExecutor extends AbstractScanExecutor {
       } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
         commandElemBytes = commandElems.get(i + 1);
         try {
-          count = Coder.bytesToInt(commandElemBytes);
+          count = narrowLongToInt(bytesToLong(commandElemBytes));
         } catch (NumberFormatException e) {
           return RedisResponse.error(ERROR_NOT_INTEGER);
         }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
@@ -18,8 +18,10 @@ package org.apache.geode.redis.internal.executor.key;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
 
@@ -36,7 +38,6 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -75,7 +76,7 @@ public class ScanExecutor extends AbstractScanExecutor {
       } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
         commandElemBytes = commandElems.get(i + 1);
         try {
-          count = Coder.bytesToInt(commandElemBytes);
+          count = narrowLongToInt(bytesToLong(commandElemBytes));
         } catch (NumberFormatException e) {
           return RedisResponse.error(ERROR_NOT_INTEGER);
         }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
@@ -15,13 +15,15 @@
 package org.apache.geode.redis.internal.executor.set;
 
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
+
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -35,7 +37,7 @@ public class SPopExecutor extends AbstractExecutor {
 
     if (commandElems.size() == 3) {
       isCountPassed = true;
-      popCount = Coder.bytesToInt(commandElems.get(2));
+      popCount = narrowLongToInt(bytesToLong(commandElems.get(2)));
     }
 
     RedisKey key = command.getKey();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
@@ -14,13 +14,15 @@
  */
 package org.apache.geode.redis.internal.executor.set;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
+
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -39,7 +41,7 @@ public class SRandMemberExecutor extends AbstractExecutor {
 
     if (commandElems.size() > 2) {
       try {
-        count = Coder.bytesToInt(commandElems.get(2));
+        count = narrowLongToInt(bytesToLong(commandElems.get(2)));
         countSpecified = true;
       } catch (NumberFormatException e) {
         return RedisResponse.error(ERROR_NOT_NUMERIC);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -20,8 +20,10 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SET;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
 
@@ -37,7 +39,6 @@ import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -89,7 +90,7 @@ public class SScanExecutor extends AbstractScanExecutor {
       } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
         commandElemBytes = commandElems.get(i + 1);
         try {
-          count = Coder.bytesToInt(commandElemBytes);
+          count = narrowLongToInt(bytesToLong(commandElemBytes));
         } catch (NumberFormatException e) {
           return RedisResponse.error(ERROR_NOT_INTEGER);
         }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeExecutor.java
@@ -18,6 +18,7 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWITHSCORES;
 
 import java.util.List;
@@ -66,16 +67,6 @@ public abstract class AbstractZRangeExecutor extends AbstractExecutor {
     }
 
     return RedisResponse.array(retVal);
-  }
-
-  private int narrowLongToInt(long toBeNarrowed) {
-    if (toBeNarrowed > Integer.MAX_VALUE) {
-      return Integer.MAX_VALUE;
-    } else if (toBeNarrowed < Integer.MIN_VALUE) {
-      return Integer.MIN_VALUE;
-    } else {
-      return (int) toBeNarrowed;
-    }
   }
 
   public abstract boolean isRev();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/BitPosExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/BitPosExecutor.java
@@ -14,12 +14,14 @@
  */
 package org.apache.geode.redis.internal.executor.string;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
+
 import java.util.List;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -41,7 +43,7 @@ public class BitPosExecutor extends AbstractExecutor {
 
     try {
       byte[] bitAr = commandElems.get(2);
-      bit = Coder.bytesToInt(bitAr);
+      bit = narrowLongToInt(bytesToLong(bitAr));
     } catch (NumberFormatException e) {
       return RedisResponse.error(ERROR_NOT_INT);
     }
@@ -53,7 +55,7 @@ public class BitPosExecutor extends AbstractExecutor {
     if (commandElems.size() > 3) {
       try {
         byte[] startAr = commandElems.get(3);
-        start = Coder.bytesToInt(startAr);
+        start = narrowLongToInt(bytesToLong(startAr));
       } catch (NumberFormatException e) {
         return RedisResponse.error(ERROR_NOT_INT);
       }
@@ -62,7 +64,7 @@ public class BitPosExecutor extends AbstractExecutor {
     if (commandElems.size() > 4) {
       try {
         byte[] endAr = commandElems.get(4);
-        end = Coder.bytesToInt(endAr);
+        end = narrowLongToInt(bytesToLong(endAr));
       } catch (NumberFormatException e) {
         return RedisResponse.error(ERROR_NOT_INT);
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/GetBitExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/GetBitExecutor.java
@@ -14,12 +14,14 @@
  */
 package org.apache.geode.redis.internal.executor.string;
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
+
 import java.util.List;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -36,7 +38,7 @@ public class GetBitExecutor extends AbstractExecutor {
     int offset;
     try {
       byte[] offAr = commandElems.get(2);
-      offset = Coder.bytesToInt(offAr);
+      offset = narrowLongToInt(bytesToLong(offAr));
     } catch (NumberFormatException e) {
       return RedisResponse.error(ERROR_NOT_INT);
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetBitExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetBitExecutor.java
@@ -15,12 +15,14 @@
 package org.apache.geode.redis.internal.executor.string;
 
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
+
 import java.util.List;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -44,8 +46,8 @@ public class SetBitExecutor extends AbstractExecutor {
     try {
       byte[] offAr = commandElems.get(2);
       byte[] valAr = commandElems.get(3);
-      offset = Coder.bytesToLong(offAr);
-      value = Coder.bytesToInt(valAr);
+      offset = bytesToLong(offAr);
+      value = narrowLongToInt(bytesToLong(valAr));
     } catch (NumberFormatException e) {
       return RedisResponse.error(ERROR_NOT_INT);
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetRangeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetRangeExecutor.java
@@ -15,12 +15,14 @@
 package org.apache.geode.redis.internal.executor.string;
 
 
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
+
 import java.util.List;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -39,7 +41,7 @@ public class SetRangeExecutor extends AbstractExecutor {
     int offset;
     try {
       byte[] offAr = commandElems.get(2);
-      offset = Coder.bytesToInt(offAr);
+      offset = narrowLongToInt(bytesToLong(offAr));
     } catch (NumberFormatException e) {
       return RedisResponse.error(ERROR_NOT_INT);
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -339,10 +339,6 @@ public class Coder {
     return new BigDecimal(bytesToString(bytes));
   }
 
-  public static int bytesToInt(byte[] bytes) {
-    return Integer.parseInt(bytesToString(bytes));
-  }
-
   public static long bytesToLong(byte[] bytes) {
     return Long.parseLong(bytesToString(bytes));
   }
@@ -462,5 +458,17 @@ public class Coder {
   public static boolean isNegativeInfinity(byte[] bytes) {
     return equalsIgnoreCaseBytes(bytes, bN_INF)
         || equalsIgnoreCaseBytes(bytes, bN_INFINITY);
+  }
+
+  // Takes a long value and converts it to an int. Values outside the range Integer.MIN_VALUE and
+  // Integer.MAX_VALUE will be converted to either Integer.MIN_VALUE or Integer.MAX_VALUE
+  public static int narrowLongToInt(long toBeNarrowed) {
+    if (toBeNarrowed > Integer.MAX_VALUE) {
+      return Integer.MAX_VALUE;
+    } else if (toBeNarrowed < Integer.MIN_VALUE) {
+      return Integer.MIN_VALUE;
+    } else {
+      return (int) toBeNarrowed;
+    }
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -22,6 +22,7 @@ import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.isNaN;
 import static org.apache.geode.redis.internal.netty.Coder.isNegativeInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.isPositiveInfinity;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +71,29 @@ public class CoderTest {
   public void doubleToString_processesLikeRedis(String inputString, String expectedString) {
     byte[] bytes = stringToBytes(inputString);
     assertThat(doubleToString(bytesToDouble(bytes))).isEqualTo(expectedString);
+  }
+
+  @Test
+  public void narrowLongToInt_correctlyConvertsLongToIntMinValue() {
+    for (long i = Integer.MIN_VALUE; i > Integer.MIN_VALUE - 10L; --i) {
+      assertThat(narrowLongToInt(i)).isEqualTo(Integer.MIN_VALUE);
+    }
+    assertThat(narrowLongToInt(Long.MIN_VALUE)).isEqualTo(Integer.MIN_VALUE);
+  }
+
+  @Test
+  public void narrowLongToInt_correctlyConvertsLongToIntMaxValue() {
+    for (long i = Integer.MAX_VALUE; i < Integer.MAX_VALUE + 10L; ++i) {
+      assertThat(narrowLongToInt(i)).isEqualTo(Integer.MAX_VALUE);
+    }
+    assertThat(narrowLongToInt(Long.MAX_VALUE)).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void narrowLongToInt_correctlyConvertsLongToInt() {
+    for (long i = -10; i < 10; ++i) {
+      assertThat(narrowLongToInt(i)).isEqualTo(Math.toIntExact(i));
+    }
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
 - Do not return errors when arguments are specified that are less than
 Integer.MIN_VALUE or less than Integer.MAX_VALE
 - Convert long arguments outside the above range to Integer.MIN_VALUE
 or Integer.MAX_VALUE to be used internally
 - Add tests for new Coder method and coverage for existing supported
 commands that take integer arguments, except HSCAN which will require
 GEODE-9429 to be fixed first

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
