### PR TITLE
GEODE-9500: clear DeltaInfo earlier

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -31,7 +31,6 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.InvalidDeltaException;
-import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.internal.cache.BucketRegion;
@@ -180,11 +179,7 @@ public abstract class AbstractRedisData implements RedisData {
 
   @Override
   public void toDelta(DataOutput out) throws IOException {
-    try {
-      deltaInfo.serializeTo(out);
-    } finally {
-      deltaInfo = null;
-    }
+    deltaInfo.serializeTo(out);
   }
 
   @Override
@@ -206,11 +201,6 @@ public abstract class AbstractRedisData implements RedisData {
         applyDelta(new AppendDeltaInfo(byteArray, sequence));
         break;
     }
-  }
-
-  @VisibleForTesting
-  protected void clearDelta() {
-    this.deltaInfo = null;
   }
 
   @Override
@@ -248,7 +238,11 @@ public abstract class AbstractRedisData implements RedisData {
         region.remove(key);
       } else {
         setDelta(deltaInfo);
-        region.put(key, this);
+        try {
+          region.put(key, this);
+        } finally {
+          setDelta(null);
+        }
       }
     }
   }


### PR DESCRIPTION
DeltaInfo is now cleared right after region.put is called and in the same method that set it.
The size tests no longer clear it.
The unit tests for delta needed to change because the deltaInfo is now cleared earlier. Using a mockito Answer allowed for the delta implementation to be validated.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
