### PR TITLE
Create ThreadLocal instance, use to manage DeltaInfos

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -180,7 +180,6 @@ public abstract class AbstractRedisData implements RedisData {
   @Override
   public void toDelta(DataOutput out) throws IOException {
     deltaInfo.get().serializeTo(out);
-    deltaInfo.remove();
   }
 
   @Override


### PR DESCRIPTION
Using a static ThreadLocal in the RedisData class, we can avoid carrying around an object reference for all instances of RedisData. This saves 4-8 bytes of memory per instance.