### PR TITLE
Revert GEODE-4181: Add JUnit 5 Support

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -583,26 +583,6 @@
         <version>2.2</version>
       </dependency>
       <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-api</artifactId>
-        <version>5.7.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-params</artifactId>
-        <version>5.7.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter-engine</artifactId>
-        <version>5.7.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.junit.vintage</groupId>
-        <artifactId>junit-vintage-engine</artifactId>
-        <version>5.7.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-api</artifactId>
         <version>3.141.59</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -65,7 +65,6 @@ class DependencyConstraints implements Plugin<Project> {
 
     // These versions are referenced in test.gradle, which is aggressively injected into all projects.
     deps.put("junit.version", "4.13.2")
-    deps.put("junit-jupiter.version", "5.7.2")
     deps.put("cglib.version", "3.3.0")
     return deps
   }
@@ -220,16 +219,6 @@ class DependencyConstraints implements Plugin<Project> {
 
     dependencySet(group: 'org.hamcrest', version: '2.2') {
       entry('hamcrest')
-    }
-
-    dependencySet(group: 'org.junit.jupiter', version: get('junit-jupiter.version')) {
-      entry('junit-jupiter-api')
-      entry('junit-jupiter-params')
-      entry('junit-jupiter-engine')
-    }
-
-    dependencySet(group: 'org.junit.vintage', version: get('junit-jupiter.version')) {
-      entry('junit-vintage-engine')
     }
 
     dependencySet(group: 'org.seleniumhq.selenium', version: '3.141.59') {

--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -41,7 +41,6 @@ dependencies {
   // test
   testImplementation('org.apache.bcel:bcel')
   testImplementation('junit:junit')
-  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
   testImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))

--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -28,13 +28,11 @@ dependencies {
 
   // test
   testImplementation('junit:junit')
-  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 
 
   // jmhTest
   jmhTestImplementation('junit:junit')
-  jmhTestRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   jmhTestImplementation('org.assertj:assertj-core')
 }

--- a/geode-concurrency-test/build.gradle
+++ b/geode-concurrency-test/build.gradle
@@ -25,7 +25,6 @@ dependencies {
   implementation('junit:junit')
   implementation('org.apache.logging.log4j:log4j-api')
   integrationTestImplementation('org.assertj:assertj-core')
-  integrationTestRuntimeOnly('org.junit.vintage:junit-vintage-engine')
 }
 
 integrationTest {

--- a/geode-jmh/build.gradle
+++ b/geode-jmh/build.gradle
@@ -27,7 +27,6 @@ dependencies {
   api('org.openjdk.jmh:jmh-core')
 
   testImplementation('junit:junit')
-  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 }

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -38,8 +38,6 @@ dependencies {
   api('junit:junit') {
     exclude module: 'hamcrest'
   }
-  api('org.junit.jupiter:junit-jupiter-api')
-  api('org.junit.jupiter:junit-jupiter-params')
   api('org.assertj:assertj-core')
   api('org.mockito:mockito-core')
 
@@ -61,9 +59,6 @@ dependencies {
   api('io.micrometer:micrometer-core')
   
   api('org.skyscreamer:jsonassert')
-
-  implementation('org.junit.jupiter:junit-jupiter-engine')
-  implementation('org.junit.vintage:junit-vintage-engine')
 
   testImplementation('pl.pragmatists:JUnitParams')
 

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
@@ -33,11 +33,11 @@ import java.util.function.Consumer;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
+import org.junit.ComparisonFailure;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.MultipleFailureException;
-import org.opentest4j.AssertionFailedError;
 
 @RunWith(JUnitParamsRunner.class)
 public class ConcurrencyRuleTest {
@@ -398,7 +398,7 @@ public class ConcurrencyRuleTest {
         .repeatForDuration(Duration.ofSeconds(2));
 
     assertThatThrownBy(() -> execution.execute(concurrencyRule))
-        .isInstanceOf(AssertionFailedError.class);
+        .isInstanceOf(ComparisonFailure.class);
     assertThat(invoked.get()).isTrue();
   }
 
@@ -518,8 +518,8 @@ public class ConcurrencyRuleTest {
     assertThat(errors.get(0)).isInstanceOf(AssertionError.class)
         .hasMessageContaining(IOException.class.getName());
     assertThat(errors.get(1)).isInstanceOf(AssertionError.class)
-        .hasMessageContaining("successful value")
-        .hasMessageContaining("wrong value");
+        .hasMessageContaining("[successful] value")
+        .hasMessageContaining("[wrong] value");
     assertThat(errors.get(2)).hasMessageContaining("foo")
         .isInstanceOf(IOException.class);
   }

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -58,16 +58,6 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-api</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-params</artifactId>
-      <scope>compile</scope>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
@@ -148,14 +138,5 @@
       <artifactId>jsonassert</artifactId>
       <scope>compile</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.vintage</groupId>
-      <artifactId>junit-vintage-engine</artifactId>
-      <scope>runtime</scope>
-    </dependency>  </dependencies>
+  </dependencies>
 </project>

--- a/geode-rebalancer/build.gradle
+++ b/geode-rebalancer/build.gradle
@@ -38,7 +38,6 @@ dependencies {
   }
 
   testImplementation('junit:junit')
-  testImplementation('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -93,7 +93,7 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 configure([integrationTest, distributedTest, performanceTest]) {
   useJUnit {
     if (project.hasProperty("testCategory")) {
-      includeTags += project.testCategory
+      includeCategories += project.testCategory
     }
   }
 }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -31,7 +31,6 @@ compileTestJava {
 }
 
 test {
-  useJUnitPlatform {}
   doFirst {
     TestPropertiesWriter.writeTestProperties(buildDir, name)
   }
@@ -92,7 +91,7 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 }
 
 configure([integrationTest, distributedTest, performanceTest]) {
-  useJUnitPlatform {
+  useJUnit {
     if (project.hasProperty("testCategory")) {
       includeTags += project.testCategory
     }
@@ -136,7 +135,6 @@ task repeatUnitTest(type: RepeatTest) {
 }
 
 configure([integrationTest, distributedTest, performanceTest, acceptanceTest, uiTest, upgradeTest]) {
-  useJUnitPlatform {}
   if (project.hasProperty('excludeTest')) {
     exclude project.getProperty('excludeTest').split(',')
   }
@@ -145,9 +143,7 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 configure([repeatDistributedTest, repeatIntegrationTest, repeatUpgradeTest, repeatUnitTest, repeatAcceptanceTest]) {
   times = Integer.parseInt(repeat)
   forkEvery 1
-  useJUnitPlatform {
-    excludeTags += "org.apache.geode.test.junit.categories.IgnoreInRepeatTestTasks"
-  }
+  useJUnit {}
   outputs.upToDateWhen { false }
 
   if (project.hasProperty("failOnNoMatchingTests")) {

--- a/static-analysis/pmd-rules/build.gradle
+++ b/static-analysis/pmd-rules/build.gradle
@@ -20,7 +20,6 @@ apply from: "${rootDir}/${scriptDir}/warnings.gradle"
 
 dependencies {
     implementation(platform(project(':boms:geode-all-bom')))
-    testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
     implementation('net.sourceforge.pmd:pmd-java')
     testImplementation('net.sourceforge.pmd:pmd-test')
 }


### PR DESCRIPTION
due to large number of Windows CI failures starting after #6740 + #6742 were merged, I want to see if reverting this change makes a difference.  If so, we should go through with this revert and try again to make Junit5 work in a new PR with Windows label.