### PR TITLE
GEODE-9369: Fix test failure when run on Windows

### DIFF
--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionTest.java
@@ -589,7 +589,7 @@ public class WanCopyRegionFunctionTest {
     Future<CliFunctionResult> future2 = executeAsyncWanCopyRegionFunction(options2);
 
     // Wait for the functions to start execution
-    Thread.sleep(100);
+    Thread.sleep(1000);
 
     // Cancel the function executions
     Object[] cancelAllOptions = new Object[] {"*", "*", true, 1L, 1};


### PR DESCRIPTION
In the test case that cancels all ongoing executions of the wan-copy command, it seems that it takes longer than 100ms to start the two command executions so, when the cancel is executed later, the executions are not yet started.
A longer sleep time to wait for the wan-copy commands to be started has been added.

See the test failure on windows here:
https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-develop-main/jobs/windows-unit-test-openjdk11/builds/143

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
