### PR TITLE
GEODE-9446: Remove unecessary byte arrays from RedisSortedSet

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/resources/0001-configure-redis-tests.patch
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/resources/0001-configure-redis-tests.patch
@@ -1423,7 +1423,7 @@ index 7122fd987..12c323fc2 100644
      }
  
 diff --git a/tests/unit/type/zset.tcl b/tests/unit/type/zset.tcl
-index a8c817f6e..a87e57797 100644
+index a8c817f6e..d0809b581 100644
 --- a/tests/unit/type/zset.tcl
 +++ b/tests/unit/type/zset.tcl
 @@ -7,22 +7,22 @@ start_server {tags {"zset"}} {
@@ -1465,6 +1465,15 @@ index a8c817f6e..a87e57797 100644
  
          test "ZSET basic ZADD and score update - $encoding" {
              r del ztmp
+@@ -40,7 +40,7 @@ start_server {tags {"zset"}} {
+         }
+ 
+         test "ZSET element can't be set to NaN with ZINCRBY" {
+-            assert_error "*not*float*" {r zadd myzset nan abc}
++            assert_error "*not*float*" {r zincrby myzset nan abc}
+         }
+ 
+         test "ZADD with options syntax error with incomplete pair" {
 @@ -257,10 +257,10 @@ start_server {tags {"zset"}} {
              assert_equal 1 [r zrank zranktmp y]
              assert_equal 2 [r zrank zranktmp z]
@@ -2264,16 +2273,21 @@ index a8c817f6e..a87e57797 100644
  
          test "ZSCORE - $encoding" {
              r del zscoretest
-@@ -809,7 +809,7 @@ start_server {tags {"zset"}} {
+@@ -809,9 +809,11 @@ start_server {tags {"zset"}} {
                  r zadd zscoretest $score $i
              }
  
 -            assert_encoding $encoding zscoretest
 +            # assert_encoding $encoding zscoretest
              for {set i 0} {$i < $elements} {incr i} {
-                 assert_equal [lindex $aux $i] [r zscore zscoretest $i]
+-                assert_equal [lindex $aux $i] [r zscore zscoretest $i]
++                set expected [lindex $aux $i]
++                set actual [r zscore zscoretest $i]
++                assert {abs($expected - $actual) < 0.0000000000000001}
              }
-@@ -824,8 +824,8 @@ start_server {tags {"zset"}} {
+         }
+ 
+@@ -824,10 +826,12 @@ start_server {tags {"zset"}} {
                  r zadd zscoretest $score $i
              }
  
@@ -2282,9 +2296,14 @@ index a8c817f6e..a87e57797 100644
 +            # r debug reload
 +            # assert_encoding $encoding zscoretest
              for {set i 0} {$i < $elements} {incr i} {
-                 assert_equal [lindex $aux $i] [r zscore zscoretest $i]
+-                assert_equal [lindex $aux $i] [r zscore zscoretest $i]
++                 set expected [lindex $aux $i]
++                 set actual [r zscore zscoretest $i]
++                 assert {abs($expected - $actual) < 0.0000000000000001}
              }
-@@ -867,7 +867,7 @@ start_server {tags {"zset"}} {
+         }
+ 
+@@ -867,7 +871,7 @@ start_server {tags {"zset"}} {
                      lappend auxlist [lindex $x 1]
                  }
  
@@ -2293,7 +2312,7 @@ index a8c817f6e..a87e57797 100644
                  set fromredis [r zrange myzset 0 -1]
                  set delta 0
                  for {set i 0} {$i < [llength $fromredis]} {incr i} {
-@@ -886,7 +886,7 @@ start_server {tags {"zset"}} {
+@@ -886,7 +890,7 @@ start_server {tags {"zset"}} {
                  r zadd zset [expr rand()] $i
              }
  
@@ -2302,7 +2321,7 @@ index a8c817f6e..a87e57797 100644
              for {set i 0} {$i < 100} {incr i} {
                  set min [expr rand()]
                  set max [expr rand()]
-@@ -961,128 +961,128 @@ start_server {tags {"zset"}} {
+@@ -961,128 +965,128 @@ start_server {tags {"zset"}} {
              assert_equal {} $err
          }
  
@@ -2553,7 +2572,7 @@ index a8c817f6e..a87e57797 100644
  
          test "ZSETs ZRANK augmented skip list stress testing - $encoding" {
              set err {}
-@@ -1094,7 +1094,7 @@ start_server {tags {"zset"}} {
+@@ -1094,7 +1098,7 @@ start_server {tags {"zset"}} {
                  } else {
                      set score [expr rand()]
                      r zadd myzset $score $i
@@ -2562,7 +2581,7 @@ index a8c817f6e..a87e57797 100644
                  }
  
                  set card [r zcard myzset]
-@@ -1111,100 +1111,100 @@ start_server {tags {"zset"}} {
+@@ -1111,100 +1115,100 @@ start_server {tags {"zset"}} {
              assert_equal {} $err
          }
  
@@ -2750,7 +2769,7 @@ index a8c817f6e..a87e57797 100644
          for {set times 0} {$times < 10} {incr times} {
              r del zset
              for {set j 0} {$j < 1000} {incr j} {
-@@ -1225,6 +1225,6 @@ start_server {tags {"zset"}} {
+@@ -1225,6 +1229,6 @@ start_server {tags {"zset"}} {
                  set prev_score $score
              }
          }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
@@ -58,7 +58,7 @@ public class MemoryOverheadIntegrationTest extends AbstractMemoryOverheadIntegra
     result.put(Measurement.SET_ENTRY, 25);
     result.put(Measurement.HASH, 312);
     result.put(Measurement.HASH_ENTRY, 50);
-    result.put(Measurement.SORTED_SET, 398);
+    result.put(Measurement.SORTED_SET, 383);
     result.put(Measurement.SORTED_SET_ENTRY, 94);
 
     return result;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/MemoryOverheadIntegrationTest.java
@@ -58,8 +58,8 @@ public class MemoryOverheadIntegrationTest extends AbstractMemoryOverheadIntegra
     result.put(Measurement.SET_ENTRY, 25);
     result.put(Measurement.HASH, 312);
     result.put(Measurement.HASH_ENTRY, 50);
-    result.put(Measurement.SORTED_SET, 414);
-    result.put(Measurement.SORTED_SET_ENTRY, 126);
+    result.put(Measurement.SORTED_SET, 398);
+    result.put(Measurement.SORTED_SET_ENTRY, 94);
 
     return result;
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZAddIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZAddIntegrationTest.java
@@ -126,6 +126,15 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "xlerb", member))
             .hasMessageContaining(ERROR_NOT_A_VALID_FLOAT);
+    assertThatThrownBy(
+        () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "nan", member))
+            .hasMessageContaining(ERROR_NOT_A_VALID_FLOAT);
+  }
+
+  @Test
+  public void shouldError_givenNaN() {
+    assertThatThrownBy(() -> jedis.zadd(SORTED_SET_KEY, Double.NaN, "member"))
+        .hasMessageContaining(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZIncrByIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZIncrByIntegrationTest.java
@@ -90,6 +90,23 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
             .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
   }
 
+  @Test
+  public void shouldError_ifResultWouldBeNaN() {
+    String increment = "-inf";
+    jedis.zadd(STRING_KEY, 10.0, STRING_MEMBER);
+    jedis.zincrby(STRING_KEY, POSITIVE_INFINITY, STRING_MEMBER);
+
+    assertThatThrownBy(() -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY,
+        increment, STRING_MEMBER))
+            .hasMessageContaining(RedisConstants.ERROR_OPERATION_PRODUCED_NAN);
+  }
+
+  @Test
+  public void shouldError_whenSettingNewScoreToNaN() {
+    assertThatThrownBy(() -> jedis.zincrby(STRING_KEY, Double.NaN, STRING_MEMBER))
+        .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
+  }
+
   /************* infinity *************/
   @Test
   public void shouldSetScoreToInfinity_ifIncrementWouldExceedMaxValue() {

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZScoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZScoreIntegrationTest.java
@@ -27,6 +27,7 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.redis.internal.netty.Coder;
 
 public abstract class AbstractZScoreIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
@@ -62,5 +63,35 @@ public abstract class AbstractZScoreIntegrationTest implements RedisIntegrationT
   public void shouldReturnScore_givenExistingKeyAndMember() {
     jedis.zadd("key", 1.0, "member");
     assertThat(jedis.zscore("key", "member")).isEqualTo(1.0);
+  }
+
+  @Test
+  public void shouldReturnScoreWithSamePrecision() {
+    String key = "key";
+    String member = "member";
+    double score = 0.6792199922163132d;
+    byte[] byteScore = "0.6792199922163132".getBytes();
+
+    jedis.zadd(key, score, member);
+
+    double retScore = jedis.zscore(key, member);
+    assertThat(retScore).isEqualTo(score);
+
+    assertThat(Coder.doubleToBytes(retScore)).isEqualTo(byteScore);
+  }
+
+  @Test
+  public void shouldReturnScoreWithCloseToSamePrecision_givenTooPreciseAScore() {
+    String key = "key";
+    String member = "member";
+    double score = 0.6792199922163132456d;
+    byte[] byteScore = "0.6792199922163132".getBytes();
+
+    jedis.zadd(key, score, member);
+
+    double retScore = jedis.zscore(key, member);
+    assertThat(retScore).isEqualTo(score);
+
+    assertThat(Coder.doubleToBytes(retScore)).isEqualTo(byteScore);
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -24,7 +24,7 @@ fromData,51
 
 org/apache/geode/redis/internal/data/RedisSortedSet,2
 toData,15
-fromData,89
+fromData,86
 
 org/apache/geode/redis/internal/data/RedisString,2
 toData,23
@@ -41,4 +41,3 @@ toData,27
 org/apache/geode/redis/internal/executor/string/SetOptions,2
 fromData,27
 toData,27
-

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -24,7 +24,7 @@ fromData,51
 
 org/apache/geode/redis/internal/data/RedisSortedSet,2
 toData,15
-fromData,86
+fromData,89
 
 org/apache/geode/redis/internal/data/RedisString,2
 toData,23

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -47,7 +47,7 @@ import org.apache.geode.redis.internal.delta.DeltaInfo;
 import org.apache.geode.redis.internal.delta.DeltaType;
 import org.apache.geode.redis.internal.delta.RemsDeltaInfo;
 import org.apache.geode.redis.internal.delta.TimestampDeltaInfo;
-import org.apache.geode.redis.internal.delta.ZaddsDeltaInfo;
+import org.apache.geode.redis.internal.delta.ZAddsDeltaInfo;
 
 public abstract class AbstractRedisData implements RedisData {
   private static final BucketRegion.PrimaryMoveReadLockAcquired primaryMoveReadLockAcquired =
@@ -204,14 +204,14 @@ public abstract class AbstractRedisData implements RedisData {
         applyDelta(new AppendDeltaInfo(byteArray, sequence));
         break;
       case ZADDS:
-        int numMembers = InternalDataSerializer.readArrayLength(in);
+        int numMembers = InternalDataSerializer.readPrimitiveInt(in);
         List<byte[]> members = new ArrayList<>();
         List<Double> scores = new ArrayList<>();
         for (int i = 0; i < numMembers; i++) {
           members.add(DataSerializer.readByteArray(in));
           scores.add(DataSerializer.readDouble(in));
         }
-        applyDelta(new ZaddsDeltaInfo(members, scores));
+        applyDelta(new ZAddsDeltaInfo(members, scores));
     }
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -34,7 +34,6 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.InvalidDeltaException;
 import org.apache.geode.cache.EntryNotFoundException;
 import org.apache.geode.cache.Region;
-import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.KnownVersion;
@@ -204,7 +203,7 @@ public abstract class AbstractRedisData implements RedisData {
         applyDelta(new AppendDeltaInfo(byteArray, sequence));
         break;
       case ZADDS:
-        int numMembers = InternalDataSerializer.readPrimitiveInt(in);
+        int numMembers = DataSerializer.readPrimitiveInt(in);
         List<byte[]> members = new ArrayList<>();
         List<Double> scores = new ArrayList<>();
         for (int i = 0; i < numMembers; i++) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -25,7 +25,6 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Objects;
 
 import org.apache.logging.log4j.Logger;
@@ -204,13 +203,13 @@ public abstract class AbstractRedisData implements RedisData {
         break;
       case ZADDS:
         int numMembers = DataSerializer.readPrimitiveInt(in);
-        List<byte[]> members = new ArrayList<>(numMembers);
-        List<Double> scores = new ArrayList<>(numMembers);
+        ZAddsDeltaInfo delta = new ZAddsDeltaInfo(numMembers);
         for (int i = 0; i < numMembers; i++) {
-          members.add(DataSerializer.readByteArray(in));
-          scores.add(DataSerializer.readDouble(in));
+          byte[] member = DataSerializer.readByteArray(in);
+          double score = DataSerializer.readPrimitiveDouble(in);
+          delta.add(member, score);
         }
-        applyDelta(new ZAddsDeltaInfo(members, scores));
+        applyDelta(delta);
     }
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -204,8 +204,8 @@ public abstract class AbstractRedisData implements RedisData {
         break;
       case ZADDS:
         int numMembers = DataSerializer.readPrimitiveInt(in);
-        List<byte[]> members = new ArrayList<>();
-        List<Double> scores = new ArrayList<>();
+        List<byte[]> members = new ArrayList<>(numMembers);
+        List<Double> scores = new ArrayList<>(numMembers);
         for (int i = 0; i < numMembers; i++) {
           members.add(DataSerializer.readByteArray(in));
           scores.add(DataSerializer.readDouble(in));

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -17,6 +17,8 @@
 package org.apache.geode.redis.internal.data;
 
 
+import static java.util.Collections.singletonList;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -67,13 +69,8 @@ class NullRedisSortedSet extends RedisSortedSet {
   @Override
   byte[] zincrby(Region<RedisKey, RedisData> region, RedisKey key, double increment,
       byte[] member) {
-    List<byte[]> membersToAdd = new ArrayList<>();
-    membersToAdd.add(member);
+    RedisSortedSet sortedSet = new RedisSortedSet(singletonList(member), singletonList(increment));
 
-    List<Double> scoresToAdd = new ArrayList<>();
-    scoresToAdd.add(increment);
-
-    RedisSortedSet sortedSet = new RedisSortedSet(membersToAdd, scoresToAdd);
     region.create(key, sortedSet);
 
     return Coder.doubleToBytes(increment);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -26,6 +26,7 @@ import org.apache.geode.redis.internal.executor.sortedset.SortedSetLexRangeOptio
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetRankRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetScoreRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
+import org.apache.geode.redis.internal.netty.Coder;
 
 class NullRedisSortedSet extends RedisSortedSet {
 
@@ -64,7 +65,7 @@ class NullRedisSortedSet extends RedisSortedSet {
   }
 
   @Override
-  double zincrby(Region<RedisKey, RedisData> region, RedisKey key, double increment,
+  byte[] zincrby(Region<RedisKey, RedisData> region, RedisKey key, double increment,
       byte[] member) {
     List<byte[]> membersToAdd = new ArrayList<>();
     membersToAdd.add(member);
@@ -75,7 +76,7 @@ class NullRedisSortedSet extends RedisSortedSet {
     RedisSortedSet sortedSet = new RedisSortedSet(membersToAdd, scoresToAdd);
     region.create(key, sortedSet);
 
-    return increment;
+    return Coder.doubleToBytes(increment);
   }
 
   @Override
@@ -145,7 +146,7 @@ class NullRedisSortedSet extends RedisSortedSet {
     return null;
   }
 
-  private double zaddIncr(Region<RedisKey, RedisData> region, RedisKey key, byte[] member,
+  private byte[] zaddIncr(Region<RedisKey, RedisData> region, RedisKey key, byte[] member,
       double increment) {
     // for zadd incr option, only one incrementing element pair is allowed to get here.
     return zincrby(region, key, increment, member);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -33,7 +33,7 @@ import org.apache.geode.redis.internal.netty.Coder;
 class NullRedisSortedSet extends RedisSortedSet {
 
   NullRedisSortedSet() {
-    super(new ArrayList<>(), new ArrayList<>());
+    super(new ArrayList<>(), new double[0]);
   }
 
   @Override
@@ -43,7 +43,7 @@ class NullRedisSortedSet extends RedisSortedSet {
 
   @Override
   Object zadd(Region<RedisKey, RedisData> region, RedisKey key, List<byte[]> members,
-      List<Double> scores, ZAddOptions options) {
+      double[] scores, ZAddOptions options) {
     if (options.isXX()) {
       if (options.isINCR()) {
         return null;
@@ -52,7 +52,7 @@ class NullRedisSortedSet extends RedisSortedSet {
     }
 
     if (options.isINCR()) {
-      return zaddIncr(region, key, members.get(0), scores.get(0));
+      return zaddIncr(region, key, members.get(0), scores[0]);
     }
 
     RedisSortedSet sortedSet = new RedisSortedSet(members, scores);
@@ -69,7 +69,7 @@ class NullRedisSortedSet extends RedisSortedSet {
   @Override
   byte[] zincrby(Region<RedisKey, RedisData> region, RedisKey key, double increment,
       byte[] member) {
-    RedisSortedSet sortedSet = new RedisSortedSet(singletonList(member), singletonList(increment));
+    RedisSortedSet sortedSet = new RedisSortedSet(singletonList(member), new double[] {increment});
 
     region.create(key, sortedSet);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -229,15 +229,13 @@ public class RedisSortedSet extends AbstractRedisData {
         continue;
       }
       boolean scoreChanged = memberAdd(member, score);
-      if (scoreChanged) {
-        if (options.isCH()) {
-          changesCount++;
-        }
-        if (deltaInfo == null) {
-          deltaInfo = new ZAddsDeltaInfo(member, score);
-        } else {
-          deltaInfo.add(member, score);
-        }
+      if (options.isCH() && scoreChanged) {
+        changesCount++;
+      }
+      if (deltaInfo == null) {
+        deltaInfo = new ZAddsDeltaInfo(member, score);
+      } else {
+        deltaInfo.add(member, score);
       }
     }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -115,7 +115,7 @@ public class RedisSortedSet extends AbstractRedisData {
     members = new MemberMap(size);
     for (int i = 0; i < size; i++) {
       byte[] member = DataSerializer.readByteArray(in);
-      double score = DataSerializer.readDouble(in);
+      double score = DataSerializer.readPrimitiveDouble(in);
       OrderedSetEntry newEntry = new OrderedSetEntry(member, score);
       members.put(member, newEntry);
       scoreSet.add(newEntry);
@@ -182,9 +182,9 @@ public class RedisSortedSet extends AbstractRedisData {
 
   private synchronized void membersAddAll(ZAddsDeltaInfo zaddsDeltaInfo) {
     List<byte[]> members = zaddsDeltaInfo.getZAddMembers();
-    List<Double> scores = zaddsDeltaInfo.getZAddScores();
+    double[] scores = zaddsDeltaInfo.getZAddScores();
     for (int i = 0; i < members.size(); i++) {
-      memberAdd(members.get(i), scores.get(i));
+      memberAdd(members.get(i), scores[i]);
     }
   }
 
@@ -228,7 +228,7 @@ public class RedisSortedSet extends AbstractRedisData {
 
       if (!addResult.equals(MemberAddResult.NO_OP)) {
         if (deltaInfo == null) {
-          deltaInfo = new ZAddsDeltaInfo(member, score);
+          deltaInfo = new ZAddsDeltaInfo(scoresToAdd.size());
         } else {
           deltaInfo.add(member, score);
         }
@@ -272,7 +272,7 @@ public class RedisSortedSet extends AbstractRedisData {
     }
 
     if (!(memberAdd(member, score) == MemberAddResult.NO_OP)) {
-      ZAddsDeltaInfo deltaInfo = new ZAddsDeltaInfo(member, score);
+      ZAddsDeltaInfo deltaInfo = new ZAddsDeltaInfo(1);
       storeChanges(region, key, deltaInfo);
     }
 
@@ -783,7 +783,7 @@ public class RedisSortedSet extends AbstractRedisData {
         byte[] member = entry.getKey();
         double score = entry.getValue().getScore();
         DataSerializer.writeByteArray(member, out);
-        DataSerializer.writeDouble(score, out);
+        DataSerializer.writePrimitiveDouble(score, out);
       }
     }
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -75,7 +75,7 @@ public class RedisSortedSet extends AbstractRedisData {
     this.members = new MemberMap(members.size() + scores.size());
 
     if (members.size() != scores.size()) {
-      throw new NumberFormatException("there must be the same number of members and scores");
+      throw new IllegalArgumentException("there must be the same number of members and scores");
     }
 
     for (int i = 0; i < members.size(); i++) {
@@ -101,8 +101,8 @@ public class RedisSortedSet extends AbstractRedisData {
       AddsDeltaInfo addsDeltaInfo = (AddsDeltaInfo) deltaInfo;
       membersAddAll(addsDeltaInfo);
     } else if (deltaInfo instanceof ZAddsDeltaInfo) {
-      ZAddsDeltaInfo ZAddsDeltaInfo = (ZAddsDeltaInfo) deltaInfo;
-      membersZAddAll(ZAddsDeltaInfo);
+      ZAddsDeltaInfo zaddsDeltaInfo = (ZAddsDeltaInfo) deltaInfo;
+      membersZAddAll(zaddsDeltaInfo);
     } else {
       RemsDeltaInfo remsDeltaInfo = (RemsDeltaInfo) deltaInfo;
       membersRemoveAll(remsDeltaInfo);
@@ -208,9 +208,9 @@ public class RedisSortedSet extends AbstractRedisData {
     }
   }
 
-  private synchronized void membersZAddAll(ZAddsDeltaInfo ZAddsDeltaInfo) {
-    List<byte[]> members = ZAddsDeltaInfo.getZAddMembers();
-    List<Double> scores = ZAddsDeltaInfo.getZAddScores();
+  private synchronized void membersZAddAll(ZAddsDeltaInfo zaddsDeltaInfo) {
+    List<byte[]> members = zaddsDeltaInfo.getZAddMembers();
+    List<Double> scores = zaddsDeltaInfo.getZAddScores();
     for (int i = 0; i < members.size(); i++) {
       memberAdd(members.get(i), scores.get(i));
     }
@@ -236,19 +236,16 @@ public class RedisSortedSet extends AbstractRedisData {
     }
 
     if (membersToAdd.size() != scoresToAdd.size()) {
-      throw new NumberFormatException("there must be the same number of members and scores");
+      throw new IllegalArgumentException("there must be the same number of members and scores");
     }
 
     ZAddsDeltaInfo deltaInfo = null;
-    Iterator<byte[]> membersIterator = membersToAdd.iterator();
-    Iterator<Double> scoresIterator = scoresToAdd.iterator();
-
     int initialSize = scoreSet.size();
     int changesCount = 0;
 
-    while (membersIterator.hasNext()) {
-      double score = scoresIterator.next();
-      byte[] member = membersIterator.next();
+    for (int i = 0; i < membersToAdd.size(); i++) {
+      double score = scoresToAdd.get(i);
+      byte[] member = membersToAdd.get(i);
       if (options.isNX() && members.containsKey(member)) {
         continue;
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -228,7 +228,8 @@ public class RedisSortedSet extends AbstractRedisData {
 
       if (!addResult.equals(MemberAddResult.NO_OP)) {
         if (deltaInfo == null) {
-          deltaInfo = new ZAddsDeltaInfo(scoresToAdd.size());
+          deltaInfo = new ZAddsDeltaInfo(membersToAdd.size());
+          deltaInfo.add(member, score);
         } else {
           deltaInfo.add(member, score);
         }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -18,12 +18,10 @@ package org.apache.geode.redis.internal.data;
 
 import static java.lang.Double.compare;
 import static org.apache.geode.internal.JvmSizeUtils.memoryOverhead;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
 import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_SORTED_SET;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SORTED_SET;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGREATEST_MEMBER_NAME;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEAST_MEMBER_NAME;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bZERO;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -54,7 +52,6 @@ import org.apache.geode.redis.internal.executor.sortedset.SortedSetLexRangeOptio
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetRankRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetScoreRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.executor.sortedset.ZAggregator;
 import org.apache.geode.redis.internal.executor.sortedset.ZKeyWeight;
 import org.apache.geode.redis.internal.netty.Coder;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -59,7 +59,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
-  public double zincrby(RedisKey key, double increment, byte[] member) {
+  public byte[] zincrby(RedisKey key, double increment, byte[] member) {
     return stripedExecute(key,
         () -> getRedisSortedSet(key, false).zincrby(getRegion(), key, increment, member));
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -42,9 +42,11 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
-  public Object zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options) {
+  public Object zadd(RedisKey key, List<byte[]> membersToAdd, List<Double> scoresToAdd,
+      ZAddOptions options) {
     return stripedExecute(key,
-        () -> getRedisSortedSet(key, false).zadd(getRegion(), key, scoresAndMembersToAdd, options));
+        () -> getRedisSortedSet(key, false).zadd(getRegion(), key, membersToAdd, scoresToAdd,
+            options));
   }
 
   public long zcard(RedisKey key) {
@@ -57,7 +59,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
-  public byte[] zincrby(RedisKey key, byte[] increment, byte[] member) {
+  public double zincrby(RedisKey key, double increment, byte[] member) {
     return stripedExecute(key,
         () -> getRedisSortedSet(key, false).zincrby(getRegion(), key, increment, member));
   }
@@ -163,7 +165,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
     getRegionProvider().orderForLocking(keysToLock);
 
     return stripedExecute(destinationKey, keysToLock,
-        () -> new RedisSortedSet(Collections.emptyList()).zunionstore(getRegionProvider(),
+        () -> getRedisSortedSet(destinationKey, false).zunionstore(getRegionProvider(),
             destinationKey, keyWeights, aggregator));
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -42,7 +42,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
-  public Object zadd(RedisKey key, List<byte[]> membersToAdd, List<Double> scoresToAdd,
+  public Object zadd(RedisKey key, List<byte[]> membersToAdd, double[] scoresToAdd,
       ZAddOptions options) {
     return stripedExecute(key,
         () -> getRedisSortedSet(key, false).zadd(getRegion(), key, membersToAdd, scoresToAdd,
@@ -165,7 +165,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
     getRegionProvider().orderForLocking(keysToLock);
 
     return stripedExecute(destinationKey, keysToLock,
-        () -> new RedisSortedSet(Collections.emptyList(), Collections.emptyList())
+        () -> new RedisSortedSet(Collections.emptyList(), new double[0])
             .zunionstore(getRegionProvider(), destinationKey, keyWeights, aggregator));
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -165,8 +165,8 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
     getRegionProvider().orderForLocking(keysToLock);
 
     return stripedExecute(destinationKey, keysToLock,
-        () -> getRedisSortedSet(destinationKey, false).zunionstore(getRegionProvider(),
-            destinationKey, keyWeights, aggregator));
+        () -> new RedisSortedSet(Collections.emptyList(), Collections.emptyList())
+            .zunionstore(getRegionProvider(), destinationKey, keyWeights, aggregator));
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/DeltaType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/DeltaType.java
@@ -20,5 +20,6 @@ public enum DeltaType {
   ADDS,
   REMS,
   TIMESTAMP,
-  APPEND
+  APPEND,
+  ZADDS
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
@@ -35,8 +35,8 @@ public class ZAddsDeltaInfo implements DeltaInfo {
   }
 
   public void add(byte[] delta, double score) {
-    this.deltas.add(delta);
     this.scores[deltas.size()] = score;
+    this.deltas.add(delta);
   }
 
   public void serializeTo(DataOutput out) throws IOException {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
@@ -30,7 +30,7 @@ public class ZAddsDeltaInfo implements DeltaInfo {
   private final double[] scores;
 
   public ZAddsDeltaInfo(int size) {
-    this.deltas = new ArrayList<>();
+    this.deltas = new ArrayList<>(size);
     this.scores = new double[size];
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
@@ -24,20 +24,19 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.geode.DataSerializer;
-import org.apache.geode.internal.InternalDataSerializer;
 
-public class ZaddsDeltaInfo implements DeltaInfo {
+public class ZAddsDeltaInfo implements DeltaInfo {
   private final ArrayList<byte[]> deltas = new ArrayList<>();
   private final ArrayList<Double> scores = new ArrayList<>();
 
-  public ZaddsDeltaInfo() {}
+  public ZAddsDeltaInfo() {}
 
-  public ZaddsDeltaInfo(List<byte[]> deltas, List<Double> scores) {
+  public ZAddsDeltaInfo(List<byte[]> deltas, List<Double> scores) {
     this.deltas.addAll(deltas);
     this.scores.addAll(scores);
   }
 
-  public ZaddsDeltaInfo(byte[] delta, Double score) {
+  public ZAddsDeltaInfo(byte[] delta, Double score) {
     this.deltas.add(delta);
     this.scores.add(score);
   }
@@ -48,15 +47,15 @@ public class ZaddsDeltaInfo implements DeltaInfo {
   }
 
   public void serializeTo(DataOutput out) throws IOException {
-    InternalDataSerializer.writeEnum(ZADDS, out);
-    InternalDataSerializer.writeArrayLength(deltas.size(), out);
+    DataSerializer.writeEnum(ZADDS, out);
+    DataSerializer.writePrimitiveInt(deltas.size(), out);
     for (int i = 0; i < deltas.size(); i++) {
       DataSerializer.writeByteArray(deltas.get(i), out);
       DataSerializer.writeDouble(scores.get(i), out);
     }
   }
 
-  public List<byte[]> getZAddsMembers() {
+  public List<byte[]> getZAddMembers() {
     return deltas;
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
@@ -27,26 +27,16 @@ import org.apache.geode.DataSerializer;
 
 public class ZAddsDeltaInfo implements DeltaInfo {
   private final List<byte[]> deltas;
-  private final List<Double> scores;
+  private final double[] scores;
 
-  public ZAddsDeltaInfo() {
+  public ZAddsDeltaInfo(int size) {
     this.deltas = new ArrayList<>();
-    this.scores = new ArrayList<>();
-  }
-
-  public ZAddsDeltaInfo(List<byte[]> deltas, List<Double> scores) {
-    this.deltas = deltas;
-    this.scores = scores;
-  }
-
-  public ZAddsDeltaInfo(byte[] delta, Double score) {
-    this();
-    add(delta, score);
+    this.scores = new double[size];
   }
 
   public void add(byte[] delta, double score) {
     this.deltas.add(delta);
-    this.scores.add(score);
+    this.scores[deltas.size()] = score;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
@@ -54,7 +44,7 @@ public class ZAddsDeltaInfo implements DeltaInfo {
     DataSerializer.writePrimitiveInt(deltas.size(), out);
     for (int i = 0; i < deltas.size(); i++) {
       DataSerializer.writeByteArray(deltas.get(i), out);
-      DataSerializer.writeDouble(scores.get(i), out);
+      DataSerializer.writePrimitiveDouble(scores[i], out);
     }
   }
 
@@ -62,7 +52,7 @@ public class ZAddsDeltaInfo implements DeltaInfo {
     return deltas;
   }
 
-  public List<Double> getZAddScores() {
+  public double[] getZAddScores() {
     return scores;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZAddsDeltaInfo.java
@@ -26,23 +26,26 @@ import java.util.List;
 import org.apache.geode.DataSerializer;
 
 public class ZAddsDeltaInfo implements DeltaInfo {
-  private final ArrayList<byte[]> deltas = new ArrayList<>();
-  private final ArrayList<Double> scores = new ArrayList<>();
+  private final List<byte[]> deltas;
+  private final List<Double> scores;
 
-  public ZAddsDeltaInfo() {}
+  public ZAddsDeltaInfo() {
+    this.deltas = new ArrayList<>();
+    this.scores = new ArrayList<>();
+  }
 
   public ZAddsDeltaInfo(List<byte[]> deltas, List<Double> scores) {
-    this.deltas.addAll(deltas);
-    this.scores.addAll(scores);
+    this.deltas = deltas;
+    this.scores = scores;
   }
 
   public ZAddsDeltaInfo(byte[] delta, Double score) {
-    this.deltas.add(delta);
-    this.scores.add(score);
+    this();
+    add(delta, score);
   }
 
   public void add(byte[] delta, double score) {
-    deltas.add(delta);
+    this.deltas.add(delta);
     this.scores.add(score);
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZaddsDeltaInfo.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/delta/ZaddsDeltaInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.redis.internal.delta;
+
+import static org.apache.geode.redis.internal.delta.DeltaType.ZADDS;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.geode.DataSerializer;
+import org.apache.geode.internal.InternalDataSerializer;
+
+public class ZaddsDeltaInfo implements DeltaInfo {
+  private final ArrayList<byte[]> deltas = new ArrayList<>();
+  private final ArrayList<Double> scores = new ArrayList<>();
+
+  public ZaddsDeltaInfo() {}
+
+  public ZaddsDeltaInfo(List<byte[]> deltas, List<Double> scores) {
+    this.deltas.addAll(deltas);
+    this.scores.addAll(scores);
+  }
+
+  public ZaddsDeltaInfo(byte[] delta, Double score) {
+    this.deltas.add(delta);
+    this.scores.add(score);
+  }
+
+  public void add(byte[] delta, double score) {
+    deltas.add(delta);
+    this.scores.add(score);
+  }
+
+  public void serializeTo(DataOutput out) throws IOException {
+    InternalDataSerializer.writeEnum(ZADDS, out);
+    InternalDataSerializer.writeArrayLength(deltas.size(), out);
+    for (int i = 0; i < deltas.size(); i++) {
+      DataSerializer.writeByteArray(deltas.get(i), out);
+      DataSerializer.writeDouble(scores.get(i), out);
+    }
+  }
+
+  public List<byte[]> getZAddsMembers() {
+    return deltas;
+  }
+
+  public List<Double> getZAddScores() {
+    return scores;
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -21,13 +21,13 @@ import org.apache.geode.redis.internal.data.RedisKey;
 
 public interface RedisSortedSetCommands {
 
-  Object zadd(RedisKey key, List<byte[]> scoresAndMembersToAdd, ZAddOptions options);
+  Object zadd(RedisKey key, List<byte[]> members, List<Double> scores, ZAddOptions options);
 
   long zcard(RedisKey key);
 
   long zcount(RedisKey key, SortedSetScoreRangeOptions rangeOptions);
 
-  byte[] zincrby(RedisKey key, byte[] increment, byte[] member);
+  double zincrby(RedisKey key, double increment, byte[] member);
 
   long zlexcount(RedisKey key, SortedSetLexRangeOptions rangeOptions);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -21,7 +21,7 @@ import org.apache.geode.redis.internal.data.RedisKey;
 
 public interface RedisSortedSetCommands {
 
-  Object zadd(RedisKey key, List<byte[]> members, List<Double> scores, ZAddOptions options);
+  Object zadd(RedisKey key, List<byte[]> members, double[] scores, ZAddOptions options);
 
   long zcard(RedisKey key);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -27,7 +27,7 @@ public interface RedisSortedSetCommands {
 
   long zcount(RedisKey key, SortedSetScoreRangeOptions rangeOptions);
 
-  double zincrby(RedisKey key, double increment, byte[] member);
+  byte[] zincrby(RedisKey key, double increment, byte[] member);
 
   long zlexcount(RedisKey key, SortedSetLexRangeOptions rangeOptions);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetScoreRangeOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetScoreRangeOptions.java
@@ -48,16 +48,10 @@ public class SortedSetScoreRangeOptions extends AbstractSortedSetRangeOptions<Do
         score = 0.0;
       } else {
         score = bytesToDouble(Arrays.copyOfRange(bytes, 1, bytes.length));
-        if (Double.isNaN(score)) {
-          throw new NumberFormatException();
-        }
       }
       return new RangeLimit<>(score, true);
     } else {
       score = bytesToDouble(bytes);
-      if (Double.isNaN(score)) {
-        throw new NumberFormatException();
-      }
       return new RangeLimit<>(score, false);
     }
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
@@ -54,10 +54,11 @@ public class ZAddExecutor extends AbstractExecutor {
 
     int size = (commandElements.size() - optionsFoundCount - 2) / 2;
     List<byte[]> members = new ArrayList<>(size);
-    List<Double> scores = new ArrayList<>(size);
-    for (int i = optionsFoundCount + 2; i < commandElements.size(); i += 2) {
+    double[] scores = new double[size];
+    int n = 0;
+    for (int i = optionsFoundCount + 2; i < commandElements.size(); i += 2, n++) {
       try {
-        scores.add(Coder.bytesToDouble(commandElements.get(i)));
+        scores[n] = Coder.bytesToDouble(commandElements.get(i));
       } catch (NumberFormatException e) {
         throw new NumberFormatException(ERROR_NOT_A_VALID_FLOAT);
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
@@ -19,7 +19,6 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_F
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR;
 import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
-import static org.apache.geode.redis.internal.netty.Coder.isNaN;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCH;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINCR;
@@ -53,8 +52,9 @@ public class ZAddExecutor extends AbstractExecutor {
       return RedisResponse.error(zAddExecutorState.exceptionMessage);
     }
 
-    List<byte[]> members = new ArrayList<>();
-    List<Double> scores = new ArrayList<>();
+    int size = (commandElements.size() - optionsFoundCount - 2) / 2;
+    List<byte[]> members = new ArrayList<>(size);
+    List<Double> scores = new ArrayList<>(size);
     for (int i = optionsFoundCount + 2; i < commandElements.size(); i += 2) {
       try {
         scores.add(Coder.bytesToDouble(commandElements.get(i)));
@@ -101,9 +101,6 @@ public class ZAddExecutor extends AbstractExecutor {
         optionsFoundCount++;
       } else if (isInfinity(subCommand)) {
         scoreFound = true;
-      } else if (isNaN(subCommand)) {
-        executorState.exceptionMessage = ERROR_NOT_A_VALID_FLOAT;
-        return 0;
       } else {
         // assume it's a double; if not, this will throw exception later
         scoreFound = true;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZIncrByExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZIncrByExecutor.java
@@ -40,7 +40,7 @@ public class ZIncrByExecutor extends AbstractExecutor {
     }
     byte[] member = commandElements.get(3);
 
-    double retVal = redisSortedSetCommands.zincrby(command.getKey(), increment, member);
-    return RedisResponse.bulkString(Coder.doubleToBytes(retVal));
+    byte[] retVal = redisSortedSetCommands.zincrby(command.getKey(), increment, member);
+    return RedisResponse.bulkString(retVal);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZIncrByExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZIncrByExecutor.java
@@ -16,10 +16,13 @@ package org.apache.geode.redis.internal.executor.sortedset;
 
 
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
+
 import java.util.List;
 
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -29,10 +32,15 @@ public class ZIncrByExecutor extends AbstractExecutor {
     RedisSortedSetCommands redisSortedSetCommands = context.getSortedSetCommands();
     List<byte[]> commandElements = command.getProcessedCommand();
 
-    byte[] increment = commandElements.get(2);
+    double increment;
+    try {
+      increment = Coder.bytesToDouble(commandElements.get(2));
+    } catch (NumberFormatException e) {
+      return RedisResponse.error(ERROR_NOT_A_VALID_FLOAT);
+    }
     byte[] member = commandElements.get(3);
 
-    byte[] retVal = redisSortedSetCommands.zincrby(command.getKey(), increment, member);
-    return RedisResponse.bulkString(retVal);
+    double retVal = redisSortedSetCommands.zincrby(command.getKey(), increment, member);
+    return RedisResponse.bulkString(Coder.doubleToBytes(retVal));
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -43,7 +43,6 @@ import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INFIN
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNaN;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bOK;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bOOM;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPERIOD;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPLUS;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bP_INF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bP_INFINITY;
@@ -53,7 +52,6 @@ import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -529,14 +527,6 @@ public class Coder {
     } else {
       return (int) toBeNarrowed;
     }
-  }
-
-  public static byte[] stripTrailingZeroFromDouble(byte[] doubleBytes) {
-    if (doubleBytes.length > 1 && doubleBytes[doubleBytes.length - 2] == bPERIOD
-        && doubleBytes[doubleBytes.length - 1] == NUMBER_0_BYTE) {
-      return Arrays.copyOfRange(doubleBytes, 0, doubleBytes.length - 2);
-    }
-    return doubleBytes;
   }
 
   /**

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -429,9 +429,10 @@ public class Coder {
    * @throws NumberFormatException if the double cannot be parsed
    */
   public static double stringToDouble(String d) {
-    if (d.equalsIgnoreCase(P_INF)) {
+    if (d.equalsIgnoreCase(P_INF) || d.equalsIgnoreCase("+infinity")
+        || d.equalsIgnoreCase("infinity")) {
       return Double.POSITIVE_INFINITY;
-    } else if (d.equalsIgnoreCase(N_INF)) {
+    } else if (d.equalsIgnoreCase(N_INF) || d.equalsIgnoreCase("-infinity")) {
       return Double.NEGATIVE_INFINITY;
     } else {
       return Double.parseDouble(d);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -415,27 +415,16 @@ public class Coder {
     }
 
     try {
-      return stringToDouble(bytesToString(bytes));
+      String d = bytesToString(bytes);
+      if (d.equalsIgnoreCase(P_INF)) {
+        return Double.POSITIVE_INFINITY;
+      } else if (d.equalsIgnoreCase(N_INF)) {
+        return Double.NEGATIVE_INFINITY;
+      } else {
+        return Double.parseDouble(d);
+      }
     } catch (NumberFormatException e) {
       throw new NumberFormatException(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
-    }
-  }
-
-  /**
-   * Redis specific manner to parse floats
-   *
-   * @param d String holding double
-   * @return Value of string
-   * @throws NumberFormatException if the double cannot be parsed
-   */
-  public static double stringToDouble(String d) {
-    if (d.equalsIgnoreCase(P_INF) || d.equalsIgnoreCase("+infinity")
-        || d.equalsIgnoreCase("infinity")) {
-      return Double.POSITIVE_INFINITY;
-    } else if (d.equalsIgnoreCase(N_INF) || d.equalsIgnoreCase("-infinity")) {
-      return Double.NEGATIVE_INFINITY;
-    } else {
-      return Double.parseDouble(d);
     }
   }
 

--- a/geode-apis-compatible-with-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-apis-compatible-with-redis-serializables.txt
+++ b/geode-apis-compatible-with-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-apis-compatible-with-redis-serializables.txt
@@ -1,6 +1,7 @@
 org/apache/geode/redis/internal/RedisCommandSupportLevel,false
 org/apache/geode/redis/internal/RedisCommandType,false,deferredParameterRequirements:org/apache/geode/redis/internal/parameters/ParameterRequirements,executor:org/apache/geode/redis/internal/executor/Executor,parameterRequirements:org/apache/geode/redis/internal/parameters/ParameterRequirements,supportLevel:org/apache/geode/redis/internal/RedisCommandSupportLevel
 org/apache/geode/redis/internal/data/RedisDataType,false,toStringValue:java/lang/String
+org/apache/geode/redis/internal/data/RedisSortedSet$MemberAddResult,false
 org/apache/geode/redis/internal/delta/DeltaType,false
 org/apache/geode/redis/internal/executor/BaseSetOptions$Exists,false
 org/apache/geode/redis/internal/netty/CoderException,true,4707944288714910949

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderStatisticsTreeTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/OrderStatisticsTreeTest.java
@@ -715,7 +715,7 @@ public class OrderStatisticsTreeTest {
   public void testGetSizeInBytesWithOrderedSetEntry() {
     Random random = new Random();
     byte[] member;
-    byte[] scoreBytes;
+    double score;
     List<RedisSortedSet.OrderedSetEntry> entries = new ArrayList<>();
     RedisSortedSet.ScoreSet tree = new RedisSortedSet.ScoreSet();
 
@@ -726,8 +726,8 @@ public class OrderStatisticsTreeTest {
     int sizeOfEntries = 0;
     for (int i = 0; i < 100; ++i) {
       member = new byte[random.nextInt(50_000)];
-      scoreBytes = String.valueOf(random.nextDouble()).getBytes();
-      RedisSortedSet.OrderedSetEntry entry = new RedisSortedSet.OrderedSetEntry(member, scoreBytes);
+      score = random.nextDouble();
+      RedisSortedSet.OrderedSetEntry entry = new RedisSortedSet.OrderedSetEntry(member, score);
       sizeOfEntries += sizer.sizeof(entry);
       entries.add(entry);
       tree.add(entry);
@@ -773,8 +773,7 @@ public class OrderStatisticsTreeTest {
     int beforeSize = sizer.sizeof(tree);
     for (int i = 0; i < 100; ++i) {
       byte[] member = new byte[i];
-      byte[] score = String.valueOf(i).getBytes();
-      RedisSortedSet.OrderedSetEntry entry = new RedisSortedSet.OrderedSetEntry(member, score);
+      RedisSortedSet.OrderedSetEntry entry = new RedisSortedSet.OrderedSetEntry(member, i);
       tree.add(entry);
       int afterSize = sizer.sizeof(tree);
       int perMemberOverhead = afterSize - beforeSize - sizer.sizeof(entry);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/SizeableBytes2ObjectOpenCustomHashMapWithCursorTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/collections/SizeableBytes2ObjectOpenCustomHashMapWithCursorTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.redis.internal.collections;
 
-import static org.apache.geode.internal.JvmSizeUtils.memoryOverhead;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
@@ -35,7 +34,6 @@ import org.apache.geode.cache.util.ObjectSizer;
 import org.apache.geode.internal.size.ReflectionObjectSizer;
 import org.apache.geode.redis.internal.data.RedisHash;
 import org.apache.geode.redis.internal.data.RedisSortedSet;
-import org.apache.geode.redis.internal.netty.Coder;
 
 public class SizeableBytes2ObjectOpenCustomHashMapWithCursorTest {
   private final ObjectSizer sizer = ReflectionObjectSizer.getInstance();
@@ -374,15 +372,12 @@ public class SizeableBytes2ObjectOpenCustomHashMapWithCursorTest {
     for (int i = initialNumberOfElements; i < totalNumberOfElements; ++i) {
       byte[] key = {(byte) i};
       RedisSortedSet.OrderedSetEntry value = hash.get(key);
-      double oldScore = value.getScore();
-      int scoreDelta =
-          memoryOverhead(Coder.doubleToBytes(i)) - memoryOverhead(Coder.doubleToBytes(oldScore));
 
       int oldSize = hash.getSizeInBytes();
       value.updateScore(i);
       int sizeDelta = hash.getSizeInBytes() - oldSize;
 
-      assertThat(sizeDelta).isEqualTo(scoreDelta);
+      assertThat(sizeDelta).isZero();
 
       assertThat(hash.getSizeInBytes()).isEqualTo(sizer.sizeof(hash));
     }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -138,7 +138,7 @@ public class RedisSortedSetTest {
   @Test
   public void equals_returnsTrue_givenDifferentEmptySortedSets() {
     RedisSortedSet sortedSet1 =
-        new RedisSortedSet(Collections.emptyList(), Collections.emptyList());
+        new RedisSortedSet(Collections.emptyList(), new double[0]);
     RedisSortedSet sortedSet2 = NullRedisDataStructures.NULL_REDIS_SORTED_SET;
     assertThat(sortedSet1).isEqualTo(sortedSet2);
     assertThat(sortedSet2).isEqualTo(sortedSet1);
@@ -150,7 +150,7 @@ public class RedisSortedSetTest {
     when(region.put(any(), any())).thenAnswer(this::validateDeltaSerialization);
     RedisSortedSet sortedSet1 = createRedisSortedSet("3.14159", "v1", "2.71828", "v2");
     List<byte[]> members = singletonList(stringToBytes("v3"));
-    List<Double> scores = singletonList(1.61803);
+    double[] scores = new double[] {1.61803D};
 
     sortedSet1.zadd(region, null, members, scores,
         new ZAddOptions(ZAddOptions.Exists.NONE, false, false));
@@ -692,7 +692,7 @@ public class RedisSortedSetTest {
   // that increase before changing the constant.
   @Test
   public void baseRedisSortedSetOverheadConstant_shouldMatchReflectedSize() {
-    RedisSortedSet set = new RedisSortedSet(Collections.emptyList(), Collections.emptyList());
+    RedisSortedSet set = new RedisSortedSet(Collections.emptyList(), new double[0]);
     RedisSortedSet.MemberMap backingMap = new RedisSortedSet.MemberMap(0);
     RedisSortedSet.ScoreSet backingTree = new RedisSortedSet.ScoreSet();
     int baseRedisSetOverhead =
@@ -719,7 +719,7 @@ public class RedisSortedSetTest {
     Region<RedisKey, RedisData> mockRegion = uncheckedCast(mock(Region.class));
     RedisKey mockKey = mock(RedisKey.class);
     ZAddOptions options = new ZAddOptions(ZAddOptions.Exists.NONE, false, false);
-    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), Collections.emptyList());
+    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), new double[0]);
 
     int expectedSize = sizer.sizeof(sortedSet);
     int actualSize = sortedSet.getSizeInBytes();
@@ -728,7 +728,7 @@ public class RedisSortedSetTest {
     // Add members and scores and confirm that the actual size is accurate after each operation
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
-      List<Double> scores = singletonList((double) i);
+      double[] scores = new double[] {(double) i};
       List<byte[]> members = singletonList(new byte[i]);
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
       expectedSize = sizer.sizeof(sortedSet);
@@ -742,19 +742,19 @@ public class RedisSortedSetTest {
     Region<RedisKey, RedisData> mockRegion = uncheckedCast(mock(Region.class));
     RedisKey mockKey = mock(RedisKey.class);
     ZAddOptions options = new ZAddOptions(ZAddOptions.Exists.NONE, false, false);
-    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), Collections.emptyList());
+    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), new double[0]);
 
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
       List<byte[]> members = singletonList(new byte[i]);
-      List<Double> scores = singletonList((double) i);
+      double[] scores = new double[] {(double) i};
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
     }
 
     // Update half the scores and confirm that the actual size is accurate after each operation
     for (int i = 0; i < numberOfEntries / 2; ++i) {
       List<byte[]> members = singletonList(new byte[i]);
-      List<Double> scores = singletonList(i * 2d);
+      double[] scores = new double[] {i * 2d};
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
       int expectedSize = sizer.sizeof(sortedSet);
       int actualSize = sortedSet.getSizeInBytes();
@@ -767,12 +767,12 @@ public class RedisSortedSetTest {
     Region<RedisKey, RedisData> mockRegion = uncheckedCast(mock(Region.class));
     RedisKey mockKey = mock(RedisKey.class);
     ZAddOptions options = new ZAddOptions(ZAddOptions.Exists.NONE, false, false);
-    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), Collections.emptyList());
+    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), new double[0]);
 
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
       List<byte[]> members = singletonList(new byte[i]);
-      List<Double> scores = singletonList((double) i);
+      double[] scores = new double[] {(double) i};
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
     }
 
@@ -791,12 +791,12 @@ public class RedisSortedSetTest {
     Region<RedisKey, RedisData> mockRegion = uncheckedCast(mock(Region.class));
     RedisKey mockKey = mock(RedisKey.class);
     ZAddOptions options = new ZAddOptions(ZAddOptions.Exists.NONE, false, false);
-    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), Collections.emptyList());
+    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), new double[0]);
 
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
       List<byte[]> members = singletonList(new byte[i]);
-      List<Double> scores = singletonList((double) i);
+      double[] scores = new double[] {(double) i};
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
     }
 
@@ -814,12 +814,12 @@ public class RedisSortedSetTest {
     Region<RedisKey, RedisData> mockRegion = uncheckedCast(mock(Region.class));
     RedisKey mockKey = mock(RedisKey.class);
     ZAddOptions options = new ZAddOptions(ZAddOptions.Exists.NONE, false, false);
-    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), Collections.emptyList());
+    RedisSortedSet sortedSet = new RedisSortedSet(Collections.emptyList(), new double[0]);
 
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
       List<byte[]> members = singletonList(new byte[i]);
-      List<Double> scores = singletonList((double) i);
+      double[] scores = new double[] {(double) i};
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
     }
 
@@ -846,12 +846,14 @@ public class RedisSortedSetTest {
 
   private RedisSortedSet createRedisSortedSet(String... membersAndScores) {
     List<byte[]> members = new ArrayList<>();
-    List<Double> scores = new ArrayList<>();
+    double[] scores = new double[100];
 
     Iterator<String> iterator = Arrays.stream(membersAndScores).iterator();
+    int i = 0;
     while (iterator.hasNext()) {
-      scores.add(Coder.bytesToDouble(iterator.next().getBytes(StandardCharsets.UTF_8)));
+      scores[i] = Coder.bytesToDouble(iterator.next().getBytes(StandardCharsets.UTF_8));
       members.add(iterator.next().getBytes(StandardCharsets.UTF_8));
+      i++;
     }
 
     return new RedisSortedSet(members, scores);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal.data;
 
+import static java.util.Collections.singletonList;
 import static org.apache.geode.redis.internal.data.RedisSortedSet.OrderedSetEntry.ORDERED_SET_ENTRY_OVERHEAD;
 import static org.apache.geode.redis.internal.data.RedisSortedSet.REDIS_SORTED_SET_OVERHEAD;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.when;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -147,10 +149,8 @@ public class RedisSortedSetTest {
     Region<RedisKey, RedisData> region = uncheckedCast(mock(Region.class));
     when(region.put(any(), any())).thenAnswer(this::validateDeltaSerialization);
     RedisSortedSet sortedSet1 = createRedisSortedSet("3.14159", "v1", "2.71828", "v2");
-    List<byte[]> members = new ArrayList<>();
-    members.add(stringToBytes("v3"));
-    List<Double> scores = new ArrayList<>();
-    scores.add(1.61803);
+    List<byte[]> members = singletonList(stringToBytes("v3"));
+    List<Double> scores = singletonList(1.61803);
 
     sortedSet1.zadd(region, null, members, scores,
         new ZAddOptions(ZAddOptions.Exists.NONE, false, false));
@@ -728,8 +728,8 @@ public class RedisSortedSetTest {
     // Add members and scores and confirm that the actual size is accurate after each operation
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
-      List<Double> scores = Collections.singletonList((double) i);
-      List<byte[]> members = Collections.singletonList(new byte[i]);
+      List<Double> scores = singletonList((double) i);
+      List<byte[]> members = singletonList(new byte[i]);
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
       expectedSize = sizer.sizeof(sortedSet);
       actualSize = sortedSet.getSizeInBytes();
@@ -746,15 +746,15 @@ public class RedisSortedSetTest {
 
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
-      List<byte[]> members = Collections.singletonList(new byte[i]);
-      List<Double> scores = Collections.singletonList((double) i);
+      List<byte[]> members = singletonList(new byte[i]);
+      List<Double> scores = singletonList((double) i);
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
     }
 
     // Update half the scores and confirm that the actual size is accurate after each operation
     for (int i = 0; i < numberOfEntries / 2; ++i) {
-      List<byte[]> members = Collections.singletonList(new byte[i]);
-      List<Double> scores = Collections.singletonList(i * 2d);
+      List<byte[]> members = singletonList(new byte[i]);
+      List<Double> scores = singletonList(i * 2d);
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
       int expectedSize = sizer.sizeof(sortedSet);
       int actualSize = sortedSet.getSizeInBytes();
@@ -771,14 +771,14 @@ public class RedisSortedSetTest {
 
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
-      List<byte[]> members = Collections.singletonList(new byte[i]);
-      List<Double> scores = Collections.singletonList((double) i);
+      List<byte[]> members = singletonList(new byte[i]);
+      List<Double> scores = singletonList((double) i);
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
     }
 
     // Remove all members and confirm that the actual size is accurate after each operation
     for (int i = 0; i < numberOfEntries; ++i) {
-      List<byte[]> memberToRemove = Collections.singletonList(new byte[i]);
+      List<byte[]> memberToRemove = singletonList(new byte[i]);
       sortedSet.zrem(mockRegion, mockKey, memberToRemove);
       int expectedSize = sizer.sizeof(sortedSet);
       int actualSize = sortedSet.getSizeInBytes();
@@ -795,8 +795,8 @@ public class RedisSortedSetTest {
 
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
-      List<byte[]> members = Collections.singletonList(new byte[i]);
-      List<Double> scores = Collections.singletonList((double) i);
+      List<byte[]> members = singletonList(new byte[i]);
+      List<Double> scores = singletonList((double) i);
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
     }
 
@@ -818,8 +818,8 @@ public class RedisSortedSetTest {
 
     int numberOfEntries = 100;
     for (int i = 0; i < numberOfEntries; ++i) {
-      List<byte[]> members = Collections.singletonList(new byte[i]);
-      List<Double> scores = Collections.singletonList((double) i);
+      List<byte[]> members = singletonList(new byte[i]);
+      List<Double> scores = singletonList((double) i);
       sortedSet.zadd(mockRegion, mockKey, members, scores, options);
     }
 
@@ -850,8 +850,8 @@ public class RedisSortedSetTest {
 
     Iterator<String> iterator = Arrays.stream(membersAndScores).iterator();
     while (iterator.hasNext()) {
-      scores.add(Coder.stringToDouble(iterator.next()));
-      members.add(Coder.stringToBytes(iterator.next()));
+      scores.add(Coder.bytesToDouble(iterator.next().getBytes(StandardCharsets.UTF_8)));
+      members.add(iterator.next().getBytes(StandardCharsets.UTF_8));
     }
 
     return new RedisSortedSet(members, scores);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -26,8 +26,9 @@ import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.stripTrailingZeroFromDouble;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNaN;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 
@@ -80,6 +81,11 @@ public class CoderTest {
     byte[] convertedBytes = doubleToBytes(d);
     String convertedString = bytesToString(convertedBytes);
     assertThat(convertedString).isEqualTo(expectedString);
+  }
+
+  @Test
+  public void bytesToDouble_errorsWhenGivenNaNAsBytes() {
+    assertThatThrownBy(() -> Coder.bytesToDouble(bNaN)).isInstanceOf(NumberFormatException.class);
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -24,7 +24,6 @@ import static org.apache.geode.redis.internal.netty.Coder.isNegativeInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.isPositiveInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
-import static org.apache.geode.redis.internal.netty.Coder.stripTrailingZeroFromDouble;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNaN;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -110,16 +109,6 @@ public class CoderTest {
       assertThat(narrowLongToInt(i)).isEqualTo(Math.toIntExact(i));
     }
   }
-
-  @Test
-  @Parameters(method = "doubleBytes")
-  public void stripTrailingZeroFromDouble_correctlyStripsTrailingZero(byte[] input,
-      byte[] expected) {
-    byte[] output = stripTrailingZeroFromDouble(input);
-    assertThat(output).containsExactly(expected);
-  }
-
-
 
   @SuppressWarnings("unused")
   private Object[] stringPairs() {

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -28,6 +28,7 @@ import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNaN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.Assert.assertArrayEquals;
 
 import java.nio.charset.StandardCharsets;
 
@@ -110,6 +111,15 @@ public class CoderTest {
     }
   }
 
+  @Test
+  @Parameters(method = "doubleBytes")
+  public void doubleToBytes_processesTrailingZeroLikeRedis(Double inputDouble,
+      byte[] expectedBytes) {
+    double d = inputDouble;
+    byte[] convertedBytes = doubleToBytes(d);
+    assertArrayEquals(convertedBytes, expectedBytes);
+  }
+
   @SuppressWarnings("unused")
   private Object[] stringPairs() {
     // string1, string2
@@ -152,17 +162,17 @@ public class CoderTest {
 
   @SuppressWarnings("unused")
   private Object[] doubleBytes() {
-    // input double bytes, double bytes with stripped trailing zero
+    // input double, double bytes with stripped trailing zero
     return new Object[] {
-        new Object[] {stringToBytes("0.0"), stringToBytes("0")},
-        new Object[] {stringToBytes("0.01"), stringToBytes("0.01")},
-        new Object[] {stringToBytes("0"), stringToBytes("0")},
-        new Object[] {stringToBytes("1.0"), stringToBytes("1")},
-        new Object[] {stringToBytes("-1.0"), stringToBytes("-1")},
-        new Object[] {stringToBytes("6.0221409E23"), stringToBytes("6.0221409E23")},
-        new Object[] {stringToBytes("6.62607E-34"), stringToBytes("6.62607E-34")},
-        new Object[] {stringToBytes("Infinity"), stringToBytes("Infinity")},
-        new Object[] {stringToBytes("NaN"), stringToBytes("NaN")},
+        new Object[] {0.0, stringToBytes("0")},
+        new Object[] {0.01, stringToBytes("0.01")},
+        new Object[] {0d, stringToBytes("0")},
+        new Object[] {1.0, stringToBytes("1")},
+        new Object[] {-1.0, stringToBytes("-1")},
+        new Object[] {6.0221409E23, stringToBytes("6.0221409E23")},
+        new Object[] {6.62607E-34, stringToBytes("6.62607E-34")},
+        new Object[] {Double.POSITIVE_INFINITY, stringToBytes("inf")},
+        new Object[] {Double.NaN, stringToBytes("NaN")},
     };
   }
 


### PR DESCRIPTION
RedisSortedSet previously stored the score as both a double and a byte
array in order to cut down on conversions using Coder. This refactor
gets rid of the byte array score and instead does a couple of
conversions. Other refactors were done to accomodate this change and
to improve on what was there

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
