### PR TITLE
GEODE-9447: fix release scripts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -280,6 +280,8 @@ Apache Geode bundles the following files under the MIT License:
     Kelvin Luck
   - MooTools (http://mootools.net), Copyright (c) 2006-2015 Valerio
     Proietti, <http://mad4milk.net/>
+  - OrderStatisticTree (https://github.com/coderodde/OrderStatisticTree),
+    Copyright (c) 2021 Rodion Efremov
   - Sizzle.js (http://sizzlejs.com/), Copyright (c) 2011, The Dojo Foundation
   - Split.js (https://github.com/nathancahill/Split.js), Copyright (c)
     2015 Nathan Cahill
@@ -289,8 +291,6 @@ Apache Geode bundles the following files under the MIT License:
   - Timeago v1.3.0 (http://timeago.yarp.com), Copyright (c) 2008-2015 Ryan
     McGeary
   - zTree v3.5.02 (http://zTree.me/), Copyright (c) 2010 Hunter.z
-  - OrderStatisticTree (https://github.com/coderodde/OrderStatisticTree),
-    Copyright (c) 2021 Rodion Efremov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -175,7 +175,7 @@ tests:
   RAM: '8'
   name: redis
 - ARTIFACT_SLUG: stressnewtestfiles
-  CALL_STACK_TIMEOUT: '20700'
+  CALL_STACK_TIMEOUT: '35100'
   CPUS: '96'
   DISK: '300GB'
   DUNIT_PARALLEL_FORKS: '24'

--- a/ci/scripts/execute_build.sh
+++ b/ci/scripts/execute_build.sh
@@ -85,7 +85,8 @@ else
 fi
 
 
-SET_JAVA_HOME="export JAVA_HOME=/usr/lib/jvm/bellsoft-java${JAVA_BUILD_VERSION}-amd64"
+JAVA_BUILD_PATH="/usr/lib/jvm/bellsoft-java${JAVA_BUILD_VERSION}-amd64"
+SET_JAVA_HOME="export JAVA_HOME=${JAVA_BUILD_PATH}"
 
 if [ -v CALL_STACK_TIMEOUT ]; then
   ssh ${SSH_OPTIONS} geode@${INSTANCE_IP_ADDRESS} "${SET_JAVA_HOME} && tmux new-session -d -s callstacks; tmux send-keys  ~/capture-call-stacks.sh\ ${PARALLEL_DUNIT}\ ${CALL_STACK_TIMEOUT} C-m"
@@ -103,7 +104,9 @@ GRADLE_ARGS="\
     -PbuildId=${BUILD_ID} \
     build install javadoc spotlessCheck rat checkPom resolveDependencies pmdMain -x test"
 
-EXEC_COMMAND="mkdir -p tmp \
+EXEC_COMMAND="echo Building with: \
+  && ${JAVA_BUILD_PATH}/bin/java -version \
+  && mkdir -p /tmp \
   && cp geode/ci/scripts/attach_sha_to_branch.sh /tmp/ \
   && /tmp/attach_sha_to_branch.sh geode ${BUILD_BRANCH} \
   && cd geode \

--- a/dev-tools/dependencies/bump.sh
+++ b/dev-tools/dependencies/bump.sh
@@ -26,6 +26,7 @@ if [ "$2" = "-l" ] ; then
   ./gradlew dependencyUpdates -Drevision=release ; find . | grep build/dependencyUpdates/report.txt | xargs cat \
    | grep ' -> ' | egrep -v '(Gradle|antlr|lucene|JUnitParams|docker-compose-rule|javax.servlet-api|springfox|derby|selenium|jgroups|jmh|\[6.0.37|commons-collections|jaxb|testcontainers|gradle-tooling-api|slf4j|archunit)' \
    | sort -u | tr -d '][' | sed -e 's/ -> / /' -e 's#.*:#'"$0 $1"' #'
+  echo "cd .. ; geode/dev-tools/release/license_review.sh -v HEAD ; cd $(pwd)"
   exit 0
 fi
 

--- a/dev-tools/dependencies/bump.sh
+++ b/dev-tools/dependencies/bump.sh
@@ -27,6 +27,7 @@ if [ "$2" = "-l" ] ; then
    | grep ' -> ' | egrep -v '(Gradle|antlr|lucene|JUnitParams|docker-compose-rule|javax.servlet-api|springfox|derby|selenium|jgroups|jmh|\[6.0.37|commons-collections|jaxb|testcontainers|gradle-tooling-api|slf4j|archunit)' \
    | sort -u | tr -d '][' | sed -e 's/ -> / /' -e 's#.*:#'"$0 $1"' #'
   echo "cd .. ; geode/dev-tools/release/license_review.sh -v HEAD && echo ':)' || echo 'ERROR(S) WERE FOUND, SEE ABOVE' ; cd $(pwd)"
+  echo "Tip: prepend SKIP=true to some lines to bump a few dependencies at once between validation checks.  Push in small batches.  Add Windows label to PR before pushing final batch."
   exit 0
 fi
 

--- a/dev-tools/dependencies/bump.sh
+++ b/dev-tools/dependencies/bump.sh
@@ -27,7 +27,8 @@ if [ "$2" = "-l" ] ; then
    | grep ' -> ' | egrep -v '(Gradle|antlr|lucene|JUnitParams|docker-compose-rule|javax.servlet-api|springfox|derby|selenium|jgroups|jmh|\[6.0.37|commons-collections|jaxb|testcontainers|gradle-tooling-api|slf4j|archunit)' \
    | sort -u | tr -d '][' | sed -e 's/ -> / /' -e 's#.*:#'"$0 $1"' #'
   echo "cd .. ; geode/dev-tools/release/license_review.sh -v HEAD && echo ':)' || echo 'ERROR(S) WERE FOUND, SEE ABOVE' ; cd $(pwd)"
-  echo "Tip: prepend SKIP=true to some lines to bump a few dependencies at once between validation checks.  Push in small batches.  Add Windows label to PR before pushing final batch."
+  echo "#Also: manually check for newer version of plugins listed in build.gradle (search on https://plugins.gradle.org/plugin)"
+  echo "#Tip: prepend SKIP=true to some lines to bump a few dependencies at once between validation checks.  Push in small batches.  Add Windows label to PR before pushing final batch."
   exit 0
 fi
 

--- a/dev-tools/dependencies/bump.sh
+++ b/dev-tools/dependencies/bump.sh
@@ -26,7 +26,7 @@ if [ "$2" = "-l" ] ; then
   ./gradlew dependencyUpdates -Drevision=release ; find . | grep build/dependencyUpdates/report.txt | xargs cat \
    | grep ' -> ' | egrep -v '(Gradle|antlr|lucene|JUnitParams|docker-compose-rule|javax.servlet-api|springfox|derby|selenium|jgroups|jmh|\[6.0.37|commons-collections|jaxb|testcontainers|gradle-tooling-api|slf4j|archunit)' \
    | sort -u | tr -d '][' | sed -e 's/ -> / /' -e 's#.*:#'"$0 $1"' #'
-  echo "cd .. ; geode/dev-tools/release/license_review.sh -v HEAD ; cd $(pwd)"
+  echo "cd .. ; geode/dev-tools/release/license_review.sh -v HEAD && echo ':)' || echo 'ERROR(S) WERE FOUND, SEE ABOVE' ; cd $(pwd)"
   exit 0
 fi
 

--- a/dev-tools/release/deploy_rc_pipeline.sh
+++ b/dev-tools/release/deploy_rc_pipeline.sh
@@ -303,7 +303,7 @@ jobs:
               echo 'deb     http://ftp.de.debian.org/debian/    stable main contrib non-free' >> /etc/apt/sources.list.d/stable.list
               echo 'deb-src http://ftp.de.debian.org/debian/    stable main contrib non-free' >> /etc/apt/sources.list.d/stable.list
               echo 'deb     http://security.debian.org/         stable/updates  main contrib non-free' >> /etc/apt/sources.list.d/stable.list
-              apt-get update
+              apt-get update || true
               DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev zlib1g-dev
               cd geode-native
               mkdir build
@@ -352,7 +352,7 @@ jobs:
               echo 'deb     http://ftp.de.debian.org/debian/    stable main contrib non-free' >> /etc/apt/sources.list.d/stable.list
               echo 'deb-src http://ftp.de.debian.org/debian/    stable main contrib non-free' >> /etc/apt/sources.list.d/stable.list
               echo 'deb     http://security.debian.org/         stable/updates  main contrib non-free' >> /etc/apt/sources.list.d/stable.list
-              apt-get update
+              apt-get update || true
               DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev zlib1g-dev
               curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-native-${VERSION}-src.tgz > src.tgz
               tar xzf src.tgz
@@ -435,7 +435,7 @@ jobs:
               mkdir -p ~/.ssh
               ssh-keygen -m PEM -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ""
               cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
-              apt-get update
+              apt-get update || true
               apt-get install openssh-server --no-install-recommends -y
               echo "StrictHostKeyChecking no" >> /etc/ssh/ssh_config
               service ssh start

--- a/dev-tools/release/license_review.sh
+++ b/dev-tools/release/license_review.sh
@@ -339,6 +339,7 @@ if [ "${licFromWs}" = "true" ] ; then
     echo "Incorrect LICENSE in binary distribution"
     echo "Expected:" $(wc -c ${BLICENSE})
     echo "Actual:" $(wc -c ${NEW_DIR}/LICENSE)
+    result=1
   fi
 
   if ! [ "$SKIP_SRC_LICENSE" = "true" ] ; then
@@ -349,13 +350,15 @@ if [ "${licFromWs}" = "true" ] ; then
       echo "Incorrect LICENSE in source distribution"
       echo "Expected:" $(wc -c ${SLICENSE})
       echo "Actual:" $(wc -c ${NEW_SRC_DIR}/LICENSE)
+      result=1
     fi
 
     banner "Checking references in source license"
-    cat $SLICENSE | checkMissing $SLICENSE
+    cat $SLICENSE | checkMissing $SLICENSE || result=1
+
 
     banner "Checking references in binary license"
-    cat $SLICENSE $SLICENSE $BLICENSE | sort | uniq -u | checkMissing $BLICENSE
+    cat $SLICENSE $SLICENSE $BLICENSE | sort | uniq -u | checkMissing $BLICENSE || result=1
   fi
 fi
 

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -259,7 +259,9 @@ echo "Building Geode docker image"
 echo "============================================================"
 set -x
 cd ${GEODE}/docker
+sed -e '/www.apache.org.dyn.closer/d' -i.backup Dockerfile
 docker build .
+mv Dockerfile.backup Dockerfile
 docker build -t apachegeode/geode:${VERSION} .
 [ -n "$LATER" ] || docker build -t apachegeode/geode:latest .
 set +x

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -506,7 +506,7 @@ echo "9. Check that ${VERSION} download info has been published to https://geode
 MAJOR="${VERSION_MM%.*}"
 MINOR="${VERSION_MM#*.}"
 PATCH="${VERSION##*.}"
-[ "${PATCH}" -ne 0 ] || echo "10. Ask on the dev list for a volunteer to begin the chore of updating 3rd-party dependency versions on develop (see dev-tools/dependencies/README.md)"
+[ "${PATCH}" -ne 0 ] || echo "10. If 3rd-party dependencies haven't been bumped in awhile, ask on the dev list for a volunteer (details in dev-tools/dependencies/README.md)"
 [ "${PATCH}" -ne 0 ] || [ "${MINOR}" -lt 15 ] || echo "11. In accordance with Geode's N-2 support policy, the time has come to ${0%/*}/end_of_support.sh -v ${MAJOR}.$((MINOR - 3))"
 [ "${PATCH}" -ne 0 ] || [ -n "$LATER" ] || echo "12. Log in to https://hub.docker.com/repository/docker/apachegeode/geode and update the latest Dockerfile linktext and url to ${VERSION_MM}"
 echo "If there are any support branches between ${VERSION_MM} and develop, manually cherry-pick '${VERSION}' bumps to those branches of geode and geode-native."

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -510,4 +510,5 @@ PATCH="${VERSION##*.}"
 echo "If there are any support branches between ${VERSION_MM} and develop, manually cherry-pick '${VERSION}' bumps to those branches of geode and geode-native."
 echo "Bump support pipeline to ${VERSION_MM}.$(( PATCH + 1 )) by plussing BumpPatch in https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-support-${VERSION_MM//./-}-main?group=Semver%20Management"
 echo "Run ${0%/*}/set_versions.sh -v ${VERSION_MM}.$(( PATCH + 1 )) -s"
+[ "${PATCH}" -ne 0 ] || echo "Run cd ${GEODE} && geode-management/src/test/script/update-management-wiki.sh"
 echo 'Finally, send announce email!'

--- a/dev-tools/release/set_versions.sh
+++ b/dev-tools/release/set_versions.sh
@@ -134,7 +134,7 @@ sed -e "s#clone -b [ds][evlopurt/0-9.]*#clone -b support/${VERSION_MM}#" \
 
 rm -f gradle.properties.bak geode-book/config.yml.bak ci/docker/cache_dependencies.sh.bak ci/images/google-geode-builder/scripts/cache_dependencies.sh.bak
 set -x
-git add gradle.properties geode-book/config.yml
+git add gradle.properties geode-book/config.yml ci/docker/cache_dependencies.sh ci/images/google-geode-builder/scripts/cache_dependencies.sh
 if [ $(git diff --staged | wc -l) -gt 0 ] ; then
   git diff --staged --color | cat
   git commit -m "Bumping version to ${VERSION}"

--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -1095,6 +1095,8 @@ Apache Geode bundles the following files under the MIT License:
     Proietti, <http://mad4milk.net/>
   - Normalize.css v2.1.0 (https://necolas.github.io/normalize.css/),
     Copyright (c) Nicolas Gallagher and Jonathan Neal
+  - OrderStatisticTree (https://github.com/coderodde/OrderStatisticTree),
+    Copyright (c) 2021 Rodion Efremov
   - Sizzle.js (http://sizzlejs.com/), Copyright (c) 2011, The Dojo Foundation
   - SLF4J API v1.7.30 (http://www.slf4j.org), Copyright (c) 2004-2017 QOS.ch
   - Split.js (https://github.com/nathancahill/Split.js), Copyright (c)

--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -1062,7 +1062,7 @@ The MIT License (http://opensource.org/licenses/mit-license.html)
 
 Apache Geode bundles the following files under the MIT License:
 
-  - Checker Qual v2.10.0 (https://checkerframework.org), Copyright (c)
+  - Checker Qual v3.8.0 (https://checkerframework.org), Copyright (c)
     2004-present by the Checker Framework developers
   - ClassGraph v4.8.115 (https://github.com/classgraph/classgraph), Copyright
     (c) 2019 Luke Hutchison

--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -221,7 +221,7 @@ Apache Geode bundles the following files under the BSD 3-Clause License:
     Copyright (c) 2002-2007 Marc Prud'hommeaux.
   - Antlr v2.7.7 (http://www.antlr.org), Copyright (c) 2012 Terrence Parr
     and Sam Harwell
-  - ASM v5.0.4 (https://asm.ow2.io) Copyright (c) 2000-2011 INRIA, France
+  - ASM v9.1 (https://asm.ow2.io) Copyright (c) 2000-2011 INRIA, France
     Telecom
   - JLine v2.12 (http://jline.sourceforge.net), Copyright (c) 2002-2006,
     Marc Prud'hommeaux <mwp1@cornell.edu>

--- a/geode-management/src/test/script/update-management-wiki.sh
+++ b/geode-management/src/test/script/update-management-wiki.sh
@@ -53,8 +53,22 @@ if [[ ${BRANCH} != "develop" ]] && [[ ${BRANCH} != "master" ]] && [[ ${BRANCH%/*
 fi
 
 SUDO=
-PIP=pip
-PYTHON=python
+if python --version | grep 'Python 3' ; then
+  PYTHON=python
+elif python3 --version | grep 'Python 3' ; then
+  PYTHON=python3
+else
+  echo "please install python 3"
+  exit 1
+fi
+if pip --version | grep 'python 3' ; then
+  PIP=pip
+elif pip3 --version | grep 'python 3' ; then
+  PIP=pip3
+else
+  echo "please install pip 3"
+  exit 1
+fi
 
 echo ""
 echo "============================================================"
@@ -80,9 +94,10 @@ GEODE_VERSION=$("$GEODE"/bin/gfsh version | sed -e 's/-SNAPSHOT//' -e 's/-build.
 [[ "${GEODE_VERSION%.*}" == "1.12" ]] && PAGE_ID=132322415
 [[ "${GEODE_VERSION%.*}" == "1.13" ]] && PAGE_ID=147426059
 [[ "${GEODE_VERSION%.*}" == "1.14" ]] && PAGE_ID=153817491
+[[ "${GEODE_VERSION%.*}" == "1.15" ]] && PAGE_ID=188744355
 
 if [[ -z "${PAGE_ID}" ]] ; then
-    echo "Please create a new wiki page for $GEODE_VERSION and add its page ID to $0 near line 83"
+    echo "Please create a new blank wiki page for $GEODE_VERSION under https://cwiki.apache.org/confluence/display/GEODE/Cluster+Management+Service+Rest+API and add its page ID to $0 near line 98"
     exit 1
 fi
 
@@ -159,7 +174,7 @@ cat static/index.html |
 # clean up a few things premailer will otherwise choke on
 grep -v doctype | sed -e 's/&mdash;/--/g' |
 # convert css style block to inline css (that is the only way confluence accepts styling)
-$SUDO $PYTHON -m premailer --method xml --encoding ascii --pretty |
+(set -o pipefail && $SUDO $PYTHON -m premailer --method xml --encoding ascii --pretty |
 # strip off the document envelope (otherwise confluence will not accept it) by keeping only lines between the body tags
 awk '
   /<\/body>/ {inbody=0}
@@ -234,7 +249,7 @@ sed -e 's/&#171;/_/g' -e 's/&#187;//g' |
 sed -e 's/class="method" style="margin-left:20p/class="method" style="margin-left:0p/' |
 # add more information at the top
 awk '/More information:/{sub(/More information:/,"Swagger: http://locator:7070/management/docs (requires access to a running locator)<br/>Codegen: <code><small>brew install swagger-codegen; swagger-codegen generate -i http://locator:7070/management'${URI_VERSION}'/api-docs</small></code><br/>More information:")}{print}' |
-cat > static/index-xhtml.html
+cat > static/index-xhtml.html)
 # if file is empty due to some error, abort!
 ! [ -z "$(cat static/index-xhtml.html)" ]
 


### PR DESCRIPTION
fix issues encountered during 1.14.0 release:
* ignore apt update failure, as it may still work (apt install is the true test)
* actually commit files modified by set-versions
* fix the version of checker-qual and asm in the license
* fix the omission of OrderStatisticTree from the binary license
* suggest running the license review script and adding Windows label and checking gradle plugin versions after a batch of dependency bumps
* sync up the callstack timeout for stressnew and add java -version to Build job
* suggest running CMS REST APIdoc update script and autodetect python3
* improve docker build flakiness with auto-retries and skip closer.lua which likely won't be working yet

Note: I'll leave this pull request open until the end of the week in case any other release script issues turn up once the vote has closed.