### PR TITLE
GEODE-9483: Make StartLocatorCommandIntegrationTest not start unneeded locator

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandIntegrationTest.java
@@ -21,7 +21,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Properties;
@@ -45,8 +47,14 @@ public class StartLocatorCommandIntegrationTest {
   private StartLocatorCommand spy;
 
   @Before
-  public void before() {
+  public void before() throws IOException {
+    final Process process = mock(Process.class);
+    when(process.getInputStream()).thenReturn(mock(InputStream.class));
+    when(process.getErrorStream()).thenReturn(mock(InputStream.class));
+    when(process.getOutputStream()).thenReturn(mock(OutputStream.class));
+
     spy = Mockito.spy(StartLocatorCommand.class);
+    doReturn(process).when(spy).getProcess(any(), any());
     doReturn(mock(Gfsh.class)).when(spy).getGfsh();
   }
 
@@ -81,11 +89,6 @@ public class StartLocatorCommandIntegrationTest {
 
   @Test
   public void startWithBindAddress() throws Exception {
-    final Process mockProcess = mock(Process.class);
-    doReturn(mock(InputStream.class)).when(mockProcess).getInputStream();
-    doReturn(mock(InputStream.class)).when(mockProcess).getErrorStream();
-    doReturn(mock(OutputStream.class)).when(mockProcess).getOutputStream();
-    doReturn(mockProcess).when(spy).getProcess(any(), any());
     commandRule.executeAndAssertThat(spy, "start locator --bind-address=127.0.0.1");
 
     ArgumentCaptor<String[]> commandLines = ArgumentCaptor.forClass(String[].class);
@@ -97,7 +100,6 @@ public class StartLocatorCommandIntegrationTest {
 
   @Test
   public void startLocatorRespectsHostnameForClients() throws Exception {
-    doReturn(mock(Process.class)).when(spy).getProcess(any(), any());
     String startLocatorCommand = new CommandStringBuilder("start locator")
         .addOption("hostname-for-clients", FAKE_HOSTNAME).toString();
 


### PR DESCRIPTION
Two of the tests in `StartLocatorCommandIntegrationTest` launch a locator
process that binds to the default HTTP service port (7070). This can
interfere with the tests that explicitly verify that the system uses the
correct HTTP service port by default.

Neither test actually needs the launched locator for any purpose.
Neither test makes a single assertion about the locator. When the tests
exit, they leave the locator running. In fact, the locator typically
finishes launching well after the tests have all exited.

Rather than fix the port assignment, this commit changes the tests so
that they do not actually launch a locator. Two of the tests in this
class already do this.