### PR TITLE
GEODE-9525: Add Radish benchmarks to CI

### DIFF
--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -497,8 +497,8 @@ jobs:
           AWS_REGION: us-west-2
           ARTIFACT_BUCKET: ((artifact-bucket))
           BENCHMARKS_BRANCH: {{benchmarks.benchmark_branch}}
-          BASELINE_BRANCH: {{benchmarks.baseline_branch}}
-          BASELINE_VERSION: {{benchmarks.baseline_version}}
+          BASELINE_BRANCH: {{var_run.baseline_branch if var_run.baseline_branch is defined else benchmarks.baseline_branch_default}}
+          BASELINE_VERSION: {{var_run.baseline_version if var_run.baseline_version is defined else benchmarks.baseline_version_default}}
           FLAGS: {{ run_var.flag }}
           TAG_POSTFIX: -{{ run_var.title }}
           TEST_OPTIONS: {{ run_var.options }}
@@ -525,8 +525,8 @@ jobs:
               AWS_DEFAULT_REGION: us-west-2
               AWS_REGION: us-west-2
               ARTIFACT_BUCKET: ((artifact-bucket))
-              BASELINE_BRANCH: {{benchmarks.baseline_branch}}
-              BASELINE_VERSION: {{benchmarks.baseline_version}}
+              BASELINE_BRANCH: {{var_run.baseline_branch if var_run.baseline_branch is defined else benchmarks.baseline_branch_default}}
+              BASELINE_VERSION: {{var_run.baseline_version if var_run.baseline_version is defined else benchmarks.baseline_version_default}}
               FLAGS: {{ run_var.flag }}
               TAG_POSTFIX: -{{ run_var.title }}
               TEST_OPTIONS: {{ run_var.options }}

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -16,8 +16,8 @@
 #
 
 benchmarks:
-  baseline_branch: ''
-  baseline_version: '1.13.4'
+  baseline_branch_default: ''
+  baseline_version_default: '1.13.4'
   benchmark_branch: ((geode-build-branch))
   flavors:
   - title: 'base'
@@ -35,6 +35,15 @@ benchmarks:
     options: '--tests=org.apache.geode.benchmark.tests.Partitioned*'
     max_in_flight: 3
     timeout: 12h
+  - title: 'radish'
+    baseline_branch: ''
+    # The current radish baseline version is taken from the commit:
+    #   GEODE-9169: remove netty context switch (#6725)
+    baseline_version: 'ed38145379d3da05ecc79a39fa145030bbd4fb1e'
+    flag: '-PtestJVM=/usr/lib/jvm/bellsoft-java11-amd64 -Pbenchmark.withRedisCluster=geode -Pbenchmark.withServerCount=2'
+    options: '--tests=org.apache.geode.benchmark.redis.tests.*'
+    max_in_flight: 5
+    timeout: 4h
 
 build_test:
   ARTIFACT_SLUG: build

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -406,7 +406,7 @@ fi
 rm settings.gradle.bak
 if [ -z "$LATER" ] ; then
   #also update benchmark baseline for develop to this new minor
-  sed -e "s/^  baseline_version:.*/  baseline_version: '${VERSION}'/" \
+  sed -e "s/^  baseline_version_default:.*/  baseline_version_default: '${VERSION}'/" \
     -i.bak ci/pipelines/shared/jinja.variables.yml
   rm ci/pipelines/shared/jinja.variables.yml.bak
   BENCHMSG=" and set as Benchmarks baseline"


### PR DESCRIPTION
- Runs Radish benchmarks on the same topology as the Geode benchmarks (2
  x servers, 1 x locator, 1 x client). Current systems are large 72 vCPU
  instances.
- Baseline is taken from when most of the major performance updates have
  been implemented.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
