### PR TITLE
[DO NOT REVIEW] GEODE-9369: wanCopyRegionFunction does not launch a new thread per ex…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -1466,8 +1466,8 @@ public class CliStrings {
       "No connection available to receiver after having copied {0} entries";
   public static final String WAN_COPY_REGION__MSG__ERROR__AFTER__HAVING__COPIED =
       "Error ({0}) in operation after having copied {1} entries";
-  public static final String WAN_COPY_REGION__MSG__CANCELED__BEFORE__HAVING__COPIED =
-      "Operation canceled before having copied all entries";
+  public static final String WAN_COPY_REGION__MSG__CANCELED__AFTER__HAVING__COPIED =
+      "Operation canceled after having copied {0} entries";
   public static final String WAN_COPY_REGION__MSG__COPIED__ENTRIES = "Entries copied: {0}";
   public static final String WAN_COPY_REGION__MSG__NO__RUNNING__COMMAND =
       "No running command to be canceled for region {0} and sender {1}";


### PR DESCRIPTION
…ecution

This PR contains a modification of the original implementation of the `WanCopyRegionFunction` function in which a new thread is not created in each function invocation.
In order to cancel ongoing invocations, a static Map variable in the `WanCopyRegionFunction` is used. The map contains the ongoing executions (key) and if the execution must be canceled (value).
In order to cancel an execution, the value in that variable must be set to true.
On the other hand, after a batch is sent, the variable is checked to see if the execution must be canceled (the value in the map for this execution is false).

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
