### PR TITLE
GEODE-4181: Add JUnit 5 Support

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -583,6 +583,26 @@
         <version>2.2</version>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.7.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>5.7.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.7.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>5.7.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-api</artifactId>
         <version>3.141.59</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -65,6 +65,7 @@ class DependencyConstraints implements Plugin<Project> {
 
     // These versions are referenced in test.gradle, which is aggressively injected into all projects.
     deps.put("junit.version", "4.13.2")
+    deps.put("junit-jupiter.version", "5.7.2")
     deps.put("cglib.version", "3.3.0")
     return deps
   }
@@ -219,6 +220,16 @@ class DependencyConstraints implements Plugin<Project> {
 
     dependencySet(group: 'org.hamcrest', version: '2.2') {
       entry('hamcrest')
+    }
+
+    dependencySet(group: 'org.junit.jupiter', version: get('junit-jupiter.version')) {
+      entry('junit-jupiter-api')
+      entry('junit-jupiter-params')
+      entry('junit-jupiter-engine')
+    }
+
+    dependencySet(group: 'org.junit.vintage', version: get('junit-jupiter.version')) {
+      entry('junit-vintage-engine')
     }
 
     dependencySet(group: 'org.seleniumhq.selenium', version: '3.141.59') {

--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   // test
   testImplementation('org.apache.bcel:bcel')
   testImplementation('junit:junit')
+  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
   testImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))

--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -28,11 +28,13 @@ dependencies {
 
   // test
   testImplementation('junit:junit')
+  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 
 
   // jmhTest
   jmhTestImplementation('junit:junit')
+  jmhTestRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   jmhTestImplementation('org.assertj:assertj-core')
 }

--- a/geode-concurrency-test/build.gradle
+++ b/geode-concurrency-test/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation('junit:junit')
   implementation('org.apache.logging.log4j:log4j-api')
   integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestRuntimeOnly('org.junit.vintage:junit-vintage-engine')
 }
 
 integrationTest {

--- a/geode-jmh/build.gradle
+++ b/geode-jmh/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   api('org.openjdk.jmh:jmh-core')
 
   testImplementation('junit:junit')
+  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 }

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -38,6 +38,8 @@ dependencies {
   api('junit:junit') {
     exclude module: 'hamcrest'
   }
+  api('org.junit.jupiter:junit-jupiter-api')
+  api('org.junit.jupiter:junit-jupiter-params')
   api('org.assertj:assertj-core')
   api('org.mockito:mockito-core')
 
@@ -59,6 +61,9 @@ dependencies {
   api('io.micrometer:micrometer-core')
   
   api('org.skyscreamer:jsonassert')
+
+  implementation('org.junit.jupiter:junit-jupiter-engine')
+  implementation('org.junit.vintage:junit-vintage-engine')
 
   testImplementation('pl.pragmatists:JUnitParams')
 

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
@@ -33,11 +33,11 @@ import java.util.function.Consumer;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
-import org.junit.ComparisonFailure;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.MultipleFailureException;
+import org.opentest4j.AssertionFailedError;
 
 @RunWith(JUnitParamsRunner.class)
 public class ConcurrencyRuleTest {
@@ -398,7 +398,7 @@ public class ConcurrencyRuleTest {
         .repeatForDuration(Duration.ofSeconds(2));
 
     assertThatThrownBy(() -> execution.execute(concurrencyRule))
-        .isInstanceOf(ComparisonFailure.class);
+        .isInstanceOf(AssertionFailedError.class);
     assertThat(invoked.get()).isTrue();
   }
 
@@ -518,8 +518,8 @@ public class ConcurrencyRuleTest {
     assertThat(errors.get(0)).isInstanceOf(AssertionError.class)
         .hasMessageContaining(IOException.class.getName());
     assertThat(errors.get(1)).isInstanceOf(AssertionError.class)
-        .hasMessageContaining("[successful] value")
-        .hasMessageContaining("[wrong] value");
+        .hasMessageContaining("successful value")
+        .hasMessageContaining("wrong value");
     assertThat(errors.get(2)).hasMessageContaining("foo")
         .isInstanceOf(IOException.class);
   }

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -58,6 +58,16 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
@@ -138,5 +148,14 @@
       <artifactId>jsonassert</artifactId>
       <scope>compile</scope>
     </dependency>
-  </dependencies>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>runtime</scope>
+    </dependency>  </dependencies>
 </project>

--- a/geode-rebalancer/build.gradle
+++ b/geode-rebalancer/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   }
 
   testImplementation('junit:junit')
+  testImplementation('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -31,6 +31,7 @@ compileTestJava {
 }
 
 test {
+  useJUnitPlatform {}
   doFirst {
     TestPropertiesWriter.writeTestProperties(buildDir, name)
   }
@@ -91,7 +92,7 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 }
 
 configure([integrationTest, distributedTest, performanceTest]) {
-  useJUnit {
+  useJUnitPlatform {
     if (project.hasProperty("testCategory")) {
       includeCategories += project.testCategory
     }
@@ -135,6 +136,7 @@ task repeatUnitTest(type: RepeatTest) {
 }
 
 configure([integrationTest, distributedTest, performanceTest, acceptanceTest, uiTest, upgradeTest]) {
+  useJUnitPlatform {}
   if (project.hasProperty('excludeTest')) {
     exclude project.getProperty('excludeTest').split(',')
   }
@@ -143,7 +145,7 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 configure([repeatDistributedTest, repeatIntegrationTest, repeatUpgradeTest, repeatUnitTest, repeatAcceptanceTest]) {
   times = Integer.parseInt(repeat)
   forkEvery 1
-  useJUnit {}
+  useJUnitPlatform {}
   outputs.upToDateWhen { false }
 
   if (project.hasProperty("failOnNoMatchingTests")) {

--- a/static-analysis/pmd-rules/build.gradle
+++ b/static-analysis/pmd-rules/build.gradle
@@ -20,6 +20,7 @@ apply from: "${rootDir}/${scriptDir}/warnings.gradle"
 
 dependencies {
     implementation(platform(project(':boms:geode-all-bom')))
+    testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
     implementation('net.sourceforge.pmd:pmd-java')
     testImplementation('net.sourceforge.pmd:pmd-test')
 }


### PR DESCRIPTION
Added JUnit 5 support to all Geode projects that use `geode-junit`.

STANDARD TEST TASKS

Updated **./gradle/test.gradle** to configure these standard test tasks
to use JUnit Platform to run tests:
- `test` and `repeatUnitTest`
- `acceptanceTest` and `repeatAcceptanceTest`
- `distributedTest` and `repeatDistributedTest`
- `integrationTest` and `repeatIntegrationTest`
- `performanceTest`
- `uiTest`
- `upgradeTest` and `repeatUpgradeTest`

STANDARD TEST MODULES

Updated **./geode-junit/build.gradle**:
- Added `junit-jupiter-api` and `junit-jupiter-params` as API
  dependencies.
- Added `junit-jupiter-engine` and `junit-vintage-engine` as
  implementation dependencies.

These changes add JUnit 5 support to any source set that depends on
`geode-junit`, either directly or via `geode-dunit`.

OTHER PROJECTS

Added `junit-vintage-engine` dependency directly to each project that
runs tests without `geode-junit` or `geode-dunit`:
- `geode-common`
- `geode-concurrency-test`
- `geode-jmh`
- `geode-modules`
- `geode-rebalancer`
- `static-analysis:pmd-rules`

These changes **do not** add JUnit 5 support to these projects.
Developers who want JUnit 5 support in these projects can declare
dependencies on `junit-jupiter-api`, `junit-jupiter-params`, and
`junit-jupiter-engine`.

SPECIFIC TESTS

Change `ConcurrencyRuleTest` to expect the exception types and exception
messages thrown by AssertJ when `opentest4j` is on the classpath.
