### PR TITLE
GEODE-4181: Use new includeTags property name

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -94,7 +94,7 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 configure([integrationTest, distributedTest, performanceTest]) {
   useJUnitPlatform {
     if (project.hasProperty("testCategory")) {
-      includeCategories += project.testCategory
+      includeTags += project.testCategory
     }
   }
 }


### PR DESCRIPTION
Change `./gradle/test.gradle` to use the new JUnit Platform property
name `includeTags` instead of the now-obsolete `includeCategories`.
