### PR TITLE
GEODE-9482: change Coder.bytesToLong to fail if bytes start with "-0" or "+"

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -362,12 +362,11 @@ public class Coder {
       i++;
       if (length == 1) {
         throw createNumberFormatException(bytes); // need a digit
+      } else if (bytes[1] == digitToAscii(0)) {
+        throw createNumberFormatException(bytes); // redis does not allow -0*
       }
     } else if (bytes[0] == bPLUS) {
-      i++;
-      if (length == 1) {
-        throw createNumberFormatException(bytes); // need a digit
-      }
+      throw createNumberFormatException(bytes); // redis does not allow +*
     }
     while (i < length) {
       int digit = asciiToDigit(bytes[i++]);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -16,7 +16,7 @@ package org.apache.geode.redis.internal.netty;
 
 import static org.apache.geode.redis.internal.netty.Coder.bytesToDouble;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-import static org.apache.geode.redis.internal.netty.Coder.doubleToString;
+import static org.apache.geode.redis.internal.netty.Coder.doubleToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.isNaN;
@@ -73,9 +73,12 @@ public class CoderTest {
 
   @Test
   @Parameters(method = "infinityReturnStrings")
-  public void doubleToString_processesLikeRedis(String inputString, String expectedString) {
+  public void doubleToBytes_processesLikeRedis(String inputString, String expectedString) {
     byte[] bytes = stringToBytes(inputString);
-    assertThat(doubleToString(bytesToDouble(bytes))).isEqualTo(expectedString);
+    double d = bytesToDouble(bytes);
+    byte[] convertedBytes = doubleToBytes(d);
+    String convertedString = bytesToString(convertedBytes);
+    assertThat(convertedString).isEqualTo(expectedString);
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -27,6 +27,7 @@ import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.stripTrailingZeroFromDouble;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.nio.charset.StandardCharsets;
 
@@ -246,6 +247,24 @@ public class CoderTest {
     byte[] lBytes = Coder.longToBytes(l);
     long l2 = Coder.bytesToLong(lBytes);
     assertThat(l2).isEqualTo(l);
+  }
+
+  @Test
+  public void bytesToLong_fails_if_MINUS_ZERO_start() {
+    assertThatThrownBy(() -> Coder.bytesToLong(Coder.stringToBytes("-01234")))
+        .isInstanceOf(NumberFormatException.class);
+    assertThatThrownBy(() -> Coder.bytesToLong(Coder.stringToBytes("-0")))
+        .isInstanceOf(NumberFormatException.class);
+  }
+
+  @Test
+  public void bytesToLong_fails_if_PLUS_start() {
+    assertThatThrownBy(() -> Coder.bytesToLong(Coder.stringToBytes("+")))
+        .isInstanceOf(NumberFormatException.class);
+    assertThatThrownBy(() -> Coder.bytesToLong(Coder.stringToBytes("+0")))
+        .isInstanceOf(NumberFormatException.class);
+    assertThatThrownBy(() -> Coder.bytesToLong(Coder.stringToBytes("+1")))
+        .isInstanceOf(NumberFormatException.class);
   }
 
 }


### PR DESCRIPTION
In addition to the change to have bytesToLong fail if the bytes begin with "-0" or "+",
this pr also has some other cleanup of Coder.
The double conversion was doing some extra comparisons (both byte[] and String comparisons). Now it just does byte[] comparisons.
The long conversion is has now also been influenced by the javolution project.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
