### PR TITLE
GEODE-9463: Add SerializableRegionRedundancyStatusImpl to accept list…

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RestoreRedundancyManagementDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RestoreRedundancyManagementDUnitTest.java
@@ -58,7 +58,7 @@ public class RestoreRedundancyManagementDUnitTest {
   @Rule
   public ClusterStartupRule cluster = new ClusterStartupRule();
 
-  private MemberVM locator;
+  private MemberVM locator1;
   private List<MemberVM> servers;
   private static final int SERVERS_TO_START = 3;
   private static final String HIGH_REDUNDANCY_REGION_NAME = "highRedundancy";
@@ -70,24 +70,33 @@ public class RestoreRedundancyManagementDUnitTest {
   private static final String NO_CONFIGURED_REDUNDANCY_REGION_NAME = "noConfiguredRedundancy";
 
   private ClusterManagementService client1;
+  private ClusterManagementService client2;
 
   @Before
   public void setup() {
-    locator = cluster.startLocatorVM(0, MemberStarterRule::withHttpService);
+    locator1 = cluster.startLocatorVM(0, MemberStarterRule::withHttpService);
+    int locator1Port = locator1.getPort();
+    MemberVM locator2 = cluster.startLocatorVM(1,
+        l -> l.withHttpService().withConnectionToLocator(locator1Port));
     servers = new ArrayList<>();
-    int locatorPort = locator.getPort();
+    int locatorPort = locator1.getPort();
     IntStream.range(0, SERVERS_TO_START)
-        .forEach(i -> servers.add(cluster.startServerVM(i + 1, locatorPort)));
+        .forEach(i -> servers.add(cluster.startServerVM(i + 2, locatorPort)));
 
     client1 = new ClusterManagementServiceBuilder()
         .setHost("localhost")
-        .setPort(locator.getHttpPort())
+        .setPort(locator1.getHttpPort())
+        .build();
+    client2 = new ClusterManagementServiceBuilder()
+        .setHost("localhost")
+        .setPort(locator2.getHttpPort())
         .build();
   }
 
   @After
   public void tearDown() {
     client1.close();
+    client2.close();
   }
 
   @Test
@@ -98,14 +107,42 @@ public class RestoreRedundancyManagementDUnitTest {
     createAndPopulateRegions(regionNames);
 
     int numberOfServers = servers.size();
-    regionNames.forEach(region -> locator
+    regionNames.forEach(region -> locator1
         .waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + region, numberOfServers));
 
     RestoreRedundancyRequest restoreRedundancyRequest = new RestoreRedundancyRequest();
 
     restoreRedundancyRequest.setIncludeRegions(regionNames);
 
-    verifyClusterManagementOperationRequestAndResponse(restoreRedundancyRequest);
+    verifyClusterManagementOperationRequestAndResponse(restoreRedundancyRequest, client1, client1);
+
+    // Confirm all regions have their configured redundancy and that primaries were balanced
+    int numberOfActiveServers = servers.size();
+    servers.get(0).invoke(() -> {
+      for (String regionName : regionNames) {
+        assertRedundancyStatusForRegion(regionName, true);
+        assertPrimariesBalanced(regionName, numberOfActiveServers, true);
+      }
+    });
+  }
+
+  @Test
+  public void canReadRestoreRedundancyResultFromDifferentLocator()
+      throws ExecutionException, InterruptedException {
+
+    List<String> regionNames = getAllRegionNames();
+    createAndPopulateRegions(regionNames);
+
+    int numberOfServers = servers.size();
+    regionNames.forEach(region -> locator1
+        .waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + region, numberOfServers));
+
+    RestoreRedundancyRequest restoreRedundancyRequest = new RestoreRedundancyRequest();
+
+    restoreRedundancyRequest.setIncludeRegions(regionNames);
+
+    // Perform the operation on locator1 and use a client connected to locator2 to get the result
+    verifyClusterManagementOperationRequestAndResponse(restoreRedundancyRequest, client1, client2);
 
     // Confirm all regions have their configured redundancy and that primaries were balanced
     int numberOfActiveServers = servers.size();
@@ -119,15 +156,16 @@ public class RestoreRedundancyManagementDUnitTest {
 
   // Helper methods
   private void verifyClusterManagementOperationRequestAndResponse(
-      RestoreRedundancyRequest restoreRedundancyRequest)
+      RestoreRedundancyRequest restoreRedundancyRequest, ClusterManagementService startClient,
+      ClusterManagementService readResultClient)
       throws InterruptedException, ExecutionException {
     ClusterManagementOperationResult<RestoreRedundancyRequest, RestoreRedundancyResults> startResult =
-        client1.start(restoreRedundancyRequest);
+        startClient.start(restoreRedundancyRequest);
 
     assertThat(startResult.isSuccessful()).isTrue();
 
     ClusterManagementOperationResult<RestoreRedundancyRequest, RestoreRedundancyResults> endResult =
-        client1.getFuture(restoreRedundancyRequest, startResult.getOperationId()).get();
+        readResultClient.getFuture(restoreRedundancyRequest, startResult.getOperationId()).get();
     RestoreRedundancyResults restoreRedundancyResult = endResult.getOperationResult();
 
     assertThat(restoreRedundancyResult.getSuccess()).isTrue();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImpl.java
@@ -36,7 +36,9 @@ public class SerializableRegionRedundancyStatusImpl extends
   /**
    * Default constructor used for serialization
    */
-  public SerializableRegionRedundancyStatusImpl() {}
+  public SerializableRegionRedundancyStatusImpl() {
+    status = RedundancyStatus.NOT_SATISFIED;
+  }
 
   public SerializableRegionRedundancyStatusImpl(PartitionedRegion region) {
     regionName = region.getName();

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -322,6 +322,8 @@ org/apache/geode/internal/cache/control/InternalResourceManager$ResourceType,fal
 org/apache/geode/internal/cache/control/MemoryThresholds$MemoryState,false
 org/apache/geode/internal/cache/control/PartitionRebalanceDetailsImpl,true,5880667005758250156,bucketCreateBytes:long,bucketCreateTime:long,bucketCreatesCompleted:int,bucketRemoveBytes:long,bucketRemoveTime:long,bucketRemovesCompleted:int,bucketTransferBytes:long,bucketTransferTime:long,bucketTransfersCompleted:int,numOfMembers:int,partitionMemberDetailsAfter:java/util/Set,partitionMemberDetailsBefore:java/util/Set,primaryTransferTime:long,primaryTransfersCompleted:int,time:long
 org/apache/geode/internal/cache/control/RebalanceResultsImpl,false,detailSet:java/util/Set,totalBucketCreateBytes:long,totalBucketCreateTime:long,totalBucketCreatesCompleted:int,totalBucketTransferBytes:long,totalBucketTransferTime:long,totalBucketTransfersCompleted:int,totalNumOfMembers:int,totalPrimaryTransferTime:long,totalPrimaryTransfersCompleted:int,totalTime:long
+org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImpl,false
+org/apache/geode/internal/cache/control/SerializableRestoreRedundancyResultsImpl,true,-6385537590999520662
 org/apache/geode/internal/cache/execute/BucketMovedException,true,4893171227542647452
 org/apache/geode/internal/cache/execute/InternalFunctionException,true,3532698050312820319
 org/apache/geode/internal/cache/execute/InternalFunctionInvocationTargetException,true,-6063507496829271815,failedIds:java/util/Set


### PR DESCRIPTION
… (#6753)

* SerializableRegionRedundancyStatusImpl is stored in RegionOperationStateStore region as
     part of OperationState used for REST client.
   * OperationState implements Serializable, which causes it to be serialized as a java
     Serialiable and also nested SerializableRegionRedundancyStatusImpl.
   * Ideally OperationState should implement DSFID to avoid this issue, however, it has been
     released already. So we will add SerializableRegionRedundancyStatusImpl to the accept list
     to avoid this serialization issue when validate-serializable-objects is set to true.

   Co-authored-by: Dan Smith <dasmith@vmware.com>

(cherry picked from commit 7f98970afafcec6b71460344e0fd6066d7a76a92)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
