### PR TITLE
GEODE-9480: Changing the version with ordinal 121 to be 1.13.2

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionRemoteContext.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionRemoteContext.java
@@ -90,7 +90,7 @@ public class FunctionRemoteContext implements DataSerializable {
     if (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_14_0)
         || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_12_1)
             && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_13_0))
-        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_1)
+        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_2)
             && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_14_0))) {
       this.principal = DataSerializer.readObject(in);
     }
@@ -118,7 +118,7 @@ public class FunctionRemoteContext implements DataSerializable {
     if (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_14_0)
         || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_12_1)
             && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_13_0))
-        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_1)
+        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_2)
             && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_14_0))) {
       DataSerializer.writeObject(this.principal, out);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
@@ -202,7 +202,7 @@ public class CommandInitializer implements CommandRegistry {
     allCommands.put(KnownVersion.GEODE_1_12_0, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_12_1, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_13_0, geode18Commands);
-    allCommands.put(KnownVersion.GEODE_1_13_1, geode18Commands);
+    allCommands.put(KnownVersion.GEODE_1_13_2, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_14_0, geode18Commands);
 
     // as of GEODE_1_15_0 we only create new command sets when the

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
@@ -205,12 +205,12 @@ public class KnownVersion extends AbstractVersion {
       new KnownVersion("GEODE", "1.13.0", (byte) 1, (byte) 13, (byte) 0, (byte) 0,
           GEODE_1_13_0_ORDINAL, true);
 
-  private static final short GEODE_1_13_1_ORDINAL = 121;
+  private static final short GEODE_1_13_2_ORDINAL = 121;
 
   @Immutable
-  public static final KnownVersion GEODE_1_13_1 =
-      new KnownVersion("GEODE", "1.13.1", (byte) 1, (byte) 13, (byte) 1, (byte) 0,
-          GEODE_1_13_1_ORDINAL, true);
+  public static final KnownVersion GEODE_1_13_2 =
+      new KnownVersion("GEODE", "1.13.2", (byte) 1, (byte) 13, (byte) 1, (byte) 0,
+          GEODE_1_13_2_ORDINAL, true);
 
   private static final short GEODE_1_14_0_ORDINAL = 125;
 

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
@@ -40,8 +40,8 @@ public class KnownVersionJUnitTest {
     compare(KnownVersion.GEODE_1_12_0, KnownVersion.GEODE_1_11_0);
     compare(KnownVersion.GEODE_1_12_1, KnownVersion.GEODE_1_12_0);
     compare(KnownVersion.GEODE_1_13_0, KnownVersion.GEODE_1_12_1);
-    compare(KnownVersion.GEODE_1_13_1, KnownVersion.GEODE_1_13_0);
-    compare(KnownVersion.GEODE_1_14_0, KnownVersion.GEODE_1_13_1);
+    compare(KnownVersion.GEODE_1_13_2, KnownVersion.GEODE_1_13_0);
+    compare(KnownVersion.GEODE_1_14_0, KnownVersion.GEODE_1_13_2);
     compare(KnownVersion.GEODE_1_15_0, KnownVersion.GEODE_1_14_0);
   }
 
@@ -63,8 +63,8 @@ public class KnownVersionJUnitTest {
         .isEqualTo(KnownVersion.GEODE_1_12_1);
     assertThat(KnownVersion.GEODE_1_13_0.getClientServerProtocolVersion())
         .isEqualTo(KnownVersion.GEODE_1_13_0);
-    assertThat(KnownVersion.GEODE_1_13_1.getClientServerProtocolVersion())
-        .isEqualTo(KnownVersion.GEODE_1_13_1);
+    assertThat(KnownVersion.GEODE_1_13_2.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_13_2);
     assertThat(KnownVersion.GEODE_1_14_0.getClientServerProtocolVersion())
         .isEqualTo(KnownVersion.GEODE_1_14_0);
     assertThat(KnownVersion.GEODE_1_15_0.getClientServerProtocolVersion())


### PR DESCRIPTION
This protocol change actually happened in 1.13.2. 1.13.1 is still using the
same protocol ordinal as 1.13.0, which is 120.

Evidence
* b2d205459bf is the commit that introduced this version in support/1.13
* b2d205459bf is only contained in rel/v1.13.2 and above
* Running geode 1.13.1, it reports its protocol version as 120.

