### PR TITLE
GEODE-9429: Allow Radish HSCAN to handle all valid values for COUNT

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/RedisIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/RedisIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 
 import redis.clients.jedis.Jedis;
@@ -25,7 +26,7 @@ public interface RedisIntegrationTest {
 
   default void flushAll() {
     ClusterNodes nodes;
-    try (Jedis jedis = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT)) {
+    try (Jedis jedis = new Jedis(BIND_ADDRESS, getPort(), REDIS_CLIENT_TIMEOUT)) {
       nodes = ClusterNodes.parseClusterNodes(jedis.clusterNodes());
     }
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -55,6 +55,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   protected JedisCluster jedis;
 
   public static final String HASH_KEY = "key";
+  public static final int SLOT_FOR_KEY = CRC16.calculate(HASH_KEY) % RegionProvider.REDIS_SLOTS;
   public static final String ZERO_CURSOR = "0";
 
   public static final String FIELD_ONE = "1";
@@ -467,9 +468,8 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, initialHashData);
     final int iterationCount = 500;
 
-    int slot = getSlotForKey();
-    Jedis jedis1 = jedis.getConnectionFromSlot(slot);
-    Jedis jedis2 = jedis.getConnectionFromSlot(slot);
+    Jedis jedis1 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+    Jedis jedis2 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
 
     new ConcurrentLoopingThreads(iterationCount,
         (i) -> multipleHScanAndAssertOnSizeOfResultSet(jedis1, initialHashData),
@@ -489,9 +489,8 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, initialHashData);
     final int iterationCount = 500;
 
-    int slot = getSlotForKey();
-    Jedis jedis1 = jedis.getConnectionFromSlot(slot);
-    Jedis jedis2 = jedis.getConnectionFromSlot(slot);
+    Jedis jedis1 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+    Jedis jedis2 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
 
     new ConcurrentLoopingThreads(iterationCount,
         (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis1, initialHashData),
@@ -512,9 +511,8 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, initialHashData);
     final int iterationCount = 500;
 
-    int slot = getSlotForKey();
-    Jedis jedis1 = jedis.getConnectionFromSlot(slot);
-    Jedis jedis2 = jedis.getConnectionFromSlot(slot);
+    Jedis jedis1 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+    Jedis jedis2 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
 
     new ConcurrentLoopingThreads(iterationCount,
         (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis1, initialHashData),
@@ -593,11 +591,6 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
       dataSet.put(BASE_FIELD + i, "value_" + i);
     }
     return dataSet;
-  }
-
-  private int getSlotForKey() {
-    int crc = CRC16.calculate(HASH_KEY);
-    return crc % RegionProvider.REDIS_SLOTS;
   }
 
   private static class MapEntryWithByteArraysComparator

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -244,9 +244,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   @Test
   public void givenInvalidRegexSyntax_returnsEmptyArray() {
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
-    ScanParams scanParams = new ScanParams();
-    scanParams.count(1);
-    scanParams.match("\\p");
+    ScanParams scanParams = new ScanParams().count(1).match("\\p");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
         jedis.hscan(HASH_KEY.getBytes(), ZERO_CURSOR.getBytes(), scanParams);
@@ -302,8 +300,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   public void givenCompleteIteration_shouldReturnCursorWithValueOfZero() {
     initializeThreeFieldHash();
 
-    ScanParams scanParams = new ScanParams();
-    scanParams.count(1);
+    ScanParams scanParams = new ScanParams().count(1);
     ScanResult<Map.Entry<byte[], byte[]>> result;
     String cursor = ZERO_CURSOR;
 
@@ -319,8 +316,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   public void givenMatch_returnsAllMatchingEntries() {
     Map<byte[], byte[]> entryMap = initializeThreeFieldHashBytes();
 
-    ScanParams scanParams = new ScanParams();
-    scanParams.match("1*");
+    ScanParams scanParams = new ScanParams().match("1*");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
         jedis.hscan(HASH_KEY.getBytes(), ZERO_CURSOR.getBytes(), scanParams);
@@ -353,9 +349,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   public void givenMatchAndCount_returnsAllMatchingKeys() {
     Map<byte[], byte[]> entryMap = initializeThreeFieldHashBytes();
 
-    ScanParams scanParams = new ScanParams();
-    scanParams.count(1);
-    scanParams.match("1*");
+    ScanParams scanParams = new ScanParams().count(1).match("1*");
     ScanResult<Map.Entry<byte[], byte[]>> result;
     List<Map.Entry<byte[], byte[]>> allEntries = new ArrayList<>();
     String cursor = ZERO_CURSOR;
@@ -432,7 +426,6 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     Map<byte[], byte[]> entryMap = initializeThreeFieldHashBytes();
 
     ScanParams scanParams = new ScanParams().count(Integer.MAX_VALUE);
-    scanParams.count(Integer.MAX_VALUE);
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
         jedis.hscan(HASH_KEY.getBytes(), ZERO_CURSOR.getBytes(), scanParams);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -20,6 +20,9 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -49,15 +52,25 @@ import org.apache.geode.redis.internal.executor.cluster.CRC16;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTest {
-
   protected JedisCluster jedis;
 
-  private static final int REDIS_CLIENT_TIMEOUT =
-      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+  public static final String HASH_KEY = "key";
+  public static final String ZERO_CURSOR = "0";
+
+  public static final String FIELD_ONE = "1";
+  public static final String VALUE_ONE = "yellow";
+  public static final String FIELD_TWO = "12";
+  public static final String VALUE_TWO = "green";
+  public static final String FIELD_THREE = "3";
+  public static final byte[] FIELD_THREE_BYTES = FIELD_THREE.getBytes();
+  public static final String VALUE_THREE = "orange";
+
+  public static final String BASE_FIELD = "baseField_";
+  private final int SIZE_OF_ENTRY_MAP = 100;
 
   @Before
   public void setUp() {
-    jedis = new JedisCluster(new HostAndPort("localhost", getPort()), REDIS_CLIENT_TIMEOUT);
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
   }
 
   @After
@@ -75,104 +88,113 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void givenMatchArgumentWithoutPatternOnExistingKey_returnsSyntaxError() {
-    jedis.hset("key", "b", "1");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
-    assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.HSCAN, "key", "0", "Match"))
-        .hasMessageContaining(ERROR_SYNTAX);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "MATCH"))
+            .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void givenMatchArgumentWithoutPatternOnNonExistentKey_returnsEmptyArray() {
-
     List<Object> result =
-        (List<Object>) jedis.sendCommand("key1", Protocol.Command.HSCAN, "key1", "0", "Match");
+        uncheckedCast(jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, "nonexistentKey",
+            ZERO_CURSOR, "MATCH"));
 
-    assertThat((List<String>) result.get(1)).isEmpty();
+    assertThat((List<?>) result.get(1)).isEmpty();
   }
 
   @Test
   public void givenCountArgumentWithoutNumberOnExistingKey_returnsSyntaxError() {
-    jedis.hset("a", "b", "1");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
-    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "Count"))
-        .hasMessageContaining(ERROR_SYNTAX);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT"))
+            .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void givenCountArgumentWithoutNumberOnNonExistentKey_returnsEmptyArray() {
     List<Object> result =
-        (List<Object>) jedis.sendCommand("b", Protocol.Command.HSCAN, "b", "0", "Count");
+        uncheckedCast(
+            jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT"));
 
-    assertThat((List<String>) result.get(1)).isEmpty();
+    assertThat((List<?>) result.get(1)).isEmpty();
   }
 
   @Test
   public void givenMatchOrCountKeywordNotSpecified_returnsSyntaxError() {
-    jedis.hset("a", "b", "1");
-    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "a*", "1"))
-        .hasMessageContaining(ERROR_SYNTAX);
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "a*", "1"))
+            .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
   public void givenCount_whenCountParameterIsNotAnInteger_returnsNotIntegerError() {
-    jedis.hset("a", "b", "1");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
     assertThatThrownBy(
-        () -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "COUNT", "MATCH"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+        () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
+            "MATCH"))
+                .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenMultipleCounts_whenAnyCountParameterIsNotAnInteger_returnsNotIntegerError() {
-    jedis.hset("a", "b", "1");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
     assertThatThrownBy(
-        () -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "COUNT", "3",
+        () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
+            "3",
             "COUNT", "sjlfs", "COUNT", "1"))
                 .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenCount_whenCountParameterIsZero_returnsSyntaxError() {
-    jedis.hset("a", "b", "1");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
     assertThatThrownBy(
-        () -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "COUNT", "0"))
-            .hasMessageContaining(ERROR_SYNTAX);
+        () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
+            ZERO_CURSOR))
+                .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
   public void givenCount_whenCountParameterIsNegative_returnsSyntaxError() {
-    jedis.hset("a", "b", "1");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
     assertThatThrownBy(
-        () -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0", "COUNT", "-37"))
-            .hasMessageContaining(ERROR_SYNTAX);
+        () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
+            "-37"))
+                .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
   public void givenMultipleCounts_whenAnyCountParameterIsLessThanOne_returnsSyntaxError() {
-    jedis.hset("key", "b", "1");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
     assertThatThrownBy(
-        () -> jedis.sendCommand("key", Protocol.Command.HSCAN, "key", "0", "COUNT", "3",
-            "COUNT", "0", "COUNT", "1"))
+        () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR,
+            "COUNT", "3",
+            "COUNT", "0",
+            "COUNT", "1"))
                 .hasMessageContaining(ERROR_SYNTAX);
   }
 
   @Test
   public void givenKeyIsNotAHash_returnsWrongTypeError() {
-    jedis.sadd("a", "1");
+    jedis.sadd(HASH_KEY, "member");
 
-    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "0"))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY,
+        ZERO_CURSOR))
+            .hasMessageContaining(ERROR_WRONG_TYPE);
   }
 
   @Test
   public void givenKeyIsNotAHash_andCursorIsNotAnInteger_returnsCursorError() {
-    jedis.sadd("a", "b");
+    jedis.sadd(HASH_KEY, "member");
 
-    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "sjfls"))
+    assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, "sjfls"))
         .hasMessageContaining(ERROR_CURSOR);
   }
 
@@ -185,15 +207,15 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void givenExistentHashKey_andCursorIsNotAnInteger_returnsCursorError() {
-    jedis.hset("a", "b", "1");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
-    assertThatThrownBy(() -> jedis.sendCommand("a", Protocol.Command.HSCAN, "a", "sjfls"))
+    assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, "sjfls"))
         .hasMessageContaining(ERROR_CURSOR);
   }
 
   @Test
   public void givenNonexistentKey_returnsEmptyArray() {
-    ScanResult<Map.Entry<String, String>> result = jedis.hscan("nonexistent", "0");
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan("nonexistent", ZERO_CURSOR);
 
     assertThat(result.isCompleteIteration()).isTrue();
     assertThat(result.getResult()).isEmpty();
@@ -201,18 +223,14 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void givenNegativeCursor_returnsEntriesUsingAbsoluteValueOfCursor() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("2", "green");
-    entryMap.put("3", "orange");
-    jedis.hmset("colors", entryMap);
+    Map<String, String> entryMap = initializeThreeFieldHash();
 
     String cursor = "-100";
     ScanResult<Map.Entry<String, String>> result;
     List<Map.Entry<String, String>> allEntries = new ArrayList<>();
 
     do {
-      result = jedis.hscan("colors", cursor);
+      result = jedis.hscan(HASH_KEY, cursor);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
@@ -224,13 +242,13 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void givenInvalidRegexSyntax_returnsEmptyArray() {
-    jedis.hset("a", "1", "green");
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
     scanParams.match("\\p");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
-        jedis.hscan("a".getBytes(), "0".getBytes(), scanParams);
+        jedis.hscan(HASH_KEY.getBytes(), ZERO_CURSOR.getBytes(), scanParams);
 
     assertThat(result.getResult()).isEmpty();
   }
@@ -240,10 +258,10 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   @Test
   public void givenHashWithOneEntry_returnsEntry() {
     Map<String, String> expected = new HashMap<>();
-    expected.put("1", "2");
-    jedis.hset("a", "1", "2");
+    expected.put(FIELD_ONE, VALUE_ONE);
+    jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
-    ScanResult<Map.Entry<String, String>> result = jedis.hscan("a", "0");
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan(HASH_KEY, ZERO_CURSOR);
 
     assertThat(result.isCompleteIteration()).isTrue();
     assertThat(result.getResult()).containsExactly(expected.entrySet().iterator().next());
@@ -251,144 +269,103 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void givenHashWithMultipleEntries_returnsAllEntries() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("2", "green");
-    entryMap.put("3", "orange");
-    jedis.hmset("colors", entryMap);
+    Map<String, String> entryMap = initializeThreeFieldHash();
 
-    ScanResult<Map.Entry<String, String>> result = jedis.hscan("colors", "0");
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan(HASH_KEY, ZERO_CURSOR);
 
     assertThat(result.isCompleteIteration()).isTrue();
     assertThat(new HashSet<>(result.getResult())).isEqualTo(entryMap.entrySet());
   }
 
-
   @Test
-  @SuppressWarnings("unchecked")
   public void givenMultipleCounts_DoesNotFail() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("12", "green");
-    entryMap.put("3", "grey");
-    jedis.hmset("colors", entryMap);
-    List<Object> result;
+    initializeThreeFieldHash();
 
-    List<byte[]> allEntries = new ArrayList<>();
-    String cursor = "0";
+    List<Object> result;
+    String cursor = ZERO_CURSOR;
 
     do {
-      result = (List<Object>) jedis.sendCommand("colors", Protocol.Command.HSCAN,
-          "colors",
+      result = uncheckedCast(jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN,
+          HASH_KEY,
           cursor,
           "COUNT", "2",
-          "COUNT", "1");
+          "COUNT", "1"));
 
-      allEntries.addAll((List<byte[]>) result.get(1));
       cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+    } while (!Arrays.equals((byte[]) result.get(0), ZERO_CURSOR.getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(ZERO_CURSOR.getBytes());
   }
 
   @Test
   public void givenCompleteIteration_shouldReturnCursorWithValueOfZero() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("2", "green");
-    entryMap.put("3", "orange");
-    jedis.hmset("colors", entryMap);
+    initializeThreeFieldHash();
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
     ScanResult<Map.Entry<byte[], byte[]>> result;
-    List<Map.Entry<byte[], byte[]>> allEntries = new ArrayList<>();
-    String cursor = "0";
+    String cursor = ZERO_CURSOR;
 
     do {
-      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
-      allEntries.addAll(result.getResult());
+      result = jedis.hscan(HASH_KEY.getBytes(), cursor.getBytes(), scanParams);
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(result.getCursor()).isEqualTo("0");
+    assertThat(result.getCursor()).isEqualTo(ZERO_CURSOR);
   }
 
   @Test
   public void givenMatch_returnsAllMatchingEntries() {
-    Map<byte[], byte[]> entryMap = new HashMap<>();
-    byte[] field3 = "3".getBytes();
-    entryMap.put("1".getBytes(), "yellow".getBytes());
-    entryMap.put("12".getBytes(), "green".getBytes());
-    entryMap.put(field3, "grey".getBytes());
-    jedis.hmset("colors".getBytes(), entryMap);
+    Map<byte[], byte[]> entryMap = initializeThreeFieldHashBytes();
 
     ScanParams scanParams = new ScanParams();
     scanParams.match("1*");
 
     ScanResult<Map.Entry<byte[], byte[]>> result =
-        jedis.hscan("colors".getBytes(), "0".getBytes(), scanParams);
+        jedis.hscan(HASH_KEY.getBytes(), ZERO_CURSOR.getBytes(), scanParams);
 
-    entryMap.remove(field3);
+    entryMap.remove(FIELD_THREE_BYTES);
     assertThat(result.isCompleteIteration()).isTrue();
     assertThat(new HashSet<>(result.getResult()))
         .usingElementComparator(new MapEntryWithByteArraysComparator())
         .containsExactlyInAnyOrderElementsOf(entryMap.entrySet());
   }
 
-  private static class MapEntryWithByteArraysComparator
-      implements Comparator<Map.Entry<byte[], byte[]>> {
-    @Override
-    public int compare(Map.Entry<byte[], byte[]> o1, Map.Entry<byte[], byte[]> o2) {
-      return Arrays.equals(o1.getKey(), o2.getKey()) &&
-          Arrays.equals(o1.getValue(), o2.getValue()) ? 0 : 1;
-    }
-  }
-
   @Test
-  @SuppressWarnings("unchecked")
   public void givenMultipleMatches_returnsEntriesMatchingLastMatchParameter() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("12", "green");
-    entryMap.put("3", "grey");
-    jedis.hmset("colors", entryMap);
+    initializeThreeFieldHash();
 
     List<Object> result =
-        (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
-            "colors".getBytes(), "0".getBytes(), "MATCH".getBytes(),
-            "3*".getBytes(),
-            "MATCH".getBytes(), "1*".getBytes());
+        uncheckedCast(jedis.sendCommand(HASH_KEY.getBytes(), Protocol.Command.HSCAN,
+            HASH_KEY.getBytes(), ZERO_CURSOR.getBytes(),
+            "MATCH".getBytes(), "3*".getBytes(),
+            "MATCH".getBytes(), "1*".getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat((List<Object>) result.get(1)).containsAll(
-        Arrays.asList("1".getBytes(), "yellow".getBytes(),
-            "12".getBytes(), "green".getBytes()));
+    assertThat((byte[]) result.get(0)).isEqualTo(ZERO_CURSOR.getBytes());
+    List<byte[]> fieldsAndValues = uncheckedCast(result.get(1));
+    assertThat(fieldsAndValues).containsAll(
+        Arrays.asList(FIELD_ONE.getBytes(), VALUE_ONE.getBytes(),
+            FIELD_TWO.getBytes(), VALUE_TWO.getBytes()));
   }
 
   @Test
   public void givenMatchAndCount_returnsAllMatchingKeys() {
-    Map<byte[], byte[]> entryMap = new HashMap<>();
-    byte[] field3 = "3".getBytes();
-    entryMap.put("1".getBytes(), "yellow".getBytes());
-    entryMap.put("12".getBytes(), "green".getBytes());
-    entryMap.put(field3, "orange".getBytes());
-    jedis.hmset("colors".getBytes(), entryMap);
+    Map<byte[], byte[]> entryMap = initializeThreeFieldHashBytes();
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
     scanParams.match("1*");
     ScanResult<Map.Entry<byte[], byte[]>> result;
     List<Map.Entry<byte[], byte[]>> allEntries = new ArrayList<>();
-    String cursor = "0";
+    String cursor = ZERO_CURSOR;
 
     do {
-      result = jedis.hscan("colors".getBytes(), cursor.getBytes(), scanParams);
+      result = jedis.hscan(HASH_KEY.getBytes(), cursor.getBytes(), scanParams);
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    entryMap.remove(field3);
+    entryMap.remove(FIELD_THREE_BYTES);
 
     assertThat(new HashSet<>(allEntries))
         .usingElementComparator(new MapEntryWithByteArraysComparator())
@@ -396,94 +373,76 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   }
 
   @Test
-  @SuppressWarnings("unchecked")
   public void givenMultipleCountsAndMatches_returnsEntriesMatchingLastMatchParameter() {
-    Map<String, String> entryMap = new HashMap<>();
-    entryMap.put("1", "yellow");
-    entryMap.put("12", "green");
-    entryMap.put("3", "grey");
-    jedis.hmset("colors", entryMap);
+    initializeThreeFieldHash();
     List<Object> result;
 
     List<byte[]> allEntries = new ArrayList<>();
-    String cursor = "0";
+    String cursor = ZERO_CURSOR;
 
     do {
       result =
-          (List<Object>) jedis.sendCommand("colors".getBytes(), Protocol.Command.HSCAN,
-              "colors".getBytes(), cursor.getBytes(),
+          uncheckedCast(jedis.sendCommand(HASH_KEY.getBytes(), Protocol.Command.HSCAN,
+              HASH_KEY.getBytes(), cursor.getBytes(),
               "COUNT".getBytes(), "37".getBytes(),
-              "MATCH".getBytes(), "3*".getBytes(), "COUNT".getBytes(),
-              "2".getBytes(),
-              "COUNT".getBytes(), "1".getBytes(), "MATCH".getBytes(),
-              "1*".getBytes());
-      allEntries.addAll((List<byte[]>) result.get(1));
+              "MATCH".getBytes(), "3*".getBytes(),
+              "COUNT".getBytes(), "2".getBytes(),
+              "COUNT".getBytes(), "1".getBytes(),
+              "MATCH".getBytes(), "1*".getBytes()));
+      List<byte[]> fieldsAndValues = uncheckedCast(result.get(1));
+      allEntries.addAll(fieldsAndValues);
       cursor = new String((byte[]) result.get(0));
-    } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
+    } while (!Arrays.equals((byte[]) result.get(0), ZERO_CURSOR.getBytes()));
 
-    assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allEntries).containsExactlyInAnyOrder("1".getBytes(),
-        "yellow".getBytes(),
-        "12".getBytes(), "green".getBytes());
+    assertThat((byte[]) result.get(0)).isEqualTo(ZERO_CURSOR.getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder(
+        FIELD_ONE.getBytes(), VALUE_ONE.getBytes(),
+        FIELD_TWO.getBytes(), VALUE_TWO.getBytes());
   }
 
   @Test
   public void should_notReturnValue_givenValueWasRemovedBeforeHSCANISCalled() {
+    Map<String, String> entryMap = initializeThreeFieldHash();
 
-    Map<String, String> data = new HashMap<>();
-    data.put("field_1", "yellow");
-    data.put("field_2", "green");
-    data.put("field_3", "grey");
-    jedis.hmset("colors", data);
-
-    jedis.hdel("colors", "field_3");
-    data.remove("field_3");
+    jedis.hdel(HASH_KEY, FIELD_THREE);
+    entryMap.remove(FIELD_THREE);
 
     GeodeAwaitility.await().untilAsserted(
-        () -> assertThat(jedis.hget("colors", "field_3")).isNull());
+        () -> assertThat(jedis.hget(HASH_KEY, FIELD_THREE)).isNull());
 
-    ScanResult<Map.Entry<String, String>> result = jedis.hscan("colors", "0");
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan(HASH_KEY, ZERO_CURSOR);
 
     assertThat(new HashSet<>(result.getResult()))
-        .containsExactlyInAnyOrderElementsOf(data.entrySet());
+        .containsExactlyInAnyOrderElementsOf(entryMap.entrySet());
   }
 
   @Test
   public void should_notErrorGivenNonzeroCursorOnFirstCall() {
+    Map<String, String> entryMap = initializeThreeFieldHash();
 
-    Map<String, String> data = new HashMap<>();
-    data.put("field_1", "yellow");
-    data.put("field_2", "green");
-    data.put("field_3", "grey");
-    jedis.hmset("colors", data);
-
-    ScanResult<Map.Entry<String, String>> result = jedis.hscan("colors", "5");
+    ScanResult<Map.Entry<String, String>> result = jedis.hscan(HASH_KEY, "5");
 
     assertThat(new HashSet<>(result.getResult()))
-        .isSubsetOf(data.entrySet());
+        .isSubsetOf(entryMap.entrySet());
   }
 
   /**** Concurrency ***/
 
-  private final int SIZE_OF_INITIAL_HASH_DATA = 100;
-  final String HASH_KEY = "key";
-  final String BASE_FIELD = "baseField_";
-
   @Test
   public void should_notLoseFields_givenConcurrentThreadsDoingHScansAndChangingValues() {
-    final Map<String, String> INITIAL_HASH_DATA = makeEntrySet(SIZE_OF_INITIAL_HASH_DATA);
-    jedis.hset(HASH_KEY, INITIAL_HASH_DATA);
-    final int ITERATION_COUNT = 500;
+    final Map<String, String> initialHashData = makeEntryMap();
+    jedis.hset(HASH_KEY, initialHashData);
+    final int iterationCount = 500;
 
-    int slot = getSlotForKey(HASH_KEY);
+    int slot = getSlotForKey();
     Jedis jedis1 = jedis.getConnectionFromSlot(slot);
     Jedis jedis2 = jedis.getConnectionFromSlot(slot);
 
-    new ConcurrentLoopingThreads(ITERATION_COUNT,
-        (i) -> multipleHScanAndAssertOnSizeOfResultSet(jedis1, INITIAL_HASH_DATA),
-        (i) -> multipleHScanAndAssertOnSizeOfResultSet(jedis2, INITIAL_HASH_DATA),
+    new ConcurrentLoopingThreads(iterationCount,
+        (i) -> multipleHScanAndAssertOnSizeOfResultSet(jedis1, initialHashData),
+        (i) -> multipleHScanAndAssertOnSizeOfResultSet(jedis2, initialHashData),
         (i) -> {
-          int fieldSuffix = i % SIZE_OF_INITIAL_HASH_DATA;
+          int fieldSuffix = i % SIZE_OF_ENTRY_MAP;
           jedis.hset(HASH_KEY, BASE_FIELD + fieldSuffix, "new_value_" + i);
         }).run();
 
@@ -493,17 +452,17 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void should_notLoseKeysForConsistentlyPresentFields_givenConcurrentThreadsAddingAndRemovingFields() {
-    final Map<String, String> INITIAL_HASH_DATA = makeEntrySet(SIZE_OF_INITIAL_HASH_DATA);
-    jedis.hset(HASH_KEY, INITIAL_HASH_DATA);
-    final int ITERATION_COUNT = 500;
+    final Map<String, String> initialHashData = makeEntryMap();
+    jedis.hset(HASH_KEY, initialHashData);
+    final int iterationCount = 500;
 
-    int slot = getSlotForKey(HASH_KEY);
+    int slot = getSlotForKey();
     Jedis jedis1 = jedis.getConnectionFromSlot(slot);
     Jedis jedis2 = jedis.getConnectionFromSlot(slot);
 
-    new ConcurrentLoopingThreads(ITERATION_COUNT,
-        (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis1, INITIAL_HASH_DATA),
-        (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis2, INITIAL_HASH_DATA),
+    new ConcurrentLoopingThreads(iterationCount,
+        (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis1, initialHashData),
+        (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis2, initialHashData),
         (i) -> {
           String field = "new_" + BASE_FIELD + i;
           jedis.hset(HASH_KEY, field, "whatever");
@@ -516,20 +475,20 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void should_notAlterUnderlyingData_givenMultipleConcurrentHscans() {
-    final Map<String, String> INITIAL_HASH_DATA = makeEntrySet(SIZE_OF_INITIAL_HASH_DATA);
-    jedis.hset(HASH_KEY, INITIAL_HASH_DATA);
-    final int ITERATION_COUNT = 500;
+    final Map<String, String> initialHashData = makeEntryMap();
+    jedis.hset(HASH_KEY, initialHashData);
+    final int iterationCount = 500;
 
-    int slot = getSlotForKey(HASH_KEY);
+    int slot = getSlotForKey();
     Jedis jedis1 = jedis.getConnectionFromSlot(slot);
     Jedis jedis2 = jedis.getConnectionFromSlot(slot);
 
-    new ConcurrentLoopingThreads(ITERATION_COUNT,
-        (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis1, INITIAL_HASH_DATA),
-        (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis2, INITIAL_HASH_DATA))
+    new ConcurrentLoopingThreads(iterationCount,
+        (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis1, initialHashData),
+        (i) -> multipleHScanAndAssertOnContentOfResultSet(i, jedis2, initialHashData))
             .run();
 
-    INITIAL_HASH_DATA
+    initialHashData
         .forEach((field, value) -> assertThat(jedis.hget(HASH_KEY, field).equals(value)));
 
     jedis1.close();
@@ -541,7 +500,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     List<String> allEntries = new ArrayList<>();
     ScanResult<Map.Entry<String, String>> result;
-    String cursor = "0";
+    String cursor = ZERO_CURSOR;
 
     do {
       result = jedis.hscan(HASH_KEY, cursor);
@@ -559,7 +518,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
       final Map<String, String> initialHashData) {
     List<Map.Entry<String, String>> allEntries = new ArrayList<>();
     ScanResult<Map.Entry<String, String>> result;
-    String cursor = "0";
+    String cursor = ZERO_CURSOR;
 
     do {
       result = jedis.hscan(HASH_KEY, cursor);
@@ -577,16 +536,44 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
         .isEqualTo(initialHashData.size());
   }
 
-  private Map<String, String> makeEntrySet(int sizeOfDataSet) {
+  private Map<String, String> initializeThreeFieldHash() {
+    Map<String, String> entryMap = new HashMap<>();
+    entryMap.put(FIELD_ONE, VALUE_ONE);
+    entryMap.put(FIELD_TWO, VALUE_TWO);
+    entryMap.put(FIELD_THREE, VALUE_THREE);
+    jedis.hmset(HASH_KEY, entryMap);
+    return entryMap;
+  }
+
+  Map<byte[], byte[]> initializeThreeFieldHashBytes() {
+    Map<byte[], byte[]> entryMap = new HashMap<>();
+    entryMap.put(FIELD_ONE.getBytes(), VALUE_ONE.getBytes());
+    entryMap.put(FIELD_TWO.getBytes(), VALUE_TWO.getBytes());
+    entryMap.put(FIELD_THREE_BYTES, VALUE_THREE.getBytes());
+    jedis.hmset(HASH_KEY.getBytes(), entryMap);
+    return entryMap;
+  }
+
+  private Map<String, String> makeEntryMap() {
     Map<String, String> dataSet = new HashMap<>();
-    for (int i = 0; i < sizeOfDataSet; i++) {
+    for (int i = 0; i < SIZE_OF_ENTRY_MAP; i++) {
       dataSet.put(BASE_FIELD + i, "value_" + i);
     }
     return dataSet;
   }
 
-  private int getSlotForKey(String key) {
-    int crc = CRC16.calculate(key);
+  private int getSlotForKey() {
+    int crc = CRC16.calculate(HASH_KEY);
     return crc % RegionProvider.REDIS_SLOTS;
+  }
+
+  private static class MapEntryWithByteArraysComparator
+      implements Comparator<Map.Entry<byte[], byte[]>> {
+
+    @Override
+    public int compare(Map.Entry<byte[], byte[]> o1, Map.Entry<byte[], byte[]> o2) {
+      return Arrays.equals(o1.getKey(), o2.getKey()) &&
+          Arrays.equals(o1.getValue(), o2.getValue()) ? 0 : 1;
+    }
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -29,8 +29,6 @@ public class RedisConstants {
   public static final String ERROR_CURSOR = "invalid cursor";
   public static final String ERROR_UNKNOWN_COMMAND =
       "unknown command `%s`, with args beginning with: %s";
-  public static final String ERROR_UNSUPPORTED_COMMAND =
-      " is not supported. To enable all unsupported commands use GFSH to execute: 'redis --enable-unsupported-commands'. Unsupported commands have not been fully tested.";
   public static final String ERROR_OUT_OF_RANGE = "The number provided is out of range";
   public static final String ERROR_NO_PASS = "Client sent AUTH, but no password is set";
   public static final String ERROR_INVALID_PWD = "invalid password";

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -246,7 +246,7 @@ public class RedisHash extends AbstractRedisData {
       LogService.getLogger().info(
           "The size of the data to be returned by hscan, {}, exceeds the maximum capacity of an array. A value for the HSCAN COUNT argument less than {} should be used",
           maximumCapacity, Integer.MAX_VALUE / 2);
-      throw new OutOfMemoryError("Requested array size exceeds VM limit");
+      throw new IllegalArgumentException("Requested array size exceeds VM limit");
     }
     List<byte[]> resultList = new ArrayList<>((int) maximumCapacity);
     do {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -240,12 +240,12 @@ public class RedisHash extends AbstractRedisData {
 
   public ImmutablePair<Integer, List<byte[]>> hscan(Pattern matchPattern, int count, int cursor) {
     // No need to allocate more space than it's possible to use given the size of the hash. We need
-    // to add 1 to hash.size() to ensure that if count > hash.size(), we return a cursor of 0
+    // to add 1 to hlen() to ensure that if count > hash.size(), we return a cursor of 0
     long maximumCapacity = 2L * Math.min(count, hlen() + 1);
     if (maximumCapacity > Integer.MAX_VALUE) {
-      LogService.getLogger().error(
-          "The size of the data to be returned by hscan, {}, exceeds the maximum capacity of an array",
-          maximumCapacity);
+      LogService.getLogger().info(
+          "The size of the data to be returned by hscan, {}, exceeds the maximum capacity of an array. A value for the HSCAN COUNT argument less than {} should be used",
+          maximumCapacity, Integer.MAX_VALUE / 2);
       throw new OutOfMemoryError("Requested array size exceeds VM limit");
     }
     List<byte[]> resultList = new ArrayList<>((int) maximumCapacity);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -43,6 +43,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.collections.SizeableObject2ObjectOpenCustomHashMapWithCursor;
 import org.apache.geode.redis.internal.delta.AddsDeltaInfo;
 import org.apache.geode.redis.internal.delta.DeltaInfo;
@@ -237,12 +238,17 @@ public class RedisHash extends AbstractRedisData {
     return new ArrayList<>(hash.keySet());
   }
 
-  public ImmutablePair<Integer, List<ImmutablePair<byte[], byte[]>>> hscan(Pattern matchPattern,
-      int count, int cursor) {
+  public ImmutablePair<Integer, List<byte[]>> hscan(Pattern matchPattern, int count, int cursor) {
     // No need to allocate more space than it's possible to use given the size of the hash. We need
     // to add 1 to hash.size() to ensure that if count > hash.size(), we return a cursor of 0
-    int maximumCapacity = Math.min(count, hash.size() + 1);
-    List<ImmutablePair<byte[], byte[]>> resultList = new ArrayList<>(maximumCapacity);
+    long maximumCapacity = 2L * Math.min(count, hlen() + 1);
+    if (maximumCapacity > Integer.MAX_VALUE) {
+      LogService.getLogger().error(
+          "The size of the data to be returned by hscan, {}, exceeds the maximum capacity of an array",
+          maximumCapacity);
+      throw new OutOfMemoryError("Requested array size exceeds VM limit");
+    }
+    List<byte[]> resultList = new ArrayList<>((int) maximumCapacity);
     do {
       cursor = hash.scan(cursor, 1,
           (list, key, value) -> addIfMatching(matchPattern, list, key, value), resultList);
@@ -251,14 +257,16 @@ public class RedisHash extends AbstractRedisData {
     return new ImmutablePair<>(cursor, resultList);
   }
 
-  private void addIfMatching(Pattern matchPattern, List<ImmutablePair<byte[], byte[]>> resultList,
-      byte[] key, byte[] value) {
+  private void addIfMatching(Pattern matchPattern, List<byte[]> resultList, byte[] key,
+      byte[] value) {
     if (matchPattern != null) {
       if (matchPattern.matcher(bytesToString(key)).matches()) {
-        resultList.add(new ImmutablePair<>(key, value));
+        resultList.add(key);
+        resultList.add(value);
       }
     } else {
-      resultList.add(new ImmutablePair<>(key, value));
+      resultList.add(key);
+      resultList.add(value);
     }
   }
 
@@ -386,4 +394,5 @@ public class RedisHash extends AbstractRedisData {
   public int getSizeInBytes() {
     return BASE_REDIS_HASH_OVERHEAD + hash.getSizeInBytes();
   }
+
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -239,13 +239,14 @@ public class RedisHash extends AbstractRedisData {
 
   public ImmutablePair<Integer, List<ImmutablePair<byte[], byte[]>>> hscan(Pattern matchPattern,
       int count, int cursor) {
-    // No need to allocate more space than it's possible to use given the size of the hash
-    int initialCapacity = Math.min(count, hash.size());
-    List<ImmutablePair<byte[], byte[]>> resultList = new ArrayList<>(initialCapacity);
+    // No need to allocate more space than it's possible to use given the size of the hash. We need
+    // to add 1 to hash.size() to ensure that if count > hash.size(), we return a cursor of 0
+    int maximumCapacity = Math.min(count, hash.size() + 1);
+    List<ImmutablePair<byte[], byte[]>> resultList = new ArrayList<>(maximumCapacity);
     do {
       cursor = hash.scan(cursor, 1,
           (list, key, value) -> addIfMatching(matchPattern, list, key, value), resultList);
-    } while (cursor != 0 && resultList.size() < count);
+    } while (cursor != 0 && resultList.size() < maximumCapacity);
 
     return new ImmutablePair<>(cursor, resultList);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
@@ -92,8 +92,8 @@ public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunction
   }
 
   @Override
-  public ImmutablePair<Integer, List<ImmutablePair<byte[], byte[]>>> hscan(RedisKey key,
-      Pattern matchPattern, int count, int cursor) {
+  public Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern, int count,
+      int cursor) {
     return stripedExecute(key,
         () -> getRedisHash(key, true)
             .hscan(matchPattern, count, cursor));

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
@@ -21,7 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
@@ -92,8 +92,8 @@ public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunction
   }
 
   @Override
-  public Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern,
-      int count, int cursor) {
+  public ImmutablePair<Integer, List<ImmutablePair<byte[], byte[]>>> hscan(RedisKey key,
+      Pattern matchPattern, int count, int cursor) {
     return stripedExecute(key,
         () -> getRedisHash(key, true)
             .hscan(matchPattern, count, cursor));

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -122,8 +122,12 @@ public class HScanExecutor extends AbstractScanExecutor {
       }
       RedisHashCommands redisHashCommands = context.getHashCommands();
 
-      Pair<Integer, List<byte[]>> scanResult =
-          redisHashCommands.hscan(key, matchPattern, count, cursor);
+      Pair<Integer, List<byte[]>> scanResult;
+      try {
+        scanResult = redisHashCommands.hscan(key, matchPattern, count, cursor);
+      } catch (IllegalArgumentException ex) {
+        return RedisResponse.error(ERROR_NOT_INTEGER);
+      }
 
       return RedisResponse.scan(new BigInteger(String.valueOf(scanResult.getLeft())),
           scanResult.getRight());

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -122,11 +122,11 @@ public class HScanExecutor extends AbstractScanExecutor {
       }
       RedisHashCommands redisHashCommands = context.getHashCommands();
 
-    Pair<Integer, List<byte[]>> scanResult =
-        redisHashCommands.hscan(key, matchPattern, count, cursor);
+      Pair<Integer, List<byte[]>> scanResult =
+          redisHashCommands.hscan(key, matchPattern, count, cursor);
 
-        return RedisResponse.scan(new BigInteger(String.valueOf(scanResult.getLeft())),
-            scanResult.getRight());
+      return RedisResponse.scan(new BigInteger(String.valueOf(scanResult.getLeft())),
+          scanResult.getRight());
     });
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 
@@ -123,8 +122,8 @@ public class HScanExecutor extends AbstractScanExecutor {
       }
       RedisHashCommands redisHashCommands = context.getHashCommands();
 
-      Pair<Integer, List<ImmutablePair<byte[], byte[]>>> scanResult =
-          redisHashCommands.hscan(key, matchPattern, count, cursor);
+    Pair<Integer, List<byte[]>> scanResult =
+        redisHashCommands.hscan(key, matchPattern, count, cursor);
 
         return RedisResponse.scan(new BigInteger(String.valueOf(scanResult.getLeft())),
             scanResult.getRight());

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 
@@ -45,8 +45,7 @@ public interface RedisHashCommands {
 
   Collection<byte[]> hkeys(RedisKey key);
 
-  ImmutablePair<Integer, List<ImmutablePair<byte[], byte[]>>> hscan(RedisKey key,
-      Pattern matchPattern, int count, int cursor);
+  Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern, int count, int cursor);
 
   long hincrby(RedisKey key, byte[] field, long increment);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
@@ -20,7 +20,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 
@@ -45,8 +45,8 @@ public interface RedisHashCommands {
 
   Collection<byte[]> hkeys(RedisKey key);
 
-  Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern, int count,
-      int cursor);
+  ImmutablePair<Integer, List<ImmutablePair<byte[], byte[]>>> hscan(RedisKey key,
+      Pattern matchPattern, int count, int cursor);
 
   long hincrby(RedisKey key, byte[] field, long increment);
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -17,12 +17,14 @@
 package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.data.RedisHash.BASE_REDIS_HASH_OVERHEAD;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.DataOutput;
@@ -183,29 +185,34 @@ public class RedisHashTest {
   @Test
   public void hscanReturnsCorrectNumberOfElements() {
     RedisHash hash = createRedisHash("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4");
-    ImmutablePair<Integer, List<ImmutablePair<byte[], byte[]>>> result =
-        hash.hscan(null, 2, 0);
+    ImmutablePair<Integer, List<byte[]>> result = hash.hscan(null, 2, 0);
 
     assertThat(result.left).isNotEqualTo(0);
-    assertThat(result.right).hasSize(2);
+    assertThat(result.right).hasSize(4);
     result = hash.hscan(null, 3, result.left);
     assertThat(result.left).isEqualTo(0);
-    assertThat(result.right).hasSize(2);
+    assertThat(result.right).hasSize(4);
   }
 
   @Test
   public void hscanOnlyReturnsElementsMatchingPattern() {
     RedisHash hash = createRedisHash("ak1", "v1", "k2", "v2", "ak3", "v3", "k4", "v4");
-    ImmutablePair<Integer, List<ImmutablePair<byte[], byte[]>>> result =
-        hash.hscan(Pattern.compile("a.*"), 3, 0);
+    ImmutablePair<Integer, List<byte[]>> result = hash.hscan(Pattern.compile("a.*"), 3, 0);
 
     assertThat(result.left).isEqualTo(0);
-    List<String> fieldsAndValues = new ArrayList<>();
-    result.right.forEach(pair -> {
-      fieldsAndValues.add(bytesToString(pair.left));
-      fieldsAndValues.add(bytesToString(pair.right));
-    });
+    List<String> fieldsAndValues =
+        result.right.stream().map(Coder::bytesToString).collect(Collectors.toList());
+
     assertThat(fieldsAndValues).containsExactly("ak1", "v1", "ak3", "v3");
+  }
+
+  @Test
+  public void hscanThrowsWhenReturnedArrayListLengthWouldExceedVMLimit() {
+    RedisHash hash = spy(new RedisHash());
+    doReturn(Integer.MAX_VALUE - 10).when(hash).hlen();
+
+    assertThatThrownBy(() -> hash.hscan(null, Integer.MAX_VALUE - 10, 0))
+        .isInstanceOf(OutOfMemoryError.class);
   }
 
   /************* Hash Size *************/

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -212,7 +212,7 @@ public class RedisHashTest {
     doReturn(Integer.MAX_VALUE - 10).when(hash).hlen();
 
     assertThatThrownBy(() -> hash.hscan(null, Integer.MAX_VALUE - 10, 0))
-        .isInstanceOf(OutOfMemoryError.class);
+        .isInstanceOf(IllegalArgumentException.class);
   }
 
   /************* Hash Size *************/


### PR DESCRIPTION
This PR is intentionally split into two commits; first an initial test clean-up and refactor, and then the commit containing the changes related to the ticket.

 - Refactor and clean up AbstractHScanIntegrationTest
 - Refactor RedisHash.hscan() to handle large COUNT values
 - Add tests to cover new behaviour

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
