### PR TITLE
GEODE-9523: Fix invalid path in ContainerInstall

### DIFF
--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ContainerInstall.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ContainerInstall.java
@@ -23,7 +23,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Properties;
 import java.util.function.IntSupplier;
@@ -144,8 +143,7 @@ public abstract class ContainerInstall {
 
     clearPreviousInstall(installDir);
 
-    String resource = getResource(getClass(), "/" + downloadURL).getPath();
-    URL url = Paths.get(resource).toUri().toURL();
+    URL url = getResource(getClass(), "/" + downloadURL);
     logger.info("Installing container from URL " + url);
 
     // Optional step to install the container from a URL pointing to its distribution


### PR DESCRIPTION
PROBLEM

`ContainerInstall` fetches a resource URL, then applies a chain of
conversions before passing the resulting URL to the `ZipURLInstaller`
constructor.  One of the conversions attempts to create a `Path` from a
string.  On Windows, the string value is not a valid path, and
`Paths.get(...)` throws an exception.

SOLUTION

Change `ContainerInstall` to remove all of the conversions. The original
resource URL is acceptable to `ZipURLInstaller` without any conversion.
