### PR TITLE
GEODE-9488: Make CqQuery test assign port

### DIFF
--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
@@ -199,7 +199,7 @@ public class CqQueryDUnitTest extends JUnit4CacheTestCase {
 
   /* Create Cache Server */
   public void createServer(VM server) {
-    createServer(server, 0);
+    createServer(server, AvailablePortHelper.getRandomAvailableTCPPort());
   }
 
   public void createServer(VM server, final int p) {


### PR DESCRIPTION
PROBLEM

`CqPerfDUnitTest.testFailOverMatchingCQsWithMultipleServers`:
1. Starts a server on an ephemeral port
2. Stops the server
3. Restarts the server on the same port

This test failed in CI because, between steps 2 and 3, another process
bound to the ephemeral port.

SOLUTION

Change `CqPerfDUnitTest.createServer(VM)` to assign an available port via
`AvailablePortHelper`, rather than specify an ephemeral port. The ports
assigned by `AvailablePortHelper` are outside of each OS's ephemeral
port range.

CONSIDERED

I could have changed just the one failing test to assign a port. But
because there is no good reason for tests to prefer ephemeral ports by
default, I decided to change the `createServer(VM)` to always assign a
port. This change preempts this kind of problem in other tests. If a
test has an explicit need for an ephemeral port, it can call
`createServer(VM, 0)` to get one.
