### PR TITLE
GEODE-9436: Implement Radish ZREMRANGEBYSCORE command

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByScoreNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByScoreNativeRedisAcceptanceTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.NativeRedisClusterTestRule;
+
+public class ZRemRangeByScoreNativeRedisAcceptanceTest
+    extends AbstractZRemRangeByScoreIntegrationTest {
+  @ClassRule
+  public static NativeRedisClusterTestRule redis = new NativeRedisClusterTestRule();
+
+  @Override
+  public int getPort() {
+    return redis.getExposedPorts().get(0);
+  }
+
+  @Override
+  public void flushAll() {
+    redis.flushAll();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByScoreDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByScoreDUnitTest.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
+
+import org.apache.geode.cache.Operation;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PartitionedRegionHelper;
+import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+public class ZRemRangeByScoreDUnitTest {
+  @Rule
+  public ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  @Rule
+  public RedisClusterStartupRule clusterStartUp = new RedisClusterStartupRule(4);
+
+  private JedisCluster jedis1;
+  private JedisCluster jedis2;
+  private List<MemberVM> servers;
+  private static final String KEY = "key";
+  private static final String MEMBER_NAME = "memberName";
+  private final int SET_SIZE = 500;
+  private final AtomicBoolean isCrashing = new AtomicBoolean(false);
+
+  @Before
+  public void setup() {
+    MemberVM locator = clusterStartUp.startLocatorVM(0);
+    int locatorPort = locator.getPort();
+    int[] redisPorts = AvailablePortHelper.getRandomAvailableTCPPorts(3);
+    MemberVM server1 = clusterStartUp.startRedisVM(1, redisPorts[0], locatorPort);
+    MemberVM server2 = clusterStartUp.startRedisVM(2, redisPorts[1], locatorPort);
+    MemberVM server3 = clusterStartUp.startRedisVM(3, redisPorts[2], locatorPort);
+    servers = new ArrayList<>();
+    servers.add(server1);
+    servers.add(server2);
+    servers.add(server3);
+
+    int redisServerPort1 = clusterStartUp.getRedisPort(1);
+    int redisServerPort2 = clusterStartUp.getRedisPort(2);
+
+    jedis1 =
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), REDIS_CLIENT_TIMEOUT);
+    jedis2 =
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort2), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    jedis1.close();
+  }
+
+  @Test
+  public void zRemRangeByScore_removesMembersInRangeFromBothServers() {
+    Map<String, Double> memberScoreMap = makeMemberScoreMap();
+    jedis1.zadd(KEY, memberScoreMap);
+    verifyDataExists(memberScoreMap);
+
+    int removeRangeSize = 4;
+    List<String> expected = new ArrayList<>(memberScoreMap.keySet().stream().sorted()
+        .collect(Collectors.toList())).subList(removeRangeSize, SET_SIZE);
+
+    // Subtract 1 from removeRangeSize here since scores start from 0, not 1
+    assertThat(jedis1.zremrangeByScore(KEY, "0", String.valueOf(removeRangeSize - 1)))
+        .isEqualTo(removeRangeSize);
+
+    for (int i = 0; i < removeRangeSize; ++i) {
+      assertThat(jedis1.zrank(KEY, MEMBER_NAME + i)).isNull();
+      assertThat(jedis2.zrank(KEY, MEMBER_NAME + i)).isNull();
+    }
+
+    assertThat(jedis1.zrange(KEY, 0, -1)).containsExactlyElementsOf(expected);
+    assertThat(jedis2.zrange(KEY, 0, -1)).containsExactlyElementsOf(expected);
+  }
+
+  @Test
+  public void zRemRangeByScore_concurrentlyRemovesMembersInRangeFromBothServers() {
+    Map<String, Double> memberScoreMap = makeMemberScoreMap();
+    jedis1.zadd(KEY, memberScoreMap);
+    verifyDataExists(memberScoreMap);
+
+    AtomicInteger totalRemoved = new AtomicInteger();
+    int rangeSize = 5;
+    new ConcurrentLoopingThreads(SET_SIZE / rangeSize,
+        (i) -> doZRemRangeByScore(i * rangeSize, totalRemoved),
+        (i) -> doZRemRangeByScore(i * rangeSize, totalRemoved)).run();
+
+    assertThat(jedis1.exists(KEY)).isFalse();
+    assertThat(jedis2.exists(KEY)).isFalse();
+
+    assertThat(totalRemoved.get()).isEqualTo(SET_SIZE);
+  }
+
+  @Test
+  public void zRemRangeByScoreRemovesMembersFromSortedSetAfterPrimaryShutsDown() {
+    Map<String, Double> memberScoreMap = makeMemberScoreMap();
+    jedis1.zadd(KEY, memberScoreMap);
+    verifyDataExists(memberScoreMap);
+
+    stopNodeWithPrimaryBucketOfTheKey(false);
+
+    doZRemRangeByScoreWithRetries(memberScoreMap);
+
+    verifyDataDoesNotExist(memberScoreMap);
+    assertThat(jedis1.exists(KEY)).isFalse();
+    assertThat(jedis2.exists(KEY)).isFalse();
+  }
+
+  @Test
+  public void zRemRangeByScoreCanRemoveMembersFromSortedSetWhenPrimaryIsCrashed()
+      throws ExecutionException, InterruptedException {
+    Map<String, Double> memberScoreMap = makeMemberScoreMap();
+
+    jedis1.zadd(KEY, memberScoreMap);
+    verifyDataExists(memberScoreMap);
+
+    String firstMember = String.join("", jedis1.zrange(KEY, 0, 0));
+    memberScoreMap.remove(firstMember);
+
+    Future<Void> future1 = executor.submit(() -> stopNodeWithPrimaryBucketOfTheKey(true));
+    Future<Void> future2 = executor.submit(this::removeAllButFirstEntry);
+
+    future1.get();
+    future2.get();
+
+    await().until(() -> verifyDataDoesNotExist(memberScoreMap));
+    assertThat(jedis1.zrank(KEY, firstMember)).isZero();
+    assertThat(jedis1.exists(KEY)).isTrue();
+  }
+
+  private void verifyDataExists(Map<String, Double> memberScoreMap) {
+    for (String member : memberScoreMap.keySet()) {
+      Double score = jedis1.zscore(KEY, member);
+      assertThat(score).isEqualTo(memberScoreMap.get(member));
+    }
+  }
+
+  private void doZRemRangeByScore(int i, AtomicInteger total) {
+    long count = jedis1.zremrangeByScore(KEY, String.valueOf(i), String.valueOf(i + 5));
+    total.addAndGet((int) count);
+  }
+
+  private void stopNodeWithPrimaryBucketOfTheKey(boolean isCrash) {
+    boolean isPrimary;
+    for (MemberVM server : servers) {
+      isPrimary = server.invoke(ZRemRangeByScoreDUnitTest::isPrimaryForKey);
+      if (isPrimary) {
+        if (isCrash) {
+          isCrashing.set(true);
+          server.getVM().bounceForcibly();
+        } else {
+          server.stop();
+        }
+        return;
+      }
+    }
+  }
+
+  private boolean verifyDataDoesNotExist(Map<String, Double> memberScoreMap) {
+    try {
+      for (String member : memberScoreMap.keySet()) {
+        Double score = jedis1.zscore(KEY, member);
+        assertThat(score).isNull();
+      }
+    } catch (JedisClusterMaxAttemptsException e) {
+      return false;
+    }
+    return true;
+  }
+
+  private void removeAllButFirstEntry() {
+    long removed = 0;
+    int rangeSize = 5;
+    await().until(isCrashing::get);
+    for (int i = 1; i < SET_SIZE; i += rangeSize) {
+      removed += jedis1.zremrangeByScore(KEY, String.valueOf(i), String.valueOf(i + rangeSize));
+    }
+    assertThat(removed).isEqualTo(SET_SIZE - 1);
+  }
+
+  private static boolean isPrimaryForKey() {
+    PartitionedRegion region = (PartitionedRegion) requireNonNull(ClusterStartupRule.getCache())
+        .getRegion(RegionProvider.REDIS_DATA_REGION);
+    int bucketId = PartitionedRegionHelper
+        .getHashKey(region, Operation.GET, new RedisKey(KEY.getBytes()), null, null);
+    return region.getLocalPrimaryBucketsListTestOnly().contains(bucketId);
+  }
+
+  private Map<String, Double> makeMemberScoreMap() {
+    Map<String, Double> scoreMemberPairs = new HashMap<>();
+    String memberName = MEMBER_NAME;
+    for (int i = 0; i < SET_SIZE; i++) {
+      memberName = memberName + i;
+      scoreMemberPairs.put(memberName, (double) i);
+    }
+    return scoreMemberPairs;
+  }
+
+  private void doZRemRangeByScoreWithRetries(Map<String, Double> map) {
+    int maxRetryAttempts = 10;
+    int retryAttempts = 0;
+    while (!zRemRangeByScoreWithRetries(map, retryAttempts, maxRetryAttempts)) {
+      retryAttempts++;
+    }
+  }
+
+  private boolean zRemRangeByScoreWithRetries(Map<String, Double> map, int retries,
+      int maxRetries) {
+    long removed;
+    try {
+      removed = jedis1.zremrangeByScore(KEY, "-inf", "+inf");
+    } catch (JedisClusterMaxAttemptsException e) {
+      if (retries < maxRetries) {
+        return false;
+      }
+      throw e;
+    }
+    assertThat(removed).isEqualTo(map.size());
+    return true;
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -298,6 +298,11 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   }
 
   @Test
+  public void testZremrangeByScore() {
+    runCommandAndAssertNoStatUpdates(SORTED_SET_KEY, k -> jedis.zremrangeByScore(k, 0.0, 1.0));
+  }
+
+  @Test
   public void testZrevrange() {
     runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zrevrange(k, 0, 1));
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRemRangeByScoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRemRangeByScoreIntegrationTest.java
@@ -1,0 +1,271 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_MIN_MAX_NOT_A_FLOAT;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Protocol;
+
+import org.apache.geode.redis.RedisIntegrationTest;
+
+public abstract class AbstractZRemRangeByScoreIntegrationTest implements RedisIntegrationTest {
+  public static final String KEY = "key";
+  public static final String MEMBER_NAME = "member";
+  private JedisCluster jedis;
+
+  @Before
+  public void setUp() {
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void shouldError_givenWrongNumberOfArguments() {
+    assertAtLeastNArgs(jedis, Protocol.Command.ZREMRANGEBYSCORE, 3);
+  }
+
+  @Test
+  public void shouldError_givenInvalidMinOrMax() {
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "notANumber", "1"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "notANumber"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "notANumber", "notANumber"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "((", "1"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "(("))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "(a", "(b"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "str", "1"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "str"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+    assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "NaN"))
+        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+  }
+
+  @Test
+  public void shouldReturnZero_givenNonExistentKey() {
+    assertThat(jedis.zremrangeByScore("fakeKey", "-inf", "inf")).isZero();
+  }
+
+  @Test
+  public void shouldReturnZero_givenMinGreaterThanMax() {
+    jedis.zadd(KEY, 1, MEMBER_NAME);
+
+    // Range +inf <= score <= -inf
+    assertThat(jedis.zremrangeByScore(KEY, "+inf", "-inf")).isZero();
+    assertThat(jedis.zscore(KEY, MEMBER_NAME)).isNotNull();
+  }
+
+  @Test
+  public void shouldRemoveRange_givenRangeIncludingScore() {
+    jedis.zadd(KEY, 1, MEMBER_NAME);
+
+    // Range -inf <= score <= +inf
+    assertThat(jedis.zremrangeByScore(KEY, "-inf", "inf")).isOne();
+    assertThat(jedis.zscore(KEY, MEMBER_NAME)).isNull();
+  }
+
+  @Test
+  public void shouldRemoveRangeThenReturnZero_givenRangeIncludingScoreAndMultipleRemoves() {
+    jedis.zadd(KEY, 1, MEMBER_NAME);
+
+    // Range -inf <= score <= +inf
+    assertThat(jedis.zremrangeByScore(KEY, "-inf", "inf")).isOne();
+    assertThat(jedis.zscore(KEY, MEMBER_NAME)).isNull();
+    assertThat(jedis.zremrangeByScore(KEY, "-inf", "inf")).isZero();
+    assertThat(jedis.zscore(KEY, MEMBER_NAME)).isNull();
+  }
+
+  @Test
+  public void shouldReturnZero_givenRangeExcludingScore() {
+    int score = 1;
+    jedis.zadd(KEY, score, MEMBER_NAME);
+
+    // Range 2 <= score <= 3
+    assertThat(jedis.zremrangeByScore(KEY, score + 1, score + 2)).isZero();
+    assertThat(jedis.zscore(KEY, MEMBER_NAME)).isNotNull();
+  }
+
+  @Test
+  public void shouldRemoveRange_givenMinAndMaxEqualToScore() {
+    int score = 1;
+    jedis.zadd(KEY, score, MEMBER_NAME);
+
+    // Range 1 <= score <= 1
+    assertThat(jedis.zremrangeByScore(KEY, score, score)).isOne();
+    assertThat(jedis.zscore(KEY, MEMBER_NAME)).isNull();
+  }
+
+  @Test
+  public void shouldRemoveRange_givenMultipleMembersWithDifferentScores() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("member1", -10.0);
+    map.put("member2", 1.0);
+    map.put("member3", 10.0);
+
+    jedis.zadd(KEY, map);
+
+    // Range -5 <= score <= 15
+    assertThat(jedis.zremrangeByScore(KEY, "-5", "15")).isEqualTo(2);
+    assertThat(jedis.zscore(KEY, "member1")).isNotNull();
+    assertThat(jedis.zscore(KEY, "member2")).isNull();
+    assertThat(jedis.zscore(KEY, "member3")).isNull();
+  }
+
+  @Test
+  public void shouldRemoveRange_givenMultipleMembersWithTheSameScoreAndMinAndMaxEqualToScore() {
+    Map<String, Double> map = new HashMap<>();
+    double score = 1;
+    map.put("member1", score);
+    map.put("member2", score);
+    map.put("member3", score);
+
+    jedis.zadd(KEY, map);
+
+    // Range 1 <= score <= 1
+    assertThat(jedis.zremrangeByScore(KEY, score, score)).isEqualTo(3);
+    assertThat(jedis.zscore(KEY, "member1")).isNull();
+    assertThat(jedis.zscore(KEY, "member2")).isNull();
+    assertThat(jedis.zscore(KEY, "member3")).isNull();
+  }
+
+  @Test
+  public void shouldRemoveRange_basicExclusivity() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("member0", 0.0);
+    map.put("member1", 1.0);
+    map.put("member2", 2.0);
+    map.put("member3", 3.0);
+    map.put("member4", 4.0);
+
+    jedis.zadd(KEY, map);
+
+    assertThat(jedis.zremrangeByScore(KEY, "(1.0", "(3.0")).isOne();
+    assertThat(jedis.zscore(KEY, "member2")).isNull();
+
+    assertThat(jedis.zremrangeByScore(KEY, "(1.0", "3.0")).isOne();
+    assertThat(jedis.zscore(KEY, "member3")).isNull();
+
+    assertThat(jedis.zremrangeByScore(KEY, "1.0", "(3.0")).isOne();
+    assertThat(jedis.zscore(KEY, "member0")).isNotNull();
+    assertThat(jedis.zscore(KEY, "member1")).isNull();
+    assertThat(jedis.zscore(KEY, "member2")).isNull();
+    assertThat(jedis.zscore(KEY, "member3")).isNull();
+    assertThat(jedis.zscore(KEY, "member4")).isNotNull();
+  }
+
+  @Test
+  public void shouldRemoveRange_givenExclusiveMin() {
+    Map<String, Double> map = getExclusiveTestMap();
+
+    jedis.zadd(KEY, map);
+
+    // Range -inf < score <= +inf
+    assertThat(jedis.zremrangeByScore(KEY, "(-inf", "+inf")).isEqualTo(2);
+    assertThat(jedis.zscore(KEY, "member1")).isNotNull();
+    assertThat(jedis.zscore(KEY, "member2")).isNull();
+    assertThat(jedis.zscore(KEY, "member3")).isNull();
+  }
+
+  @Test
+  public void shouldRemoveRange_givenExclusiveMax() {
+    Map<String, Double> map = getExclusiveTestMap();
+
+    jedis.zadd(KEY, map);
+
+    // Range -inf <= score < +inf
+    assertThat(jedis.zremrangeByScore(KEY, "-inf", "(+inf")).isEqualTo(2);
+    assertThat(jedis.zscore(KEY, "member1")).isNull();
+    assertThat(jedis.zscore(KEY, "member2")).isNull();
+    assertThat(jedis.zscore(KEY, "member3")).isNotNull();
+  }
+
+  @Test
+  public void shouldRemoveRange_givenExclusiveMinAndMax() {
+    Map<String, Double> map = getExclusiveTestMap();
+
+    jedis.zadd(KEY, map);
+
+    // Range -inf < score < +inf
+    assertThat(jedis.zremrangeByScore(KEY, "(-inf", "(+inf")).isOne();
+    assertThat(jedis.zscore(KEY, "member1")).isNotNull();
+    assertThat(jedis.zscore(KEY, "member2")).isNull();
+    assertThat(jedis.zscore(KEY, "member3")).isNotNull();
+  }
+
+  private Map<String, Double> getExclusiveTestMap() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("member1", Double.NEGATIVE_INFINITY);
+    map.put("member2", 1.0);
+    map.put("member3", Double.POSITIVE_INFINITY);
+    return map;
+  }
+
+  @Test
+  public void shouldReturnZero_givenExclusiveMinAndMaxEqualToScore() {
+    double score = 1;
+    jedis.zadd(KEY, score, MEMBER_NAME);
+
+    String scoreExclusive = "(" + score;
+    assertThat(jedis.zremrangeByScore(KEY, scoreExclusive, scoreExclusive)).isZero();
+    assertThat(jedis.zscore(KEY, MEMBER_NAME)).isNotNull();
+  }
+
+  @Test
+  // Using only "(" as either the min or the max is equivalent to "(0"
+  public void shouldRemoveRange_givenLeftParenOnlyForMinOrMax() {
+    Map<String, Double> map = new HashMap<>();
+
+    map.put("slightlyLessThanZero", -0.01);
+    map.put("zero", 0.0);
+    map.put("slightlyMoreThanZero", 0.01);
+
+    jedis.zadd(KEY, map);
+
+    // Range 0 < score <= inf
+    assertThat(jedis.zremrangeByScore(KEY, "(", "inf")).isOne();
+    assertThat(jedis.zscore(KEY, "slightlyMoreThanZero")).isNull();
+
+    // Range -inf <= score < 0
+    assertThat(jedis.zremrangeByScore(KEY, "-inf", "(")).isOne();
+    assertThat(jedis.zscore(KEY, "slightlyLessThanZero")).isNull();
+    assertThat(jedis.zscore(KEY, "zero")).isNotNull();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByScoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByScoreIntegrationTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+
+public class ZRemRangeByScoreIntegrationTest extends AbstractZRemRangeByScoreIntegrationTest {
+  @ClassRule
+  public static GeodeRedisServerRule redis = new GeodeRedisServerRule();
+
+  @Override
+  public int getPort() {
+    return redis.getPort();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -108,6 +108,7 @@ import org.apache.geode.redis.internal.executor.sortedset.ZRangeByScoreExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRangeExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRankExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRemExecutor;
+import org.apache.geode.redis.internal.executor.sortedset.ZRemRangeByScoreExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRevRangeByLexExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRevRangeByScoreExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRevRangeExecutor;
@@ -229,6 +230,7 @@ public enum RedisCommandType {
   ZRANGEBYSCORE(new ZRangeByScoreExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),
   ZRANK(new ZRankExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
   ZREM(new ZRemExecutor(), SUPPORTED, new MinimumParameterRequirements(3)),
+  ZREMRANGEBYSCORE(new ZRemRangeByScoreExecutor(), SUPPORTED, new ExactParameterRequirements(4)),
   ZREVRANGE(new ZRevRangeExecutor(), SUPPORTED, new MinimumParameterRequirements(4)
       .and(new MaximumParameterRequirements(5, ERROR_SYNTAX))),
   ZREVRANGEBYLEX(new ZRevRangeByLexExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -92,6 +92,7 @@ class NullRedisSortedSet extends RedisSortedSet {
     return Collections.emptyList();
   }
 
+  @Override
   List<byte[]> zrange(SortedSetRankRangeOptions rangeOptions) {
     return Collections.emptyList();
   }
@@ -106,6 +107,13 @@ class NullRedisSortedSet extends RedisSortedSet {
     return Collections.emptyList();
   }
 
+  @Override
+  long zremrangebyscore(Region<RedisKey, RedisData> region, RedisKey key,
+      SortedSetScoreRangeOptions rangeOptions) {
+    return 0;
+  }
+
+  @Override
   List<byte[]> zrevrange(SortedSetRankRangeOptions rangeOptions) {
     return Collections.emptyList();
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -101,6 +101,12 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
+  public long zremrangebyscore(RedisKey key, SortedSetScoreRangeOptions rangeOptions) {
+    return stripedExecute(key,
+        () -> getRedisSortedSet(key, false).zremrangebyscore(getRegion(), key, rangeOptions));
+  }
+
+  @Override
   public List<byte[]> zrevrange(RedisKey key, SortedSetRankRangeOptions rangeOptions) {
     return stripedExecute(key, () -> getRedisSortedSet(key, true).zrevrange(rangeOptions));
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -45,6 +45,8 @@ public interface RedisSortedSetCommands {
 
   long zrem(RedisKey key, List<byte[]> membersToRemove);
 
+  long zremrangebyscore(RedisKey key, SortedSetScoreRangeOptions rangeOptions);
+
   List<byte[]> zrevrange(RedisKey key, SortedSetRankRangeOptions rangeOptions);
 
   List<byte[]> zrevrangebylex(RedisKey key, SortedSetLexRangeOptions rangeOptions);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByScoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRemRangeByScoreExecutor.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.RedisResponse;
+
+public class ZRemRangeByScoreExecutor extends ZRangeByScoreExecutor {
+  @Override
+  public RedisResponse getEmptyResponse() {
+    return RedisResponse.integer(0);
+  }
+
+  @Override
+  public RedisResponse executeRangeCommand(RedisSortedSetCommands commands, RedisKey key,
+      SortedSetScoreRangeOptions options) {
+    return RedisResponse.integer(commands.zremrangebyscore(key, options));
+  }
+}


### PR DESCRIPTION
 - Add iteratorRangeRemove() and removeRange() methods to RedisSortedSet
 - Add ZRemRangeByScoreExecutor as subclass of ZRangeByScoreExecutor
 - Add tests for ZREMRANGEBYSCORE

Authored-by: Donal Evans <doevans@vmware.com>

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
