### PR TITLE
GEODE-9489: Assert exception type, not message

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -23,6 +23,7 @@ import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.BindException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 
@@ -101,7 +102,7 @@ public class GeodeRedisServerStartupDUnitTest {
           .withProperty(REDIS_PORT, "" + port)
           .withProperty(REDIS_BIND_ADDRESS, "localhost")
           .withProperty(REDIS_ENABLED, "true")))
-              .hasRootCauseMessage("Address already in use");
+              .hasRootCauseExactlyInstanceOf(BindException.class);
     }
   }
 


### PR DESCRIPTION
PROBLEM

`GeodeRedisServerStartupDUnitTest.startupFailsGivenPortAlreadyInUse()`
asserted that the root cause message of the expected exception was
exactly "Address already in use". The JDK makes no guarantee about the
exception message of a `BindException`, so this assertion is overly
strict.

SOLUTION

Change the test to assert that the thrown exception is a
`BindException`.
