### PR TITLE
Revert "GEODE-9408: Avoid duplicate events sent by Serial Gateway Sen…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
@@ -17,7 +17,6 @@ package org.apache.geode.cache.wan;
 import java.util.List;
 
 import org.apache.geode.annotations.Immutable;
-import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 /**
@@ -176,13 +175,6 @@ public interface GatewaySender {
   int GET_TRANSACTION_EVENTS_FROM_QUEUE_RETRIES =
       Integer.getInteger(GeodeGlossary.GEMFIRE_PREFIX + "get-transaction-events-from-queue-retries",
           10);
-  /**
-   * Milliseconds to wait before retrying to get events for a transaction from the
-   * gateway sender queue when group-transaction-events is true.
-   */
-  int GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS =
-      SystemPropertyHelper.getProductIntegerProperty(
-          SystemPropertyHelper.GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS).orElse(1);
 
   /**
    * The order policy. This enum is applicable only when concurrency-level is > 1.
@@ -430,14 +422,6 @@ public interface GatewaySender {
   boolean mustGroupTransactionEvents();
 
   /**
-   * Returns retriesToGetTransactionEventsFromQueue int property for this GatewaySender.
-   *
-   * @return retriesToGetTransactionEventsFromQueue int property for this GatewaySender
-   *
-   */
-  int getRetriesToGetTransactionEventsFromQueue();
-
-  /**
    * Returns the number of dispatcher threads working for this <code>GatewaySender</code>. Default
    * number of dispatcher threads is 5.
    *
@@ -515,13 +499,5 @@ public interface GatewaySender {
    *
    */
   void setGatewayEventFilters(List<GatewayEventFilter> filters);
-
-  /**
-   * Set the number of retries to get transaction events
-   * for this GatewaySender when GroupTransactionEvents
-   * is set.
-   *
-   */
-  void setRetriesToGetTransactionEventsFromQueue(int retries);
 
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySenderFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySenderFactory.java
@@ -50,15 +50,6 @@ public interface GatewaySenderFactory {
   GatewaySenderFactory setGroupTransactionEvents(boolean groupTransactionEvents);
 
   /**
-   * Sets the maximum number of retries to get events from the queue
-   * to complete a transaction when groupTransactionEvents is true.
-   *
-   * @param retries the maximum number of retries.
-   */
-  GatewaySenderFactory setRetriesToGetTransactionEventsFromQueue(int retries);
-
-
-  /**
    * Adds a <code>GatewayEventFilter</code>
    *
    * @param filter GatewayEventFilter

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
@@ -127,8 +127,6 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
 
   protected boolean groupTransactionEvents;
 
-  protected int retriesToGetTransactionEventsFromQueue;
-
   protected boolean isForInternalUse;
 
   protected boolean isDiskSynchronous;
@@ -246,51 +244,50 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       GatewaySenderAttributes attrs) {
     this.cache = cache;
     this.statisticsClock = statisticsClock;
-    id = attrs.getId();
-    socketBufferSize = attrs.getSocketBufferSize();
-    socketReadTimeout = attrs.getSocketReadTimeout();
-    queueMemory = attrs.getMaximumQueueMemory();
-    batchSize = attrs.getBatchSize();
-    batchTimeInterval = attrs.getBatchTimeInterval();
-    isConflation = attrs.isBatchConflationEnabled();
-    isPersistence = attrs.isPersistenceEnabled();
-    alertThreshold = attrs.getAlertThreshold();
-    manualStart = attrs.isManualStart();
-    isParallel = attrs.isParallel();
-    groupTransactionEvents = attrs.mustGroupTransactionEvents();
-    retriesToGetTransactionEventsFromQueue = attrs.getRetriesToGetTransactionEventsFromQueue();
-    isForInternalUse = attrs.isForInternalUse();
-    diskStoreName = attrs.getDiskStoreName();
-    remoteDSId = attrs.getRemoteDSId();
-    eventFilters = Collections.unmodifiableList(attrs.getGatewayEventFilters());
-    transFilters = Collections.unmodifiableList(attrs.getGatewayTransportFilters());
-    listeners = attrs.getAsyncEventListeners();
-    substitutionFilter = attrs.getGatewayEventSubstitutionFilter();
-    locatorDiscoveryCallback = attrs.getGatewayLocatoDiscoveryCallback();
-    isDiskSynchronous = attrs.isDiskSynchronous();
-    policy = attrs.getOrderPolicy();
-    dispatcherThreads = attrs.getDispatcherThreads();
-    parallelismForReplicatedRegion = attrs.getParallelismForReplicatedRegion();
+    this.id = attrs.getId();
+    this.socketBufferSize = attrs.getSocketBufferSize();
+    this.socketReadTimeout = attrs.getSocketReadTimeout();
+    this.queueMemory = attrs.getMaximumQueueMemory();
+    this.batchSize = attrs.getBatchSize();
+    this.batchTimeInterval = attrs.getBatchTimeInterval();
+    this.isConflation = attrs.isBatchConflationEnabled();
+    this.isPersistence = attrs.isPersistenceEnabled();
+    this.alertThreshold = attrs.getAlertThreshold();
+    this.manualStart = attrs.isManualStart();
+    this.isParallel = attrs.isParallel();
+    this.groupTransactionEvents = attrs.mustGroupTransactionEvents();
+    this.isForInternalUse = attrs.isForInternalUse();
+    this.diskStoreName = attrs.getDiskStoreName();
+    this.remoteDSId = attrs.getRemoteDSId();
+    this.eventFilters = Collections.unmodifiableList(attrs.getGatewayEventFilters());
+    this.transFilters = Collections.unmodifiableList(attrs.getGatewayTransportFilters());
+    this.listeners = attrs.getAsyncEventListeners();
+    this.substitutionFilter = attrs.getGatewayEventSubstitutionFilter();
+    this.locatorDiscoveryCallback = attrs.getGatewayLocatoDiscoveryCallback();
+    this.isDiskSynchronous = attrs.isDiskSynchronous();
+    this.policy = attrs.getOrderPolicy();
+    this.dispatcherThreads = attrs.getDispatcherThreads();
+    this.parallelismForReplicatedRegion = attrs.getParallelismForReplicatedRegion();
     // divide the maximumQueueMemory of sender equally using number of dispatcher threads.
     // if dispatcherThreads is 1 then maxMemoryPerDispatcherQueue will be same as maximumQueueMemory
     // of sender
-    maxMemoryPerDispatcherQueue = queueMemory / dispatcherThreads;
-    serialNumber = DistributionAdvisor.createSerialNumber();
-    isMetaQueue = attrs.isMetaQueue();
-    enforceThreadsConnectSameReceiver = attrs.getEnforceThreadsConnectSameReceiver();
-    if (!(cache instanceof CacheCreation)) {
-      myDSId = cache.getInternalDistributedSystem().getDistributionManager()
+    this.maxMemoryPerDispatcherQueue = this.queueMemory / this.dispatcherThreads;
+    this.serialNumber = DistributionAdvisor.createSerialNumber();
+    this.isMetaQueue = attrs.isMetaQueue();
+    this.enforceThreadsConnectSameReceiver = attrs.getEnforceThreadsConnectSameReceiver();
+    if (!(this.cache instanceof CacheCreation)) {
+      this.myDSId = this.cache.getInternalDistributedSystem().getDistributionManager()
           .getDistributedSystemId();
-      stopper = new Stopper(cache.getCancelCriterion());
-      senderAdvisor = GatewaySenderAdvisor.createGatewaySenderAdvisor(this);
-      if (!isForInternalUse()) {
-        statistics = new GatewaySenderStats(cache.getDistributedSystem(),
+      this.stopper = new Stopper(cache.getCancelCriterion());
+      this.senderAdvisor = GatewaySenderAdvisor.createGatewaySenderAdvisor(this);
+      if (!this.isForInternalUse()) {
+        this.statistics = new GatewaySenderStats(cache.getDistributedSystem(),
             "gatewaySenderStats-", id, statisticsClock);
       }
       initializeEventIdIndex();
     }
-    isBucketSorted = attrs.isBucketSorted();
-    forwardExpirationDestroy = attrs.isForwardExpirationDestroy();
+    this.isBucketSorted = attrs.isBucketSorted();
+    this.forwardExpirationDestroy = attrs.isForwardExpirationDestroy();
   }
 
   public GatewaySenderAdvisor getSenderAdvisor() {
@@ -313,135 +310,135 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
 
   @Override
   public boolean isPrimary() {
-    return getSenderAdvisor().isPrimary();
+    return this.getSenderAdvisor().isPrimary();
   }
 
   public void setIsPrimary(boolean isPrimary) {
-    getSenderAdvisor().setIsPrimary(isPrimary);
+    this.getSenderAdvisor().setIsPrimary(isPrimary);
   }
 
   @Override
   public InternalCache getCache() {
-    return cache;
+    return this.cache;
   }
 
   @Override
   public int getAlertThreshold() {
-    return alertThreshold;
+    return this.alertThreshold;
   }
 
   @Override
   public int getBatchSize() {
-    return batchSize;
+    return this.batchSize;
   }
 
   @Override
   public int getBatchTimeInterval() {
-    return batchTimeInterval;
+    return this.batchTimeInterval;
   }
 
   @Override
   public String getDiskStoreName() {
-    return diskStoreName;
+    return this.diskStoreName;
   }
 
   @Override
   public List<GatewayEventFilter> getGatewayEventFilters() {
-    return eventFilters;
+    return this.eventFilters;
   }
 
   @Override
   public GatewayEventSubstitutionFilter getGatewayEventSubstitutionFilter() {
-    return substitutionFilter;
+    return this.substitutionFilter;
   }
 
   @Override
   public String getId() {
-    return id;
+    return this.id;
   }
 
   public long getStartTime() {
-    return startTime;
+    return this.startTime;
   }
 
   @Override
   public int getRemoteDSId() {
-    return remoteDSId;
+    return this.remoteDSId;
   }
 
   @Override
   public List<GatewayTransportFilter> getGatewayTransportFilters() {
-    return transFilters;
+    return this.transFilters;
   }
 
   public List<AsyncEventListener> getAsyncEventListeners() {
-    return listeners;
+    return this.listeners;
   }
 
   public boolean hasListeners() {
-    return !listeners.isEmpty();
+    return !this.listeners.isEmpty();
   }
 
   @Override
   public boolean isForwardExpirationDestroy() {
-    return forwardExpirationDestroy;
+    return this.forwardExpirationDestroy;
   }
 
   @Override
   public boolean isManualStart() {
-    return manualStart;
+    return this.manualStart;
   }
 
   @Override
   public int getMaximumQueueMemory() {
-    return queueMemory;
+    return this.queueMemory;
   }
 
   public int getMaximumMemeoryPerDispatcherQueue() {
-    return maxMemoryPerDispatcherQueue;
+    return this.maxMemoryPerDispatcherQueue;
   }
 
   @Override
   public int getSocketBufferSize() {
-    return socketBufferSize;
+    return this.socketBufferSize;
   }
 
   @Override
   public int getSocketReadTimeout() {
-    return socketReadTimeout;
+    return this.socketReadTimeout;
   }
 
   @Override
   public boolean isBatchConflationEnabled() {
-    return isConflation;
+    return this.isConflation;
   }
 
   public void test_setBatchConflationEnabled(boolean enableConflation) {
-    isConflation = enableConflation;
+    this.isConflation = enableConflation;
   }
 
   @Override
   public boolean isPersistenceEnabled() {
-    return isPersistence;
+    return this.isPersistence;
   }
 
   @Override
   public boolean isDiskSynchronous() {
-    return isDiskSynchronous;
+    return this.isDiskSynchronous;
   }
 
   @Override
   public int getMaxParallelismForReplicatedRegion() {
-    return parallelismForReplicatedRegion;
+    return this.parallelismForReplicatedRegion;
   }
 
   public LocatorDiscoveryCallback getLocatorDiscoveryCallback() {
-    return locatorDiscoveryCallback;
+    return this.locatorDiscoveryCallback;
   }
 
   @Override
   public DistributionAdvisor getDistributionAdvisor() {
-    return senderAdvisor;
+    return this.senderAdvisor;
   }
 
   @Override
@@ -466,45 +463,45 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
 
   @Override
   public int getDispatcherThreads() {
-    return dispatcherThreads;
+    return this.dispatcherThreads;
   }
 
   @Override
   public OrderPolicy getOrderPolicy() {
-    return policy;
+    return this.policy;
   }
 
   @Override
   public Profile getProfile() {
-    return senderAdvisor.createProfile();
+    return this.senderAdvisor.createProfile();
   }
 
   @Override
   public int getSerialNumber() {
-    return serialNumber;
+    return this.serialNumber;
   }
 
   public boolean getBucketSorted() {
-    return isBucketSorted;
+    return this.isBucketSorted;
   }
 
   @Override
   public boolean getIsMetaQueue() {
-    return isMetaQueue;
+    return this.isMetaQueue;
   }
 
   @Override
   public InternalDistributedSystem getSystem() {
-    return cache.getInternalDistributedSystem();
+    return this.cache.getInternalDistributedSystem();
   }
 
   public int getEventIdIndex() {
-    return eventIdIndex;
+    return this.eventIdIndex;
   }
 
   @Override
   public boolean getEnforceThreadsConnectSameReceiver() {
-    return enforceThreadsConnectSameReceiver;
+    return this.enforceThreadsConnectSameReceiver;
   }
 
   @Override
@@ -519,7 +516,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       return false;
     }
     AbstractGatewaySender sender = (AbstractGatewaySender) obj;
-    if (sender.getId().equals(getId())) {
+    if (sender.getId().equals(this.getId())) {
       return true;
     }
     return false;
@@ -527,7 +524,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
 
   @Override
   public int hashCode() {
-    return getId().hashCode();
+    return this.getId().hashCode();
   }
 
   public PoolImpl getProxy() {
@@ -539,12 +536,12 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     if (filter == null) {
       return;
     }
-    if (eventFilters.isEmpty()) {
+    if (this.eventFilters.isEmpty()) {
       return;
     }
-    List<GatewayEventFilter> templist = new ArrayList<>(eventFilters);
+    List<GatewayEventFilter> templist = new ArrayList<>(this.eventFilters);
     templist.remove(filter);
-    eventFilters = Collections.unmodifiableList(templist);
+    this.eventFilters = Collections.unmodifiableList(templist);
   }
 
   @Override
@@ -553,28 +550,23 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       throw new IllegalStateException(
           "null value can not be added to gateway-event-filters list");
     }
-    List<GatewayEventFilter> templist = new ArrayList<>(eventFilters);
+    List<GatewayEventFilter> templist = new ArrayList<>(this.eventFilters);
     templist.add(filter);
-    eventFilters = Collections.unmodifiableList(templist);
+    this.eventFilters = Collections.unmodifiableList(templist);
   }
 
   @Override
   public boolean isParallel() {
-    return isParallel;
+    return this.isParallel;
   }
 
   @Override
   public boolean mustGroupTransactionEvents() {
-    return groupTransactionEvents;
-  }
-
-  @Override
-  public int getRetriesToGetTransactionEventsFromQueue() {
-    return retriesToGetTransactionEventsFromQueue;
+    return this.groupTransactionEvents;
   }
 
   public boolean isForInternalUse() {
-    return isForInternalUse;
+    return this.isForInternalUse;
   }
 
   @Override
@@ -605,15 +597,15 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   @Override
   public void destroy(boolean initiator) {
     try {
-      getLifeCycleLock().writeLock().lock();
+      this.getLifeCycleLock().writeLock().lock();
       // first, check if this sender is attached to any region. If so, throw
       // GatewaySenderException
-      Set<InternalRegion> regions = cache.getApplicationRegions();
+      Set<InternalRegion> regions = this.cache.getApplicationRegions();
       Iterator regionItr = regions.iterator();
       while (regionItr.hasNext()) {
         LocalRegion region = (LocalRegion) regionItr.next();
 
-        if (region.getAttributes().getGatewaySenderIds().contains(id)) {
+        if (region.getAttributes().getGatewaySenderIds().contains(this.id)) {
           throw new GatewaySenderException(
               String.format(
                   "The GatewaySender %s could not be destroyed as it is still used by region(s).",
@@ -621,7 +613,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
         }
       }
       // close the GatewaySenderAdvisor
-      GatewaySenderAdvisor advisor = getSenderAdvisor();
+      GatewaySenderAdvisor advisor = this.getSenderAdvisor();
       if (advisor != null) {
         if (logger.isDebugEnabled()) {
           logger.debug("Stopping the GatewaySender advisor");
@@ -630,7 +622,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       }
 
       // remove the sender from the cache
-      cache.removeGatewaySender(this);
+      this.cache.removeGatewaySender(this);
 
       // destroy the region underneath the sender's queue
       if (initiator) {
@@ -655,7 +647,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
               // the region might have already been destroyed by other node. Just
               // log
               // the exception.
-              logger.info(
+              this.logger.info(
                   "Region {} that underlies the GatewaySender {} is already destroyed.",
                   e.getRegionFullPath(), this);
             }
@@ -663,7 +655,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
         } // END if (regionQueues != null)
       }
     } finally {
-      getLifeCycleLock().writeLock().unlock();
+      this.getLifeCycleLock().writeLock().unlock();
     }
   }
 
@@ -674,8 +666,8 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       pause();
 
       // Rebalance the event processor if necessary
-      if (eventProcessor != null) {
-        eventProcessor.rebalance();
+      if (this.eventProcessor != null) {
+        this.eventProcessor.rebalance();
       }
     } finally {
       // Resume the sender
@@ -693,16 +685,16 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   @Override
   public void setBatchSize(int batchSize) {
     this.batchSize = batchSize;
-    if (eventProcessor != null) {
-      eventProcessor.setBatchSize(batchSize);
+    if (this.eventProcessor != null) {
+      this.eventProcessor.setBatchSize(this.batchSize);
     }
-  }
+  };
 
   @Override
   public void setBatchTimeInterval(int batchTimeInterval) {
     this.batchTimeInterval = batchTimeInterval;
-    if (eventProcessor != null) {
-      eventProcessor.setBatchTimeInterval(batchTimeInterval);
+    if (this.eventProcessor != null) {
+      this.eventProcessor.setBatchTimeInterval(this.batchTimeInterval);
     }
   };
 
@@ -714,16 +706,11 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   @Override
   public void setGatewayEventFilters(List<GatewayEventFilter> filters) {
     if (filters.isEmpty()) {
-      eventFilters = Collections.emptyList();
+      this.eventFilters = Collections.emptyList();
     } else {
-      eventFilters = Collections.unmodifiableList(filters);
+      this.eventFilters = Collections.unmodifiableList(filters);
     }
-  }
-
-  @Override
-  public void setRetriesToGetTransactionEventsFromQueue(int retries) {
-    retriesToGetTransactionEventsFromQueue = retries;
-  }
+  };
 
   public boolean beforeEnqueue(GatewayQueueEvent gatewayEvent) {
     boolean enqueue = true;
@@ -738,7 +725,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
 
   protected void stopProcessing() {
     // Stop the dispatcher
-    AbstractGatewaySenderEventProcessor ev = eventProcessor;
+    AbstractGatewaySenderEventProcessor ev = this.eventProcessor;
     if (ev != null && !ev.isStopped()) {
       ev.stopProcessing();
     }
@@ -775,11 +762,11 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     // violence.
     t.interrupt(); // give up
     proxy.emergencyClose(); // VIOLENCE!
-    proxy = null;
+    this.proxy = null;
   }
 
   public int getMyDSId() {
-    return myDSId;
+    return this.myDSId;
   }
 
   /**
@@ -797,7 +784,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   public CancelCriterion getStopper() {
-    return stopper;
+    return this.stopper;
   }
 
   @Override
@@ -810,7 +797,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   public synchronized boolean setServerLocation(ServerLocation location) {
-    serverLocation = location;
+    this.serverLocation = location;
     return true;
   }
 
@@ -818,7 +805,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     final CancelCriterion stper;
 
     Stopper(CancelCriterion stopper) {
-      stper = stopper;
+      this.stper = stopper;
     }
 
     @Override
@@ -835,9 +822,9 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   public RegionQueue getQueue() {
-    if (eventProcessor != null) {
-      if (!(eventProcessor instanceof ConcurrentSerialGatewaySenderEventProcessor)) {
-        return eventProcessor.getQueue();
+    if (this.eventProcessor != null) {
+      if (!(this.eventProcessor instanceof ConcurrentSerialGatewaySenderEventProcessor)) {
+        return this.eventProcessor.getQueue();
       } else {
         throw new IllegalArgumentException("getQueue() for concurrent serial gateway sender");
       }
@@ -847,31 +834,31 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
 
   @Override
   public Set<RegionQueue> getQueues() {
-    if (eventProcessor != null) {
-      if (!(eventProcessor instanceof ConcurrentSerialGatewaySenderEventProcessor)) {
+    if (this.eventProcessor != null) {
+      if (!(this.eventProcessor instanceof ConcurrentSerialGatewaySenderEventProcessor)) {
         Set<RegionQueue> queues = new HashSet<RegionQueue>();
-        queues.add(eventProcessor.getQueue());
+        queues.add(this.eventProcessor.getQueue());
         return queues;
       }
-      return ((ConcurrentSerialGatewaySenderEventProcessor) eventProcessor).getQueues();
+      return ((ConcurrentSerialGatewaySenderEventProcessor) this.eventProcessor).getQueues();
     }
     return null;
   }
 
   protected void waitForRunningStatus() {
-    synchronized (eventProcessor.getRunningStateLock()) {
-      while (eventProcessor.getException() == null && eventProcessor.isStopped()) {
+    synchronized (this.eventProcessor.getRunningStateLock()) {
+      while (this.eventProcessor.getException() == null && this.eventProcessor.isStopped()) {
         try {
-          eventProcessor.getRunningStateLock().wait(1000);
+          this.eventProcessor.getRunningStateLock().wait(1000);
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();
         }
       }
-      Exception ex = eventProcessor.getException();
+      Exception ex = this.eventProcessor.getException();
       if (ex != null) {
         throw new GatewaySenderException(
             String.format("Could not start a gateway sender %s because of exception %s",
-                new Object[] {getId(), ex.getMessage()}),
+                new Object[] {this.getId(), ex.getMessage()}),
             ex.getCause());
       }
     }
@@ -891,88 +878,88 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
    * processor has not yet started.
    */
   public void pauseEvenIfProcessorStopped() {
-    if (eventProcessor != null) {
-      getLifeCycleLock().writeLock().lock();
+    if (this.eventProcessor != null) {
+      this.getLifeCycleLock().writeLock().lock();
       try {
-        eventProcessor.pauseDispatching();
+        this.eventProcessor.pauseDispatching();
         InternalDistributedSystem system =
-            (InternalDistributedSystem) cache.getDistributedSystem();
+            (InternalDistributedSystem) this.cache.getDistributedSystem();
         system.handleResourceEvent(ResourceEvent.GATEWAYSENDER_PAUSE, this);
         logger.info("Paused {}", this);
 
         enqueueTempEvents();
       } finally {
-        getLifeCycleLock().writeLock().unlock();
+        this.getLifeCycleLock().writeLock().unlock();
       }
     }
   }
 
   @Override
   public void pause() {
-    if (eventProcessor != null) {
-      getLifeCycleLock().writeLock().lock();
+    if (this.eventProcessor != null) {
+      this.getLifeCycleLock().writeLock().lock();
       try {
-        if (eventProcessor.isStopped()) {
+        if (this.eventProcessor.isStopped()) {
           return;
         }
-        eventProcessor.pauseDispatching();
+        this.eventProcessor.pauseDispatching();
 
         InternalDistributedSystem system =
-            (InternalDistributedSystem) cache.getDistributedSystem();
+            (InternalDistributedSystem) this.cache.getDistributedSystem();
         system.handleResourceEvent(ResourceEvent.GATEWAYSENDER_PAUSE, this);
 
         logger.info("Paused {}", this);
 
         enqueueTempEvents();
       } finally {
-        getLifeCycleLock().writeLock().unlock();
+        this.getLifeCycleLock().writeLock().unlock();
       }
     }
   }
 
   @Override
   public void resume() {
-    if (eventProcessor != null) {
-      getLifeCycleLock().writeLock().lock();
+    if (this.eventProcessor != null) {
+      this.getLifeCycleLock().writeLock().lock();
       try {
-        if (eventProcessor.isStopped()) {
+        if (this.eventProcessor.isStopped()) {
           return;
         }
-        eventProcessor.resumeDispatching();
+        this.eventProcessor.resumeDispatching();
 
 
         InternalDistributedSystem system =
-            (InternalDistributedSystem) cache.getDistributedSystem();
+            (InternalDistributedSystem) this.cache.getDistributedSystem();
         system.handleResourceEvent(ResourceEvent.GATEWAYSENDER_RESUME, this);
 
         logger.info("Resumed {}", this);
 
         enqueueTempEvents();
       } finally {
-        getLifeCycleLock().writeLock().unlock();
+        this.getLifeCycleLock().writeLock().unlock();
       }
     }
   }
 
   @Override
   public boolean isPaused() {
-    if (eventProcessor != null) {
-      return eventProcessor.isPaused();
+    if (this.eventProcessor != null) {
+      return this.eventProcessor.isPaused();
     }
     return false;
   }
 
   @Override
   public boolean isRunning() {
-    if (eventProcessor != null) {
-      return !eventProcessor.isStopped();
+    if (this.eventProcessor != null) {
+      return !this.eventProcessor.isStopped();
     }
     return false;
   }
 
   @Override
   public AbstractGatewaySenderEventProcessor getEventProcessor() {
-    return eventProcessor;
+    return this.eventProcessor;
   }
 
   /**
@@ -987,8 +974,8 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     // Check for eviction and expiration events.
     if (event.getOperation().isLocal() || event.getOperation().isExpiration()) {
       // Check if its AEQ and is configured to forward expiration destroy events.
-      if (event.getOperation().isExpiration() && isAsyncEventQueue()
-          && isForwardExpirationDestroy()) {
+      if (event.getOperation().isExpiration() && this.isAsyncEventQueue()
+          && this.isForwardExpirationDestroy()) {
         return true;
       }
       return false;
@@ -1023,7 +1010,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       // this filter is defined by Asif which exist in old wan too. new wan has
       // other GatewaEventFilter. Do we need to get rid of this filter. Cheetah is
       // not considering this filter
-      if (!filter.enqueueEvent(event)) {
+      if (!this.filter.enqueueEvent(event)) {
         stats.incEventsFiltered();
         return;
       }
@@ -1037,7 +1024,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
         // call getNewValue.
         // event.getNewValue(); // to deserialize the value if necessary
         logger.debug("{} : About to notify {} to perform operation {} for {} callback arg {}",
-            isPrimary(), getId(), operation, clonedEvent, callbackArg);
+            this.isPrimary(), getId(), operation, clonedEvent, callbackArg);
       }
 
       if (callbackArg instanceof GatewaySenderEventCallbackArgument) {
@@ -1045,18 +1032,18 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
         if (isDebugEnabled) {
           logger.debug(
               "{}: Event originated in {}. My DS id is {}. The remote DS id is {}. The recipients are: {}",
-              this, seca.getOriginatingDSId(), getMyDSId(), getRemoteDSId(),
+              this, seca.getOriginatingDSId(), this.getMyDSId(), this.getRemoteDSId(),
               seca.getRecipientDSIds());
         }
         if (seca.getOriginatingDSId() == DEFAULT_DISTRIBUTED_SYSTEM_ID) {
           if (isDebugEnabled) {
             logger.debug(
                 "{}: Event originated in {}. My DS id is {}. The remote DS id is {}. The recipients are: {}",
-                this, seca.getOriginatingDSId(), getMyDSId(), getRemoteDSId(),
+                this, seca.getOriginatingDSId(), this.getMyDSId(), this.getRemoteDSId(),
                 seca.getRecipientDSIds());
           }
 
-          seca.setOriginatingDSId(getMyDSId());
+          seca.setOriginatingDSId(this.getMyDSId());
           seca.initializeReceipientDSIds(allRemoteDSIds);
 
         } else {
@@ -1066,18 +1053,18 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
           AbstractGatewaySenderEventProcessor ep = getEventProcessor();
           // if manual-start is true, ep is null
           if (ep == null || !(ep.getDispatcher() instanceof GatewaySenderEventCallbackDispatcher)) {
-            if (seca.getOriginatingDSId() == getRemoteDSId()) {
+            if (seca.getOriginatingDSId() == this.getRemoteDSId()) {
               if (isDebugEnabled) {
                 logger.debug(
                     "{}: Event originated in {}. My DS id is {}. It is being dropped as remote is originator.",
                     this, seca.getOriginatingDSId(), getMyDSId());
               }
               return;
-            } else if (seca.getRecipientDSIds().contains(getRemoteDSId())) {
+            } else if (seca.getRecipientDSIds().contains(this.getRemoteDSId())) {
               if (isDebugEnabled) {
                 logger.debug(
                     "{}: Event originated in {}. My DS id is {}. The remote DS id is {}.. It is being dropped as remote ds is already a recipient. Recipients are: {}",
-                    this, seca.getOriginatingDSId(), getMyDSId(), getRemoteDSId(),
+                    this, seca.getOriginatingDSId(), getMyDSId(), this.getRemoteDSId(),
                     seca.getRecipientDSIds());
               }
               return;
@@ -1087,13 +1074,13 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
         }
       } else {
         GatewaySenderEventCallbackArgument geCallbackArg =
-            new GatewaySenderEventCallbackArgument(callbackArg, getMyDSId(), allRemoteDSIds);
+            new GatewaySenderEventCallbackArgument(callbackArg, this.getMyDSId(), allRemoteDSIds);
         clonedEvent.setCallbackArgument(geCallbackArg);
       }
 
       // If this gateway is not running, return
       if (!isRunning()) {
-        if (isPrimary()) {
+        if (this.isPrimary()) {
           recordDroppedEvent(clonedEvent);
         }
         if (isDebugEnabled) {
@@ -1102,12 +1089,12 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
         return;
       }
 
-      if (!getLifeCycleLock().readLock().tryLock()) {
-        synchronized (queuedEventsSync) {
-          if (!enqueuedAllTempQueueEvents) {
-            if (!getLifeCycleLock().readLock().tryLock()) {
+      if (!this.getLifeCycleLock().readLock().tryLock()) {
+        synchronized (this.queuedEventsSync) {
+          if (!this.enqueuedAllTempQueueEvents) {
+            if (!this.getLifeCycleLock().readLock().tryLock()) {
               Object substituteValue = getSubstituteValue(clonedEvent, operation);
-              tmpQueuedEvents.add(new TmpQueueEvent(operation, clonedEvent, substituteValue));
+              this.tmpQueuedEvents.add(new TmpQueueEvent(operation, clonedEvent, substituteValue));
               freeClonedEvent = false;
               stats.incTempQueueSize();
               if (isDebugEnabled) {
@@ -1117,8 +1104,8 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
             }
           }
         }
-        if (enqueuedAllTempQueueEvents) {
-          getLifeCycleLock().readLock().lock();
+        if (this.enqueuedAllTempQueueEvents) {
+          this.getLifeCycleLock().readLock().lock();
         }
       }
       try {
@@ -1128,17 +1115,17 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
           if (isDebugEnabled) {
             logger.debug("Returning back without putting into the gateway sender queue:" + event);
           }
-          if (isPrimary()) {
+          if (this.isPrimary()) {
             recordDroppedEvent(clonedEvent);
           }
           return;
         }
 
         try {
-          AbstractGatewaySenderEventProcessor ev = eventProcessor;
+          AbstractGatewaySenderEventProcessor ev = this.eventProcessor;
           if (ev == null) {
             getStopper().checkCancelInProgress(null);
-            getCache().getDistributedSystem().getCancelCriterion().checkCancelInProgress(null);
+            this.getCache().getDistributedSystem().getCancelCriterion().checkCancelInProgress(null);
             // event processor will be null if there was an authorization
             // problem
             // connecting to the other site (bug #40681)
@@ -1166,7 +1153,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
               e);
         }
       } finally {
-        getLifeCycleLock().readLock().unlock();
+        this.getLifeCycleLock().readLock().unlock();
       }
     } finally {
       if (freeClonedEvent) {
@@ -1176,8 +1163,8 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   private void recordDroppedEvent(EntryEventImpl event) {
-    if (eventProcessor != null) {
-      eventProcessor.registerEventDroppedInPrimaryQueue(event);
+    if (this.eventProcessor != null) {
+      this.eventProcessor.registerEventDroppedInPrimaryQueue(event);
     } else {
       tmpDroppedEvents.add(event);
       if (logger.isDebugEnabled()) {
@@ -1204,11 +1191,11 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
    * ParallelGatewaySenderQueue.addPartitionedRegionForRegion
    */
   public void enqueueTempEvents() {
-    if (eventProcessor != null) {// Fix for defect #47308
+    if (this.eventProcessor != null) {// Fix for defect #47308
       // process tmpDroppedEvents
       EntryEventImpl droppedEvent;
       while ((droppedEvent = tmpDroppedEvents.poll()) != null) {
-        eventProcessor.registerEventDroppedInPrimaryQueue(droppedEvent);
+        this.eventProcessor.registerEventDroppedInPrimaryQueue(droppedEvent);
       }
 
       TmpQueueEvent nextEvent = null;
@@ -1216,7 +1203,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
       try {
         // Now finish emptying the queue with synchronization to make
         // sure we don't miss any events.
-        synchronized (queuedEventsSync) {
+        synchronized (this.queuedEventsSync) {
           while ((nextEvent = tmpQueuedEvents.poll()) != null) {
             try {
               if (logger.isDebugEnabled()) {
@@ -1224,13 +1211,13 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
                     nextEvent);
               }
               stats.decTempQueueSize();
-              eventProcessor.enqueueEvent(nextEvent.getOperation(), nextEvent.getEvent(),
+              this.eventProcessor.enqueueEvent(nextEvent.getOperation(), nextEvent.getEvent(),
                   nextEvent.getSubstituteValue());
             } finally {
               nextEvent.release();
             }
           }
-          enqueuedAllTempQueueEvents = true;
+          this.enqueuedAllTempQueueEvents = true;
         }
       } catch (CacheException e) {
         logger.debug("caught cancel exception", e);
@@ -1249,8 +1236,8 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
    *
    */
   public boolean removeFromTempQueueEvents(Object tailKey) {
-    synchronized (queuedEventsSync) {
-      Iterator<TmpQueueEvent> itr = tmpQueuedEvents.iterator();
+    synchronized (this.queuedEventsSync) {
+      Iterator<TmpQueueEvent> itr = this.tmpQueuedEvents.iterator();
       while (itr.hasNext()) {
         TmpQueueEvent event = itr.next();
         if (tailKey.equals(event.getEvent().getTailKey())) {
@@ -1278,11 +1265,11 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     while ((nextEvent = tmpQueuedEvents.poll()) != null) {
       nextEvent.release();
     }
-    synchronized (queuedEventsSync) {
+    synchronized (this.queuedEventsSync) {
       while ((nextEvent = tmpQueuedEvents.poll()) != null) {
         nextEvent.release();
       }
-      enqueuedAllTempQueueEvents = false;
+      this.enqueuedAllTempQueueEvents = false;
     }
 
     statistics.setQueueSize(0);
@@ -1294,9 +1281,9 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   public Object getSubstituteValue(EntryEventImpl clonedEvent, EnumListenerEvent operation) {
     // Get substitution value to enqueue if necessary
     Object substituteValue = null;
-    if (substitutionFilter != null) {
+    if (this.substitutionFilter != null) {
       try {
-        substituteValue = substitutionFilter.getSubstituteValue(clonedEvent);
+        substituteValue = this.substitutionFilter.getSubstituteValue(clonedEvent);
         // If null is returned from the filter, null is set in the value
         if (substituteValue == null) {
           substituteValue = GatewaySenderEventImpl.TOKEN_NULL;
@@ -1353,9 +1340,9 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
         }
 
         // Store the index locally
-        eventIdIndex = index;
+        this.eventIdIndex = index;
         if (logger.isDebugEnabled()) {
-          logger.debug("{}: {} event id index: {}", this, messagePrefix, eventIdIndex);
+          logger.debug("{}: {} event id index: {}", this, messagePrefix, this.eventIdIndex);
         }
       }
     } finally {
@@ -1370,10 +1357,10 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   private Region<String, Integer> getEventIdIndexMetaDataRegion() {
-    if (eventIdIndexMetaDataRegion == null) {
-      eventIdIndexMetaDataRegion = initializeEventIdIndexMetaDataRegion(this);
+    if (this.eventIdIndexMetaDataRegion == null) {
+      this.eventIdIndexMetaDataRegion = initializeEventIdIndexMetaDataRegion(this);
     }
-    return eventIdIndexMetaDataRegion;
+    return this.eventIdIndexMetaDataRegion;
   }
 
   private static synchronized Region<String, Integer> initializeEventIdIndexMetaDataRegion(
@@ -1437,12 +1424,12 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
 
   @Override
   public int getEventQueueSize() {
-    AbstractGatewaySenderEventProcessor localProcessor = eventProcessor;
+    AbstractGatewaySenderEventProcessor localProcessor = this.eventProcessor;
     return localProcessor == null ? 0 : localProcessor.eventQueueSize();
   }
 
   public int getSecondaryEventQueueSize() {
-    AbstractGatewaySenderEventProcessor localProcessor = eventProcessor;
+    AbstractGatewaySenderEventProcessor localProcessor = this.eventProcessor;
     return localProcessor == null ? 0 : localProcessor.secondaryEventQueueSize();
   }
 
@@ -1451,11 +1438,11 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   protected boolean isAsyncEventQueue() {
-    return getAsyncEventListeners() != null && !getAsyncEventListeners().isEmpty();
+    return this.getAsyncEventListeners() != null && !this.getAsyncEventListeners().isEmpty();
   }
 
   public Object getLockForConcurrentDispatcher() {
-    return lockForConcurrentDispatcher;
+    return this.lockForConcurrentDispatcher;
   }
 
   public ReentrantReadWriteLock getLifeCycleLock() {
@@ -1494,7 +1481,7 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   public String getExpectedReceiverUniqueId() {
-    return expectedReceiverUniqueId;
+    return this.expectedReceiverUniqueId;
   }
 
   /**
@@ -1510,8 +1497,8 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     public final GatewaySenderEventImpl event;
 
     public EventWrapper(GatewaySenderEventImpl e) {
-      event = e;
-      timeout = System.currentTimeMillis() + EVENT_TIMEOUT;
+      this.event = e;
+      this.timeout = System.currentTimeMillis() + EVENT_TIMEOUT;
     }
   }
 
@@ -1530,26 +1517,26 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     private final Object substituteValue;
 
     public TmpQueueEvent(EnumListenerEvent op, @Retained EntryEventImpl e, Object subValue) {
-      operation = op;
-      event = e;
-      substituteValue = subValue;
+      this.operation = op;
+      this.event = e;
+      this.substituteValue = subValue;
     }
 
     public EnumListenerEvent getOperation() {
-      return operation;
+      return this.operation;
     }
 
     public @Unretained EntryEventImpl getEvent() {
-      return event;
+      return this.event;
     }
 
     public Object getSubstituteValue() {
-      return substituteValue;
+      return this.substituteValue;
     }
 
     @Override
     public void release() {
-      event.release();
+      this.event.release();
     }
   }
 
@@ -1575,20 +1562,20 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
   }
 
   protected void putSynchronizationEvent(GatewayQueueEvent event) {
-    if (eventProcessor != null) {
-      lifeCycleLock.readLock().lock();
+    if (this.eventProcessor != null) {
+      this.lifeCycleLock.readLock().lock();
       try {
         logger.info("{}: Enqueueing synchronization event: {}",
             this, event);
-        eventProcessor.enqueueEvent(event);
-        statistics.incSynchronizationEventsEnqueued();
+        this.eventProcessor.enqueueEvent(event);
+        this.statistics.incSynchronizationEventsEnqueued();
       } catch (Throwable t) {
         logger.warn(String.format(
             "%s: Caught the following exception attempting to enqueue synchronization event=%s:",
             new Object[] {this, event}),
             t);
       } finally {
-        lifeCycleLock.readLock().unlock();
+        this.lifeCycleLock.readLock().unlock();
       }
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderAttributes.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/GatewaySenderAttributes.java
@@ -77,9 +77,6 @@ public class GatewaySenderAttributes {
 
   private boolean groupTransactionEvents = GatewaySender.DEFAULT_MUST_GROUP_TRANSACTION_EVENTS;
 
-  private int retriesToGetTransactionEventsFromQueue =
-      GatewaySender.GET_TRANSACTION_EVENTS_FROM_QUEUE_RETRIES;
-
   private boolean isForInternalUse = GatewaySender.DEFAULT_IS_FOR_INTERNAL_USE;
 
   private boolean isBucketSorted = GatewaySenderAttributes.DEFAULT_IS_BUCKETSORTED;
@@ -171,10 +168,6 @@ public class GatewaySenderAttributes {
     groupTransactionEvents = groupTransEvents;
   }
 
-  public void setRetriesToGetTransactionEventsFromQueue(int retries) {
-    retriesToGetTransactionEventsFromQueue = retries;
-  }
-
   public void setForInternalUse(boolean forInternalUse) {
     isForInternalUse = forInternalUse;
   }
@@ -261,10 +254,6 @@ public class GatewaySenderAttributes {
 
   public boolean mustGroupTransactionEvents() {
     return this.groupTransactionEvents;
-  }
-
-  public int getRetriesToGetTransactionEventsFromQueue() {
-    return this.retriesToGetTransactionEventsFromQueue;
   }
 
   public boolean isForInternalUse() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/parallel/ParallelGatewaySenderQueue.java
@@ -16,7 +16,7 @@ package org.apache.geode.internal.cache.wan.parallel;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.wan.GatewaySender.DEFAULT_BATCH_SIZE;
-import static org.apache.geode.cache.wan.GatewaySender.GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS;
+import static org.apache.geode.cache.wan.GatewaySender.GET_TRANSACTION_EVENTS_FROM_QUEUE_RETRIES;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.BEFORE_INITIAL_IMAGE;
 
 import java.util.ArrayList;
@@ -1404,19 +1404,13 @@ public class ParallelGatewaySenderQueue implements RegionQueue {
         }
       }
       if (incompleteTransactionIdsInBatch.size() == 0 ||
-          retries >= sender.getRetriesToGetTransactionEventsFromQueue()) {
+          retries++ == GET_TRANSACTION_EVENTS_FROM_QUEUE_RETRIES) {
         break;
-      }
-      retries++;
-      try {
-        Thread.sleep(GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
       }
     }
     if (incompleteTransactionIdsInBatch.size() > 0) {
-      logger.warn("Not able to retrieve all events for transactions: {} after {} retries of {}ms",
-          incompleteTransactionIdsInBatch, retries, GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS);
+      logger.warn("Not able to retrieve all events for transactions: {} after {} retries",
+          incompleteTransactionIdsInBatch, retries);
       stats.incBatchesWithIncompleteTransactions();
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -15,7 +15,7 @@
 package org.apache.geode.internal.cache.wan.serial;
 
 import static org.apache.geode.cache.wan.GatewaySender.DEFAULT_BATCH_SIZE;
-import static org.apache.geode.cache.wan.GatewaySender.GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS;
+import static org.apache.geode.cache.wan.GatewaySender.GET_TRANSACTION_EVENTS_FROM_QUEUE_RETRIES;
 
 import java.util.ArrayList;
 import java.util.Deque;
@@ -120,13 +120,10 @@ public class SerialGatewaySenderQueue implements RegionQueue {
 
   /**
    * Contains the set of peekedIds that were peeked to complete a transaction
-   * inside a batch when groupTransactionEvents is set and whose event has been
-   * removed from the queue because an ack has been received from the receiver.
-   * Elements from this set are deleted when the event with the previous id
-   * is removed.
+   * inside a batch when groupTransactionEvents is set and that have
+   * been sent in a batch but have not yet been removed.
    */
-  private final Set<Long> extraPeekedIdsRemovedButPreviousIdNotRemoved =
-      ConcurrentHashMap.newKeySet();
+  private final Set<Long> extraPeekedIdsSentNotRemoved = ConcurrentHashMap.newKeySet();
 
   /**
    * The name of the <code>Region</code> backing this queue
@@ -312,22 +309,21 @@ public class SerialGatewaySenderQueue implements RegionQueue {
     if (peekedIds.isEmpty()) {
       return;
     }
-    boolean wasEmpty = lastDispatchedKey == lastDestroyedKey;
     Long key = peekedIds.remove();
-    if (!extraPeekedIds.remove(key)) {
-      updateHeadKey(key);
-      lastDispatchedKey = key;
-    } else {
-      extraPeekedIdsRemovedButPreviousIdNotRemoved.add(key);
-    }
-    removeIndex(key);
-    // Remove the entry at that key with a callback arg signifying it is
-    // a WAN queue so that AbstractRegionEntry.destroy can get the value
-    // even if it has been evicted to disk. In the normal case, the
-    // AbstractRegionEntry.destroy only gets the value in the VM.
+    boolean isExtraPeeked = extraPeekedIds.remove(key);
     try {
+      // Increment the head key
+      if (!isExtraPeeked) {
+        updateHeadKey(key.longValue());
+      }
+      removeIndex(key);
+      // Remove the entry at that key with a callback arg signifying it is
+      // a WAN queue so that AbstractRegionEntry.destroy can get the value
+      // even if it has been evicted to disk. In the normal case, the
+      // AbstractRegionEntry.destroy only gets the value in the VM.
       this.region.localDestroy(key, WAN_QUEUE_TOKEN);
       this.stats.decQueueSize();
+
     } catch (EntryNotFoundException ok) {
       // this is acceptable because the conflation can remove entries
       // out from underneath us.
@@ -338,16 +334,27 @@ public class SerialGatewaySenderQueue implements RegionQueue {
       }
     }
 
-    // Update head key and lastDispatchedKey with those extraPeekedIds removed
-    // that are consecutive to lastDispatchedKey so that they are not returned
-    // later by peekAhead given that they were already sent.
-    long tmpKey = lastDispatchedKey;
-    while (extraPeekedIdsRemovedButPreviousIdNotRemoved.contains(tmpKey = inc(tmpKey))) {
-      extraPeekedIdsRemovedButPreviousIdNotRemoved.remove(tmpKey);
-      updateHeadKey(tmpKey);
-      lastDispatchedKey = tmpKey;
+    boolean wasEmpty = this.lastDispatchedKey == this.lastDestroyedKey;
+    if (!isExtraPeeked) {
+      this.lastDispatchedKey = key;
+      // Remove also the extraPeekedIds right after this one so that
+      // they do not stay in the secondary's queue forever
+      long tmpKey = key;
+      while (extraPeekedIdsSentNotRemoved.contains(tmpKey = inc(tmpKey))) {
+        extraPeekedIdsSentNotRemoved.remove(tmpKey);
+        this.lastDispatchedKey = tmpKey;
+        updateHeadKey(tmpKey);
+      }
+    } else {
+      extraPeekedIdsSentNotRemoved.add(key);
+      // Remove if previous key was already dispatched so that it does
+      // not stay in the secondary's queue forever
+      long tmpKey = dec(key);
+      if (this.lastDispatchedKey == tmpKey) {
+        this.lastDispatchedKey = key;
+        updateHeadKey(key);
+      }
     }
-
     if (wasEmpty) {
       synchronized (this) {
         notifyAll();
@@ -489,19 +496,13 @@ public class SerialGatewaySenderQueue implements RegionQueue {
         }
       }
       if (incompleteTransactionIdsInBatch.size() == 0 ||
-          retries >= sender.getRetriesToGetTransactionEventsFromQueue()) {
+          retries++ == GET_TRANSACTION_EVENTS_FROM_QUEUE_RETRIES) {
         break;
-      }
-      retries++;
-      try {
-        Thread.sleep(GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
       }
     }
     if (incompleteTransactionIdsInBatch.size() > 0) {
-      logger.warn("Not able to retrieve all events for transactions: {} after {} retries of {}ms",
-          incompleteTransactionIdsInBatch, retries, GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS);
+      logger.warn("Not able to retrieve all events for transactions: {} after {} retries",
+          incompleteTransactionIdsInBatch, retries);
       stats.incBatchesWithIncompleteTransactions();
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
@@ -100,13 +100,6 @@ public class SystemPropertyHelper {
   public static final String PARALLEL_DISK_STORE_RECOVERY = "parallelDiskStoreRecovery";
 
   /**
-   * Milliseconds to wait before retrying to get events for a transaction from the
-   * gateway sender queue when group-transaction-events is true.
-   */
-  public static final String GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS =
-      "get-transaction-events-from-queue-wait-time-ms";
-
-  /**
    * This method will try to look up "geode." and "gemfire." versions of the system property. It
    * will check and prefer "geode." setting first, then try to check "gemfire." setting.
    *

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -1795,10 +1795,6 @@ public class WANTestBase extends DistributedTestCase {
           numDispatcherThreadsForTheRun, GatewaySender.DEFAULT_ORDER_POLICY,
           GatewaySender.DEFAULT_SOCKET_BUFFER_SIZE);
       gateway.setGroupTransactionEvents(groupTransactionEvents);
-      if (groupTransactionEvents) {
-        // Set a very high value to avoid flakiness in test cases
-        gateway.setRetriesToGetTransactionEventsFromQueue(100);
-      }
       gateway.create(dsName, remoteDsId);
     } finally {
       exln.remove();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANStatsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANStatsDUnitTest.java
@@ -14,10 +14,8 @@
  */
 package org.apache.geode.internal.cache.wan.parallel;
 
-import static org.apache.geode.internal.Assert.fail;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
@@ -390,137 +388,6 @@ public class ParallelWANStatsDUnitTest extends WANTestBase {
     assertEquals(2, v4List.get(4) + v5List.get(4) + v6List.get(4) + v7List.get(4));
     // batches redistributed:
     assertEquals(0, v4List.get(5) + v5List.get(5) + v6List.get(5) + v7List.get(5));
-  }
-
-  @Test
-  public void testPRParallelPropagationWithGroupTransactionEventsWithoutBatchRedistributionSendsBatchesWithCompleteTransactions_SeveralClients() {
-    testPRParallelPropagationWithGroupTransactionEventsSendsBatchesWithCompleteTransactions_SeveralClients(
-        false);
-  }
-
-  @Test
-  public void testPRParallelPropagationWithGroupTransactionEventsWithBatchRedistributionSendsBatchesWithCompleteTransactions_SeveralClients() {
-    testPRParallelPropagationWithGroupTransactionEventsSendsBatchesWithCompleteTransactions_SeveralClients(
-        true);
-  }
-
-  public void testPRParallelPropagationWithGroupTransactionEventsSendsBatchesWithCompleteTransactions_SeveralClients(
-      boolean isBatchesRedistributed) {
-    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-
-    createCacheInVMs(nyPort, vm2);
-
-    if (!isBatchesRedistributed) {
-      createReceiverInVMs(vm2);
-    }
-
-    createSenders(lnPort, true);
-
-    createReceiverCustomerOrderShipmentPR(vm2);
-
-    createSenderCustomerOrderShipmentPRs(vm4);
-    createSenderCustomerOrderShipmentPRs(vm5);
-    createSenderCustomerOrderShipmentPRs(vm6);
-    createSenderCustomerOrderShipmentPRs(vm7);
-
-    startSenderInVMs("ln", vm4, vm5, vm6, vm7);
-
-    int clients = 4;
-    int transactions = 300;
-    // batchSize is 10. Each transaction will contain 1 order + 3 shipments = 4 events.
-    // As a result, all batches will contain extra events to complete the
-    // transactions it will deliver.
-    int shipmentsPerTransaction = 3;
-
-    final List<Map<Object, Object>> customerData = new ArrayList<>(clients);
-    for (int intCustId = 0; intCustId < clients; intCustId++) {
-      final Map<Object, Object> custKeyValue = new HashMap<>();
-      CustId custId = new CustId(intCustId);
-      custKeyValue.put(custId, new Customer());
-      customerData.add(new HashMap());
-      vm4.invoke(() -> WANTestBase.putGivenKeyValue(customerRegionName, custKeyValue));
-
-      for (int i = 0; i < transactions; i++) {
-        OrderId orderId = new OrderId(i, custId);
-        customerData.get(intCustId).put(orderId, new Order());
-        for (int j = 0; j < shipmentsPerTransaction; j++) {
-          customerData.get(intCustId).put(new ShipmentId(i + j, orderId), new Shipment());
-        }
-      }
-    }
-
-    List<AsyncInvocation<?>> asyncInvocations = new ArrayList<>(clients);
-
-    int eventsPerTransaction = shipmentsPerTransaction + 1;
-    for (int i = 0; i < clients; i++) {
-      final int intCustId = i;
-      AsyncInvocation<?> asyncInvocation =
-          vm4.invokeAsync(() -> WANTestBase.doOrderAndShipmentPutsInsideTransactions(
-              customerData.get(intCustId),
-              eventsPerTransaction));
-      asyncInvocations.add(asyncInvocation);
-    }
-
-    try {
-      for (AsyncInvocation<?> asyncInvocation : asyncInvocations) {
-        asyncInvocation.await();
-      }
-    } catch (InterruptedException e) {
-      fail("Interrupted");
-    }
-
-    vm4.invoke(() -> WANTestBase.validateRegionSize(customerRegionName, clients));
-    vm4.invoke(() -> WANTestBase.validateRegionSize(orderRegionName, transactions * clients));
-    vm4.invoke(() -> WANTestBase.validateRegionSize(shipmentRegionName,
-        transactions * shipmentsPerTransaction * clients));
-
-    if (isBatchesRedistributed) {
-      // wait for batches to be redistributed and then start the receiver
-      vm4.invoke(() -> await()
-          .until(() -> WANTestBase.getSenderStats("ln", -1).get(5) > 0));
-      createReceiverInVMs(vm2);
-    }
-
-    // Check that all entries have been written in the receiver
-    vm2.invoke(
-        () -> WANTestBase.validateRegionSize(customerRegionName, clients));
-    vm2.invoke(
-        () -> WANTestBase.validateRegionSize(orderRegionName, transactions * clients));
-    vm2.invoke(
-        () -> WANTestBase.validateRegionSize(shipmentRegionName,
-            shipmentsPerTransaction * transactions * clients));
-
-    checkQueuesAreEmptyAndOnlyCompleteTransactionsAreReplicated(isBatchesRedistributed);
-  }
-
-  private void checkQueuesAreEmptyAndOnlyCompleteTransactionsAreReplicated(
-      boolean isBatchesRedistributed) {
-    ArrayList<Integer> v4List =
-        (ArrayList<Integer>) vm4.invoke(() -> WANTestBase.getSenderStats("ln", 0));
-    ArrayList<Integer> v5List =
-        (ArrayList<Integer>) vm5.invoke(() -> WANTestBase.getSenderStats("ln", 0));
-    ArrayList<Integer> v6List =
-        (ArrayList<Integer>) vm6.invoke(() -> WANTestBase.getSenderStats("ln", 0));
-    ArrayList<Integer> v7List =
-        (ArrayList<Integer>) vm7.invoke(() -> WANTestBase.getSenderStats("ln", 0));
-
-    // queue size:
-    assertEquals(0, v4List.get(0) + v5List.get(0) + v6List.get(0) + v7List.get(0));
-    // batches redistributed:
-    int batchesRedistributed = v4List.get(5) + v5List.get(5) + v6List.get(5) + v7List.get(5);
-    if (isBatchesRedistributed) {
-      assertThat(batchesRedistributed).isGreaterThan(0);
-    } else {
-      assertThat(batchesRedistributed).isEqualTo(0);
-    }
-    // batches with incomplete transactions
-    assertThat(v4List.get(13) + v5List.get(13) + v6List.get(13) + v7List.get(7)).isEqualTo(0);
-
-    vm4.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
-    vm5.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
-    vm6.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
-    vm7.invoke(() -> WANTestBase.validateParallelSenderQueueAllBucketsDrained("ln"));
   }
 
   @Test
@@ -1259,6 +1126,7 @@ public class ParallelWANStatsDUnitTest extends WANTestBase {
     verifyConflationIndexesSize(senderId, 0, vm1);
   }
 
+
   @Test
   public void testPartitionedRegionParallelPropagation_RestartSenders_NoRedundancy() {
     Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
@@ -1341,7 +1209,7 @@ public class ParallelWANStatsDUnitTest extends WANTestBase {
     try {
       Thread.sleep(maximumTimeBetweenPingsInGatewayReceiver + 2000);
     } catch (InterruptedException e) {
-      fail("Interrupted");
+      e.printStackTrace();
     }
 
     assertNotEquals(0, (int) vm4.invoke(() -> getGatewaySenderPoolDisconnects(senderId)));

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANStatsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANStatsDUnitTest.java
@@ -17,13 +17,10 @@ package org.apache.geode.internal.cache.wan.serial;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.apache.geode.test.dunit.Wait.pause;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.Test;
@@ -54,7 +51,7 @@ public class SerialWANStatsDUnitTest extends WANTestBase {
   }
 
   @Test
-  public void testReplicatedSerialPropagation() {
+  public void testReplicatedSerialPropagation() throws Exception {
     Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
     Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
@@ -214,103 +211,8 @@ public class SerialWANStatsDUnitTest extends WANTestBase {
   }
 
   @Test
-  public void testReplicatedSerialPropagationWithGroupTransactionEventsWithoutBatchRedistributionSendsBatchesWithCompleteTransactions_SeveralClients() {
-    testReplicatedSerialPropagationWithGroupTransactionEventsSendsBatchesWithCompleteTransactions_SeveralClients(
-        false);
-  }
-
-  @Test
-  public void testReplicatedSerialPropagationWithGroupTransactionEventsWithBatchRedistributionSendsBatchesWithCompleteTransactions_SeveralClients() {
-    testReplicatedSerialPropagationWithGroupTransactionEventsSendsBatchesWithCompleteTransactions_SeveralClients(
-        true);
-  }
-
-  public void testReplicatedSerialPropagationWithGroupTransactionEventsSendsBatchesWithCompleteTransactions_SeveralClients(
-      boolean isBatchRedistribution) {
-    Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
-    Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
-
-    createCacheInVMs(nyPort, vm2);
-    if (!isBatchRedistribution) {
-      vm2.invoke(() -> WANTestBase.createReceiver());
-    }
-
-    createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
-
-    final int batchSize = 10;
-
-    boolean groupTransactionEvents = true;
-    vm4.invoke(
-        () -> WANTestBase.createSender("ln", 2, false, 100, batchSize, false, false, null, true,
-            groupTransactionEvents));
-    vm5.invoke(
-        () -> WANTestBase.createSender("ln", 2, false, 100, batchSize, false, false, null, true,
-            groupTransactionEvents));
-    vm6.invoke(
-        () -> WANTestBase.createSender("ln", 2, false, 100, batchSize, false, false, null, true,
-            groupTransactionEvents));
-    vm7.invoke(
-        () -> WANTestBase.createSender("ln", 2, false, 100, batchSize, false, false, null, true,
-            groupTransactionEvents));
-
-    final String regionName = testName + "_RR";
-
-    vm2.invoke(() -> WANTestBase.createReplicatedRegion(regionName, null, isOffHeap()));
-
-    startSenderInVMs("ln", vm4, vm5, vm6, vm7);
-
-    vm4.invoke(() -> WANTestBase.createReplicatedRegion(regionName, "ln", isOffHeap()));
-    vm5.invoke(() -> WANTestBase.createReplicatedRegion(regionName, "ln", isOffHeap()));
-    vm6.invoke(() -> WANTestBase.createReplicatedRegion(regionName, "ln", isOffHeap()));
-    vm7.invoke(() -> WANTestBase.createReplicatedRegion(regionName, "ln", isOffHeap()));
-
-    int clients = 2;
-    int eventsPerTransaction = batchSize + 1;
-    int entriesPerInvocation = eventsPerTransaction * 200;
-
-    final List<Map<Object, Object>> data = new ArrayList<>(clients);
-    for (int clientId = 0; clientId < clients; clientId++) {
-      final Map<Object, Object> keyValues = new HashMap<>();
-      for (int i = entriesPerInvocation * clientId; i < entriesPerInvocation
-          * (clientId + 1); i++) {
-        keyValues.put(i, i + "_Value");
-      }
-      data.add(keyValues);
-    }
-
-    int entries = entriesPerInvocation * clients;
-
-    List<AsyncInvocation> invocations = new ArrayList<AsyncInvocation>(clients);
-    for (int i = 0; i < clients; i++) {
-      final int index = i;
-      AsyncInvocation asyncInvocation =
-          vm4.invokeAsync(() -> WANTestBase.doPutsInsideTransactions(regionName, data.get(index),
-              eventsPerTransaction));
-      invocations.add(asyncInvocation);
-    }
-
-    try {
-      for (AsyncInvocation invocation : invocations) {
-        invocation.await();
-      }
-    } catch (InterruptedException e) {
-      e.printStackTrace();
-    }
-
-    if (isBatchRedistribution) {
-      // wait for batches to be redistributed and then start the receiver
-      vm4.invoke(() -> await()
-          .until(() -> WANTestBase.getSenderStats("ln", -1).get(5) > 0));
-      vm2.invoke(() -> WANTestBase.createReceiver());
-    }
-
-    vm2.invoke(() -> WANTestBase.validateRegionSize(regionName, entries));
-
-    checkQueuesAreEmptyAndOnlyCompleteTransactionsAreReplicated(isBatchRedistribution);
-  }
-
-  @Test
-  public void testReplicatedSerialPropagationWithBatchRedistWithoutGroupTransactionEventsSendsBatchesWithIncompleteTransactions() {
+  public void testReplicatedSerialPropagationWithBatchRedistWithoutGroupTransactionEventsSendsBatchesWithIncompleteTransactions()
+      throws Exception {
     Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
     Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
 
@@ -820,7 +722,7 @@ public class SerialWANStatsDUnitTest extends WANTestBase {
   }
 
   @Test
-  public void testSerialPropagationWithFilter() {
+  public void testSerialPropagationWithFilter() throws Exception {
 
     Integer lnPort = vm0.invoke(() -> WANTestBase.createFirstLocatorWithDSId(1));
     Integer nyPort = vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnPort));
@@ -922,30 +824,4 @@ public class SerialWANStatsDUnitTest extends WANTestBase {
     vm4.invoke(() -> WANTestBase.checkConflatedStats("ln", 500));
   }
 
-  private void checkQueuesAreEmptyAndOnlyCompleteTransactionsAreReplicated(
-      boolean isBatchesRedistributed) {
-    // Wait for sender queues to be empty
-    List<Integer> v4List =
-        vm4.invoke(() -> WANTestBase.getSenderStats("ln", 0));
-    List<Integer> v5List =
-        vm5.invoke(() -> WANTestBase.getSenderStats("ln", 0));
-    List<Integer> v6List =
-        vm6.invoke(() -> WANTestBase.getSenderStats("ln", 0));
-    List<Integer> v7List =
-        vm7.invoke(() -> WANTestBase.getSenderStats("ln", 0));
-
-    // queue size must be 0
-    assertThat(v4List.get(0) + v5List.get(0) + v6List.get(0) + v7List.get(0)).isEqualTo(0);
-
-    // batches redistributed:
-    int batchesRedistributed = v4List.get(5) + v5List.get(5) + v6List.get(5) + v7List.get(5);
-    if (isBatchesRedistributed) {
-      assertThat(batchesRedistributed).isGreaterThan(0);
-    } else {
-      assertThat(batchesRedistributed).isEqualTo(0);
-    }
-
-    // batches with incomplete transactions must be 0
-    assertThat(v4List.get(13) + v5List.get(13) + v6List.get(13) + v7List.get(13)).isEqualTo(0);
-  }
 }

--- a/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderFactoryImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderFactoryImpl.java
@@ -79,12 +79,6 @@ public class GatewaySenderFactoryImpl implements InternalGatewaySenderFactory {
   }
 
   @Override
-  public GatewaySenderFactory setRetriesToGetTransactionEventsFromQueue(int retries) {
-    this.attrs.setRetriesToGetTransactionEventsFromQueue(retries);
-    return this;
-  }
-
-  @Override
   public GatewaySenderFactory setForInternalUse(boolean isForInternalUse) {
     this.attrs.setForInternalUse(isForInternalUse);
     return this;


### PR DESCRIPTION
…der when group-transaction-events is true (#6663)"

This reverts commit b377e3f808562fdf59d2753a5a58fd9b9d603883.

---

I've reviewed the code that went in with #b377e3, and I think we should revert it to rework WanCopyRegionFunction and its unit test. The unit test currently mocks three methods in WanCopyRegionFunction (known as partial mocking) which is a sign that dependencies are hidden inside the class and need to be pulled up to the constructor.

WanCopyRegionFunction also has a static final ExecutorService which is never shutdown. The ExecutorService should live outside WanCopyRegionFunction, be passed in via the constructor, and be shutdown when the Cache closes.

The intermittent test failures are not specific to Windows and are likely to also fail on a slow Linux machine.

We really need to avoid Thread sleeps especially in unit tests. This and the partial mocking are signs that the class needs to change to better enable unit testing.

I'll be more than happy to help but I think we need to revert it so we have time to discuss it without everyone else being affected by failing tests.