### PR TITLE
GEODE-9514: optimize how Coder reads and writes "int" and "long" values

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -103,13 +103,9 @@ public class Coder {
       toWrite = stringToBytes(value);
       writeStringResponse(buffer, toWrite);
     } else if (v instanceof Integer) {
-      buffer.writeByte(INTEGER_ID);
-      appendAsciiDigitsToByteBuf((Integer) v, buffer);
-      buffer.writeBytes(bCRLF);
+      getIntegerResponse(buffer, (int) v);
     } else if (v instanceof Long) {
-      buffer.writeByte(INTEGER_ID);
-      appendAsciiDigitsToByteBuf((Long) v, buffer);
-      buffer.writeBytes(bCRLF);
+      getIntegerResponse(buffer, (long) v);
     } else {
       throw new CoderException();
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -153,14 +153,10 @@ public class Coder {
     }
   }
 
-  @Immutable
-  private static final byte[] TWO_ASCII = intToBytes(2);
-
   public static ByteBuf getScanResponse(ByteBuf buffer, BigInteger cursor,
       List<?> scanResult) {
     buffer.writeByte(ARRAY_ID);
-    appendAsciiDigitsToByteBuf(2, buffer);
-    buffer.writeBytes(TWO_ASCII);
+    buffer.writeByte('2');
     buffer.writeBytes(bCRLF);
     byte[] cursorBytes = stringToBytes(cursor.toString());
     writeStringResponse(buffer, cursorBytes);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -181,35 +181,35 @@ public class CoderTest {
   }
 
   @Test
-  public void verify_convertLongToAsciiDigits_withByteBuf() {
+  public void verify_appendAsciiDigitsToByteBuf() {
     for (long i = Long.MAX_VALUE; i > Long.MAX_VALUE - 1000; i--) {
-      verify_convertLongToAsciiDigits(i);
+      verify_appendAsciiDigitsToByteBuf(i);
     }
     for (long i = Long.MIN_VALUE; i < Long.MIN_VALUE + 1000; i++) {
-      verify_convertLongToAsciiDigits(i);
+      verify_appendAsciiDigitsToByteBuf(i);
     }
     for (long i = Integer.MAX_VALUE + 1000; i > Integer.MAX_VALUE - 1000; i--) {
-      verify_convertLongToAsciiDigits(i);
+      verify_appendAsciiDigitsToByteBuf(i);
     }
     for (long i = Integer.MIN_VALUE + 1000; i > Integer.MIN_VALUE - 1000; i--) {
-      verify_convertLongToAsciiDigits(i);
+      verify_appendAsciiDigitsToByteBuf(i);
     }
     for (long i = Short.MAX_VALUE + 1000; i > Short.MAX_VALUE - 1000; i--) {
-      verify_convertLongToAsciiDigits(i);
+      verify_appendAsciiDigitsToByteBuf(i);
     }
     for (long i = Short.MIN_VALUE + 1000; i > Short.MIN_VALUE - 1000; i--) {
-      verify_convertLongToAsciiDigits(i);
+      verify_appendAsciiDigitsToByteBuf(i);
     }
     for (long i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
-      verify_convertLongToAsciiDigits(i);
+      verify_appendAsciiDigitsToByteBuf(i);
     }
   }
 
-  private void verify_convertLongToAsciiDigits(long value) {
+  private void verify_appendAsciiDigitsToByteBuf(long value) {
     String expected = Long.toString(value);
     ByteBuf buf = ByteBufAllocator.DEFAULT.heapBuffer();
 
-    Coder.convertLongToAsciiDigits(value, buf);
+    Coder.appendAsciiDigitsToByteBuf(value, buf);
 
     assertThat(buf.toString(StandardCharsets.UTF_8)).isEqualTo(expected);
   }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -181,36 +181,68 @@ public class CoderTest {
   }
 
   @Test
-  public void verify_appendAsciiDigitsToByteBuf_conversions() {
+  public void verify_convertLongToAsciiDigits_withByteBuf() {
     for (long i = Long.MAX_VALUE; i > Long.MAX_VALUE - 1000; i--) {
-      verify_appendAsciiDigitsToByteBuf(i);
+      verify_convertLongToAsciiDigits(i);
     }
     for (long i = Long.MIN_VALUE; i < Long.MIN_VALUE + 1000; i++) {
-      verify_appendAsciiDigitsToByteBuf(i);
+      verify_convertLongToAsciiDigits(i);
     }
     for (long i = Integer.MAX_VALUE + 1000; i > Integer.MAX_VALUE - 1000; i--) {
-      verify_appendAsciiDigitsToByteBuf(i);
+      verify_convertLongToAsciiDigits(i);
     }
     for (long i = Integer.MIN_VALUE + 1000; i > Integer.MIN_VALUE - 1000; i--) {
-      verify_appendAsciiDigitsToByteBuf(i);
+      verify_convertLongToAsciiDigits(i);
     }
     for (long i = Short.MAX_VALUE + 1000; i > Short.MAX_VALUE - 1000; i--) {
-      verify_appendAsciiDigitsToByteBuf(i);
+      verify_convertLongToAsciiDigits(i);
     }
     for (long i = Short.MIN_VALUE + 1000; i > Short.MIN_VALUE - 1000; i--) {
-      verify_appendAsciiDigitsToByteBuf(i);
+      verify_convertLongToAsciiDigits(i);
     }
     for (long i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
-      verify_appendAsciiDigitsToByteBuf(i);
+      verify_convertLongToAsciiDigits(i);
     }
   }
 
-  private void verify_appendAsciiDigitsToByteBuf(long value) {
+  private void verify_convertLongToAsciiDigits(long value) {
     String expected = Long.toString(value);
     ByteBuf buf = ByteBufAllocator.DEFAULT.heapBuffer();
 
-    Coder.appendAsciiDigitsToByteBuf(value, buf);
+    Coder.convertLongToAsciiDigits(value, buf);
 
     assertThat(buf.toString(StandardCharsets.UTF_8)).isEqualTo(expected);
   }
+
+  @Test
+  public void verify_longToBytes_bytesToLong_consistency() {
+    for (long i = Long.MAX_VALUE; i > Long.MAX_VALUE - 1000; i--) {
+      verify_longToBytes_bytesToLong_consistency(i);
+    }
+    for (long i = Long.MIN_VALUE; i < Long.MIN_VALUE + 1000; i++) {
+      verify_longToBytes_bytesToLong_consistency(i);
+    }
+    for (long i = Integer.MAX_VALUE + 1000; i > Integer.MAX_VALUE - 1000; i--) {
+      verify_longToBytes_bytesToLong_consistency(i);
+    }
+    for (long i = Integer.MIN_VALUE + 1000; i > Integer.MIN_VALUE - 1000; i--) {
+      verify_longToBytes_bytesToLong_consistency(i);
+    }
+    for (long i = Short.MAX_VALUE + 1000; i > Short.MAX_VALUE - 1000; i--) {
+      verify_longToBytes_bytesToLong_consistency(i);
+    }
+    for (long i = Short.MIN_VALUE + 1000; i > Short.MIN_VALUE - 1000; i--) {
+      verify_longToBytes_bytesToLong_consistency(i);
+    }
+    for (long i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
+      verify_longToBytes_bytesToLong_consistency(i);
+    }
+  }
+
+  private void verify_longToBytes_bytesToLong_consistency(long l) {
+    byte[] lBytes = Coder.longToBytes(l);
+    long l2 = Coder.bytesToLong(lBytes);
+    assertThat(l2).isEqualTo(l);
+  }
+
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -28,6 +28,10 @@ import static org.apache.geode.redis.internal.netty.Coder.stripTrailingZeroFromD
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.Charset;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
@@ -176,4 +180,25 @@ public class CoderTest {
     };
   }
 
+  @Test
+  public void verify_appendAsciiDigitsToByteBuf_conversions() {
+    verify_appendAsciiDigitsToByteBuf(Long.MAX_VALUE);
+    verify_appendAsciiDigitsToByteBuf(Long.MIN_VALUE);
+    verify_appendAsciiDigitsToByteBuf(Integer.MAX_VALUE);
+    verify_appendAsciiDigitsToByteBuf(Integer.MIN_VALUE);
+    verify_appendAsciiDigitsToByteBuf(Short.MAX_VALUE);
+    verify_appendAsciiDigitsToByteBuf(Short.MIN_VALUE);
+    for (long i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
+      verify_appendAsciiDigitsToByteBuf(i);
+    }
+  }
+
+  private void verify_appendAsciiDigitsToByteBuf(long value) {
+    String expected = Long.toString(value);
+    ByteBuf buf = ByteBufAllocator.DEFAULT.heapBuffer();
+
+    Coder.appendAsciiDigitsToByteBuf(value, buf);
+
+    assertThat(buf.toString(Charset.defaultCharset())).isEqualTo(expected);
+  }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -28,7 +28,7 @@ import static org.apache.geode.redis.internal.netty.Coder.stripTrailingZeroFromD
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -182,12 +182,24 @@ public class CoderTest {
 
   @Test
   public void verify_appendAsciiDigitsToByteBuf_conversions() {
-    verify_appendAsciiDigitsToByteBuf(Long.MAX_VALUE);
-    verify_appendAsciiDigitsToByteBuf(Long.MIN_VALUE);
-    verify_appendAsciiDigitsToByteBuf(Integer.MAX_VALUE);
-    verify_appendAsciiDigitsToByteBuf(Integer.MIN_VALUE);
-    verify_appendAsciiDigitsToByteBuf(Short.MAX_VALUE);
-    verify_appendAsciiDigitsToByteBuf(Short.MIN_VALUE);
+    for (long i = Long.MAX_VALUE; i > Long.MAX_VALUE - 1000; i--) {
+      verify_appendAsciiDigitsToByteBuf(i);
+    }
+    for (long i = Long.MIN_VALUE; i < Long.MIN_VALUE + 1000; i++) {
+      verify_appendAsciiDigitsToByteBuf(i);
+    }
+    for (long i = Integer.MAX_VALUE + 1000; i > Integer.MAX_VALUE - 1000; i--) {
+      verify_appendAsciiDigitsToByteBuf(i);
+    }
+    for (long i = Integer.MIN_VALUE + 1000; i > Integer.MIN_VALUE - 1000; i--) {
+      verify_appendAsciiDigitsToByteBuf(i);
+    }
+    for (long i = Short.MAX_VALUE + 1000; i > Short.MAX_VALUE - 1000; i--) {
+      verify_appendAsciiDigitsToByteBuf(i);
+    }
+    for (long i = Short.MIN_VALUE + 1000; i > Short.MIN_VALUE - 1000; i--) {
+      verify_appendAsciiDigitsToByteBuf(i);
+    }
     for (long i = Byte.MIN_VALUE; i <= Byte.MAX_VALUE; i++) {
       verify_appendAsciiDigitsToByteBuf(i);
     }
@@ -199,6 +211,6 @@ public class CoderTest {
 
     Coder.appendAsciiDigitsToByteBuf(value, buf);
 
-    assertThat(buf.toString(Charset.defaultCharset())).isEqualTo(expected);
+    assertThat(buf.toString(StandardCharsets.UTF_8)).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
Added convertLongToAsciiDigits to Coder so that ints and longs can more efficiently be converted to bytes. The goal was to reduce
the number of short lived object allocations based on this observation:
  Refactor the getIntegerResponse(ByteBuf buffer, long l) method to write byte string representation to avoid allocating transient char[], String, and byte[]. The existing allocations accounted for 17% of objects requiring GC.

So now when converting an int or long we never convert it to a String and for some values (-99..99) we don't allocate a new byte array. The same is also true when converting a sequence of bytes from command input into a long; we no longer allocate a short lived String.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
