### PR TITLE
GEODE-9451: add isExpired to SecurityManager interface

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/security/SecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/SecurityService.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Callable;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.util.ThreadState;
 
+import org.apache.geode.security.AuthenticationExpiredException;
 import org.apache.geode.security.PostProcessor;
 import org.apache.geode.security.ResourcePermission;
 import org.apache.geode.security.ResourcePermission.Operation;
@@ -41,19 +42,45 @@ public interface SecurityService {
 
   Callable associateWith(Callable callable);
 
-  void authorize(Resource resource, Operation operation);
+  /**
+   * @throw AuthenticationExpiredException if the principal has expired.
+   */
+  void authorize(Resource resource, Operation operation) throws AuthenticationExpiredException;
 
-  void authorize(Resource resource, Operation operation, Target target);
+  /**
+   * @throw AuthenticationExpiredException if the principal has expired.
+   */
+  void authorize(Resource resource, Operation operation, Target target)
+      throws AuthenticationExpiredException;
 
-  void authorize(Resource resource, Operation operation, String target);
+  /**
+   * @throw AuthenticationExpiredException if the principal has expired.
+   */
+  void authorize(Resource resource, Operation operation, String target)
+      throws AuthenticationExpiredException;
 
-  void authorize(Resource resource, Operation operation, String target, Object key);
+  /**
+   * @throw AuthenticationExpiredException if the principal has expired.
+   */
+  void authorize(Resource resource, Operation operation, String target, Object key)
+      throws AuthenticationExpiredException;
 
-  void authorize(Resource resource, Operation operation, Target target, String key);
+  /**
+   * @throw AuthenticationExpiredException if the principal has expired.
+   */
+  void authorize(Resource resource, Operation operation, Target target, String key)
+      throws AuthenticationExpiredException;
 
-  void authorize(ResourcePermission context);
+  /**
+   * @throw AuthenticationExpiredException if the principal has expired.
+   */
+  void authorize(ResourcePermission context) throws AuthenticationExpiredException;
 
-  void authorize(ResourcePermission context, Subject currentUser);
+  /**
+   * @throw AuthenticationExpiredException if the principal has expired.
+   */
+  void authorize(ResourcePermission context, Subject currentUser)
+      throws AuthenticationExpiredException;
 
   void close();
 

--- a/geode-core/src/main/java/org/apache/geode/security/SecurityManager.java
+++ b/geode-core/src/main/java/org/apache/geode/security/SecurityManager.java
@@ -69,17 +69,25 @@ public interface SecurityManager {
   Object authenticate(Properties credentials) throws AuthenticationFailedException;
 
   /**
-   * Authorize the ResourcePermission for a given Principal
+   * Authorize the ResourcePermission for a given valid Principal.
+   * This method only checks permission. Principal expiration is checked by isExpired method
    *
    * @param principal The principal that's requesting the permission
    * @param permission The permission requested
    * @return true if authorized, false if not
    *
-   * @throw AuthenticationExpiredException if the principal has expired.
    */
-  default boolean authorize(Object principal, ResourcePermission permission)
-      throws AuthenticationExpiredException {
+  default boolean authorize(Object principal, ResourcePermission permission) {
     return true;
+  }
+
+  /**
+   * checks if the given principal is expired or not
+   *
+   * @return true if the given principal is expired, false if not
+   */
+  default boolean isExpired(Object principal) {
+    return false;
   }
 
   /**

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -110,12 +110,11 @@ public class AuthExpirationDUnitTest {
     Region<Object, Object> region = server.getCache().getRegion("/region");
     assertThat(region.size()).isEqualTo(2);
     Map<String, List<String>> authorizedOps = ExpirableSecurityManager.getAuthorizedOps();
-    Map<String, List<String>> unAuthorizedOps = ExpirableSecurityManager.getUnAuthorizedOps();
+    List<String> unauthorizedUsers = ExpirableSecurityManager.getUnauthorizedUsers();
     assertThat(authorizedOps.keySet().size()).isEqualTo(2);
     assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:WRITE:region:0");
     assertThat(authorizedOps.get("user2")).asList().containsExactly("DATA:WRITE:region:1");
-    assertThat(unAuthorizedOps.keySet().size()).isEqualTo(1);
-    assertThat(unAuthorizedOps.get("user1")).asList().containsExactly("DATA:WRITE:region:1");
+    assertThat(unauthorizedUsers).asList().containsExactly("user1");
   }
 
   @Test
@@ -171,9 +170,8 @@ public class AuthExpirationDUnitTest {
     assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:WRITE:region:1");
     assertThat(authorizedOps.get("user1_extended")).asList().containsExactly("DATA:WRITE:region:3");
 
-    Map<String, List<String>> unAuthorizedOps = ExpirableSecurityManager.getUnAuthorizedOps();
-    assertThat(unAuthorizedOps.keySet().size()).isEqualTo(1);
-    assertThat(unAuthorizedOps.get("user1")).asList().containsExactly("DATA:WRITE:region:3");
+    List<String> unAuthorizedUsers = ExpirableSecurityManager.getUnauthorizedUsers();
+    assertThat(unAuthorizedUsers).asList().containsExactly("user1");
   }
 
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationMultiServerDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationMultiServerDUnitTest.java
@@ -89,8 +89,8 @@ public class AuthExpirationMultiServerDUnitTest implements Serializable {
       Map<String, List<String>> authorizedOps = ExpirableSecurityManager.getAuthorizedOps();
       assertThat(authorizedOps.keySet().contains("test")).isTrue();
       assertThat(authorizedOps.keySet().size()).isEqualTo(1);
-      Map<String, List<String>> unAuthorizedOps = ExpirableSecurityManager.getUnAuthorizedOps();
-      assertThat(unAuthorizedOps.keySet().size()).isEqualTo(0);
+      List<String> unAuthorizedUsers = ExpirableSecurityManager.getUnauthorizedUsers();
+      assertThat(unAuthorizedUsers).asList().hasSize(0);
     });
 
     // client is connected to server1, server1 gets all the initial contact,
@@ -101,17 +101,16 @@ public class AuthExpirationMultiServerDUnitTest implements Serializable {
           "DATA:WRITE:replicateRegion:0", "DATA:WRITE:partitionRegion:0");
       assertThat(authorizedOps.get("user2")).asList().containsExactlyInAnyOrder(
           "DATA:WRITE:replicateRegion:1", "DATA:WRITE:partitionRegion:1");
-      Map<String, List<String>> unAuthorizedOps = ExpirableSecurityManager.getUnAuthorizedOps();
-      assertThat(unAuthorizedOps.get("user1")).asList()
-          .containsExactly("DATA:WRITE:replicateRegion:1");
+      List<String> unAuthorizedUsers = ExpirableSecurityManager.getUnauthorizedUsers();
+      assertThat(unAuthorizedUsers).asList().containsExactly("user1");
     });
 
     // server2 performs no authorization checks
     server2.invoke(() -> {
       Map<String, List<String>> authorizedOps = ExpirableSecurityManager.getAuthorizedOps();
-      Map<String, List<String>> unAuthorizedOps = ExpirableSecurityManager.getUnAuthorizedOps();
       assertThat(authorizedOps.size()).isEqualTo(0);
-      assertThat(unAuthorizedOps.size()).isEqualTo(0);
+      List<String> unAuthorizedUsers = ExpirableSecurityManager.getUnauthorizedUsers();
+      assertThat(unAuthorizedUsers).asList().hasSize(0);
     });
 
     MemberVM.invokeInEveryMember(() -> {


### PR DESCRIPTION
We need a method to simply check the expiration without permission check for message dispatcher. Having this method would also make the SecurityManager authorize method not responsible for expiration checks.