### PR TITLE
GEODE-9439: Convert CertificateBuilder to sun/jdk APIs

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -358,11 +358,6 @@
         <version>4.1.0</version>
       </dependency>
       <dependency>
-        <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.69</version>
-      </dependency>
-      <dependency>
         <groupId>org.codehaus.cargo</groupId>
         <artifactId>cargo-core-uberjar</artifactId>
         <version>1.9.5</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -146,7 +146,6 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.apache.shiro', name: 'shiro-core', version: get('shiro.version'))
         api(group: 'org.assertj', name: 'assertj-core', version: '3.20.2')
         api(group: 'org.awaitility', name: 'awaitility', version: '4.1.0')
-        api(group: 'org.bouncycastle', name: 'bcpkix-jdk15on', version: '1.69')
         api(group: 'org.codehaus.cargo', name: 'cargo-core-uberjar', version: '1.9.5')
         api(group: 'org.eclipse.jetty', name: 'jetty-server', version: get('jetty.version'))
         api(group: 'org.eclipse.jetty', name: 'jetty-webapp', version: get('jetty.version'))

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -19,6 +19,10 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
 apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 
+compileJava {
+  options.compilerArgs << '-Xlint:-sunapi'
+  options.compilerArgs << '-XDenableSunApiLintControl'
+}
 
 dependencies {
   api(platform(project(':boms:geode-all-bom')))

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -51,7 +51,6 @@ dependencies {
   api('org.apache.logging.log4j:log4j-api')
   
   api('org.awaitility:awaitility')
-  api('org.bouncycastle:bcpkix-jdk15on')
   api('org.hamcrest:hamcrest')
   api('io.micrometer:micrometer-core')
   

--- a/geode-junit/src/main/java/org/apache/geode/cache/ssl/CertificateBuilder.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/ssl/CertificateBuilder.java
@@ -192,22 +192,22 @@ public class CertificateBuilder {
 
       byte[] keyIdBytes = new KeyIdentifier(publicKey).getIdentifier();
       SubjectKeyIdentifierExtension keyIdentifier = new SubjectKeyIdentifierExtension(keyIdBytes);
-      extensions.set(keyIdentifier.getExtensionId().toString(), keyIdentifier);
+      extensions.set(SubjectKeyIdentifierExtension.NAME, keyIdentifier);
 
       GeneralNames subjectAltNames = san();
       if (!subjectAltNames.isEmpty()) {
         SubjectAlternativeNameExtension altNames =
             new SubjectAlternativeNameExtension(subjectAltNames);
-        extensions.set(altNames.getExtensionId().toString(), altNames);
+        extensions.set(SubjectAlternativeNameExtension.NAME, altNames);
       }
 
       if (isCA) {
         KeyUsageExtension usageExtension = new KeyUsageExtension();
         usageExtension.set(KeyUsageExtension.KEY_CERTSIGN, true);
-        extensions.set(usageExtension.getExtensionId().toString(), usageExtension);
+        extensions.set(KeyUsageExtension.NAME, usageExtension);
 
         BasicConstraintsExtension basicConstraints = new BasicConstraintsExtension(true, 0);
-        extensions.set(basicConstraints.getExtensionId().toString(), basicConstraints);
+        extensions.set(BasicConstraintsExtension.NAME, basicConstraints);
       }
 
       if (!extensions.getAllExtensions().isEmpty()) {
@@ -216,6 +216,12 @@ public class CertificateBuilder {
 
       // Sign the cert to identify the algorithm that's used.
       X509CertImpl cert = new X509CertImpl(info);
+      cert.sign(privateKey, algorithm);
+
+      // Update the algorithm, and resign.
+      algo = (AlgorithmId) cert.get(X509CertImpl.SIG_ALG);
+      info.set(CertificateAlgorithmId.NAME + "." + CertificateAlgorithmId.ALGORITHM, algo);
+      cert = new X509CertImpl(info);
       cert.sign(privateKey, algorithm);
 
       return cert;

--- a/geode-junit/src/main/java/org/apache/geode/cache/ssl/CertificateBuilder.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/ssl/CertificateBuilder.java
@@ -14,11 +14,11 @@
  */
 package org.apache.geode.cache.ssl;
 
-import static java.util.stream.Collectors.toList;
-
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigInteger;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -30,28 +30,26 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.AlgorithmIdentifier;
-import org.bouncycastle.asn1.x509.BasicConstraints;
-import org.bouncycastle.asn1.x509.Extension;
-import org.bouncycastle.asn1.x509.GeneralName;
-import org.bouncycastle.asn1.x509.GeneralNames;
-import org.bouncycastle.asn1.x509.KeyUsage;
-import org.bouncycastle.asn1.x509.SubjectKeyIdentifier;
-import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
-import org.bouncycastle.cert.X509CertificateHolder;
-import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
-import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
-import org.bouncycastle.crypto.util.PrivateKeyFactory;
-import org.bouncycastle.crypto.util.PublicKeyFactory;
-import org.bouncycastle.crypto.util.SubjectPublicKeyInfoFactory;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
-import org.bouncycastle.operator.ContentSigner;
-import org.bouncycastle.operator.DefaultDigestAlgorithmIdentifierFinder;
-import org.bouncycastle.operator.DefaultSignatureAlgorithmIdentifierFinder;
-import org.bouncycastle.operator.bc.BcRSAContentSignerBuilder;
+import sun.security.x509.AlgorithmId;
+import sun.security.x509.BasicConstraintsExtension;
+import sun.security.x509.CertificateAlgorithmId;
+import sun.security.x509.CertificateExtensions;
+import sun.security.x509.CertificateSerialNumber;
+import sun.security.x509.CertificateValidity;
+import sun.security.x509.CertificateVersion;
+import sun.security.x509.CertificateX509Key;
+import sun.security.x509.DNSName;
+import sun.security.x509.GeneralName;
+import sun.security.x509.GeneralNames;
+import sun.security.x509.IPAddressName;
+import sun.security.x509.KeyIdentifier;
+import sun.security.x509.KeyUsageExtension;
+import sun.security.x509.SubjectAlternativeNameExtension;
+import sun.security.x509.SubjectKeyIdentifierExtension;
+import sun.security.x509.X500Name;
+import sun.security.x509.X509CertImpl;
+import sun.security.x509.X509CertInfo;
+
 
 /**
  * Class which allows easily building certificates. It can also be used to build
@@ -79,16 +77,27 @@ public class CertificateBuilder {
   }
 
   private static GeneralName dnsGeneralName(String name) {
-    return new GeneralName(GeneralName.dNSName, name);
+    try {
+      return new GeneralName(new DNSName(name));
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
   }
 
   private static GeneralName ipGeneralName(InetAddress hostAddress) {
-    return new GeneralName(GeneralName.iPAddress,
-        new DEROctetString(hostAddress.getAddress()));
+    try {
+      return new GeneralName(new IPAddressName(hostAddress.getAddress()));
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
   }
 
   public CertificateBuilder commonName(String cn) {
-    this.name = new X500Name("CN=" + cn + ", O=Geode");
+    try {
+      this.name = new X500Name("O=Geode, CN=" + cn);
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
     return this;
   }
 
@@ -102,6 +111,15 @@ public class CertificateBuilder {
     return this;
   }
 
+  public CertificateBuilder sanIpAddress(String address) {
+    try {
+      this.ipAddresses.add(InetAddress.getByName(address));
+    } catch (UnknownHostException ex) {
+      throw new RuntimeException(ex);
+    }
+    return this;
+  }
+
   public CertificateBuilder isCA() {
     this.isCA = true;
     return this;
@@ -112,17 +130,17 @@ public class CertificateBuilder {
     return this;
   }
 
-  private byte[] san() throws IOException {
-    List<GeneralName> names = dnsNames.stream()
-        .map(CertificateBuilder::dnsGeneralName)
-        .collect(toList());
+  private GeneralNames san() throws IOException {
+    GeneralNames names = new GeneralNames();
+    for (String name : dnsNames) {
+      names.add(CertificateBuilder.dnsGeneralName(name));
+    }
 
-    names.addAll(ipAddresses.stream()
-        .map(CertificateBuilder::ipGeneralName)
-        .collect(toList()));
+    for (InetAddress address : ipAddresses) {
+      names.add(CertificateBuilder.ipGeneralName(address));
+    }
 
-    return names.isEmpty() ? null
-        : new GeneralNames(names.toArray(new GeneralName[] {})).getEncoded();
+    return names;
   }
 
   public CertificateMaterial generate() {
@@ -146,58 +164,63 @@ public class CertificateBuilder {
   }
 
   private X509Certificate generate(PublicKey publicKey, PrivateKey privateKey) {
+    Date from = new Date();
+    Date to = new Date(from.getTime() + days * 86_400_000L);
+
+    CertificateValidity interval = new CertificateValidity(from, to);
+    BigInteger sn = new BigInteger(64, new SecureRandom());
+
+    X509CertInfo info = new X509CertInfo();
+
     try {
-      AlgorithmIdentifier sigAlgId =
-          new DefaultSignatureAlgorithmIdentifierFinder().find(algorithm);
-      AlgorithmIdentifier digAlgId = new DefaultDigestAlgorithmIdentifierFinder().find(sigAlgId);
-      AsymmetricKeyParameter publicKeyAsymKeyParam =
-          PublicKeyFactory.createKey(publicKey.getEncoded());
-      AsymmetricKeyParameter privateKeyAsymKeyParam =
-          PrivateKeyFactory.createKey(privateKey.getEncoded());
-      SubjectPublicKeyInfo subPubKeyInfo =
-          SubjectPublicKeyInfo.getInstance(publicKey.getEncoded());
+      info.set(X509CertInfo.VALIDITY, interval);
+      info.set(X509CertInfo.SERIAL_NUMBER, new CertificateSerialNumber(sn));
+      info.set(X509CertInfo.SUBJECT, name);
+      info.set(X509CertInfo.KEY, new CertificateX509Key(publicKey));
+      info.set(X509CertInfo.VERSION, new CertificateVersion(CertificateVersion.V3));
+      AlgorithmId algo = new AlgorithmId(AlgorithmId.md5WithRSAEncryption_oid);
+      info.set(X509CertInfo.ALGORITHM_ID, new CertificateAlgorithmId(algo));
 
-      ContentSigner sigGen =
-          new BcRSAContentSignerBuilder(sigAlgId, digAlgId).build(privateKeyAsymKeyParam);
-
-      Date from = new Date();
-      Date to = new Date(from.getTime() + days * 86400000L);
-      BigInteger sn = new BigInteger(64, new SecureRandom());
-
-      X509v3CertificateBuilder v3CertGen;
       if (issuer == null) {
         // This is a self-signed certificate
-        v3CertGen = new X509v3CertificateBuilder(name, sn, from, to, name, subPubKeyInfo);
+        info.set(X509CertInfo.ISSUER, name);
       } else {
-        v3CertGen = new X509v3CertificateBuilder(
-            new X500Name(issuer.getCertificate().getIssuerDN().getName()),
-            sn, from, to, name, subPubKeyInfo);
+        info.set(X509CertInfo.ISSUER, issuer.getCertificate().getSubjectDN());
       }
 
-      byte[] subjectAltName = san();
-      if (subjectAltName != null) {
-        v3CertGen.addExtension(Extension.subjectAlternativeName, false, subjectAltName);
+      CertificateExtensions extensions = new CertificateExtensions();
+
+      byte[] keyIdBytes = new KeyIdentifier(publicKey).getIdentifier();
+      SubjectKeyIdentifierExtension keyIdentifier = new SubjectKeyIdentifierExtension(keyIdBytes);
+      extensions.set(keyIdentifier.getExtensionId().toString(), keyIdentifier);
+
+      GeneralNames subjectAltNames = san();
+      if (!subjectAltNames.isEmpty()) {
+        SubjectAlternativeNameExtension altNames =
+            new SubjectAlternativeNameExtension(subjectAltNames);
+        extensions.set(altNames.getExtensionId().toString(), altNames);
       }
 
       if (isCA) {
-        v3CertGen.addExtension(Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign));
-        v3CertGen.addExtension(Extension.basicConstraints, true, new BasicConstraints(0));
+        KeyUsageExtension usageExtension = new KeyUsageExtension();
+        usageExtension.set(KeyUsageExtension.KEY_CERTSIGN, true);
+        extensions.set(usageExtension.getExtensionId().toString(), usageExtension);
+
+        BasicConstraintsExtension basicConstraints = new BasicConstraintsExtension(true, 0);
+        extensions.set(basicConstraints.getExtensionId().toString(), basicConstraints);
       }
 
-      // Not strictly necessary, but this makes the certs look like those generated
-      // by `keytool`.
-      SubjectKeyIdentifier subjectKeyIdentifier =
-          new SubjectKeyIdentifier(
-              SubjectPublicKeyInfoFactory.createSubjectPublicKeyInfo(publicKeyAsymKeyParam)
-                  .getEncoded());
-      v3CertGen.addExtension(Extension.subjectKeyIdentifier, false, subjectKeyIdentifier);
+      if (!extensions.getAllExtensions().isEmpty()) {
+        info.set(X509CertInfo.EXTENSIONS, extensions);
+      }
 
-      X509CertificateHolder certificateHolder = v3CertGen.build(sigGen);
-      return new JcaX509CertificateConverter()
-          .setProvider(new BouncyCastleProvider())
-          .getCertificate(certificateHolder);
-    } catch (Exception e) {
-      throw new RuntimeException("Unable to create certificate", e);
+      // Sign the cert to identify the algorithm that's used.
+      X509CertImpl cert = new X509CertImpl(info);
+      cert.sign(privateKey, algorithm);
+
+      return cert;
+    } catch (Exception ex) {
+      throw new RuntimeException("Unable to create certificate", ex);
     }
   }
 

--- a/geode-junit/src/main/java/org/apache/geode/cache/ssl/CertificateMaterial.java
+++ b/geode-junit/src/main/java/org/apache/geode/cache/ssl/CertificateMaterial.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.ssl;
 
+import java.io.Serializable;
 import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -29,15 +30,15 @@ import java.util.Optional;
  * @see CertificateBuilder
  * @see CertStores
  */
-public class CertificateMaterial {
+public class CertificateMaterial implements Serializable {
   private final X509Certificate certificate;
   private final KeyPair keyPair;
-  private final Optional<X509Certificate> issuer;
+  private final X509Certificate issuer;
 
   public CertificateMaterial(X509Certificate certificate, KeyPair keyPair, X509Certificate issuer) {
     this.certificate = certificate;
     this.keyPair = keyPair;
-    this.issuer = Optional.ofNullable(issuer);
+    this.issuer = issuer;
   }
 
   public X509Certificate getCertificate() {
@@ -53,6 +54,6 @@ public class CertificateMaterial {
   }
 
   public Optional<X509Certificate> getIssuer() {
-    return issuer;
+    return Optional.ofNullable(issuer);
   }
 }

--- a/geode-junit/src/test/java/org/apache/geode/cache/ssl/CertificateBuildingTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/cache/ssl/CertificateBuildingTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.cache.ssl;
+
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import org.junit.Test;
+
+public class CertificateBuildingTest {
+
+  @Test
+  public void builtCertificatesCanBeValidatedCorrectly() throws Exception {
+    CertificateMaterial ca = new CertificateBuilder(10, "SHA256withRSA")
+        .commonName("my test CA")
+        .isCA()
+        .generate();
+
+    CertificateMaterial cert = new CertificateBuilder(10, "SHA256withRSA")
+        .commonName("test-host")
+        .sanDnsName("another-hostname")
+        .sanIpAddress("127.0.0.1")
+        .issuedBy(ca)
+        .generate();
+
+    KeyStore certStore = KeyStore.getInstance("JKS");
+    certStore.load(null, "password".toCharArray());
+    certStore.setCertificateEntry("ca", ca.getCertificate());
+
+    TrustManagerFactory trustManagerFactory =
+        TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    trustManagerFactory.init(certStore);
+
+    for (TrustManager trustManager : trustManagerFactory.getTrustManagers()) {
+      if (trustManager instanceof X509TrustManager) {
+        X509TrustManager x509TrustManager = (X509TrustManager) trustManager;
+        x509TrustManager
+            .checkServerTrusted(new X509Certificate[] {
+                ca.getCertificate(),
+                cert.getCertificate()},
+                "RSA");
+      }
+    }
+  }
+
+}

--- a/geode-junit/src/test/java/org/apache/geode/cache/ssl/CertificateBuildingTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/cache/ssl/CertificateBuildingTest.java
@@ -53,7 +53,6 @@ public class CertificateBuildingTest {
         X509TrustManager x509TrustManager = (X509TrustManager) trustManager;
         x509TrustManager
             .checkServerTrusted(new X509Certificate[] {
-                ca.getCertificate(),
                 cert.getCertificate()},
                 "RSA");
       }

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -124,11 +124,6 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
       <scope>compile</scope>


### PR DESCRIPTION
- Makes it easier to de/serialize created certificates
- Remove the requirement for the Bouncy Castle library
- Java 9 has a very similar utility which we should be able
  to switch to once we move away from 8.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
