### PR TITLE
GEODE-9506: Do not use random ephemeral port to start Redis servers

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -84,9 +84,8 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
   }
 
   private ServerStarterRule withRedis(ServerStarterRule rule) {
-    int randomPort = AvailablePortHelper.getRandomAvailableTCPPort();
     return rule.withProperty(REDIS_BIND_ADDRESS, BIND_ADDRESS)
-        .withProperty(REDIS_PORT, String.valueOf(randomPort))
+        .withProperty(REDIS_PORT, "0")
         .withProperty(REDIS_ENABLED, "true")
         .withSystemProperty(GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM,
             "true");

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -32,6 +32,7 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.logging.internal.log4j.api.FastLogger;
 import org.apache.geode.redis.ClusterNode;
 import org.apache.geode.redis.ClusterNodes;
@@ -83,8 +84,9 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
   }
 
   private ServerStarterRule withRedis(ServerStarterRule rule) {
+    int randomPort = AvailablePortHelper.getRandomAvailableTCPPort();
     return rule.withProperty(REDIS_BIND_ADDRESS, BIND_ADDRESS)
-        .withProperty(REDIS_PORT, "0")
+        .withProperty(REDIS_PORT, String.valueOf(randomPort))
         .withProperty(REDIS_ENABLED, "true")
         .withSystemProperty(GeodeRedisServer.ENABLE_UNSUPPORTED_COMMANDS_PARAM,
             "true");

--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -32,7 +32,6 @@ import redis.clients.jedis.Jedis;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.logging.internal.log4j.api.FastLogger;
 import org.apache.geode.redis.ClusterNode;
 import org.apache.geode.redis.ClusterNodes;

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionsAndCrashesDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/session/SessionsAndCrashesDUnitTest.java
@@ -62,11 +62,9 @@ public class SessionsAndCrashesDUnitTest {
   private static final int NUM_SESSIONS = 100;
   private static final List<String> sessionIds = new ArrayList<>(NUM_SESSIONS);
   private static MemberVM locator;
-  private static MemberVM server1;
   private static MemberVM server2;
   private static MemberVM server3;
   private static int[] redisPorts;
-  private static JedisCluster jedis;
 
   private SessionRepository<Session> sessionRepository;
   private ConfigurableApplicationContext springContext;
@@ -75,16 +73,13 @@ public class SessionsAndCrashesDUnitTest {
   public static void classSetup() {
     locator = cluster.startLocatorVM(0);
 
-    server1 = startRedisVM(1, 0);
-    server2 = startRedisVM(2, 0);
-    server3 = startRedisVM(3, 0);
+    redisPorts = AvailablePortHelper.getRandomAvailableTCPPorts(3);
 
-    redisPorts = new int[] {
-        cluster.getRedisPort(1),
-        cluster.getRedisPort(2),
-        cluster.getRedisPort(3)};
+    startRedisVM(1, redisPorts[0]);
+    server2 = startRedisVM(2, redisPorts[1]);
+    server3 = startRedisVM(3, redisPorts[2]);
 
-    jedis = new JedisCluster(new HostAndPort("localhost", redisPorts[0]), JEDIS_TIMEOUT);
+    new JedisCluster(new HostAndPort("localhost", redisPorts[0]), JEDIS_TIMEOUT);
   }
 
   private static MemberVM startRedisVM(int vmId, Integer redisPort) {


### PR DESCRIPTION
Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
