### PR TITLE
GEODE-9519: Implement Radish ZSCAN command

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZScanNativeRedisIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZScanNativeRedisIntegrationTest.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.NativeRedisClusterTestRule;
+
+public class ZScanNativeRedisIntegrationTest extends AbstractZScanIntegrationTest {
+
+  @ClassRule
+  public static NativeRedisClusterTestRule redis = new NativeRedisClusterTestRule();
+
+  @Override
+  public int getPort() {
+    return redis.getExposedPorts().get(0);
+  }
+
+  @Override
+  public void flushAll() {
+    redis.flushAll();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/AbstractHScanIntegrationTest.java
@@ -252,10 +252,9 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
   }
 
   @Test
-  public void shouldNotError_givenCursorEqualToUnsignedLongMaxValue() {
+  public void shouldNotError_givenCursorEqualToLongMaxValue() {
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
-    jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY,
-        UNSIGNED_LONG_CAPACITY.toString());
+    jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, String.valueOf(Long.MAX_VALUE));
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/HScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/hash/HScanIntegrationTest.java
@@ -16,13 +16,7 @@ package org.apache.geode.redis.internal.executor.hash;
 
 
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import java.math.BigInteger;
-
 import org.junit.ClassRule;
-import org.junit.Test;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 
@@ -34,29 +28,5 @@ public class HScanIntegrationTest extends AbstractHScanIntegrationTest {
   @Override
   public int getPort() {
     return server.getPort();
-  }
-
-
-  // Note: these tests will not pass native redis, so included here in concrete test class
-  @Test
-  public void givenCursorGreaterThanIntMaxValue_returnsCursorError() {
-    int largestCursorValue = Integer.MAX_VALUE;
-
-    BigInteger tooBigCursor =
-        new BigInteger(String.valueOf(largestCursorValue)).add(BigInteger.valueOf(1));
-
-    assertThatThrownBy(() -> jedis.hscan("a", tooBigCursor.toString()))
-        .hasMessageContaining(ERROR_CURSOR);
-  }
-
-  @Test
-  public void givenCursorLessThanIntMinValue_returnsCursorError() {
-    int smallestCursorValue = Integer.MIN_VALUE;
-
-    BigInteger tooSmallCursor =
-        new BigInteger(String.valueOf(smallestCursorValue)).subtract(BigInteger.valueOf(1));
-
-    assertThatThrownBy(() -> jedis.hscan("a", tooSmallCursor.toString()))
-        .hasMessageContaining(ERROR_CURSOR);
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -349,6 +349,11 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   }
 
   @Test
+  public void testZscan() {
+    runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, (k, v) -> jedis.zscan(k, v));
+  }
+
+  @Test
   public void testZscore() {
     runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, (k, v) -> jedis.zscore(k, v));
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZScanIntegrationTest.java
@@ -1,0 +1,548 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.ScanParams;
+import redis.clients.jedis.ScanResult;
+import redis.clients.jedis.Tuple;
+
+import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.executor.cluster.CRC16;
+
+public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTest {
+  protected JedisCluster jedis;
+
+  public static final String KEY = "key";
+  public static final int SLOT_FOR_KEY = CRC16.calculate(KEY) % RegionProvider.REDIS_SLOTS;
+  public static final String ZERO_CURSOR = "0";
+  public static final BigInteger UNSIGNED_LONG_CAPACITY = new BigInteger("18446744073709551615");
+
+  public static final String MEMBER_ONE = "member1";
+  public static final double SCORE_ONE = 1.1;
+  public static final String MEMBER_TWO = "member12";
+  public static final double SCORE_TWO = 2.2;
+  public static final String MEMBER_THREE = "member3";
+  public static final double SCORE_THREE = 3.3;
+
+  public static final String BASE_MEMBER = "baseMember_";
+  private final int SIZE_OF_ENTRY_SET = 100;
+
+  @Before
+  public void setUp() {
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    flushAll();
+    jedis.close();
+  }
+
+  /********* Parameter Checks **************/
+
+  @Test
+  public void givenLessThanTwoArguments_returnsWrongNumberOfArgumentsError() {
+    assertAtLeastNArgs(jedis, Protocol.Command.ZSCAN, 2);
+  }
+
+  @Test
+  public void givenMatchArgumentWithoutPatternOnExistingKey_returnsSyntaxError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "MATCH"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenMatchArgumentWithoutPatternOnNonExistentKey_returnsEmptyArray() {
+    List<Object> result =
+        uncheckedCast(jedis.sendCommand(KEY, Protocol.Command.ZSCAN, "nonexistentKey",
+            ZERO_CURSOR, "MATCH"));
+
+    assertThat((List<?>) result.get(1)).isEmpty();
+  }
+
+  @Test
+  public void givenCountArgumentWithoutNumberOnExistingKey_returnsSyntaxError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenCountArgumentWithoutNumberOnNonExistentKey_returnsEmptyArray() {
+    List<Object> result =
+        uncheckedCast(
+            jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT"));
+
+    assertThat((List<?>) result.get(1)).isEmpty();
+  }
+
+  @Test
+  public void givenMatchOrCountKeywordNotSpecified_returnsSyntaxError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "a*", "1"))
+            .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsNotAnInteger_returnsNotIntegerError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
+            "MATCH"))
+                .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void givenMultipleCounts_whenAnyCountParameterIsNotAnInteger_returnsNotIntegerError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
+            "3",
+            "COUNT", "sjlfs", "COUNT", "1"))
+                .hasMessageContaining(ERROR_NOT_INTEGER);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsZero_returnsSyntaxError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
+            ZERO_CURSOR))
+                .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenCount_whenCountParameterIsNegative_returnsSyntaxError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
+            "-37"))
+                .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenMultipleCounts_whenAnyCountParameterIsLessThanOne_returnsSyntaxError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    assertThatThrownBy(
+        () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR,
+            "COUNT", "3",
+            "COUNT", "0",
+            "COUNT", "1"))
+                .hasMessageContaining(ERROR_SYNTAX);
+  }
+
+  @Test
+  public void givenKeyIsNotASortedSet_returnsWrongTypeError() {
+    jedis.sadd(KEY, "member");
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
+        ZERO_CURSOR))
+            .hasMessageContaining(ERROR_WRONG_TYPE);
+  }
+
+  @Test
+  public void givenKeyIsNotASortedSet_andCursorIsNotAnInteger_returnsCursorError() {
+    jedis.sadd(KEY, "member");
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, "sjfls"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenNonexistentKey_andCursorIsNotAnInteger_returnsCursorError() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand("notReal", Protocol.Command.ZSCAN, "notReal", "sjfls"))
+            .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenExistentSortedSetKey_andCursorIsNotAnInteger_returnsCursorError() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, "sjfls"))
+        .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void givenNonexistentKey_returnsEmptyArray() {
+    ScanResult<Tuple> result = jedis.zscan("nonexistent", ZERO_CURSOR);
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(result.getResult()).isEmpty();
+  }
+
+  @Test
+  public void givenNegativeCursor_returnsEntriesUsingAbsoluteValueOfCursor() {
+    Map<String, Double> entryMap = initializeThreeFieldSortedSet();
+
+    String cursor = "-100";
+    ScanResult<Tuple> result;
+    List<Tuple> allEntries = new ArrayList<>();
+
+    do {
+      result = jedis.zscan(KEY, cursor);
+      allEntries.addAll(result.getResult());
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    assertThat(tupleCollectionToMap(allEntries)).containsExactlyInAnyOrderEntriesOf(entryMap);
+  }
+
+  @Test
+  public void shouldReturnError_givenCursorGreaterThanUnsignedLongMaxValue() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
+        UNSIGNED_LONG_CAPACITY.add(new BigInteger("10")).toString()))
+            .hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void shouldNotError_givenCursorEqualToUnsignedLongMaxValue() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+    jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, UNSIGNED_LONG_CAPACITY.toString());
+  }
+
+  @Test
+  public void givenInvalidRegexSyntax_returnsEmptyArray() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+    ScanParams scanParams = new ScanParams().count(1).match("\\p");
+
+    ScanResult<Tuple> result = jedis.zscan(KEY.getBytes(), ZERO_CURSOR.getBytes(), scanParams);
+
+    assertThat(result.getResult()).isEmpty();
+  }
+
+  // Happy path behavior checks start here
+
+  @Test
+  public void givenSortedSetWithOneEntry_returnsEntry() {
+    Map<String, Double> expected = new HashMap<>();
+    expected.put(MEMBER_ONE, SCORE_ONE);
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    ScanResult<Tuple> result = jedis.zscan(KEY, ZERO_CURSOR);
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(tupleCollectionToMap(result.getResult()))
+        .containsExactlyInAnyOrderEntriesOf(expected);
+  }
+
+  @Test
+  public void givenSortedSetWithMultipleEntries_returnsAllEntries() {
+    Map<String, Double> entryMap = initializeThreeFieldSortedSet();
+
+    ScanResult<Tuple> result = jedis.zscan(KEY, ZERO_CURSOR);
+
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(tupleCollectionToMap(result.getResult()))
+        .containsExactlyInAnyOrderEntriesOf(entryMap);
+  }
+
+  @Test
+  public void givenMultipleCounts_DoesNotFail() {
+    initializeThreeFieldSortedSet();
+
+    List<Object> result;
+    String cursor = ZERO_CURSOR;
+
+    do {
+      result = uncheckedCast(jedis.sendCommand(KEY, Protocol.Command.ZSCAN,
+          KEY,
+          cursor,
+          "COUNT", "2",
+          "COUNT", "1"));
+
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), ZERO_CURSOR.getBytes()));
+
+    assertThat((byte[]) result.get(0)).isEqualTo(ZERO_CURSOR.getBytes());
+  }
+
+  @Test
+  public void givenCompleteIteration_shouldReturnCursorWithValueOfZero() {
+    initializeThreeFieldSortedSet();
+
+    ScanParams scanParams = new ScanParams().count(1);
+    ScanResult<Tuple> result;
+    String cursor = ZERO_CURSOR;
+
+    do {
+      result = jedis.zscan(KEY.getBytes(), cursor.getBytes(), scanParams);
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    assertThat(result.getCursor()).isEqualTo(ZERO_CURSOR);
+  }
+
+  @Test
+  public void givenMatch_returnsAllMatchingEntries() {
+    Map<String, Double> entryMap = initializeThreeFieldSortedSet();
+
+    ScanParams scanParams = new ScanParams().match("*1*");
+
+    ScanResult<Tuple> result =
+        jedis.zscan(KEY.getBytes(), ZERO_CURSOR.getBytes(), scanParams);
+
+    entryMap.remove(MEMBER_THREE);
+    assertThat(result.isCompleteIteration()).isTrue();
+    assertThat(tupleCollectionToMap(result.getResult()))
+        .containsExactlyInAnyOrderEntriesOf(entryMap);
+  }
+
+  @Test
+  public void givenMultipleMatches_returnsEntriesMatchingLastMatchParameter() {
+    initializeThreeFieldSortedSet();
+
+    List<Object> result =
+        uncheckedCast(jedis.sendCommand(KEY.getBytes(), Protocol.Command.ZSCAN,
+            KEY.getBytes(), ZERO_CURSOR.getBytes(),
+            "MATCH".getBytes(), "*3".getBytes(),
+            "MATCH".getBytes(), "*1*".getBytes()));
+
+    assertThat((byte[]) result.get(0)).isEqualTo(ZERO_CURSOR.getBytes());
+    List<byte[]> membersAndScores = uncheckedCast(result.get(1));
+    System.out.println(
+        "DONAL: members and scores = " + membersAndScores.stream().map(String::new).collect(
+            Collectors.joining(", ")));
+    assertThat(membersAndScores).containsExactlyInAnyOrder(
+        MEMBER_ONE.getBytes(), String.valueOf(SCORE_ONE).getBytes(),
+        MEMBER_TWO.getBytes(), String.valueOf(SCORE_TWO).getBytes());
+  }
+
+  @Test
+  public void givenMatchAndCount_returnsAllMatchingKeys() {
+    Map<String, Double> entryMap = initializeThreeFieldSortedSet();
+
+    ScanParams scanParams = new ScanParams().count(1).match("*1*");
+    ScanResult<Tuple> result;
+    List<Tuple> allEntries = new ArrayList<>();
+    String cursor = ZERO_CURSOR;
+
+    do {
+      result = jedis.zscan(KEY.getBytes(), cursor.getBytes(), scanParams);
+      allEntries.addAll(result.getResult());
+      cursor = result.getCursor();
+    } while (!result.isCompleteIteration());
+
+    entryMap.remove(MEMBER_THREE);
+    assertThat(tupleCollectionToMap(allEntries)).containsExactlyInAnyOrderEntriesOf(entryMap);
+  }
+
+  @Test
+  public void givenMultipleCountsAndMatches_returnsEntriesMatchingLastMatchParameter() {
+    initializeThreeFieldSortedSet();
+    List<Object> result;
+
+    List<byte[]> allEntries = new ArrayList<>();
+    String cursor = ZERO_CURSOR;
+
+    do {
+      result =
+          uncheckedCast(jedis.sendCommand(KEY.getBytes(), Protocol.Command.ZSCAN,
+              KEY.getBytes(), cursor.getBytes(),
+              "COUNT".getBytes(), "37".getBytes(),
+              "MATCH".getBytes(), "3*".getBytes(),
+              "COUNT".getBytes(), "2".getBytes(),
+              "COUNT".getBytes(), "1".getBytes(),
+              "MATCH".getBytes(), "*1*".getBytes()));
+      List<byte[]> membersAndScores = uncheckedCast(result.get(1));
+      allEntries.addAll(membersAndScores);
+      cursor = new String((byte[]) result.get(0));
+    } while (!Arrays.equals((byte[]) result.get(0), ZERO_CURSOR.getBytes()));
+
+    assertThat((byte[]) result.get(0)).isEqualTo(ZERO_CURSOR.getBytes());
+    assertThat(allEntries).containsExactlyInAnyOrder(
+        MEMBER_ONE.getBytes(), String.valueOf(SCORE_ONE).getBytes(),
+        MEMBER_TWO.getBytes(), String.valueOf(SCORE_TWO).getBytes());
+  }
+
+  @Test
+  public void should_notReturnMember_givenMemberWasRemovedBeforeZscanIsCalled() {
+    Map<String, Double> entryMap = initializeThreeFieldSortedSet();
+
+    jedis.zrem(KEY, MEMBER_THREE);
+    entryMap.remove(MEMBER_THREE);
+
+    assertThat(jedis.zscore(KEY, MEMBER_THREE)).isNull();
+
+    ScanResult<Tuple> result = jedis.zscan(KEY, ZERO_CURSOR);
+
+    assertThat(tupleCollectionToMap(result.getResult()))
+        .containsExactlyInAnyOrderEntriesOf(entryMap);
+  }
+
+  @Test
+  public void should_notErrorGivenNonzeroCursorOnFirstCall() {
+    initializeThreeFieldSortedSet();
+
+    ScanResult<Tuple> result = jedis.zscan(KEY, "5");
+
+    assertThat(result.getResult().size()).isNotZero();
+  }
+
+  @Test
+  public void should_notErrorGivenCountEqualToIntegerMaxValue() {
+    Map<String, Double> entryMap = initializeThreeFieldSortedSet();
+
+    ScanParams scanParams = new ScanParams().count(Integer.MAX_VALUE);
+
+    ScanResult<Tuple> result =
+        jedis.zscan(KEY.getBytes(), ZERO_CURSOR.getBytes(), scanParams);
+    assertThat(tupleCollectionToMap(result.getResult()))
+        .containsExactlyInAnyOrderEntriesOf(entryMap);
+  }
+
+  @Test
+  public void should_notErrorGivenCountGreaterThanIntegerMaxValue() {
+    initializeThreeFieldSortedSet();
+
+    String greaterThanInt = String.valueOf(2L * Integer.MAX_VALUE);
+    List<Object> result =
+        uncheckedCast(jedis.sendCommand(KEY.getBytes(), Protocol.Command.ZSCAN,
+            KEY.getBytes(), ZERO_CURSOR.getBytes(),
+            "COUNT".getBytes(), greaterThanInt.getBytes()));
+
+    assertThat((byte[]) result.get(0)).isEqualTo(ZERO_CURSOR.getBytes());
+
+    List<byte[]> membersAndScores = uncheckedCast(result.get(1));
+    assertThat(membersAndScores).containsExactlyInAnyOrder(
+        MEMBER_ONE.getBytes(), String.valueOf(SCORE_ONE).getBytes(),
+        MEMBER_TWO.getBytes(), String.valueOf(SCORE_TWO).getBytes(),
+        MEMBER_THREE.getBytes(), String.valueOf(SCORE_THREE).getBytes());
+  }
+
+  // Concurrency
+
+  @Test
+  public void should_notLoseMembers_givenConcurrentThreadsDoingZScansAndChangingValues() {
+    final Map<String, Double> initialSortedSetData = makeEntryMap();
+    jedis.zadd(KEY, initialSortedSetData);
+    final int iterationCount = 500;
+
+    Jedis jedis1 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+    Jedis jedis2 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+
+    new ConcurrentLoopingThreads(iterationCount,
+        (i) -> multipleZScanAndAssertOnContentOfResultSet(jedis1, initialSortedSetData, true),
+        (i) -> multipleZScanAndAssertOnContentOfResultSet(jedis2, initialSortedSetData, true),
+        (i) -> jedis.zadd(KEY, i + SIZE_OF_ENTRY_SET, BASE_MEMBER + i % SIZE_OF_ENTRY_SET)).run();
+
+    jedis1.close();
+    jedis2.close();
+  }
+
+  @Test
+  public void should_notLoseKeysForConsistentlyPresentFields_givenConcurrentThreadsAddingAndRemovingFields() {
+    final Map<String, Double> initialSortedSetData = makeEntryMap();
+    jedis.zadd(KEY, initialSortedSetData);
+    final int iterationCount = 500;
+
+    Jedis jedis1 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+    Jedis jedis2 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+
+    new ConcurrentLoopingThreads(iterationCount,
+        (i) -> multipleZScanAndAssertOnContentOfResultSet(jedis1, initialSortedSetData, false),
+        (i) -> multipleZScanAndAssertOnContentOfResultSet(jedis2, initialSortedSetData, false),
+        (i) -> {
+          String member = "new_" + BASE_MEMBER + i;
+          jedis.zadd(KEY, 0.1, member);
+          jedis.zrem(KEY, member);
+        }).run();
+
+    jedis1.close();
+    jedis2.close();
+  }
+
+  private void multipleZScanAndAssertOnContentOfResultSet(Jedis jedis,
+      final Map<String, Double> initialSortedSetData, boolean assertOnSizeOnly) {
+    Set<Tuple> allEntries = new HashSet<>();
+    ScanResult<Tuple> result;
+    String cursor = ZERO_CURSOR;
+
+    do {
+      result = jedis.zscan(KEY, cursor);
+      cursor = result.getCursor();
+      allEntries.addAll(result.getResult());
+    } while (!result.isCompleteIteration());
+
+    if (assertOnSizeOnly) {
+      assertThat(allEntries.size()).isEqualTo(initialSortedSetData.size());
+    } else {
+      assertThat(tupleCollectionToMap(allEntries)).containsAllEntriesOf(initialSortedSetData);
+    }
+  }
+
+  Map<String, Double> initializeThreeFieldSortedSet() {
+    Map<String, Double> entryMap = new HashMap<>();
+    entryMap.put(MEMBER_ONE, SCORE_ONE);
+    entryMap.put(MEMBER_TWO, SCORE_TWO);
+    entryMap.put(MEMBER_THREE, SCORE_THREE);
+    jedis.zadd(KEY, entryMap);
+    return entryMap;
+  }
+
+  private Map<String, Double> makeEntryMap() {
+    Map<String, Double> dataSet = new HashMap<>();
+    for (int i = 0; i < SIZE_OF_ENTRY_SET; i++) {
+      dataSet.put(BASE_MEMBER + i, (double) i);
+    }
+    return dataSet;
+  }
+
+  private Map<String, Double> tupleCollectionToMap(Collection<Tuple> allEntries) {
+    return allEntries.stream().collect(Collectors.toMap(Tuple::getElement, Tuple::getScore));
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZScanIntegrationTest.java
@@ -252,9 +252,9 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
   }
 
   @Test
-  public void shouldNotError_givenCursorEqualToUnsignedLongMaxValue() {
+  public void shouldNotError_givenCursorEqualToLongMaxValue() {
     jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
-    jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, UNSIGNED_LONG_CAPACITY.toString());
+    jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, String.valueOf(Long.MAX_VALUE));
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZScanIntegrationTest.java
@@ -14,11 +14,17 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 
 public class ZScanIntegrationTest extends AbstractZScanIntegrationTest {
+  String GREATER_THAN_LONG_MAX = "9_223_372_036_854_775_808";
 
   @ClassRule
   public static GeodeRedisServerRule server = new GeodeRedisServerRule();
@@ -28,4 +34,15 @@ public class ZScanIntegrationTest extends AbstractZScanIntegrationTest {
     return server.getPort();
   }
 
+  // Redis allows CURSOR values up to UNSIGNED_LONG_CAPACITY, but behaviour for CURSOR values
+  // greater than Integer.MAX_VALUE is undefined, so we choose to return an error if a value greater
+  // than Long.MAX_VALUE is passed
+  @Test
+  public void shouldReturnError_givenCursorGreaterThanLongMaxValue() {
+    jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
+
+    assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
+        GREATER_THAN_LONG_MAX))
+            .hasMessageContaining(ERROR_CURSOR);
+  }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZScanIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZScanIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+
+public class ZScanIntegrationTest extends AbstractZScanIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -105,6 +105,7 @@ import org.apache.geode.redis.internal.executor.sortedset.ZRevRangeByLexExecutor
 import org.apache.geode.redis.internal.executor.sortedset.ZRevRangeByScoreExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRevRangeExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZRevRankExecutor;
+import org.apache.geode.redis.internal.executor.sortedset.ZScanExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZScoreExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZUnionStoreExecutor;
 import org.apache.geode.redis.internal.executor.string.AppendExecutor;
@@ -246,6 +247,8 @@ public enum RedisCommandType {
   ZREVRANGEBYLEX(new ZRevRangeByLexExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),
   ZREVRANGEBYSCORE(new ZRevRangeByScoreExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),
   ZREVRANK(new ZRevRankExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
+  ZSCAN(new ZScanExecutor(), SUPPORTED, new MinimumParameterRequirements(3),
+      new OddParameterRequirements(ERROR_SYNTAX)),
   ZSCORE(new ZScoreExecutor(), SUPPORTED, new ExactParameterRequirements(3)),
   ZUNIONSTORE(new ZUnionStoreExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -16,7 +16,6 @@
 
 package org.apache.geode.redis.internal.data;
 
-
 import static java.util.Collections.singletonList;
 
 import java.util.ArrayList;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -244,10 +244,9 @@ public class RedisHash extends AbstractRedisData {
       throw new IllegalArgumentException("Requested array size exceeds VM limit");
     }
     List<byte[]> resultList = new ArrayList<>((int) maximumCapacity);
-    do {
-      cursor = hash.scan(cursor, 1,
-          (list, key, value) -> addIfMatching(matchPattern, list, key, value), resultList);
-    } while (cursor != 0 && resultList.size() < maximumCapacity);
+
+    cursor = hash.scan(cursor, count,
+        (list, key, value) -> addIfMatching(matchPattern, list, key, value), resultList);
 
     return new ImmutablePair<>(cursor, resultList);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -65,7 +65,7 @@ import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisSortedSet extends AbstractRedisData {
   protected static final int REDIS_SORTED_SET_OVERHEAD = memoryOverhead(RedisSortedSet.class);
-  public static final Logger logger = LogService.getLogger();
+  private static final Logger logger = LogService.getLogger();
 
   private MemberMap members;
   private final ScoreSet scoreSet = new ScoreSet();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.DataSerializer;
 import org.apache.geode.annotations.VisibleForTesting;
@@ -64,6 +65,7 @@ import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisSortedSet extends AbstractRedisData {
   protected static final int REDIS_SORTED_SET_OVERHEAD = memoryOverhead(RedisSortedSet.class);
+  public static final Logger logger = LogService.getLogger();
 
   private MemberMap members;
   private final ScoreSet scoreSet = new ScoreSet();
@@ -391,7 +393,7 @@ public class RedisSortedSet extends AbstractRedisData {
     // need to add 1 to zcard() to ensure that if count > members.size(), we return a cursor of 0
     long maximumCapacity = 2L * Math.min(count, zcard() + 1);
     if (maximumCapacity > Integer.MAX_VALUE) {
-      LogService.getLogger().info(
+      logger.info(
           "The size of the data to be returned by zscan, {}, exceeds the maximum capacity of an array. A value for the ZSCAN COUNT argument less than {} should be used",
           maximumCapacity, Integer.MAX_VALUE / 2);
       throw new IllegalArgumentException("Requested array size exceeds VM limit");

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -397,10 +397,9 @@ public class RedisSortedSet extends AbstractRedisData {
       throw new IllegalArgumentException("Requested array size exceeds VM limit");
     }
     List<byte[]> resultList = new ArrayList<>((int) maximumCapacity);
-    do {
-      cursor = members.scan(cursor, 1,
-          (list, key, value) -> addIfMatching(matchPattern, list, key, value.score), resultList);
-    } while (cursor != 0 && resultList.size() < maximumCapacity);
+
+    cursor = members.scan(cursor, count,
+        (list, key, value) -> addIfMatching(matchPattern, list, key, value.score), resultList);
 
     return new ImmutablePair<>(cursor, resultList);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -20,6 +20,9 @@ package org.apache.geode.redis.internal.data;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommands;
@@ -144,6 +147,13 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   @Override
   public long zrevrank(RedisKey key, byte[] member) {
     return stripedExecute(key, () -> getRedisSortedSet(key, true).zrevrank(member));
+  }
+
+  @Override
+  public Pair<Integer, List<byte[]>> zscan(RedisKey key, Pattern matchPattern, int count,
+      int cursor) {
+    return stripedExecute(key,
+        () -> getRedisSortedSet(key, true).zscan(matchPattern, count, cursor));
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
@@ -17,11 +17,10 @@
 package org.apache.geode.redis.internal.executor;
 
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.nio.charset.Charset;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 
@@ -154,12 +153,12 @@ public class RedisResponse {
     return new RedisResponse((buffer) -> Coder.getWrongTypeResponse(buffer, error));
   }
 
-  public static RedisResponse scan(BigInteger cursor, List<?> scanResult) {
+  public static RedisResponse scan(int cursor, List<?> scanResult) {
     return new RedisResponse((buffer) -> Coder.getScanResponse(buffer, cursor, scanResult));
   }
 
   public static RedisResponse emptyScan() {
-    return scan(new BigInteger("0"), new ArrayList<>());
+    return scan(0, Collections.emptyList());
   }
 
   /**

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -14,123 +14,28 @@
  */
 package org.apache.geode.redis.internal.executor.hash;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_HASH;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
-import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
 
-import java.math.BigInteger;
 import java.util.List;
 import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.logging.log4j.Logger;
 
-import org.apache.geode.logging.internal.log4j.api.LogService;
-import org.apache.geode.redis.internal.data.RedisData;
-import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
+import org.apache.geode.redis.internal.data.RedisDataType;
 import org.apache.geode.redis.internal.data.RedisKey;
-import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
-import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-/**
- * Implementation of the HScan command used to incrementally iterate over a collection of elements.
- */
 public class HScanExecutor extends AbstractScanExecutor {
 
-  private static final Logger logger = LogService.getLogger();
+  @Override
+  protected Pair<Integer, List<byte[]>> executeScan(ExecutionHandlerContext context, RedisKey key,
+      Pattern pattern, int count, int cursor) {
+    return context.getHashCommands().hscan(key, pattern, count, cursor);
+  }
 
   @Override
-  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-
-    List<byte[]> commandElems = command.getProcessedCommand();
-
-    String cursorString = bytesToString(commandElems.get(2));
-    int cursor;
-
-    try {
-      cursor = Integer.parseInt(cursorString);
-    } catch (NumberFormatException e) {
-      return RedisResponse.error(ERROR_CURSOR);
-    }
-
-    RedisKey key = command.getKey();
-
-    // Because we're trying to preserve the same semantics of error conditions, with native redis,
-    // the ordering of input validation is reflected here. To that end the first check ends up
-    // being an existence check of the key. That causes a race since the data value needs to be
-    // accessed again when the actual command does its work. If the relevant bucket doesn't get
-    // locked throughout the call, the bucket may move producing inconsistent results.
-    return context.getRegionProvider().execute(key, () -> {
-
-      RedisData value = context.getRegionProvider().getRedisData(key);
-      if (value.isNull()) {
-        context.getRedisStats().incKeyspaceMisses();
-        return RedisResponse.emptyScan();
-      }
-
-      if (value.getType() != REDIS_HASH) {
-        throw new RedisDataTypeMismatchException(ERROR_WRONG_TYPE);
-      }
-
-      command.getCommandType().checkDeferredParameters(command, context);
-      int count = DEFAULT_COUNT;
-      byte[] globPattern = null;
-
-      for (int i = 3; i < commandElems.size(); i = i + 2) {
-        byte[] commandElemBytes = commandElems.get(i);
-        if (equalsIgnoreCaseBytes(commandElemBytes, bMATCH)) {
-          commandElemBytes = commandElems.get(i + 1);
-          globPattern = commandElemBytes;
-
-        } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
-          commandElemBytes = commandElems.get(i + 1);
-          try {
-            count = narrowLongToInt(bytesToLong(commandElemBytes));
-          } catch (NumberFormatException e) {
-            return RedisResponse.error(ERROR_NOT_INTEGER);
-          }
-
-          if (count < 1) {
-            return RedisResponse.error(ERROR_SYNTAX);
-          }
-
-        } else {
-          return RedisResponse.error(ERROR_SYNTAX);
-        }
-      }
-
-      Pattern matchPattern;
-      try {
-        matchPattern = convertGlobToRegex(globPattern);
-      } catch (PatternSyntaxException e) {
-        logger.warn(
-            "Could not compile the pattern: '{}' due to the following exception: '{}'. HSCAN will return an empty list.",
-            globPattern, e.getMessage());
-
-        return RedisResponse.emptyScan();
-      }
-      RedisHashCommands redisHashCommands = context.getHashCommands();
-
-      Pair<Integer, List<byte[]>> scanResult;
-      try {
-        scanResult = redisHashCommands.hscan(key, matchPattern, count, cursor);
-      } catch (IllegalArgumentException ex) {
-        return RedisResponse.error(ERROR_NOT_INTEGER);
-      }
-
-      return RedisResponse.scan(new BigInteger(String.valueOf(scanResult.getLeft())),
-          scanResult.getRight());
-    });
+  protected RedisDataType getDataType() {
+    return REDIS_HASH;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/AbstractScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/AbstractScanExecutor.java
@@ -134,15 +134,16 @@ public abstract class AbstractScanExecutor extends AbstractExecutor {
    * @param pattern A glob pattern.
    * @return A regex pattern to recognize the given glob pattern.
    */
-  protected Pattern convertGlobToRegex(byte[] pattern) {
+  @VisibleForTesting
+  public Pattern convertGlobToRegex(byte[] pattern) {
     if (pattern == null) {
       return null;
     }
     return GlobPattern.createPattern(pattern);
   }
+
   // Redis allows values for CURSOR up to UNSIGNED_LONG_CAPACITY, but internally it only makes sense
   // for us to use values up to Integer.MAX_VALUE, so safely narrow any cursor values to int here
-
   @VisibleForTesting
   public int getIntCursor(String cursorString) {
     BigInteger tempCursor;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
@@ -35,6 +35,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.data.RedisDataType;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.RedisResponse;
@@ -103,7 +104,7 @@ public class ScanExecutor extends AbstractScanExecutor {
         scan(getDataRegion(context).keySet(), matchPattern, count, cursor);
     context.setScanCursor(scanResult.getLeft());
 
-    return RedisResponse.scan(scanResult.getLeft(), scanResult.getRight());
+    return RedisResponse.scan(scanResult.getLeft().intValue(), scanResult.getRight());
   }
 
   private Pair<BigInteger, List<Object>> scan(Collection<RedisKey> list,
@@ -142,5 +143,17 @@ public class ScanExecutor extends AbstractScanExecutor {
       scanResult = new ImmutablePair<>(new BigInteger(String.valueOf(i + 1)), returnList);
     }
     return scanResult;
+  }
+
+  // TODO: When SCAN is supported, refactor to use these methods and not override executeCommand()
+  @Override
+  protected Pair<Integer, List<byte[]>> executeScan(ExecutionHandlerContext context, RedisKey key,
+      Pattern pattern, int count, int cursor) {
+    return null;
+  }
+
+  @Override
+  protected RedisDataType getDataType() {
+    return null;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
@@ -43,6 +43,7 @@ import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class ScanExecutor extends AbstractScanExecutor {
+  private static final BigInteger UNSIGNED_LONG_CAPACITY = new BigInteger("18446744073709551615");
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.data.RedisData;
+import org.apache.geode.redis.internal.data.RedisDataType;
 import org.apache.geode.redis.internal.data.RedisDataTypeMismatchException;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.RedisResponse;
@@ -120,6 +121,18 @@ public class SScanExecutor extends AbstractScanExecutor {
 
     context.setSscanCursor(scanResult.getLeft());
 
-    return RedisResponse.scan(scanResult.getLeft(), scanResult.getRight());
+    return RedisResponse.scan(scanResult.getLeft().intValue(), scanResult.getRight());
+  }
+
+  // TODO: When SSCAN is supported, refactor to use these methods and not override executeCommand()
+  @Override
+  protected Pair<Integer, List<byte[]>> executeScan(ExecutionHandlerContext context, RedisKey key,
+      Pattern pattern, int count, int cursor) {
+    return null;
+  }
+
+  @Override
+  protected RedisDataType getDataType() {
+    return null;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -45,6 +45,7 @@ import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class SScanExecutor extends AbstractScanExecutor {
+  private static final BigInteger UNSIGNED_LONG_CAPACITY = new BigInteger("18446744073709551615");
 
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -16,6 +16,9 @@
 package org.apache.geode.redis.internal.executor.sortedset;
 
 import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 
@@ -58,6 +61,8 @@ public interface RedisSortedSetCommands {
   List<byte[]> zrevrangebyscore(RedisKey key, SortedSetScoreRangeOptions rangeOptions);
 
   long zrevrank(RedisKey key, byte[] member);
+
+  Pair<Integer, List<byte[]>> zscan(RedisKey key, Pattern matchPattern, int count, int cursor);
 
   byte[] zscore(RedisKey key, byte[] member);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutor.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SORTED_SET;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import org.apache.geode.redis.internal.data.RedisDataType;
+import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+
+public class ZScanExecutor extends AbstractScanExecutor {
+
+  @Override
+  protected Pair<Integer, List<byte[]>> executeScan(ExecutionHandlerContext context, RedisKey key,
+      Pattern pattern, int count, int cursor) {
+    return context.getSortedSetCommands().zscan(key, pattern, count, cursor);
+  }
+
+  @Override
+  protected RedisDataType getDataType() {
+    return REDIS_SORTED_SET;
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -50,7 +50,6 @@ import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWRONGTY
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.util.Collection;
 import java.util.List;
@@ -150,12 +149,11 @@ public class Coder {
     }
   }
 
-  public static ByteBuf getScanResponse(ByteBuf buffer, BigInteger cursor,
-      List<?> scanResult) {
+  public static ByteBuf getScanResponse(ByteBuf buffer, int cursor, List<?> scanResult) {
     buffer.writeByte(ARRAY_ID);
     buffer.writeByte(digitToAscii(2));
     buffer.writeBytes(bCRLF);
-    byte[] cursorBytes = stringToBytes(cursor.toString());
+    byte[] cursorBytes = intToBytes(cursor);
     writeStringResponse(buffer, cursorBytes);
     buffer.writeByte(ARRAY_ID);
     appendAsciiDigitsToByteBuf(scanResult.size(), buffer);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -203,7 +203,6 @@ public class RedisHashTest {
     RedisHash hash = createRedisHash("ak1", "v1", "k2", "v2", "ak3", "v3", "k4", "v4");
     ImmutablePair<Integer, List<byte[]>> result = hash.hscan(Pattern.compile("a.*"), 3, 0);
 
-    assertThat(result.left).isEqualTo(0);
     List<String> fieldsAndValues =
         result.right.stream().map(Coder::bytesToString).collect(Collectors.toList());
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutorTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutorTest.java
@@ -14,84 +14,24 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
-import static org.apache.geode.redis.internal.executor.key.AbstractScanExecutor.UNSIGNED_LONG_CAPACITY;
-import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
-import java.math.BigInteger;
-import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import org.apache.geode.redis.internal.RedisException;
-import org.apache.geode.redis.internal.executor.RedisResponse;
 import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
-import org.apache.geode.redis.internal.netty.Command;
-import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class ZScanExecutorTest {
   AbstractScanExecutor scanExecutor;
-  private Command mockCommand;
-  private ExecutionHandlerContext mockContext;
 
   @Before
   public void setUp() {
-    mockCommand = mock(Command.class);
-    when(mockCommand.getProcessedCommand()).thenReturn(
-        Arrays.asList(stringToBytes("ZSCAN"), stringToBytes("key"), stringToBytes("0")));
-    mockContext = mock(ExecutionHandlerContext.class);
     scanExecutor = spy(new ZScanExecutor());
-  }
-
-  @Test
-  public void executeCommand_returnsErrorResponse_whenGetIntCursorThrows() {
-    doThrow(new RedisException()).when(scanExecutor).getIntCursor(anyString());
-    assertThat(scanExecutor.executeCommand(mockCommand, mockContext).toString())
-        .isEqualTo(RedisResponse.error(ERROR_CURSOR).toString());
   }
 
   @Test
   public void convertGlobToRegex_handlesNullPattern() {
     assertThat(scanExecutor.convertGlobToRegex(null)).isNull();
-  }
-
-  @Test
-  public void getIntCursor_throwsForNonIntegerString() {
-    assertThatThrownBy(() -> scanExecutor.getIntCursor("notANumber"))
-        .isInstanceOf(RedisException.class).hasMessageContaining(ERROR_CURSOR);
-  }
-
-  @Test
-  public void getIntCursor_throwsForIntegerOutOfRange() {
-    String overULongCapacity = UNSIGNED_LONG_CAPACITY.add(new BigInteger("1")).toString();
-    assertThatThrownBy(() -> scanExecutor.getIntCursor(overULongCapacity))
-        .isInstanceOf(RedisException.class).hasMessageContaining(ERROR_CURSOR);
-  }
-
-  @Test
-  public void getIntCursor_narrowsToIntWhenGreaterThanIntegerMaxValue() {
-    String uLongCapacity = UNSIGNED_LONG_CAPACITY.toString();
-    assertThat(scanExecutor.getIntCursor(uLongCapacity)).isEqualTo(Integer.MAX_VALUE);
-
-    String longMax = String.valueOf(Long.MAX_VALUE);
-    assertThat(scanExecutor.getIntCursor(longMax)).isEqualTo(Integer.MAX_VALUE);
-
-    String overIntMax = String.valueOf(Integer.MAX_VALUE + 10L);
-    assertThat(scanExecutor.getIntCursor(overIntMax)).isEqualTo(Integer.MAX_VALUE);
-  }
-
-  @Test
-  public void getIntCursor_returnsIntWhenLessThanIntegerMaxValue() {
-    final long underIntMax = Integer.MAX_VALUE - 10L;
-    assertThat(scanExecutor.getIntCursor(String.valueOf(underIntMax))).isEqualTo(underIntMax);
-
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutorTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
+import static org.apache.geode.redis.internal.executor.key.AbstractScanExecutor.UNSIGNED_LONG_CAPACITY;
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.redis.internal.RedisException;
+import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
+import org.apache.geode.redis.internal.netty.Command;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+
+public class ZScanExecutorTest {
+  AbstractScanExecutor scanExecutor;
+  private Command mockCommand;
+  private ExecutionHandlerContext mockContext;
+
+  @Before
+  public void setUp() {
+    mockCommand = mock(Command.class);
+    when(mockCommand.getProcessedCommand()).thenReturn(
+        Arrays.asList(stringToBytes("ZSCAN"), stringToBytes("key"), stringToBytes("0")));
+    mockContext = mock(ExecutionHandlerContext.class);
+    scanExecutor = spy(new ZScanExecutor());
+  }
+
+  @Test
+  public void executeCommand_returnsErrorResponse_whenGetIntCursorThrows() {
+    doThrow(new RedisException()).when(scanExecutor).getIntCursor(anyString());
+    assertThat(scanExecutor.executeCommand(mockCommand, mockContext).toString())
+        .isEqualTo(RedisResponse.error(ERROR_CURSOR).toString());
+  }
+
+  @Test
+  public void convertGlobToRegex_handlesNullPattern() {
+    assertThat(scanExecutor.convertGlobToRegex(null)).isNull();
+  }
+
+  @Test
+  public void getIntCursor_throwsForNonIntegerString() {
+    assertThatThrownBy(() -> scanExecutor.getIntCursor("notANumber"))
+        .isInstanceOf(RedisException.class).hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void getIntCursor_throwsForIntegerOutOfRange() {
+    String overULongCapacity = UNSIGNED_LONG_CAPACITY.add(new BigInteger("1")).toString();
+    assertThatThrownBy(() -> scanExecutor.getIntCursor(overULongCapacity))
+        .isInstanceOf(RedisException.class).hasMessageContaining(ERROR_CURSOR);
+  }
+
+  @Test
+  public void getIntCursor_narrowsToIntWhenGreaterThanIntegerMaxValue() {
+    String uLongCapacity = UNSIGNED_LONG_CAPACITY.toString();
+    assertThat(scanExecutor.getIntCursor(uLongCapacity)).isEqualTo(Integer.MAX_VALUE);
+
+    String longMax = String.valueOf(Long.MAX_VALUE);
+    assertThat(scanExecutor.getIntCursor(longMax)).isEqualTo(Integer.MAX_VALUE);
+
+    String overIntMax = String.valueOf(Integer.MAX_VALUE + 10L);
+    assertThat(scanExecutor.getIntCursor(overIntMax)).isEqualTo(Integer.MAX_VALUE);
+  }
+
+  @Test
+  public void getIntCursor_returnsIntWhenLessThanIntegerMaxValue() {
+    final long underIntMax = Integer.MAX_VALUE - 10L;
+    assertThat(scanExecutor.getIntCursor(String.valueOf(underIntMax))).isEqualTo(underIntMax);
+
+  }
+}


### PR DESCRIPTION
This PR is intentionally split into two commits, the first refactors the existing *SCAN implementations and some related code. The second implements the ZSCAN command and adds tests. The changes in the first commit also address GEODE-9427 as a side-effect.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
