### PR TITLE
GEODE-9388: Implement Radish ZRANGEBYLEX Command

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexNativeRedisAcceptanceTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.NativeRedisClusterTestRule;
+
+public class ZRangeByLexNativeRedisAcceptanceTest extends AbstractZRangeByLexIntegrationTest {
+  @ClassRule
+  public static NativeRedisClusterTestRule server = new NativeRedisClusterTestRule();
+
+  @Override
+  public int getPort() {
+    return server.getExposedPorts().get(0);
+  }
+
+  @Override
+  public void flushAll() {
+    server.flushAll();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -263,6 +263,16 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   }
 
   @Test
+  public void testZrangeByLex() {
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zrangeByLex(k, "-", "+"));
+  }
+
+  @Test
+  public void testZrangeByScore() {
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zrangeByScore(k, 0.0, 1.0));
+  }
+
+  @Test
   public void testZrank() {
     runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, (k, m) -> jedis.zrank(k, m));
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
@@ -104,13 +104,10 @@ public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegra
   }
 
   @Test
-  public void shouldError_givenNegativeLimitOffset() {
+  public void shouldError_givenNegativeZeroLimitOffset() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "-0", "10"))
             .hasMessageContaining(ERROR_NOT_INTEGER);
-
-    assertThatThrownBy(() -> jedis.zrangeByLex(KEY, "-", "+", -1, 10))
-        .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -123,7 +120,7 @@ public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegra
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -376,6 +373,16 @@ public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegra
     // Range (v * 4) <= member name <= (v * 6), offset = 0, count = 10
     assertThat(jedis.zrangeByLex(KEY, "[" + min, "[" + max, 0, 10))
         .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldReturnEmptyCollection_givenNonZeroNegativeLimitOffset() {
+    populateSortedSet();
+
+    int offset = -7;
+
+    // Range (v * 1) <= member name <= (v * 3), offset = 7, count = 10
+    assertThat(jedis.zrangeByLex(KEY, "-", "+", offset, 10)).isEmpty();
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
@@ -1,0 +1,438 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_MIN_MAX_NOT_A_VALID_STRING;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Protocol;
+
+import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.redis.internal.netty.Coder;
+
+@RunWith(JUnitParamsRunner.class)
+public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegrationTest {
+  public static final String KEY = "key";
+  public static final int SCORE = 1;
+  public static final String BASE_MEMBER_NAME = "v";
+
+  JedisCluster jedis;
+
+  @Before
+  public void setUp() {
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void shouldError_givenWrongNumberOfArguments() {
+    assertAtLeastNArgs(jedis, Protocol.Command.ZRANGEBYLEX, 3);
+  }
+
+  @Test
+  @Parameters({"a", "--", "++"})
+  public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
+    assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", invalidArgument, "+"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+    assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", "-", invalidArgument))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+    assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", invalidArgument, invalidArgument))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+  }
+
+  @Test
+  public void shouldError_givenInvalidLimitFormat() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT"))
+            .hasMessageContaining(ERROR_SYNTAX);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT", "0"))
+            .hasMessageContaining(ERROR_SYNTAX);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LAMAT", "0", "10"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenNonIntegerLimitArguments() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT", "0", "invalid"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT", "invalid", "10"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void shouldError_givenNegativeLimitOffset() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT", "-0", "10"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+
+    assertThatThrownBy(() -> jedis.zrangeByLex(KEY, "-", "+", -1, 10))
+        .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void shouldError_givenMultipleLimits_withFirstLimitIncorrectlySpecified() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT", "0", "invalid",
+        "LIMIT", "0", "10"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT", "0",
+        "LIMIT", "0", "10"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenMultipleLimits_withLastLimitIncorrectlySpecified() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT", "0", "10",
+        "LIMIT", "0", "invalid"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
+        "LIMIT", "0", "10",
+        "LIMIT", "0"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldReturnEmptyCollection_givenNonExistentKey() {
+    assertThat(jedis.zrangeByLex("fakeKey", "-", "+")).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnEmptyCollection_givenMinGreaterThanMax() {
+    jedis.zadd(KEY, SCORE, "member");
+
+    // Range + <= member name <= -
+    assertThat(jedis.zrangeByLex(KEY, "+", "-")).isEmpty();
+    // Range z <= member name <= a
+    assertThat(jedis.zrangeByLex(KEY, "[z", "[a")).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnMember_givenMemberNameInRange() {
+    String memberName = "member";
+    jedis.zadd(KEY, SCORE, memberName);
+
+    // Range m <= member name <= n
+    assertThat(jedis.zrangeByLex(KEY, "[m", "[n")).containsExactly(memberName);
+    // Range -infinity <= member name <= n
+    assertThat(jedis.zrangeByLex(KEY, "-", "[n")).containsExactly(memberName);
+    // Range m <= member name <= +infinity
+    assertThat(jedis.zrangeByLex(KEY, "[m", "+")).containsExactly(memberName);
+  }
+
+  @Test
+  public void shouldReturnMember_givenMinEqualToMemberNameAndMinInclusive() {
+    String memberName = "member";
+    jedis.zadd(KEY, SCORE, memberName);
+
+    // Range member <= member name <= n
+    assertThat(jedis.zrangeByLex(KEY, "[" + memberName, "[n")).containsExactly(memberName);
+  }
+
+  @Test
+  public void shouldReturnMember_givenMaxEqualToMemberNameAndMaxInclusive() {
+    String memberName = "member";
+    jedis.zadd(KEY, SCORE, memberName);
+
+    // Range a <= member name <= member
+    assertThat(jedis.zrangeByLex(KEY, "[a", "[" + memberName)).containsExactly(memberName);
+  }
+
+  @Test
+  public void shouldReturnMember_givenMinAndMaxEqualToMemberNameAndMinAndMaxInclusive() {
+    String memberName = "member";
+    jedis.zadd(KEY, SCORE, memberName);
+
+    assertThat(jedis.zrangeByLex(KEY, "[" + memberName, "[" + memberName))
+        .containsExactly(memberName);
+  }
+
+  @Test
+  @Parameters({"[", "(", "", "-", "+"})
+  public void shouldReturnMember_givenMemberNameIsSpecialCharacter(String memberName) {
+    jedis.zadd(KEY, SCORE, memberName);
+
+    assertThat(jedis.zrangeByLex(KEY, "[" + memberName, "[" + memberName))
+        .containsExactly(memberName);
+  }
+
+  @Test
+  public void shouldReturnEmptyCollection_givenMinEqualToMemberNameAndMinExclusive() {
+    String memberName = "member";
+    jedis.zadd(KEY, SCORE, memberName);
+
+    // Range member < member name <= n
+    assertThat(jedis.zrangeByLex(KEY, "(" + memberName, "[n")).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnEmptyCollection_givenMaxEqualToMemberNameAndMaxExclusive() {
+    String memberName = "member";
+    jedis.zadd(KEY, SCORE, memberName);
+
+    // Range a <= member name < member
+    assertThat(jedis.zrangeByLex(KEY, "[a", "(" + memberName)).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnEmptyCollection_givenRangeExcludingMember() {
+    String memberName = "member";
+    jedis.zadd(KEY, SCORE, memberName);
+
+    // Range n <= member name <= o
+    assertThat(jedis.zrangeByLex(KEY, "[n", "[o")).isEmpty();
+  }
+
+  @Test
+  public void shouldReturnRange_givenMultipleMembersInRange_withInclusiveMinAndMax() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 3;
+    int maxLength = 6;
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    List<String> expected = members.subList(minLength - 1, maxLength);
+
+    // Range (v * 3) <= member name <= (v * 6)
+    assertThat(jedis.zrangeByLex(KEY, "[" + min, "[" + max))
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldReturnRange_givenMultipleMembersInRange_withExclusiveMinAndMax() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 1;
+    int maxLength = 7;
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    List<String> expected = members.subList(minLength, maxLength - 1);
+
+    // Range (v * 1) < member name < (v * 7)
+    assertThat(jedis.zrangeByLex(KEY, "(" + min, "(" + max))
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldReturnRange_givenMultipleMembersInRange_withInclusiveMinAndExclusiveMax() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 5;
+    int maxLength = 8;
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    List<String> expected = members.subList(minLength - 1, maxLength - 1);
+
+    // Range (v * 5) <= member name < (v * 8)
+    assertThat(jedis.zrangeByLex(KEY, "[" + min, "(" + max))
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldReturnRange_givenMultipleMembersInRange_withExclusiveMinAndInclusiveMax() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 2;
+    int maxLength = 5;
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    List<String> expected = members.subList(minLength, maxLength);
+
+    // Range (v * 2) < member name <= (v * 5)
+    assertThat(jedis.zrangeByLex(KEY, "(" + min, "[" + max))
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldReturnRange_givenMultipleMembersInRangeUsingMinusAndPlusArguments() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 4;
+    int maxLength = 8;
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    List<String> expected = members.subList(0, maxLength);
+
+    // Range -infinity <= member name <= (v * 8)
+    assertThat(jedis.zrangeByLex(KEY, "-", "[" + max))
+        .containsExactlyElementsOf(expected);
+
+    expected = members.subList(minLength - 1, members.size());
+
+    // Range (v * 4) <= member name < +infinity
+    assertThat(jedis.zrangeByLex(KEY, "[" + min, "+"))
+        .containsExactlyElementsOf(expected);
+
+    // Range -infinity <= member name < +infinity
+    assertThat(jedis.zrangeByLex(KEY, "-", "+"))
+        .containsExactlyElementsOf(members);
+  }
+
+  @Test
+  public void shouldReturnRange_givenValidLimit() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 1;
+    int maxLength = 7;
+
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    int offset = 2;
+    int count = 3;
+
+    int sublistMin = minLength + offset - 1;
+    int sublistMax = sublistMin + count;
+
+    List<String> expected = members.subList(sublistMin, sublistMax);
+
+    // Range (v * 1) <= member name <= (v * 7), offset = 2, count = 3
+    assertThat(jedis.zrangeByLex(KEY, "[" + min, "[" + max, offset, count))
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldReturnAllElementsInRange_givenNegativeCount() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 1;
+
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+
+    int offset = 2;
+
+    int sublistMin = minLength + offset - 1;
+    List<String> expected = members.subList(sublistMin, members.size());
+
+    // Range (v * 1) <= member name <= +infinity, offset = 2, count = -1
+    assertThat(jedis.zrangeByLex(KEY, "[" + min, "+", offset, -1))
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldReturnRange_givenCountLargerThanRange() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 4;
+    int maxLength = 6;
+
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    List<String> expected = members.subList(minLength - 1, maxLength);
+
+    // Range (v * 4) <= member name <= (v * 6), offset = 0, count = 10
+    assertThat(jedis.zrangeByLex(KEY, "[" + min, "[" + max, 0, 10))
+        .containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void shouldReturnEmptyCollection_givenOffsetLargerThanRange() {
+    populateSortedSet();
+
+    int minLength = 1;
+    int maxLength = 3;
+
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    int offset = 7;
+
+    // Range (v * 1) <= member name <= (v * 3), offset = 7, count = 10
+    assertThat(jedis.zrangeByLex(KEY, "[" + min, "[" + max, offset, 10)).isEmpty();
+  }
+
+  @Test
+  public void shouldUseLastLimit_givenMultipleValidLimitsProvided() {
+    List<String> members = populateSortedSet();
+
+    int minLength = 2;
+    int maxLength = 8;
+
+    String min = StringUtils.repeat(BASE_MEMBER_NAME, minLength);
+    String max = StringUtils.repeat(BASE_MEMBER_NAME, maxLength);
+
+    int offset = 2;
+    int count = 3;
+
+    int sublistMin = minLength + offset - 1;
+    int sublistMax = sublistMin + count;
+
+    // Add 1 to sublistMax, as subList uses exclusive maximum
+    List<String> expected = members.subList(sublistMin, sublistMax);
+
+    // Range (v * 2) <= member name <= (v * 8), offset = 2, count = 3
+    List<byte[]> result = uncheckedCast(
+        jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "[" + min, "[" + max,
+            "LIMIT", "0", "10",
+            "LIMIT", String.valueOf(offset), String.valueOf(count)));
+
+    List<String> actual = result.stream().map(Coder::bytesToString).collect(Collectors.toList());
+    assertThat(actual).containsExactlyElementsOf(expected);
+  }
+
+  // Add 10 members with the same score and member names consisting of 'v' repeated an increasing
+  // number of times
+  private List<String> populateSortedSet() {
+    List<String> members = new ArrayList<>();
+    String memberName = BASE_MEMBER_NAME;
+    for (int i = 0; i < 10; ++i) {
+      jedis.zadd(KEY, SCORE, memberName);
+      members.add(memberName);
+      memberName += BASE_MEMBER_NAME;
+    }
+    return members;
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
@@ -300,7 +300,7 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -328,7 +328,7 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
         "LIMIT", "0",
         "LIMIT", "0", "10",
         "WITHSCORES"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -343,7 +343,7 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
         "LIMIT", "0", "10",
         "LIMIT", "0",
         "WITHSCORES"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessageContaining(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
@@ -291,6 +291,62 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
   }
 
   @Test
+  public void shouldError_givenMultipleLimits_withFirstLimitIncorrectlySpecified() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
+        "LIMIT", "0", "invalid",
+        "LIMIT", "0", "10"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
+        "LIMIT", "0",
+        "LIMIT", "0", "10"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenMultipleLimits_withLastLimitIncorrectlySpecified() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
+        "LIMIT", "0", "10",
+        "LIMIT", "0", "invalid"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
+        "LIMIT", "0", "10",
+        "LIMIT", "0"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenMultipleLimitsAndWithscores_withFirstLimitIncorrectlySpecified() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
+        "WITHSCORES",
+        "LIMIT", "0", "invalid",
+        "LIMIT", "0", "10"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
+        "LIMIT", "0",
+        "LIMIT", "0", "10",
+        "WITHSCORES"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenMultipleLimitsAndWithscores_withLastLimitIncorrectlySpecified() {
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
+        "WITHSCORES",
+        "LIMIT", "0", "10",
+        "LIMIT", "0", "invalid"))
+            .hasMessageContaining(ERROR_NOT_INTEGER);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
+        "LIMIT", "0", "10",
+        "LIMIT", "0",
+        "WITHSCORES"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
   public void shouldReturnRange_givenMultipleCopiesOfWithscoresAndOrLimit() {
     createZSetRangeTestMap();
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexIntegrationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+
+public class ZRangeByLexIntegrationTest extends AbstractZRangeByLexIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -100,6 +100,7 @@ import org.apache.geode.redis.internal.executor.sortedset.ZAddExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZCardExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZCountExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZIncrByExecutor;
+import org.apache.geode.redis.internal.executor.sortedset.ZRangeByLexExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRangeByScoreExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRangeExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRankExecutor;
@@ -214,6 +215,7 @@ public enum RedisCommandType {
   ZINCRBY(new ZIncrByExecutor(), SUPPORTED, new ExactParameterRequirements(4)),
   ZRANGE(new ZRangeExecutor(), SUPPORTED, new MinimumParameterRequirements(4)
       .and(new MaximumParameterRequirements(5, ERROR_SYNTAX))),
+  ZRANGEBYLEX(new ZRangeByLexExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),
   ZRANGEBYSCORE(new ZRangeByScoreExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),
   ZRANK(new ZRankExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
   ZREM(new ZRemExecutor(), SUPPORTED, new MinimumParameterRequirements(3)),

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -46,7 +46,7 @@ public class RedisConstants {
   public static final String ERROR_INVALID_EXPIRE_TIME = "invalid expire time in set";
   public static final String ERROR_NOT_A_VALID_FLOAT = "value is not a valid float";
   public static final String ERROR_MIN_MAX_NOT_A_VALID_STRING =
-      "min or max is not a valid string range item";
+      "min or max not valid string range item";
   public static final String ERROR_MIN_MAX_NOT_A_FLOAT = "min or max is not a float";
   public static final String ERROR_OOM_COMMAND_NOT_ALLOWED =
       "command not allowed when used memory > 'maxmemory'";

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -45,6 +45,8 @@ public class RedisConstants {
   public static final String ERROR_SYNTAX = "syntax error";
   public static final String ERROR_INVALID_EXPIRE_TIME = "invalid expire time in set";
   public static final String ERROR_NOT_A_VALID_FLOAT = "value is not a valid float";
+  public static final String ERROR_MIN_MAX_NOT_A_VALID_STRING =
+      "min or max is not a valid string range item";
   public static final String ERROR_MIN_MAX_NOT_A_FLOAT = "min or max is not a float";
   public static final String ERROR_OOM_COMMAND_NOT_ALLOWED =
       "command not allowed when used memory > 'maxmemory'";

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -23,7 +23,8 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.redis.internal.executor.sortedset.SortedSetRangeOptions;
+import org.apache.geode.redis.internal.executor.sortedset.SortedSetLexRangeOptions;
+import org.apache.geode.redis.internal.executor.sortedset.SortedSetScoreRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
 
 class NullRedisSortedSet extends RedisSortedSet {
@@ -58,12 +59,17 @@ class NullRedisSortedSet extends RedisSortedSet {
   }
 
   @Override
-  long zcount(SortedSetRangeOptions rangeOptions) {
+  long zcount(SortedSetScoreRangeOptions rangeOptions) {
     return 0;
   }
 
   @Override
-  List<byte[]> zrangebyscore(SortedSetRangeOptions rangeOptions, boolean withScores) {
+  List<byte[]> zrangebylex(SortedSetLexRangeOptions rangeOptions) {
+    return Collections.emptyList();
+  }
+
+  @Override
+  List<byte[]> zrangebyscore(SortedSetScoreRangeOptions rangeOptions, boolean withScores) {
     return Collections.emptyList();
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -21,7 +21,8 @@ import java.util.List;
 
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommands;
-import org.apache.geode.redis.internal.executor.sortedset.SortedSetRangeOptions;
+import org.apache.geode.redis.internal.executor.sortedset.SortedSetLexRangeOptions;
+import org.apache.geode.redis.internal.executor.sortedset.SortedSetScoreRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
 
 public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFunctionExecutor
@@ -46,7 +47,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
-  public long zcount(RedisKey key, SortedSetRangeOptions rangeOptions) {
+  public long zcount(RedisKey key, SortedSetScoreRangeOptions rangeOptions) {
     return stripedExecute(key, () -> getRedisSortedSet(key, true).zcount(rangeOptions));
   }
 
@@ -63,7 +64,13 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
-  public List<byte[]> zrangebyscore(RedisKey key, SortedSetRangeOptions rangeOptions,
+  public List<byte[]> zrangebylex(RedisKey key, SortedSetLexRangeOptions rangeOptions) {
+    return stripedExecute(key,
+        () -> getRedisSortedSet(key, true).zrangebylex(rangeOptions));
+  }
+
+  @Override
+  public List<byte[]> zrangebyscore(RedisKey key, SortedSetScoreRangeOptions rangeOptions,
       boolean withScores) {
     return stripedExecute(key,
         () -> getRedisSortedSet(key, true).zrangebyscore(rangeOptions, withScores));

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractSortedSetRangeOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractSortedSetRangeOptions.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
+import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLIMIT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMINUS;
+
+import java.util.List;
+
+public abstract class AbstractSortedSetRangeOptions<T> {
+  boolean isMinExclusive;
+  T minimum;
+  boolean isMaxExclusive;
+  T maximum;
+  boolean hasLimit;
+  int offset;
+  int count;
+
+  AbstractSortedSetRangeOptions(byte[] minimumBytes, byte[] maximumBytes) {
+    parseMinimum(minimumBytes);
+    parseMaximum(maximumBytes);
+  }
+
+  void parseLimitArguments(List<byte[]> commandElements, int commandIndex) {
+    if (!equalsIgnoreCaseBytes(commandElements.get(commandIndex - 2), bLIMIT)) {
+      throw new IllegalArgumentException();
+    } else {
+      byte[] offsetBytes = commandElements.get(commandIndex - 1);
+      if (offsetBytes[0] == bMINUS) {
+        throw new NumberFormatException();
+      }
+      // Only set the values for the first limit we parse
+
+      int parsedOffset = narrowLongToInt(bytesToLong(offsetBytes));
+      int parsedCount = narrowLongToInt(bytesToLong(commandElements.get(commandIndex)));
+      if (!hasLimit) {
+        hasLimit = true;
+        this.offset = parsedOffset;
+        this.count = parsedCount;
+        if (this.count < 0) {
+          this.count = Integer.MAX_VALUE;
+        }
+      }
+    }
+  }
+
+  // If limit specified but count is zero, or min > max, or min == max and either are exclusive, the
+  // range cannot contain any elements
+  boolean isEmptyRange() {
+    int minVsMax = compareMinToMax();
+    return (hasLimit && (count == 0 || offset < 0)) || minVsMax == 1
+        || (minVsMax == 0 && (isMinExclusive || isMaxExclusive));
+  }
+
+  public boolean isMinExclusive() {
+    return isMinExclusive;
+  }
+
+  public T getMinimum() {
+    return minimum;
+  }
+
+  public boolean isMaxExclusive() {
+    return isMaxExclusive;
+  }
+
+  public T getMaximum() {
+    return maximum;
+  }
+
+  public boolean hasLimit() {
+    return hasLimit;
+  }
+
+  public int getOffset() {
+    return offset;
+  }
+
+  public int getCount() {
+    return count;
+  }
+
+  abstract void parseMinimum(byte[] minimumBytes);
+
+  abstract void parseMaximum(byte[] maximumBytes);
+
+  abstract int compareMinToMax();
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractSortedSetRangeOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractSortedSetRangeOptions.java
@@ -15,7 +15,6 @@
 package org.apache.geode.redis.internal.executor.sortedset;
 
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLIMIT;
@@ -39,15 +38,12 @@ public abstract class AbstractSortedSetRangeOptions<T> {
   }
 
   void parseLimitArguments(List<byte[]> commandElements, int commandIndex) {
-    String element = bytesToString(commandElements.get(commandIndex));
     if (!equalsIgnoreCaseBytes(commandElements.get(commandIndex), bLIMIT)) {
-      System.out.println("DONAL: throwing because " + element + " is not LIMIT");
       throw new IllegalArgumentException();
     }
 
     // Throw if we don't have enough arguments left to correctly specify LIMIT
     if (commandElements.size() <= commandIndex + 2) {
-      System.out.println("DONAL: throwing because not enough arguments");
       throw new IllegalArgumentException();
     }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -25,13 +25,16 @@ public interface RedisSortedSetCommands {
 
   long zcard(RedisKey key);
 
-  long zcount(RedisKey key, SortedSetRangeOptions rangeOptions);
+  long zcount(RedisKey key, SortedSetScoreRangeOptions rangeOptions);
 
   byte[] zincrby(RedisKey key, byte[] increment, byte[] member);
 
   List<byte[]> zrange(RedisKey key, int min, int max, boolean withScores);
 
-  List<byte[]> zrangebyscore(RedisKey key, SortedSetRangeOptions rangeOptions, boolean withScores);
+  List<byte[]> zrangebylex(RedisKey key, SortedSetLexRangeOptions rangeOptions);
+
+  List<byte[]> zrangebyscore(RedisKey key, SortedSetScoreRangeOptions rangeOptions,
+      boolean withScores);
 
   long zrank(RedisKey key, byte[] member);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetLexRangeOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetLexRangeOptions.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.data.RedisSortedSet.checkDummyMemberNames;
+import static org.apache.geode.redis.internal.data.RedisSortedSet.javaImplementationOfAnsiCMemCmp;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGREATEST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEAST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEFT_PAREN;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEFT_SQUARE_BRACKET;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMINUS;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPLUS;
+
+import java.util.Arrays;
+
+public class SortedSetLexRangeOptions extends AbstractSortedSetRangeOptions<byte[]> {
+
+  SortedSetLexRangeOptions(byte[] minimumBytes, byte[] maximumBytes) {
+    super(minimumBytes, maximumBytes);
+  }
+
+  @Override
+  void parseMinimum(byte[] minBytes) {
+    if (minBytes.length == 1) {
+      if (minBytes[0] == bPLUS) {
+        isMinExclusive = false;
+        minimum = bGREATEST_MEMBER_NAME;
+      } else if (minBytes[0] == bMINUS) {
+        isMinExclusive = false;
+        minimum = bLEAST_MEMBER_NAME;
+      } else if (minBytes[0] == bLEFT_PAREN) {
+        isMinExclusive = true;
+        minimum = new byte[0];
+      } else if (minBytes[0] == bLEFT_SQUARE_BRACKET) {
+        isMinExclusive = false;
+        minimum = new byte[0];
+      } else {
+        throw new IllegalArgumentException();
+      }
+    } else if (minBytes[0] == bLEFT_PAREN) {
+      isMinExclusive = true;
+      minimum = Arrays.copyOfRange(minBytes, 1, minBytes.length);
+    } else if (minBytes[0] == bLEFT_SQUARE_BRACKET) {
+      isMinExclusive = false;
+      minimum = Arrays.copyOfRange(minBytes, 1, minBytes.length);
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  void parseMaximum(byte[] maxBytes) {
+    if (maxBytes.length == 1) {
+      if (maxBytes[0] == bPLUS) {
+        isMaxExclusive = false;
+        maximum = bGREATEST_MEMBER_NAME;
+      } else if (maxBytes[0] == bMINUS) {
+        isMaxExclusive = false;
+        maximum = bLEAST_MEMBER_NAME;
+      } else if (maxBytes[0] == bLEFT_PAREN) {
+        isMaxExclusive = true;
+        maximum = new byte[0];
+      } else if (maxBytes[0] == bLEFT_SQUARE_BRACKET) {
+        isMaxExclusive = false;
+        maximum = new byte[0];
+      } else {
+        throw new IllegalArgumentException();
+      }
+    } else if (maxBytes[0] == bLEFT_PAREN) {
+      isMaxExclusive = true;
+      maximum = Arrays.copyOfRange(maxBytes, 1, maxBytes.length);
+    } else if (maxBytes[0] == bLEFT_SQUARE_BRACKET) {
+      isMaxExclusive = false;
+      maximum = Arrays.copyOfRange(maxBytes, 1, maxBytes.length);
+    } else {
+      throw new IllegalArgumentException();
+    }
+  }
+
+  @Override
+  int compareMinToMax() {
+    int dummyNameComparison = checkDummyMemberNames(minimum, maximum);
+    if (dummyNameComparison == 0) {
+      return javaImplementationOfAnsiCMemCmp(minimum, maximum);
+    } else {
+      return dummyNameComparison;
+    }
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetScoreRangeOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetScoreRangeOptions.java
@@ -19,77 +19,46 @@ import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEFT_PA
 
 import java.util.Arrays;
 
-public class SortedSetRangeOptions {
-  private final double minDouble;
-  private final boolean minExclusive;
-  private final double maxDouble;
-  private final boolean maxExclusive;
+public class SortedSetScoreRangeOptions extends AbstractSortedSetRangeOptions<Double> {
 
-  private boolean hasLimit = false;
-  private int offset = 0;
-  private int count = 0;
+  public SortedSetScoreRangeOptions(byte[] minBytes, byte[] maxBytes) {
+    super(minBytes, maxBytes);
+  }
 
-  public SortedSetRangeOptions(byte[] minBytes, byte[] maxBytes) {
+  @Override
+  void parseMinimum(byte[] minBytes) {
     if (minBytes[0] == bLEFT_PAREN) {
       // A value of "(" is equivalent to "(0"
       if (minBytes.length == 1) {
-        minDouble = 0;
+        minimum = 0.0;
       } else {
-        minDouble =
-            bytesToDouble(Arrays.copyOfRange(minBytes, 1, minBytes.length));
+        minimum = bytesToDouble(Arrays.copyOfRange(minBytes, 1, minBytes.length));
       }
-      minExclusive = true;
+      isMinExclusive = true;
     } else {
-      minExclusive = false;
-      minDouble = bytesToDouble(minBytes);
+      isMinExclusive = false;
+      minimum = bytesToDouble(minBytes);
     }
+  }
 
+  @Override
+  void parseMaximum(byte[] maxBytes) {
     if (maxBytes[0] == bLEFT_PAREN) {
       // A value of "(" is equivalent to "(0"
       if (maxBytes.length == 1) {
-        maxDouble = 0;
+        maximum = 0.0;
       } else {
-        maxDouble =
-            bytesToDouble(Arrays.copyOfRange(maxBytes, 1, maxBytes.length));
+        maximum = bytesToDouble(Arrays.copyOfRange(maxBytes, 1, maxBytes.length));
       }
-      maxExclusive = true;
+      isMaxExclusive = true;
     } else {
-      maxExclusive = false;
-      maxDouble = bytesToDouble(maxBytes);
+      isMaxExclusive = false;
+      maximum = bytesToDouble(maxBytes);
     }
   }
 
-  public void setLimitValues(int offset, int count) {
-    hasLimit = true;
-    this.offset = offset;
-    this.count = count;
-  }
-
-  public double getMinDouble() {
-    return minDouble;
-  }
-
-  public boolean isMinExclusive() {
-    return minExclusive;
-  }
-
-  public double getMaxDouble() {
-    return maxDouble;
-  }
-
-  public boolean isMaxExclusive() {
-    return maxExclusive;
-  }
-
-  public boolean hasLimit() {
-    return hasLimit;
-  }
-
-  public int getOffset() {
-    return offset;
-  }
-
-  public int getCount() {
-    return count;
+  @Override
+  int compareMinToMax() {
+    return Double.compare(minimum, maximum);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZCountExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZCountExecutor.java
@@ -30,20 +30,18 @@ public class ZCountExecutor extends AbstractExecutor {
 
     List<byte[]> commandElements = command.getProcessedCommand();
 
-    SortedSetRangeOptions rangeOptions;
+    SortedSetScoreRangeOptions rangeOptions;
 
     try {
       byte[] minBytes = commandElements.get(2);
       byte[] maxBytes = commandElements.get(3);
-      rangeOptions = new SortedSetRangeOptions(minBytes, maxBytes);
+      rangeOptions = new SortedSetScoreRangeOptions(minBytes, maxBytes);
     } catch (NumberFormatException ex) {
       return RedisResponse.error(ERROR_MIN_MAX_NOT_A_FLOAT);
     }
 
     // If the range is empty (min > max or min == max and both are exclusive), return early
-    if (rangeOptions.getMinDouble() > rangeOptions.getMaxDouble() ||
-        (rangeOptions.getMinDouble() == rangeOptions.getMaxDouble())
-            && rangeOptions.isMinExclusive() && rangeOptions.isMaxExclusive()) {
+    if (rangeOptions.isEmptyRange()) {
       return RedisResponse.integer(0);
     }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexExecutor.java
@@ -42,15 +42,14 @@ public class ZRangeByLexExecutor extends AbstractExecutor {
 
     // Native redis allows multiple "limit ? ?" clauses; the last "limit" clause overrides any
     // previous ones
-    // In order to match the error reporting behaviour of native Redis, the argument list must be
-    // parsed in reverse order. Stop parsing at index = 4, since 0 is the command name, 1 is the
-    // key, 2 is the min and 3 is the max
+    // Start parsing at index = 4, since 0 is the command name, 1 is the key, 2 is the min and 3 is
+    // the max
     if (commandElements.size() >= 5) {
-      for (int index = commandElements.size() - 1; index > 3; --index) {
+      for (int index = 4; index < commandElements.size(); ++index) {
         try {
           rangeOptions.parseLimitArguments(commandElements, index);
-          // If we successfully parse a set of three LIMIT options, decrement the index past them
-          index -= 2;
+          // If we successfully parse a set of three LIMIT options, increment the index past them
+          index += 2;
         } catch (NumberFormatException nfex) {
           return RedisResponse.error(ERROR_NOT_INTEGER);
         } catch (IllegalArgumentException iex) {
@@ -61,6 +60,10 @@ public class ZRangeByLexExecutor extends AbstractExecutor {
 
     // If the range is empty, return early
     if (rangeOptions.isEmptyRange()) {
+      return RedisResponse.emptyArray();
+    }
+    // If offset is negative
+    if (rangeOptions.offset < 0) {
       return RedisResponse.emptyArray();
     }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexExecutor.java
@@ -14,11 +14,9 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_MIN_MAX_NOT_A_FLOAT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_MIN_MAX_NOT_A_VALID_STRING;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWITHSCORES;
 
 import java.util.List;
 
@@ -27,39 +25,32 @@ import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ZRangeByScoreExecutor extends AbstractExecutor {
+public class ZRangeByLexExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElements = command.getProcessedCommand();
 
-    SortedSetScoreRangeOptions rangeOptions;
+    SortedSetLexRangeOptions rangeOptions;
 
     try {
       byte[] minBytes = commandElements.get(2);
       byte[] maxBytes = commandElements.get(3);
-      rangeOptions = new SortedSetScoreRangeOptions(minBytes, maxBytes);
-    } catch (NumberFormatException ex) {
-      return RedisResponse.error(ERROR_MIN_MAX_NOT_A_FLOAT);
+      rangeOptions = new SortedSetLexRangeOptions(minBytes, maxBytes);
+    } catch (IllegalArgumentException ex) {
+      return RedisResponse.error(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     }
 
-    // Native redis allows multiple "withscores" and "limit ? ?" clauses; the last "limit"
-    // clause overrides any previous ones
+    // Native redis allows multiple "limit ? ?" clauses; the last "limit" clause overrides any
+    // previous ones
     // In order to match the error reporting behaviour of native Redis, the argument list must be
     // parsed in reverse order. Stop parsing at index = 4, since 0 is the command name, 1 is the
     // key, 2 is the min and 3 is the max
-    boolean withScores = false;
-
     if (commandElements.size() >= 5) {
       for (int index = commandElements.size() - 1; index > 3; --index) {
         try {
-          byte[] commandBytes = commandElements.get(index);
-          if (equalsIgnoreCaseBytes(commandBytes, bWITHSCORES)) {
-            withScores = true;
-          } else {
-            rangeOptions.parseLimitArguments(commandElements, index);
-            // If we successfully parse a set of three LIMIT options, decrement the index past them
-            index -= 2;
-          }
+          rangeOptions.parseLimitArguments(commandElements, index);
+          // If we successfully parse a set of three LIMIT options, decrement the index past them
+          index -= 2;
         } catch (NumberFormatException nfex) {
           return RedisResponse.error(ERROR_NOT_INTEGER);
         } catch (IllegalArgumentException iex) {
@@ -74,7 +65,7 @@ public class ZRangeByScoreExecutor extends AbstractExecutor {
     }
 
     List<byte[]> result =
-        context.getSortedSetCommands().zrangebyscore(command.getKey(), rangeOptions, withScores);
+        context.getSortedSetCommands().zrangebylex(command.getKey(), rangeOptions);
 
     return RedisResponse.array(result);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByScoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByScoreExecutor.java
@@ -44,13 +44,12 @@ public class ZRangeByScoreExecutor extends AbstractExecutor {
 
     // Native redis allows multiple "withscores" and "limit ? ?" clauses; the last "limit"
     // clause overrides any previous ones
-    // In order to match the error reporting behaviour of native Redis, the argument list must be
-    // parsed in reverse order. Stop parsing at index = 4, since 0 is the command name, 1 is the
-    // key, 2 is the min and 3 is the max
+    // Start parsing at index = 4, since 0 is the command name, 1 is the key, 2 is the min and 3 is
+    // the max
     boolean withScores = false;
 
     if (commandElements.size() >= 5) {
-      for (int index = commandElements.size() - 1; index > 3; --index) {
+      for (int index = 4; index < commandElements.size(); ++index) {
         try {
           byte[] commandBytes = commandElements.get(index);
           if (equalsIgnoreCaseBytes(commandBytes, bWITHSCORES)) {
@@ -58,7 +57,7 @@ public class ZRangeByScoreExecutor extends AbstractExecutor {
           } else {
             rangeOptions.parseLimitArguments(commandElements, index);
             // If we successfully parse a set of three LIMIT options, decrement the index past them
-            index -= 2;
+            index += 2;
           }
         } catch (NumberFormatException nfex) {
           return RedisResponse.error(ERROR_NOT_INTEGER);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByScoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByScoreExecutor.java
@@ -56,7 +56,7 @@ public class ZRangeByScoreExecutor extends AbstractExecutor {
             withScores = true;
           } else {
             rangeOptions.parseLimitArguments(commandElements, index);
-            // If we successfully parse a set of three LIMIT options, decrement the index past them
+            // If we successfully parse a set of three LIMIT options, increment the index past them
             index += 2;
           }
         } catch (NumberFormatException nfex) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -175,12 +175,13 @@ public class StringBytesGlossary {
   @MakeImmutable
   public static final byte[] bABSTTL = stringToBytes("ABSTTL");
 
-  // AbstractZRangeExecutor
+  // Various ZRangeExecutors
   @MakeImmutable
   public static final byte[] bWITHSCORES = stringToBytes("WITHSCORES");
-
   @MakeImmutable
   public static final byte[] bLIMIT = stringToBytes("LIMIT");
+  public static final byte bPLUS = SIMPLE_STRING_ID; // +
+  public static final byte bMINUS = ERROR_ID; // -
 
   // ********** Constants for Double Infinity comparisons **********
   public static final String P_INF = "+inf";
@@ -229,8 +230,9 @@ public class StringBytesGlossary {
 
   public static final byte bLEFT_PAREN = 40; // (
 
-  public static final byte bPERIOD = 46; // .
+  public static final byte bLEFT_SQUARE_BRACKET = 91; // [
 
+  public static final byte bPERIOD = 46; // .
 
   public static final String PING_RESPONSE = "PONG";
 
@@ -245,9 +247,9 @@ public class StringBytesGlossary {
 
   /**
    * These member names will always be evaluated to be "greater than" or "less than" any other when
-   * using the {@link RedisSortedSet.OrderedSetEntry#compareTo(RedisSortedSet.OrderedSetEntry)}
-   * method, so the rank of an entry using these names will be less than or greater than all other
-   * members with the same score.
+   * using the {@link RedisSortedSet#checkDummyMemberNames(byte[], byte[])} method, so the rank of
+   * an entry using these names will be less than or greater than all other members with the same
+   * score.
    * These values should always be compared using {@code ==} rather than {@code Array.equals()} so
    * that we can differentiate between the use of these constants and a value potentially entered by
    * the user, which while equal in content, will not share the same memory address.

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -257,4 +257,6 @@ public class StringBytesGlossary {
   public static final byte[] bGREATEST_MEMBER_NAME = new byte[] {-1};
 
   public static final byte[] bLEAST_MEMBER_NAME = new byte[] {-2};
+
+  public static final byte[] bNEGATIVE_ZERO = stringToBytes("-0");
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/SupportedCommandsJUnitTest.java
@@ -92,6 +92,7 @@ public class SupportedCommandsJUnitTest {
       "ZCARD",
       "ZCOUNT",
       "ZRANGE",
+      "ZRANGEBYLEX",
       "ZRANGEBYSCORE",
       "ZRANK",
       "ZREM",

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -314,35 +314,35 @@ public class RedisSortedSetTest {
   }
 
   @Test
-  public void dummyOrderedSetEntryCompareTo_throws_givenBothArraysAreGreatestOrLeastMemberNameAndScoresAreEqual() {
+  public void scoreDummyOrderedSetEntryCompareTo_throws_givenBothArraysAreGreatestOrLeastMemberNameAndScoresAreEqual() {
     double score = 1.0;
 
     RedisSortedSet.AbstractOrderedSetEntry greatest1 =
-        new RedisSortedSet.DummyOrderedSetEntry(score, true, true);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(score, true, true);
     RedisSortedSet.AbstractOrderedSetEntry greatest2 =
-        new RedisSortedSet.DummyOrderedSetEntry(score, false, false);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(score, false, false);
 
     // noinspection ResultOfMethodCallIgnored
     assertThatThrownBy(() -> greatest1.compareTo(greatest2))
         .isInstanceOf(IllegalStateException.class);
 
     RedisSortedSet.AbstractOrderedSetEntry least1 =
-        new RedisSortedSet.DummyOrderedSetEntry(score, false, true);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(score, false, true);
     RedisSortedSet.AbstractOrderedSetEntry least2 =
-        new RedisSortedSet.DummyOrderedSetEntry(score, true, false);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(score, true, false);
 
     // noinspection ResultOfMethodCallIgnored
     assertThatThrownBy(() -> least1.compareTo(least2)).isInstanceOf(IllegalStateException.class);
   }
 
   @Test
-  public void dummyOrderedSetEntryCompareTo_handlesDummyMemberNames_givenScoresAreEqual() {
+  public void scoreDummyOrderedSetEntryCompareTo_handlesDummyMemberNames_givenScoresAreEqual() {
     double score = 1.0;
 
     RedisSortedSet.AbstractOrderedSetEntry greatest =
-        new RedisSortedSet.DummyOrderedSetEntry(score, true, true);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(score, true, true);
     RedisSortedSet.AbstractOrderedSetEntry least =
-        new RedisSortedSet.DummyOrderedSetEntry(score, true, false);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(score, true, false);
     RedisSortedSet.AbstractOrderedSetEntry middle =
         new RedisSortedSet.OrderedSetEntry(stringToBytes("middle"), doubleToBytes(score));
 
@@ -357,17 +357,17 @@ public class RedisSortedSetTest {
   }
 
   @Test
-  public void dummyOrderedSetEntryCompareTo_handlesDummyMemberNameEquivalents_givenScoresAreEqual() {
+  public void scoreDummyOrderedSetEntryCompareTo_handlesDummyMemberNameEquivalents_givenScoresAreEqual() {
     double score = 1.0;
     byte[] scoreBytes = doubleToBytes(score);
 
     RedisSortedSet.AbstractOrderedSetEntry greatest =
-        new RedisSortedSet.DummyOrderedSetEntry(score, true, true);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(score, true, true);
     RedisSortedSet.AbstractOrderedSetEntry greatestEquivalent =
         new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME.clone(), scoreBytes);
 
     RedisSortedSet.AbstractOrderedSetEntry least =
-        new RedisSortedSet.DummyOrderedSetEntry(score, true, false);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(score, true, false);
     RedisSortedSet.AbstractOrderedSetEntry leastEquivalent =
         new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME.clone(), scoreBytes);
 
@@ -379,21 +379,101 @@ public class RedisSortedSetTest {
   }
 
   @Test
-  public void dummyOrderedSetEntryConstructor_setsAppropriateMemberName() {
+  public void scoreDummyOrderedSetEntryConstructor_setsAppropriateMemberName() {
     RedisSortedSet.AbstractOrderedSetEntry entry =
-        new RedisSortedSet.DummyOrderedSetEntry(1, false, false);
+        new RedisSortedSet.ScoreDummyOrderedSetEntry(1, false, false);
     assertThat(entry.getMember()).isSameAs(bGREATEST_MEMBER_NAME);
 
-    entry = new RedisSortedSet.DummyOrderedSetEntry(1, true, false);
+    entry = new RedisSortedSet.ScoreDummyOrderedSetEntry(1, true, false);
     assertThat(entry.getMember()).isSameAs(bLEAST_MEMBER_NAME);
 
-    entry = new RedisSortedSet.DummyOrderedSetEntry(1, false, true);
+    entry = new RedisSortedSet.ScoreDummyOrderedSetEntry(1, false, true);
     assertThat(entry.getMember()).isSameAs(bLEAST_MEMBER_NAME);
 
-    entry = new RedisSortedSet.DummyOrderedSetEntry(1, true, true);
+    entry = new RedisSortedSet.ScoreDummyOrderedSetEntry(1, true, true);
     assertThat(entry.getMember()).isSameAs(bGREATEST_MEMBER_NAME);
   }
 
+  @Test
+  public void memberDummyOrderedSetEntryCompareTo_handlesDummyMemberNames() {
+    double score = 1.0;
+
+    RedisSortedSet.AbstractOrderedSetEntry greatest =
+        new RedisSortedSet.MemberDummyOrderedSetEntry(bGREATEST_MEMBER_NAME, score, false, false);
+    RedisSortedSet.AbstractOrderedSetEntry least =
+        new RedisSortedSet.MemberDummyOrderedSetEntry(bLEAST_MEMBER_NAME, score, false, false);
+    RedisSortedSet.AbstractOrderedSetEntry middle =
+        new RedisSortedSet.MemberDummyOrderedSetEntry(stringToBytes("middle"), score, false, false);
+
+    // greatest > least
+    assertThat(greatest.compareTo(least)).isEqualTo(1);
+    // greatest > middle
+    assertThat(greatest.compareTo(middle)).isEqualTo(1);
+    // middle < greatest
+    assertThat(middle.compareTo(greatest)).isEqualTo(-1);
+    // middle > least
+    assertThat(middle.compareTo(least)).isEqualTo(1);
+    // least < greatest
+    assertThat(least.compareTo(greatest)).isEqualTo(-1);
+    // least < middle
+    assertThat(least.compareTo(middle)).isEqualTo(-1);
+  }
+
+  @Test
+  public void memberDummyOrderedSetEntryCompareTo_withEqualMemberNamesAndExclusiveMinimum() {
+    byte[] memberName = stringToBytes("member");
+    double score = 1.0;
+    RedisSortedSet.AbstractOrderedSetEntry realEntry =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(score));
+
+    RedisSortedSet.AbstractOrderedSetEntry exclusiveMin =
+        new RedisSortedSet.MemberDummyOrderedSetEntry(memberName, score, true, true);
+
+    // exclusiveMin > realEntry
+    assertThat(exclusiveMin.compareTo(realEntry)).isEqualTo(1);
+  }
+
+  @Test
+  public void memberDummyOrderedSetEntryCompareTo_withEqualMemberNamesAndInclusiveMinimum() {
+    byte[] memberName = stringToBytes("member");
+    double score = 1.0;
+    RedisSortedSet.AbstractOrderedSetEntry realEntry =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(score));
+
+    RedisSortedSet.AbstractOrderedSetEntry inclusiveMin =
+        new RedisSortedSet.MemberDummyOrderedSetEntry(memberName, score, false, true);
+
+    // inclusiveMin < realEntry
+    assertThat(inclusiveMin.compareTo(realEntry)).isEqualTo(-1);
+  }
+
+  @Test
+  public void memberDummyOrderedSetEntryCompareTo_withEqualMemberNamesAndExclusiveMaximum() {
+    byte[] memberName = stringToBytes("member");
+    double score = 1.0;
+    RedisSortedSet.AbstractOrderedSetEntry realEntry =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(score));
+
+    RedisSortedSet.AbstractOrderedSetEntry exclusiveMax =
+        new RedisSortedSet.MemberDummyOrderedSetEntry(memberName, score, true, false);
+
+    // exclusiveMax < realEntry
+    assertThat(exclusiveMax.compareTo(realEntry)).isEqualTo(-1);
+  }
+
+  @Test
+  public void memberDummyOrderedSetEntryCompareTo_withEqualMemberNamesAndInclusiveMaximum() {
+    byte[] memberName = stringToBytes("member");
+    double score = 1.0;
+    RedisSortedSet.AbstractOrderedSetEntry realEntry =
+        new RedisSortedSet.OrderedSetEntry(memberName, doubleToBytes(score));
+
+    RedisSortedSet.AbstractOrderedSetEntry inclusiveMax =
+        new RedisSortedSet.MemberDummyOrderedSetEntry(memberName, score, false, false);
+
+    // inclusiveMax > realEntry
+    assertThat(inclusiveMax.compareTo(realEntry)).isEqualTo(1);
+  }
 
   /******** constants *******/
   // These tests contain the math that is used to derive the constants in RedisSortedSet and


### PR DESCRIPTION
 - Add ZRANGEBYLEX to supported commands
 - Introduce AbstractSortedSetRangeOptions class to handle behaviour
 common to -BYSCORE and -BYLEX ranges
 - Introduce SortedSetLexRangeOptions to handle parsing lexical ranges
 - Rename SortedSetRangeOptions to SortedSetScoreRangeOptions
 - Introduce MemberDummyOrderedSetEntry to support getting rank by lex
 - Rename DummyOrderedSetEntry to ScoreDummyOrderedSetEntry
 - Add unit tests for MemberDummyOrderedSetEntry
 - Add integration tests for ZRANGEBYLEX
 - Refactor RedisSortedSet.zrangebyscore() to use
 SortedSetScoreRangeOptions
 - Add missing HitsMissesIntegrationTest for ZRANGEBYSCORE
 - Refactor argument parsing in ZRangeByScoreExecutor to allow correct
 error behaviour with multiple LIMIT options, one of which is
 incorrectly formatted
 - Add tests to confirm correct behaviour for ZRANGEBYSCORE for above
 case

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
