### PR TITLE
GEODE-9252: Wait longer for Redis cluster to be formed

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
@@ -135,7 +135,7 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
     int primaryCount = 0;
 
     try (Jedis jedis = new Jedis("localhost", port)) {
-      for (int i = 0; i < 10; i++) {
+      for (int i = 0; i < 60; i++) {
         nodes = ClusterNodes.parseClusterNodes(jedis.clusterNodes()).getNodes();
         primaryCount = nodes.stream().mapToInt(x -> x.primary ? 1 : 0).sum();
         if (primaryCount == wantedPrimaries) {
@@ -143,7 +143,7 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
         }
 
         try {
-          Thread.sleep(500);
+          Thread.sleep(1000);
         } catch (InterruptedException ignored) {
         }
       }


### PR DESCRIPTION
- Increase the wait from 5 to 60 seconds

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
