### PR TITLE
GEODE-9289: Configuration class modified into VersionedDataSerializable

### DIFF
--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1980,9 +1980,11 @@ org/apache/geode/management/internal/ManagerStartupMessage,2
 fromData,17
 toData,17
 
-org/apache/geode/management/internal/configuration/domain/Configuration,2
+org/apache/geode/management/internal/configuration/domain/Configuration,4
 fromData,112
+fromDataPre_GEODE_1_12_0_0,71
 toData,82
+toDataPre_GEODE_1_12_0_0,63
 
 org/apache/geode/management/internal/configuration/domain/ConfigurationChangeResult,2
 fromData,31

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/Configuration.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/domain/Configuration.java
@@ -37,8 +37,8 @@ import javax.xml.transform.TransformerException;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
-import org.apache.geode.DataSerializable;
 import org.apache.geode.DataSerializer;
+import org.apache.geode.internal.VersionedDataSerializable;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.Version;
 import org.apache.geode.internal.serialization.Versioning;
@@ -50,7 +50,7 @@ import org.apache.geode.management.internal.configuration.utils.XmlUtils;
  * Domain object for all the configuration related data.
  *
  */
-public class Configuration implements DataSerializable {
+public class Configuration implements VersionedDataSerializable {
   private static final long serialVersionUID = 1L;
   private String configName;
   private String cacheXmlContent;
@@ -161,6 +161,16 @@ public class Configuration implements DataSerializable {
     return deployments.keySet();
   }
 
+  public void toDataPre_GEODE_1_12_0_0(DataOutput out) throws IOException {
+    DataSerializer.writeString(configName, out);
+    DataSerializer.writeString(cacheXmlFileName, out);
+    DataSerializer.writeString(cacheXmlContent, out);
+    DataSerializer.writeString(propertiesFileName, out);
+    DataSerializer.writeProperties(gemfireProperties, out);
+    HashSet<String> jarNames = new HashSet<>(deployments.keySet());
+    DataSerializer.writeHashSet(jarNames, out);
+  }
+
   @Override
   public void toData(DataOutput out) throws IOException {
     DataSerializer.writeString(configName, out);
@@ -175,6 +185,19 @@ public class Configuration implements DataSerializable {
     // As of 1.12, this class starting writing the current version
     VersioningIO.writeOrdinal(out, KnownVersion.getCurrentVersion().ordinal(), true);
     DataSerializer.writeHashMap(deployments, out);
+  }
+
+  public void fromDataPre_GEODE_1_12_0_0(DataInput in) throws IOException, ClassNotFoundException {
+    this.configName = DataSerializer.readString(in);
+    this.cacheXmlFileName = DataSerializer.readString(in);
+    this.cacheXmlContent = DataSerializer.readString(in);
+    this.propertiesFileName = DataSerializer.readString(in);
+    this.gemfireProperties = DataSerializer.readProperties(in);
+    HashSet<String> jarNames = DataSerializer.readHashSet(in);
+    jarNames.stream()
+        .map(x -> new Deployment(x, null, null))
+        .forEach(deployment -> deployments.put(deployment.getFileName(),
+            deployment));
   }
 
   @Override
@@ -237,4 +260,8 @@ public class Configuration implements DataSerializable {
         gemfireProperties, deployments);
   }
 
+  @Override
+  public KnownVersion[] getSerializationVersions() {
+    return new KnownVersion[] {KnownVersion.GEODE_1_12_0};
+  }
 }


### PR DESCRIPTION
	* This was suppose to be a part of the initial commit for GEODE-9289
	* However we had to wait for a revert in the deployement data structure in GEODE-9377
	* This commit is already a part of the previous releases of Apache Geode

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
