### PR TITLE
GEODE-9526: Fix path computation in DiskStore test

### DIFF
--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -16,7 +16,6 @@
 package org.apache.geode.management.internal.cli.commands;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
-import static org.apache.geode.internal.lang.SystemUtils.CURRENT_DIRECTORY;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -583,8 +582,7 @@ public class DiskStoreCommandsDUnitTest implements Serializable {
     File[] diskDirs = diskStore.getDiskDirs();
     assertThat(diskDirs.length).isEqualTo(1);
     File diskDir = diskDirs[0];
-    String absoluteDiskDirectoryName = diskDirectoryName.startsWith(File.separator)
-        ? diskDirectoryName : CURRENT_DIRECTORY + File.separator + diskDirectoryName;
+    String absoluteDiskDirectoryName = Paths.get(diskDirectoryName).toAbsolutePath().toString();
     assertThat(diskDir.getAbsolutePath()).isEqualTo(absoluteDiskDirectoryName);
   }
 


### PR DESCRIPTION
PROBLEM

`DiskStoreCommandsDUnitTest.verifyDiskStoreInServer(...)` incorrectly
assumes thatif a file path does not start with a file separator, it must
be relative. It attempts to convert such a path to absolute by
prepending the current directory onto it:

```
String absoluteDiskDirectoryName = diskDirectoryName.startsWith(File.separator)
        ? diskDirectoryName
        : CURRENT_DIRECTORY + File.separator + diskDirectoryName;
```

On Windows, an absolute file path can begin with a letter, e.g.
`C:\Users\geode\AppData\Local\Temp\junit783716437098694709\DISKSTORE`.
The test incorrectly interprets a path like this as relative, and
prepends the current directory onto it, producing an invalid path. It
then uses this incorrect path in an assertion, causing the test to fail
when it should pass.

SOLUTION

Use Java's `Path` implementation for the OS to compute the absolute form of the given file path.
