### PR TITLE
GEODE-9071: Add wait before checking cq listener invocations.

### DIFF
--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionCqQueryDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionCqQueryDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.cache.query.cq.dunit;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Assert.assertEquals;
 import static org.apache.geode.test.dunit.Assert.assertFalse;
 import static org.apache.geode.test.dunit.Assert.assertNotNull;
@@ -183,7 +184,8 @@ public class PartitionedRegionCqQueryDUnitTest extends JUnit4CacheTestCase {
           .isNotNull();
       CqQueryTestListener cqListener =
           (CqQueryTestListener) cqQuery.getCqAttributes().getCqListener();
-      assertThat(cqListener.getTotalEventCount()).isEqualTo(numObjects - 1);
+      await().untilAsserted(
+          () -> assertThat(cqListener.getTotalEventCount()).isEqualTo(numObjects - 1));
     });
 
     cqHelper.closeClient(client);
@@ -248,7 +250,8 @@ public class PartitionedRegionCqQueryDUnitTest extends JUnit4CacheTestCase {
           .isNotNull();
       CqQueryTestListener cqListener =
           (CqQueryTestListener) cqQuery.getCqAttributes().getCqListener();
-      assertThat(cqListener.getTotalEventCount()).isEqualTo(numObjects - 1);
+      await().untilAsserted(
+          () -> assertThat(cqListener.getTotalEventCount()).isEqualTo(numObjects - 1));
     });
 
     cqHelper.closeClient(client);


### PR DESCRIPTION
  * Cq events sent to client asynchronously. Need to wait events are
    all delivered.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
