### PR TITLE
GEODE-9480: Changing the version with ordinal 121 to be 1.13.2

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionRemoteContext.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/FunctionRemoteContext.java
@@ -90,7 +90,7 @@ public class FunctionRemoteContext implements DataSerializable {
     if (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_14_0)
         || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_12_1)
             && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_13_0))
-        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_1)
+        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_2)
             && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_14_0))) {
       this.principal = DataSerializer.readObject(in);
     }
@@ -118,7 +118,7 @@ public class FunctionRemoteContext implements DataSerializable {
     if (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_14_0)
         || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_12_1)
             && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_13_0))
-        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_1)
+        || (dataStreamVersion.isNewerThanOrEqualTo(KnownVersion.GEODE_1_13_2)
             && dataStreamVersion.isOlderThan(KnownVersion.GEODE_1_14_0))) {
       DataSerializer.writeObject(this.principal, out);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
@@ -202,7 +202,7 @@ public class CommandInitializer implements CommandRegistry {
     allCommands.put(KnownVersion.GEODE_1_12_0, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_12_1, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_13_0, geode18Commands);
-    allCommands.put(KnownVersion.GEODE_1_13_1, geode18Commands);
+    allCommands.put(KnownVersion.GEODE_1_13_2, geode18Commands);
 
     allCommands.put(KnownVersion.GEODE_1_14_0, geode18Commands);
 

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
@@ -237,12 +237,12 @@ public class KnownVersion extends AbstractVersion {
       new KnownVersion("GEODE", "1.13.0", (byte) 1, (byte) 13, (byte) 0, (byte) 0,
           GEODE_1_13_0_ORDINAL, true);
 
-  private static final short GEODE_1_13_1_ORDINAL = 121;
+  private static final short GEODE_1_13_2_ORDINAL = 121;
 
   @Immutable
-  public static final KnownVersion GEODE_1_13_1 =
-      new KnownVersion("GEODE", "1.13.1", (byte) 1, (byte) 13, (byte) 1, (byte) 0,
-          GEODE_1_13_1_ORDINAL, true);
+  public static final KnownVersion GEODE_1_13_2 =
+      new KnownVersion("GEODE", "1.13.2", (byte) 1, (byte) 13, (byte) 1, (byte) 0,
+          GEODE_1_13_2_ORDINAL, true);
 
   private static final short GEODE_1_14_0_ORDINAL = 125;
 

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
@@ -41,7 +41,7 @@ public class KnownVersionJUnitTest {
     compare(KnownVersion.GEODE_1_12_1, KnownVersion.GEODE_1_12_0);
     compare(KnownVersion.GEODE_1_13_0, KnownVersion.GEODE_1_12_1);
     compare(KnownVersion.GEODE_1_13_2, KnownVersion.GEODE_1_13_0);
-    compare(KnownVersion.GEODE_1_14_0, KnownVersion.GEODE_1_13_1);
+    compare(KnownVersion.GEODE_1_14_0, KnownVersion.GEODE_1_13_2);
   }
 
   @Test

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
@@ -40,7 +40,7 @@ public class KnownVersionJUnitTest {
     compare(KnownVersion.GEODE_1_12_0, KnownVersion.GEODE_1_11_0);
     compare(KnownVersion.GEODE_1_12_1, KnownVersion.GEODE_1_12_0);
     compare(KnownVersion.GEODE_1_13_0, KnownVersion.GEODE_1_12_1);
-    compare(KnownVersion.GEODE_1_13_1, KnownVersion.GEODE_1_13_0);
+    compare(KnownVersion.GEODE_1_13_2, KnownVersion.GEODE_1_13_0);
     compare(KnownVersion.GEODE_1_14_0, KnownVersion.GEODE_1_13_1);
   }
 
@@ -62,8 +62,8 @@ public class KnownVersionJUnitTest {
         .isEqualTo(KnownVersion.GEODE_1_12_1);
     assertThat(KnownVersion.GEODE_1_13_0.getClientServerProtocolVersion())
         .isEqualTo(KnownVersion.GEODE_1_13_0);
-    assertThat(KnownVersion.GEODE_1_13_1.getClientServerProtocolVersion())
-        .isEqualTo(KnownVersion.GEODE_1_13_1);
+    assertThat(KnownVersion.GEODE_1_13_2.getClientServerProtocolVersion())
+        .isEqualTo(KnownVersion.GEODE_1_13_2);
     assertThat(KnownVersion.GEODE_1_14_0.getClientServerProtocolVersion())
         .isEqualTo(KnownVersion.GEODE_1_14_0);
   }


### PR DESCRIPTION
This protocol change actually happened in 1.13.2. 1.13.1 is still using the
same protocol ordinal as 1.13.0, which is 120.

Evidence
* b2d205459bf is the commit that introduced this version in support/1.13
* b2d205459bf is only contained in rel/v1.13.2 and above
* Running geode 1.13.1, it reports it's protocol version as 120.

(cherry picked from commit 2a90a583015352c1cc0f041008ec2a6ea7b5505c)
