### PR TITLE
GEODE-9453: The server, once a user expires, should clean the user at…

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/SecurityWithExpirationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/SecurityWithExpirationIntegrationTest.java
@@ -27,6 +27,7 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.security.SecurityServiceFactory;
 import org.apache.geode.security.AuthenticationExpiredException;
+import org.apache.geode.security.AuthenticationFailedException;
 import org.apache.geode.security.ExpirableSecurityManager;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
@@ -45,14 +46,20 @@ public class SecurityWithExpirationIntegrationTest {
 
   @After
   public void after() throws Exception {
-    securityService.logout();
     ExpirableSecurityManager.reset();
   }
 
   @Test
-  public void testThrowAuthenticationExpiredException() {
+  public void testAuthenticationWhenUserExpired() {
     ExpirableSecurityManager.addExpiredUser("data");
+    assertThatThrownBy(() -> this.securityService.login(loginCredentials("data", "data")))
+        .isInstanceOf(AuthenticationFailedException.class);
+  }
+
+  @Test
+  public void testAuthorizationWhenUserExpired() {
     this.securityService.login(loginCredentials("data", "data"));
+    ExpirableSecurityManager.addExpiredUser("data");
     assertThatThrownBy(() -> this.securityService.authorize(ResourcePermissions.DATA_READ))
         .isInstanceOf(AuthenticationExpiredException.class);
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -268,7 +268,6 @@ public class IntegratedSecurityService implements SecurityService {
       throw new NotAuthorizedException(message, e);
     } catch (AuthenticationExpiredException expired) {
       // log out the user and clean thread context
-
       logout();
       // still throw it upstream so that caller can react to re-authenticate
       throw expired;

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -99,6 +99,9 @@ public class AuthExpirationDUnitTest {
     // expire the current user
     ExpirableSecurityManager.addExpiredUser("user1");
 
+    // if client, even after getting AuthExpiredExpiration, still sends in
+    // old credentials, the operation will fail (we only try re-authenticate once)
+    // this test makes sure no lingering old credentials will allow the operations to succeed.
     clientVM.invoke(() -> {
       ClientCache clientCache = ClusterStartupRule.getClientCache();
       Region<Object, Object> region = clientCache.getRegion("region");
@@ -128,7 +131,7 @@ public class AuthExpirationDUnitTest {
   }
 
   @Test
-  public void clientShouldReAuthenticateWhenCredentialExpiredAndOperationSucceed()
+  public void singleUserModeShouldReAuthenticateWhenCredentialExpiredAndOperationSucceed()
       throws Exception {
     int serverPort = server.getPort();
     ClientVM clientVM = lsRule.startClientVM(0, clientVersion,
@@ -169,7 +172,8 @@ public class AuthExpirationDUnitTest {
   }
 
   @Test
-  public void userShouldReAuthenticateWhenCredentialExpiredAndOperationSucceed() throws Exception {
+  public void multiUserModeShouldReAuthenticateWhenCredentialExpiredAndOperationSucceed()
+      throws Exception {
     int serverPort = server.getPort();
     ClientVM clientVM = lsRule.startClientVM(0, clientVersion,
         c -> c.withMultiUser(true)

--- a/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
@@ -18,6 +18,7 @@ package org.apache.geode.security;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -39,6 +40,15 @@ public class ExpirableSecurityManager extends SimpleSecurityManager {
       new ConcurrentHashMap<>();
   private static final Map<String, List<String>> UNAUTHORIZED_OPS =
       new ConcurrentHashMap<>();
+
+  @Override
+  public Object authenticate(final Properties credentials) throws AuthenticationFailedException {
+    Object user = super.authenticate(credentials);
+    if (EXPIRED_USERS.contains((String) user)) {
+      throw new AuthenticationFailedException("User already expired.");
+    }
+    return user;
+  }
 
   @Override
   public boolean authorize(Object principal, ResourcePermission permission) {


### PR DESCRIPTION
…tributes from the server.

This logout the given subject when an AuthExpiredException is encountered. 

This PR doesn't try to clean out the `ClientUserAuths.uniqueIdVsSubject` map for the following reasons:
1. there is no clean way to get access to it unless using the static variable in `ServerConnection`
2. when a clients connects, multiple threads calls into the server to authenticate, resulting into multiple in that entries in that map, each with different unique id and unique subject/principal, even though it's the same user. Logging out one subject nulls one but didn't null the others. The other subject in the map won't be able to do anything anyway because every attempted operation will logout the user.
3. This map will eventually get cleaned up when connection closes or dies, so there isn't much point trying to clean up the nullified subject in this map (as far I can tell). 

Would love to get more feedback on this.

