### PR TITLE
GEODE-9443: Increase pid_max in CI images

### DIFF
--- a/ci/images/google-geode-builder/scripts/setup.sh
+++ b/ci/images/google-geode-builder/scripts/setup.sh
@@ -98,3 +98,4 @@ echo "export PATH=/google-cloud-sdk/bin:${PATH}" > /etc/profile.d/google_sdk_pat
 apt-get remove -y unattended-upgrades && apt-get -y autoremove
 apt-get clean
 rm -rf /var/lib/apt/lists/*
+echo "kernel.pid_max=983040" > /etc/sysctl.d/99-geode.conf


### PR DESCRIPTION
Certain Geode tests create a lot of threads. When these tests run in
parallel with many other tests (as they do in CI), the whole set of
concurrently running tests can overwhelm the Linux kernel's ability to
assign PIDs to new threads. When this happens, test processes, Gradle
processes, and other processes can become unable to create new threads.

The relevant system parameter is `kernel.pid_max`. In our CI images,
`pid_max` is 98,304.

This commit raises CI images' `pid_max` to 983040 (10x the default
value). A build can run 24 concurrent instances of even our most
thread-heavy tests without exceeding this threshold.

Co-authored-by: Dale Emery <demery@vmware.com>
