### PR TITLE
GEODE-9492: Ignore default port test in stress tests

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -29,6 +29,7 @@ import java.net.Socket;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.inet.LocalHostUtil;
@@ -37,6 +38,7 @@ import org.apache.geode.redis.internal.GeodeRedisService;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+import org.apache.geode.test.junit.categories.IgnoreInRepeatTestTasks;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 
 public class GeodeRedisServerStartupDUnitTest {
@@ -47,6 +49,7 @@ public class GeodeRedisServerStartupDUnitTest {
   @ClassRule
   public static GfshCommandRule gfsh = new GfshCommandRule();
 
+  @Category(IgnoreInRepeatTestTasks.class)
   @Test
   public void startupOnDefaultPort() {
     MemberVM server = cluster.startServerVM(0, s -> s

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/categories/IgnoreInRepeatTestTasks.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/categories/IgnoreInRepeatTestTasks.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.categories;
+
+/**
+ * Marks a test class or method for exclusion from repeat test tasks.
+ */
+public interface IgnoreInRepeatTestTasks {
+}

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -145,7 +145,9 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 configure([repeatDistributedTest, repeatIntegrationTest, repeatUpgradeTest, repeatUnitTest, repeatAcceptanceTest]) {
   times = Integer.parseInt(repeat)
   forkEvery 1
-  useJUnitPlatform {}
+  useJUnitPlatform {
+    excludeTags += "org.apache.geode.test.junit.categories.IgnoreInRepeatTestTasks"
+  }
   outputs.upToDateWhen { false }
 
   if (project.hasProperty("failOnNoMatchingTests")) {


### PR DESCRIPTION
PROBLEM

`GeodeRedisServerStartupDUnitTest.startupOnDefaultPort()` tests the
system's use of a fixed port. Repeat test tasks run multiple instances
of this test concurrently. Most of the concurrently running instances of
the test are likely to fail when they find that port already in use.

SOLUTION

- Add an `IgnoreInRepeatTestTasks` test category.
- Configure repeat tests to exclude tests with the
  `IgnoreInRepeatTestTasks` category.
- Add the `IgnoreInRepeatTestTasks` category to
  `GeodeRedisServerStartupDUnitTest.startupOnDefaultPort()`
