### PR TITLE
GEODE-9457: re-authentication in event dispatcher

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/SecurityWithExpirationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/SecurityWithExpirationIntegrationTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -27,6 +26,7 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.security.SecurityServiceFactory;
 import org.apache.geode.security.AuthenticationExpiredException;
+import org.apache.geode.security.AuthenticationFailedException;
 import org.apache.geode.security.ExpirableSecurityManager;
 import org.apache.geode.test.junit.categories.SecurityTest;
 
@@ -43,15 +43,17 @@ public class SecurityWithExpirationIntegrationTest {
     securityService = SecurityServiceFactory.create(this.props);
   }
 
-  @After
-  public void after() throws Exception {
-    securityService.logout();
+  @Test
+  public void testAuthenticationWhenUserExpired() {
+    getSecurityManager().addExpiredUser("data");
+    assertThatThrownBy(() -> this.securityService.login(loginCredentials("data", "data")))
+        .isInstanceOf(AuthenticationFailedException.class);
   }
 
   @Test
-  public void testThrowAuthenticationExpiredException() {
-    getSecurityManager().addExpiredUser("data");
+  public void testAuthorizationWhenUserExpired() {
     this.securityService.login(loginCredentials("data", "data"));
+    getSecurityManager().addExpiredUser("data");
     assertThatThrownBy(() -> this.securityService.authorize(ResourcePermissions.DATA_READ))
         .isInstanceOf(AuthenticationExpiredException.class);
   }

--- a/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-core/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1729,6 +1729,10 @@ org/apache/geode/internal/cache/tier/sockets/ClientProxyMembershipID,2
 fromData,19
 toData,19
 
+org/apache/geode/internal/cache/tier/sockets/ClientReAuthenticateMessage,2
+fromData,10
+toData,10
+
 org/apache/geode/internal/cache/tier/sockets/ClientTombstoneMessage,2
 fromData,63
 toData,59

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/AbstractOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/AbstractOp.java
@@ -166,11 +166,14 @@ public abstract class AbstractOp implements Op {
   }
 
   /**
-   * New implementations of AbstractOp should override this method to return false if the
-   * implementation should be excluded from client authentication. e.g. PingOp#needsUserId()
-   * <P/>
-   * Also, such an operation's <code>MessageType</code> must be added in the 'if' condition in
-   * {@link ServerConnection#updateAndGetSecurityPart()}
+   * @return true if this operation needs to be authenticated first
+   *
+   *         New implementations of AbstractOp should override this method to return false if the
+   *         implementation should be excluded from client authentication. e.g. PingOp#needsUserId()
+   *         <P/>
+   *         Also, such an operation's <code>MessageType</code> must be added in the 'if' condition
+   *         in
+   *         {@link ServerConnection#updateAndGetSecurityPart()}
    *
    * @see AbstractOp#sendMessage(Connection)
    * @see ServerConnection#updateAndGetSecurityPart()

--- a/geode-core/src/main/java/org/apache/geode/internal/DSFIDFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DSFIDFactory.java
@@ -368,6 +368,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientInterestMessageImpl;
 import org.apache.geode.internal.cache.tier.sockets.ClientMarkerMessageImpl;
 import org.apache.geode.internal.cache.tier.sockets.ClientPingMessageImpl;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
+import org.apache.geode.internal.cache.tier.sockets.ClientReAuthenticateMessage;
 import org.apache.geode.internal.cache.tier.sockets.ClientTombstoneMessage;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
@@ -699,6 +700,7 @@ public class DSFIDFactory implements DataSerializableFixedID {
     serializer.registerDSFID(STATE_STABILIZATION_MESSAGE, StateStabilizationMessage.class);
     serializer.registerDSFID(STATE_STABILIZED_MESSAGE, StateStabilizedMessage.class);
     serializer.registerDSFID(CLIENT_MARKER_MESSAGE_IMPL, ClientMarkerMessageImpl.class);
+    serializer.registerDSFID(CLIENT_RE_AUTHENTICATE, ClientReAuthenticateMessage.class);
     serializer.registerDSFID(TX_LOCK_UPDATE_PARTICIPANTS_MESSAGE,
         TXLockUpdateParticipantsMessage.class);
     serializer.registerDSFID(TX_ORIGINATOR_RECOVERY_MESSAGE, TXOriginatorRecoveryMessage.class);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/MessageType.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/MessageType.java
@@ -380,10 +380,15 @@ public class MessageType {
   public static final int PUT_ALL_WITH_CALLBACK = 108;
 
   public static final int REMOVE_ALL = 109;
+
+  /**
+   * @since Geode 1.15
+   */
+  public static final int CLIENT_RE_AUTHENTICATE = 110;
   /**
    * Must be equal to last valid message id.
    */
-  private static final int LAST_VALID_MESSAGE_ID = REMOVE_ALL;
+  private static final int LAST_VALID_MESSAGE_ID = CLIENT_RE_AUTHENTICATE;
 
 
   public static boolean validate(int messageType) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -202,7 +202,7 @@ public abstract class BaseCommand implements Command {
       // now, so don't let this thread continue.
       throw err;
     } catch (Throwable e) {
-      BaseCommand.handleThrowable(clientMessage, serverConnection, e);
+      handleThrowable(clientMessage, serverConnection, e);
     } finally {
       EntryLogger.clearSource();
     }
@@ -612,7 +612,7 @@ public abstract class BaseCommand implements Command {
     }
   }
 
-  protected static void writeResponse(Object data, Object callbackArg, Message origMsg,
+  public void writeResponse(Object data, Object callbackArg, Message origMsg,
       boolean isObject, ServerConnection serverConnection) throws IOException {
     Message responseMsg = serverConnection.getResponseMessage();
     responseMsg.setMessageType(MessageType.RESPONSE);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
@@ -254,6 +254,7 @@ public class CacheClientNotifier {
     DistributedSystem system = getCache().getDistributedSystem();
     Properties sysProps = system.getProperties();
     String authenticator = sysProps.getProperty(SECURITY_CLIENT_AUTHENTICATOR);
+    // in multi-user case, this would return null
     Object subjectOrPrincipal =
         getSubjectOrPrincipal(clientRegistrationMetadata, member, system, authenticator);
     Subject subject = subjectOrPrincipal instanceof Subject ? (Subject) subjectOrPrincipal : null;
@@ -839,6 +840,7 @@ public class CacheClientNotifier {
       final DistributedMember member, final DistributedSystem system, final String authenticator) {
     final Object subjectOrPrincipal;
 
+    // in multi-user case, this would be null
     if (clientRegistrationMetadata.getClientCredentials() != null) {
       if (securityLogWriter.fineEnabled()) {
         securityLogWriter

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientReAuthenticateMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientReAuthenticateMessage.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.tier.sockets;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.geode.annotations.Immutable;
+import org.apache.geode.internal.cache.EventID;
+import org.apache.geode.internal.cache.tier.MessageType;
+import org.apache.geode.internal.serialization.DeserializationContext;
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.internal.serialization.SerializationContext;
+
+public class ClientReAuthenticateMessage implements ClientMessage {
+  @Immutable
+  public static final KnownVersion RE_AUTHENTICATION_START_VERSION = KnownVersion.GEODE_1_15_0;
+  /**
+   * This {@code ClientMessage}'s {@code EventID}
+   */
+  private final EventID eventId;
+
+  public ClientReAuthenticateMessage() {
+    this(new EventID());
+  }
+
+  public ClientReAuthenticateMessage(EventID eventId) {
+    this.eventId = eventId;
+  }
+
+  @Override
+  public Message getMessage(CacheClientProxy proxy, boolean notify) throws IOException {
+    Message message = new Message(1, KnownVersion.CURRENT);
+    message.setMessageType(MessageType.CLIENT_RE_AUTHENTICATE);
+    message.setTransactionId(0);
+    message.addObjPart(eventId);
+    return message;
+  }
+
+  @Override
+  public boolean shouldBeConflated() {
+    return true;
+  }
+
+  @Override
+  public void toData(DataOutput out,
+      SerializationContext context) throws IOException {
+    eventId.toData(out, context);
+  }
+
+  @Override
+  public int getDSFID() {
+    return CLIENT_RE_AUTHENTICATE;
+  }
+
+  @Override
+  public void fromData(DataInput in,
+      DeserializationContext context) throws IOException, ClassNotFoundException {
+    eventId.fromData(in, context);
+  }
+
+  @Override
+  public EventID getEventId() {
+    return eventId;
+  }
+
+  @Override
+  public String getRegionToConflate() {
+    return "gemfire_reserved_region_name_for_client_re_authenticate";
+  }
+
+  @Override
+  public Object getKeyToConflate() {
+    // This method can be called by HARegionQueue.
+    // Use this to identify the message type.
+    return "re_authenticate";
+  }
+
+  @Override
+  public Object getValueToConflate() {
+    // This method can be called by HARegionQueue
+    // Use this to identify the message type.
+    return "re_authenticate";
+  }
+
+  @Override
+  public void setLatestValue(Object value) {}
+
+  @Override
+  public KnownVersion[] getSerializationVersions() {
+    return null;
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Handshake.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/Handshake.java
@@ -424,7 +424,6 @@ public abstract class Handshake {
   }
 
   protected Properties getCredentials(DistributedMember member) {
-
     String authInitMethod = this.system.getProperties().getProperty(SECURITY_CLIENT_AUTH_INIT);
     return getCredentials(authInitMethod, this.system.getSecurityProperties(), member, false,
         (InternalLogWriter) this.system.getLogWriter(),

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OldClientSupportService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OldClientSupportService.java
@@ -25,7 +25,6 @@ import org.apache.geode.internal.serialization.KnownVersion;
  * Support for old GemFire clients
  */
 public interface OldClientSupportService extends CacheService {
-
   /**
    * translates the given throwable into one that can be sent to an old GemFire client
    *

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/PutUserCredentials.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/PutUserCredentials.java
@@ -39,45 +39,44 @@ public class PutUserCredentials extends BaseCommand {
       throws IOException, ClassNotFoundException, InterruptedException {
     boolean isSecureMode = clientMessage.isSecureMode();
 
-    // if (!isSecureMode)
-    // client has not send secuirty header, need to send exception and log this in security (file)
-
-    if (isSecureMode) {
-
-      int numberOfParts = clientMessage.getNumberOfParts();
-
-      if (numberOfParts == 1) {
-        // need to get credentials
-        try {
-          serverConnection.setAsTrue(REQUIRES_RESPONSE);
-          byte[] uniqueId = serverConnection.setCredentials(clientMessage);
-          writeResponse(uniqueId, null, clientMessage, false, serverConnection);
-        } catch (GemFireSecurityException gfse) {
-          if (serverConnection.getSecurityLogWriter().warningEnabled()) {
-            serverConnection.getSecurityLogWriter().warning(String.format("%s",
-                serverConnection.getName() + ": Security exception: " + gfse.toString()
-                    + (gfse.getCause() != null ? ", caused by: " + gfse.getCause().toString()
-                        : "")));
-          }
-          writeException(clientMessage, gfse, false, serverConnection);
-        } catch (Exception ex) {
-          if (serverConnection.getLogWriter().warningEnabled()) {
-            serverConnection.getLogWriter().warning(
-                String.format("An exception was thrown for client [%s]. %s",
-                    serverConnection.getProxyID(), ""),
-                ex);
-          }
-          writeException(clientMessage, ex, false, serverConnection);
-        } finally {
-          serverConnection.setAsTrue(RESPONDED);
-        }
-
-      } else {
-        // need to throw some exeception
-      }
-    } else {
-      // need to throw exception
+    if (!isSecureMode) {
+      // client has not send security header, need to send exception and log this in security (file)
+      return;
     }
+
+    int numberOfParts = clientMessage.getNumberOfParts();
+    if (numberOfParts != 1) {
+      // need to throw exception
+      return;
+    }
+
+    // client older than 1.14 will send in existing uniqueId to re-authenticate
+    long existingUniqueId = serverConnection.getUniqueId();
+    // need to get credentials
+    try {
+      serverConnection.setAsTrue(REQUIRES_RESPONSE);
+      byte[] uniqueId = serverConnection.setCredentials(clientMessage, existingUniqueId);
+      writeResponse(uniqueId, null, clientMessage, false, serverConnection);
+    } catch (GemFireSecurityException gfse) {
+      if (serverConnection.getSecurityLogWriter().warningEnabled()) {
+        serverConnection.getSecurityLogWriter().warning(String.format("%s",
+            serverConnection.getName() + ": Security exception: " + gfse.toString()
+                + (gfse.getCause() != null ? ", caused by: " + gfse.getCause().toString()
+                    : "")));
+      }
+      writeException(clientMessage, gfse, false, serverConnection);
+    } catch (Exception ex) {
+      if (serverConnection.getLogWriter().warningEnabled()) {
+        serverConnection.getLogWriter().warning(
+            String.format("An exception was thrown for client [%s]. %s",
+                serverConnection.getProxyID(), ""),
+            ex);
+      }
+      writeException(clientMessage, ex, false, serverConnection);
+    } finally {
+      serverConnection.setAsTrue(RESPONDED);
+    }
+
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
@@ -107,6 +107,13 @@ public class SystemPropertyHelper {
       "get-transaction-events-from-queue-wait-time-ms";
 
   /**
+   * Milliseconds to wait for the client to re-authenticate back before unregister this client
+   * proxy. If client re-authenticate back successfully within this period, messages will continue
+   * to be delivered to the client
+   */
+  public static final String RE_AUTHENTICATE_WAIT_TIME = "reauthenticate.wait.time";
+
+  /**
    * This method will try to look up "geode." and "gemfire." versions of the system property. It
    * will check and prefer "geode." setting first, then try to check "gemfire." setting.
    *
@@ -136,6 +143,41 @@ public class SystemPropertyHelper {
     } else {
       return Optional.empty();
     }
+  }
+
+  /**
+   * This method will try to look up "geode." and "gemfire." versions of the system property. It
+   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
+   *
+   * @param name system property name set in Geode
+   * @return an Optional containing the Long value of the system property
+   */
+  public static Optional<Long> getProductLongProperty(String name) {
+    Long propertyValue = Long.getLong(GEODE_PREFIX + name);
+    if (propertyValue == null) {
+      propertyValue = Long.getLong(GEMFIRE_PREFIX + name);
+    }
+
+    if (propertyValue != null) {
+      return Optional.of(propertyValue);
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * This method will try to look up "geode." and "gemfire." versions of the system property. It
+   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
+   *
+   * @param name system property name set in Geode
+   * @return the integer value of the system property if exits or the default value
+   */
+  public static Integer getProductIntegerProperty(String name, int defaultValue) {
+    return getProductIntegerProperty(name).orElse(defaultValue);
+  }
+
+  public static Long getProductLongProperty(String name, long defaultValue) {
+    return getProductLongProperty(name).orElse(defaultValue);
   }
 
   /**
@@ -190,4 +232,5 @@ public class SystemPropertyHelper {
   public static boolean restoreIdleExpirationBehavior() {
     return getProductBooleanProperty("restoreIdleExpirationBehavior").orElse(false);
   }
+
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -246,21 +246,8 @@ public class IntegratedSecurityService implements SecurityService {
 
   @Override
   public void authorize(final ResourcePermission context) {
-    if (context == null) {
-      return;
-    }
-    if (context.getResource() == Resource.NULL && context.getOperation() == Operation.NULL) {
-      return;
-    }
-
     Subject currentUser = getSubject();
-    try {
-      currentUser.checkPermission(context);
-    } catch (ShiroException e) {
-      String message = currentUser.getPrincipal() + " not authorized for " + context;
-      logger.info("NotAuthorizedException: {}", message);
-      throw new NotAuthorizedException(message, e);
-    }
+    authorize(context, currentUser);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/security/SecurityManager.java
+++ b/geode-core/src/main/java/org/apache/geode/security/SecurityManager.java
@@ -75,7 +75,7 @@ public interface SecurityManager {
    * @param permission The permission requested
    * @return true if authorized, false if not
    *
-   * @throw AuthenticationExpiredException if the principal has expired.
+   * @throws AuthenticationExpiredException if the principal has expired.
    */
   default boolean authorize(Object principal, ResourcePermission permission)
       throws AuthenticationExpiredException {

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -352,7 +352,7 @@ org/apache/geode/internal/cache/snapshot/WindowedExporter$WindowedArgs,true,1,ex
 org/apache/geode/internal/cache/snapshot/WindowedExporter$WindowedExportFunction,true,1
 org/apache/geode/internal/cache/tier/BatchException,true,-6707074107791305564,_index:int
 org/apache/geode/internal/cache/tier/sockets/ClientTombstoneMessage$TOperation,false
-org/apache/geode/internal/cache/tier/sockets/MessageDispatcher$1,true,0,this$0:org/apache/geode/internal/cache/tier/sockets/MessageDispatcher
+org/apache/geode/internal/cache/tier/sockets/MessageDispatcher$1,true,0
 org/apache/geode/internal/cache/tier/sockets/MessageTooLargeException,true,-8970585803331525833
 org/apache/geode/internal/cache/tier/sockets/UnregisterAllInterest,true,5026160621257178459
 org/apache/geode/internal/cache/tx/TransactionalOperation$ServerRegionOperation,false

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/AuthenticateUserOpTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/AuthenticateUserOpTest.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.client.internal;
+
+import static org.apache.geode.cache.client.internal.AuthenticateUserOp.NOT_A_USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.cache.tier.sockets.Message;
+
+public class AuthenticateUserOpTest {
+
+  private AuthenticateUserOp.AuthenticateUserOpImpl impl;
+  private ConnectionImpl connection;
+  private InternalDistributedSystem system;
+  private byte[] credentialBytes;
+  private Message message;
+
+  @Before
+  public void before() throws Exception {
+    connection = mock(ConnectionImpl.class);
+    system = mock(InternalDistributedSystem.class);
+    credentialBytes = "test".getBytes(StandardCharsets.UTF_8);
+    message = mock(Message.class);
+  }
+
+  @Test
+  public void constructorWithNoArg() throws Exception {
+    impl = spy(new AuthenticateUserOp.AuthenticateUserOpImpl());
+    doReturn(system).when(impl).getConnectedSystem();
+    Properties properties = new Properties();
+    when(system.getSecurityProperties()).thenReturn(properties);
+    doReturn(credentialBytes).when(impl).getCredentialBytes(any(), any());
+    doReturn(NOT_A_USER_ID).when(impl).getUserId(connection);
+    doReturn(message).when(impl).getMessage();
+    impl.sendMessage(connection);
+
+    // verify we are using system.getSecurityProperties to get the credential bytes
+    ArgumentCaptor<Properties> captor = ArgumentCaptor.forClass(Properties.class);
+    verify(impl).getCredentialBytes(eq(connection), captor.capture());
+    assertThat(captor.getValue()).isEqualTo(properties);
+  }
+
+  @Test
+  public void constructorWithProperties() throws Exception {
+    Properties properties = new Properties();
+    impl = spy(new AuthenticateUserOp.AuthenticateUserOpImpl(properties));
+    doReturn(system).when(impl).getConnectedSystem();
+    doReturn(credentialBytes).when(impl).getCredentialBytes(any(), any());
+    doReturn(NOT_A_USER_ID).when(impl).getUserId(connection);
+    doReturn(message).when(impl).getMessage();
+    impl.sendMessage(connection);
+
+    // verify we are using the properties in constructor to get the credential bytes
+    ArgumentCaptor<Properties> captor = ArgumentCaptor.forClass(Properties.class);
+    verify(impl).getCredentialBytes(eq(connection), captor.capture());
+    assertThat(captor.getValue()).isEqualTo(properties);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
@@ -1,0 +1,123 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.net.Socket;
+
+import org.apache.shiro.subject.Subject;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.internal.cache.Conflatable;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy.CacheClientProxyStatsFactory;
+import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy.MessageDispatcherFactory;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.internal.statistics.StatisticsClock;
+
+public class CacheClientProxyTest {
+  private CacheClientProxy proxy;
+  private CacheClientNotifier notifier;
+  private Socket socket;
+  private ClientProxyMembershipID id;
+  private KnownVersion version;
+  private SecurityService securityService;
+  private Subject subject;
+  private StatisticsClock clock;
+  private InternalCache cache;
+  private StatisticsFactory statsFactory;
+  private CacheClientProxyStatsFactory proxyStatsFactory;
+  private MessageDispatcherFactory dispatcherFactory;
+  private InetAddress inetAddress;
+  private CacheServerStats stats;
+
+  @Before
+  public void before() throws Exception {
+    notifier = mock(CacheClientNotifier.class);
+    stats = mock(CacheServerStats.class);
+    socket = mock(Socket.class);
+    inetAddress = mock(InetAddress.class);
+    when(socket.getInetAddress()).thenReturn(inetAddress);
+    when(notifier.getAcceptorStats()).thenReturn(stats);
+    id = mock(ClientProxyMembershipID.class);
+    version = KnownVersion.TEST_VERSION;
+    securityService = mock(SecurityService.class);
+    subject = mock(Subject.class);
+    clock = mock(StatisticsClock.class);
+    cache = mock(InternalCache.class);
+    statsFactory = mock(StatisticsFactory.class);
+    proxyStatsFactory = mock(CacheClientProxyStatsFactory.class);
+    dispatcherFactory = mock(MessageDispatcherFactory.class);
+  }
+
+  @Test
+  public void noExceptionWhenGettingSubjectForCQWhenSubjectIsNotNull() {
+    proxy = spy(new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
+        securityService, subject, clock, statsFactory, proxyStatsFactory, dispatcherFactory));
+    proxy.getSubject("cq");
+  }
+
+  @Test
+  public void noExceptionWhenGettingSubjectForCQWhenSubjectIsNull() {
+    proxy = spy(new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
+        securityService, null, clock, statsFactory, proxyStatsFactory, dispatcherFactory));
+    proxy.getSubject("cq");
+  }
+
+  @Test
+  public void deliverMessageWhenSubjectIsNotNull() {
+    when(proxyStatsFactory.create(any(), any(), any()))
+        .thenReturn(mock(CacheClientProxyStats.class));
+    proxy = spy(new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
+        securityService, subject, clock, statsFactory, proxyStatsFactory, dispatcherFactory));
+    assertThat(proxy.getSubject()).isNotNull();
+    Conflatable message = mock(ClientUpdateMessage.class);
+    when(securityService.needPostProcess()).thenReturn(true);
+    proxy.deliverMessage(message);
+    verify(securityService).bindSubject(subject);
+    verify(securityService).postProcess(any(), any(), any(), anyBoolean());
+  }
+
+  @Test
+  public void deliverMessageWhenSubjectIsNull() {
+    when(proxyStatsFactory.create(any(), any(), any()))
+        .thenReturn(mock(CacheClientProxyStats.class));
+    proxy = spy(new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
+        securityService, null, clock, statsFactory, proxyStatsFactory, dispatcherFactory));
+    assertThat(proxy.getSubject()).isNull();
+    Conflatable message = mock(ClientUpdateMessage.class);
+    when(securityService.needPostProcess()).thenReturn(true);
+    when(proxyStatsFactory.create(any(), any(), any()))
+        .thenReturn(mock(CacheClientProxyStats.class));
+    proxy.deliverMessage(message);
+    verify(securityService, never()).bindSubject(subject);
+    verify(securityService, never()).postProcess(any(), any(), any(), anyBoolean());
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuthsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuthsTest.java
@@ -1,0 +1,84 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.shiro.subject.Subject;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClientUserAuthsTest {
+  private ClientUserAuths auth;
+  private Subject subject1;
+  private Subject subject2;
+
+  @Before
+  public void before() throws Exception {
+    subject1 = mock(Subject.class);
+    subject2 = mock(Subject.class);
+    when(subject1.getPrincipal()).thenReturn("user1");
+    when(subject2.getPrincipal()).thenReturn("user2");
+    auth = spy(new ClientUserAuths(0));
+    doReturn(123L).when(auth).getNextID();
+  }
+
+  @Test
+  public void putSubjectWithNegativeOneWillProduceNewId() throws Exception {
+    Long uniqueId = auth.putSubject(subject1, -1);
+    assertThat(uniqueId).isEqualTo(123L);
+  }
+
+  @Test
+  public void putSubjectWithZeroWillProduceNewId() throws Exception {
+    Long uniqueId = auth.putSubject(subject1, 0);
+    assertThat(uniqueId).isEqualTo(123L);
+  }
+
+  @Test
+  public void putSubjectWithExistingId() throws Exception {
+    Long uniqueId = auth.putSubject(subject1, 456L);
+    assertThat(uniqueId).isEqualTo(456L);
+  }
+
+  @Test
+  public void replacedSubjectShouldLogout() throws Exception {
+    Long id1 = auth.putSubject(subject1, -1);
+    Long id2 = auth.putSubject(subject2, id1);
+    assertThat(id1).isEqualTo(id2);
+    verify(auth).removeSubject(eq(id1));
+    verify(subject1).logout();
+  }
+
+  @Test
+  public void cqSubjectIsTracked() throws Exception {
+    Long id1 = auth.putSubject(subject1, -1);
+    auth.setUserAuthAttributesForCq("cq1", id1, true);
+    Subject subject = auth.getSubject("cq1");
+    assertThat(subject).isEqualTo(subject1);
+
+    auth.removeUserAuthAttributesForCq("cq1", true);
+    assertThat(auth.getSubject("cq1")).isNull();
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
@@ -1,0 +1,167 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.internal.cache.tier.sockets;
+
+import static org.apache.geode.internal.lang.SystemPropertyHelper.RE_AUTHENTICATE_WAIT_TIME;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.shiro.subject.Subject;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.internal.cache.EventID;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.ha.HARegionQueue;
+import org.apache.geode.internal.cache.ha.HARegionQueueStats;
+import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl.CqNameToOp;
+import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.security.AuthenticationExpiredException;
+import org.apache.geode.security.ResourcePermission;
+
+public class MessageDispatcherTest {
+  private MessageDispatcher dispatcher;
+  private CacheClientProxy proxy;
+  private ClientUpdateMessage message;
+  private InternalCache cache;
+  private SecurityService securityService;
+  private Subject subject;
+  private CacheClientNotifier notifier;
+  private ClientProxyMembershipID proxyId;
+  private HARegionQueue messageQueue;
+  private HARegionQueueStats queueStats;
+  private CancelCriterion cancelCriterion;
+  private CacheClientProxyStats proxyStats;
+  private EventID eventID;
+
+  @Before
+  public void before() throws Exception {
+    proxy = mock(CacheClientProxy.class);
+    message = mock(ClientUpdateMessageImpl.class);
+    cache = mock(InternalCache.class);
+    subject = mock(Subject.class);
+    securityService = mock(SecurityService.class);
+    notifier = mock(CacheClientNotifier.class);
+    proxyId = mock(ClientProxyMembershipID.class);
+    messageQueue = mock(HARegionQueue.class);
+    queueStats = mock(HARegionQueueStats.class);
+    cancelCriterion = mock(CancelCriterion.class);
+    proxyStats = mock(CacheClientProxyStats.class);
+    eventID = mock(EventID.class);
+    when(messageQueue.getStatistics()).thenReturn(queueStats);
+    when(cache.getSecurityService()).thenReturn(securityService);
+    when(proxy.getCache()).thenReturn(cache);
+    when(cache.getCancelCriterion()).thenReturn(cancelCriterion);
+    when(proxy.getCacheClientNotifier()).thenReturn(notifier);
+    when(proxy.getProxyID()).thenReturn(proxyId);
+    when(proxy.getHARegionName()).thenReturn("haRegion");
+    when(proxy.getStatistics()).thenReturn(proxyStats);
+    dispatcher = spy(new MessageDispatcher(proxy, "dispatcher", messageQueue));
+  }
+
+  @Test
+  public void onlyAuthorizeClientUpdateMessage() throws Exception {
+    ClientMessage message = mock(ClientMessage.class);
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
+    dispatcher.dispatchMessage(message);
+    verify(securityService, never()).authorize(any(ResourcePermission.class), any(Subject.class));
+  }
+
+  @Test
+  public void noAuthorizeIfNoIntegratedSecurity() throws Exception {
+    when(securityService.isIntegratedSecurity()).thenReturn(false);
+    dispatcher.dispatchMessage(message);
+    verify(securityService, never()).authorize(any(ResourcePermission.class), any(Subject.class));
+  }
+
+
+  @Test
+  public void useProxySingleUserToAuthorizeIfExists() throws Exception {
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
+    when(proxy.getSubject()).thenReturn(subject);
+    dispatcher.dispatchMessage(message);
+    verify(securityService).authorize(any(ResourcePermission.class), eq(subject));
+  }
+
+  @Test
+  public void useCqNameToFindSubjectToAuthorize() throws Exception {
+    when(securityService.isIntegratedSecurity()).thenReturn(true);
+    when(proxy.getSubject()).thenReturn(null);
+    CqNameToOp clientCqs = mock(CqNameToOp.class);
+    when(message.getClientCq(any())).thenReturn(clientCqs);
+    String[] names = {"cq1"};
+    when(clientCqs.getNames()).thenReturn(names);
+    when(proxy.getSubject("cq1")).thenReturn(subject);
+    dispatcher.dispatchMessage(message);
+    verify(securityService).authorize(any(ResourcePermission.class), eq(subject));
+  }
+
+  @Test
+  public void normalRunWillDispatchMessage() throws Exception {
+    doReturn(false, false, true).when(dispatcher).isStopped();
+    when(messageQueue.peek()).thenReturn(message);
+    dispatcher.runDispatcher();
+    verify(dispatcher).dispatchMessage(message);
+  }
+
+  @Test
+  public void newClientWillGetClientReAuthenticateMessage() throws Exception {
+    doReturn(false, false, false, false, false, true).when(dispatcher).isStopped();
+    doThrow(AuthenticationExpiredException.class).when(dispatcher).dispatchMessage(any());
+    when(messageQueue.peek()).thenReturn(message);
+    when(proxy.getVersion()).thenReturn(KnownVersion.GEODE_1_15_0);
+    doReturn(eventID).when(dispatcher).createEventId();
+    doNothing().when(dispatcher).sendMessageDirectly(any());
+
+    // make sure wait time is short
+    doReturn(-1L).when(dispatcher).getSystemProperty(eq(RE_AUTHENTICATE_WAIT_TIME), anyLong());
+    dispatcher.runDispatcher();
+
+    // verify a ReAuthenticate message will be send to the user
+    verify(dispatcher).sendMessageDirectly(any(ClientReAuthenticateMessage.class));
+
+    // since we keep throwing the AuthenticationExpiredException, we will eventually call this
+    verify(dispatcher).pauseOrUnregisterProxy(any(AuthenticationExpiredException.class));
+  }
+
+  @Test
+  public void oldClientWillNotGetClientReAuthenticateMessage() throws Exception {
+    doReturn(false, false, false, false, false, true).when(dispatcher).isStopped();
+    // make sure wait time is short
+    doReturn(-1L).when(dispatcher).getSystemProperty(eq(RE_AUTHENTICATE_WAIT_TIME), anyLong());
+
+    doThrow(AuthenticationExpiredException.class).when(dispatcher).dispatchMessage(any());
+    when(messageQueue.peek()).thenReturn(message);
+    when(proxy.getVersion()).thenReturn(KnownVersion.GEODE_1_14_0);
+    dispatcher.runDispatcher();
+    verify(dispatcher, never()).sendMessageDirectly(any());
+    // we will eventually pauseOrUnregisterProxy
+    verify(dispatcher).pauseOrUnregisterProxy(any(AuthenticationExpiredException.class));
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/PutUserCredentialsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/PutUserCredentialsTest.java
@@ -1,0 +1,79 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.internal.cache.tier.sockets.command;
+
+import static org.apache.geode.internal.cache.tier.Command.REQUIRES_RESPONSE;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.internal.cache.tier.sockets.Message;
+import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
+import org.apache.geode.internal.security.SecurityService;
+
+public class PutUserCredentialsTest {
+  private PutUserCredentials command;
+  private Message message;
+  private ServerConnection connection;
+  private SecurityService securityService;
+
+
+  @Before
+  public void before() throws Exception {
+    command = spy(new PutUserCredentials());
+    message = mock(Message.class);
+    connection = mock(ServerConnection.class);
+    securityService = mock(SecurityService.class);
+  }
+
+  @Test
+  public void doNothingIfNotSecureMode() throws Exception {
+    when(message.isSecureMode()).thenReturn(false);
+    command.cmdExecute(message, connection, securityService, 0);
+    verify(connection, never()).getUniqueId();
+  }
+
+  @Test
+  public void doNothingIfInvalidParts() throws Exception {
+    when(message.isSecureMode()).thenReturn(true);
+    when(message.getNumberOfParts()).thenReturn(2);
+    command.cmdExecute(message, connection, securityService, 0);
+    verify(connection, never()).getUniqueId();
+  }
+
+  @Test
+  public void setUniqueIdIfMessageIsValid() throws Exception {
+    when(message.isSecureMode()).thenReturn(true);
+    when(message.getNumberOfParts()).thenReturn(1);
+    when(connection.getUniqueId()).thenReturn(-1L);
+    doNothing().when(command).writeResponse(
+        eq(null), eq(null), eq(message), eq(false), eq(connection));
+    command.cmdExecute(message, connection, securityService, 0);
+    verify(connection).getUniqueId();
+    verify(connection).setAsTrue(REQUIRES_RESPONSE);
+    verify(connection).setCredentials(message, -1l);
+    verify(command).writeResponse(eq(null), eq(null), eq(message), eq(false), eq(connection));
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/lang/SystemPropertyHelperTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/lang/SystemPropertyHelperTest.java
@@ -75,6 +75,27 @@ public class SystemPropertyHelperTest {
   }
 
   @Test
+  public void getIntegerPropertyWithDefaultValue() {
+    String testProperty = "testIntegerProperty";
+    assertThat(SystemPropertyHelper.getProductIntegerProperty(testProperty, 1000)).isEqualTo(1000);
+  }
+
+  @Test
+  public void getLongPropertyWithoutDefaultReturnsGemfirePrefixIfGeodeMissing() {
+    String testProperty = "testLongProperty";
+    String gemfirePrefixProperty = "gemfire." + testProperty;
+    System.setProperty(gemfirePrefixProperty, "1");
+    assertThat(SystemPropertyHelper.getProductLongProperty(testProperty).get()).isEqualTo(1);
+    System.clearProperty(gemfirePrefixProperty);
+  }
+
+  @Test
+  public void getLongPropertyWithDefaultValue() {
+    String testProperty = "testIntegerProperty";
+    assertThat(SystemPropertyHelper.getProductLongProperty(testProperty, 1000)).isEqualTo(1000);
+  }
+
+  @Test
   public void getIntegerPropertyReturnsEmptyOptionalIfPropertiesMissing() {
     String testProperty = "notSetProperty";
     assertThat(SystemPropertyHelper.getProductIntegerProperty(testProperty).isPresent()).isFalse();

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -15,14 +15,16 @@
 package org.apache.geode.security;
 
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
-import static org.apache.geode.test.version.VersionManager.CURRENT_VERSION;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,16 +39,28 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientRegionFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.client.ServerOperationException;
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqException;
+import org.apache.geode.cache.query.CqExistsException;
+import org.apache.geode.cache.query.CqListener;
+import org.apache.geode.cache.query.CqQuery;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.RegionNotFoundException;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
+import org.apache.geode.test.version.TestVersion;
+import org.apache.geode.test.version.VersionManager;
 
 @Category({SecurityTest.class})
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class AuthExpirationDUnitTest {
+  private static String test_start_version = "1.14.0";
   private static RegionService user0Service;
   private static RegionService user1Service;
 
@@ -55,8 +69,8 @@ public class AuthExpirationDUnitTest {
 
   @Parameterized.Parameters(name = "{0}")
   public static Collection<String> data() {
-    // only test the current version and the latest released version
-    return Arrays.asList(CURRENT_VERSION, "1.13.3");
+    // only test versions greater than or equal to 1.14.0
+    return VersionManager.getInstance().getVersionsLaterThanAndEqualTo(test_start_version);
   }
 
   @Rule
@@ -70,11 +84,62 @@ public class AuthExpirationDUnitTest {
       .withSecurityManager(ExpirableSecurityManager.class)
       .withRegion(RegionShortcut.REPLICATE, "region");
 
+
+  private ClientVM clientVM;
+
   @Test
-  public void clientShouldReAuthenticateWhenCredentialExpiredAndOperationSucceed()
-      throws Exception {
+  public void clientWithNoUserRefreshWillNotSucceed() throws Exception {
     int serverPort = server.getPort();
     ClientVM clientVM = lsRule.startClientVM(0, clientVersion,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      ClientRegionFactory<Object, Object> clientRegionFactory =
+          clientCache.createClientRegionFactory(ClientRegionShortcut.PROXY);
+      Region<Object, Object> region = clientRegionFactory.create("region");
+      region.put(0, "value0");
+    });
+
+    // expire the current user
+    ExpirableSecurityManager securityManager = getSecurityManager();
+    securityManager.addExpiredUser("user1");
+
+    // if client, even after getting AuthExpiredExpiration, still sends in
+    // old credentials, the operation will fail (we only try re-authenticate once)
+    // this test makes sure no lingering old credentials will allow the operations to succeed.
+    clientVM.invoke(() -> {
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Object, Object> region = clientCache.getRegion("region");
+      doPutAndExpectFailure(region, 100);
+    });
+
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    assertThat(region).hasSize(1);
+    Map<String, List<String>> authorizedOps = securityManager.getAuthorizedOps();
+    Map<String, List<String>> unAuthorizedOps = securityManager.getUnAuthorizedOps();
+    assertThat(authorizedOps.keySet()).containsExactly("user1");
+    assertThat(authorizedOps.get("user1")).containsExactly("DATA:WRITE:region:0");
+    assertThat(unAuthorizedOps.keySet()).containsExactly("user1");
+  }
+
+  private static void doPutAndExpectFailure(Region<Object, Object> region, int times) {
+    for (int i = 1; i < times; i++) {
+      assertThatThrownBy(() -> region.put(1, "value1"))
+          .isInstanceOf(ServerOperationException.class)
+          .getCause().isInstanceOfAny(AuthenticationFailedException.class,
+              AuthenticationRequiredException.class);
+    }
+  }
+
+  @Test
+  public void singleUserModeShouldReAuthenticateWhenCredentialExpiredAndOperationSucceed()
+      throws Exception {
+    int serverPort = server.getPort();
+    clientVM = lsRule.startClientVM(0, clientVersion,
         c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
             .withPoolSubscription(true)
             .withServerConnection(serverPort));
@@ -107,17 +172,18 @@ public class AuthExpirationDUnitTest {
     assertThat(region.size()).isEqualTo(2);
     Map<String, List<String>> authorizedOps = securityManager.getAuthorizedOps();
     Map<String, List<String>> unAuthorizedOps = securityManager.getUnAuthorizedOps();
-    assertThat(authorizedOps.keySet().size()).isEqualTo(2);
-    assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:WRITE:region:0");
-    assertThat(authorizedOps.get("user2")).asList().containsExactly("DATA:WRITE:region:1");
-    assertThat(unAuthorizedOps.keySet().size()).isEqualTo(1);
-    assertThat(unAuthorizedOps.get("user1")).asList().containsExactly("DATA:WRITE:region:1");
+    assertThat(authorizedOps.keySet()).hasSize(2);
+    assertThat(authorizedOps.get("user1")).containsExactly("DATA:WRITE:region:0");
+    assertThat(authorizedOps.get("user2")).containsExactly("DATA:WRITE:region:1");
+    assertThat(unAuthorizedOps.keySet()).hasSize(1);
+    assertThat(unAuthorizedOps.get("user1")).containsExactly("DATA:WRITE:region:1");
   }
 
   @Test
-  public void userShouldReAuthenticateWhenCredentialExpiredAndOperationSucceed() throws Exception {
+  public void multiUserModeShouldReAuthenticateWhenCredentialExpiredAndOperationSucceed()
+      throws Exception {
     int serverPort = server.getPort();
-    ClientVM clientVM = lsRule.startClientVM(0, clientVersion,
+    clientVM = lsRule.startClientVM(0, clientVersion,
         c -> c.withMultiUser(true)
             .withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
             .withPoolSubscription(true)
@@ -146,7 +212,6 @@ public class AuthExpirationDUnitTest {
     ExpirableSecurityManager securityManager = getSecurityManager();
     securityManager.addExpiredUser("user1");
     clientVM.invoke(() -> {
-
       Region<Object, Object> region = user0Service.getRegion("/region");
       region.put(2, "value3");
 
@@ -175,5 +240,221 @@ public class AuthExpirationDUnitTest {
 
   private ExpirableSecurityManager getSecurityManager() {
     return (ExpirableSecurityManager) server.getCache().getSecurityService().getSecurityManager();
+  }
+
+  private static EventsCqListner CQLISTENER0;
+  private static EventsCqListner CQLISTENER1;
+
+  @Test
+  public void cqNewerClientWillReAuthenticateAutomatically() throws Exception {
+    // this test should only test the newer client
+    if (TestVersion.compare(clientVersion, test_start_version) <= 0) {
+      return;
+    }
+
+    startClientWithCQ();
+
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    region.put("1", "value1");
+    clientVM.invoke(() -> {
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .asList()
+              .containsExactly("1"));
+    });
+
+    // expire the current user
+    getSecurityManager().addExpiredUser("user1");
+
+    // update the user to be used before we try to send the 2nd event
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user2");
+    });
+
+    // do a second put, the event should be queued until client re-authenticate
+    region.put("2", "value2");
+
+    clientVM.invoke(() -> {
+      // the client will eventually get the 2nd event
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .asList()
+              .containsExactly("1", "2"));
+    });
+
+    Map<String, List<String>> authorizedOps = getSecurityManager().getAuthorizedOps();
+    assertThat(authorizedOps.keySet().size()).isEqualTo(2);
+    assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:READ:region",
+        "DATA:READ:region:1");
+    assertThat(authorizedOps.get("user2")).asList().containsExactly("DATA:READ:region:2");
+
+    Map<String, List<String>> unAuthorizedOps = getSecurityManager().getUnAuthorizedOps();
+    assertThat(unAuthorizedOps.keySet().size()).isEqualTo(1);
+    assertThat(unAuthorizedOps.get("user1")).asList().containsExactly("DATA:READ:region:2");
+  }
+
+  @Test
+  public void cqOlderClientWillNotReAuthenticate() throws Exception {
+    // this test should only test the older client
+    if (TestVersion.compare(clientVersion, test_start_version) > 0) {
+      return;
+    }
+
+    startClientWithCQ();
+
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    region.put("1", "value1");
+    clientVM.invoke(() -> {
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .containsExactly("1"));
+    });
+
+    // expire the current user
+    ExpirableSecurityManager securityManager = getSecurityManager();
+    securityManager.addExpiredUser("user1");
+
+    // do a second put, the event should not be delivered to the client
+    region.put("2", "value2");
+
+    clientVM.invoke(() -> {
+      // even user gets refreshed, the old client wouldn't be able to send in the new credentials
+      UpdatableUserAuthInitialize.setUser("user2");
+      await().during(6, TimeUnit.SECONDS)
+          .untilAsserted(
+              () -> assertThat(CQLISTENER0.getKeys())
+                  .containsExactly("1"));
+    });
+    Map<String, List<String>> authorizedOps = securityManager.getAuthorizedOps();
+    assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:READ:region",
+        "DATA:READ:region:1");
+
+    Map<String, List<String>> unAuthorizedOps = securityManager.getUnAuthorizedOps();
+    assertThat(unAuthorizedOps.keySet().size()).isEqualTo(1);
+    assertThat(unAuthorizedOps.get("user1")).asList().contains("DATA:READ:region:2");
+  }
+
+  @Test
+  // re-authentication in Multi-user mode in event dispatching is not supported.
+  // we do support re-auth in multi-user mode in non-event dispatching case.
+  // in event dispatching case, if one user's credential expired,
+  // the client will be terminated by the CacheClientUpdater
+  public void multiUserCq() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = lsRule.startClientVM(0, clientVersion,
+        c -> c.withMultiUser(true)
+            .withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user0");
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      clientCache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
+      Properties userSecurityProperties = new Properties();
+      userSecurityProperties.put(SECURITY_CLIENT_AUTH_INIT,
+          UpdatableUserAuthInitialize.class.getName());
+      user0Service = clientCache.createAuthenticatedView(userSecurityProperties);
+      CQLISTENER0 = createAndExecuteCQ(user0Service.getQueryService(), "cq1",
+          "select * from /region r where r.length<=2");
+
+
+      UpdatableUserAuthInitialize.setUser("user1");
+      user1Service = clientCache.createAuthenticatedView(userSecurityProperties);
+      CQLISTENER1 = createAndExecuteCQ(user1Service.getQueryService(), "cq2",
+          "select * from /region r where r.length>=2");
+    });
+
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    region.put("1", "1");
+    getSecurityManager().addExpiredUser("user1");
+    region.put("11", "11");
+    region.put("111", "111");
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1_extended");
+      // user0Service listener will get one event
+      await().during(10, TimeUnit.SECONDS).untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .containsExactly("1"));
+
+      // user1Service listener will not get any events
+      await().during(10, TimeUnit.SECONDS).untilAsserted(
+          () -> assertThat(CQLISTENER1.getKeys()).isEmpty());
+
+      user0Service.close();
+      user1Service.close();
+    });
+
+    Map<String, List<String>> unAuthorizedOps = getSecurityManager().getUnAuthorizedOps();
+    assertThat(unAuthorizedOps.keySet()).hasSize(1);
+    assertThat(unAuthorizedOps.get("user1")).asList().contains("DATA:READ:region:11");
+  }
+
+  @Test
+  public void cqOlderClientWithClientInteractionWillDeliverEventEventually() throws Exception {
+    // this test should only test the older client
+    if (TestVersion.compare(clientVersion, test_start_version) > 0) {
+      return;
+    }
+    startClientWithCQ();
+
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    region.put("1", "value1");
+    getSecurityManager().addExpiredUser("user1");
+    region.put("2", "value2");
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user2");
+      Region<Object, Object> proxyRegion =
+          ClusterStartupRule.clientCacheRule.createProxyRegion("region");
+      proxyRegion.put("3", "value3");
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .containsExactly("1", "2", "3"));
+
+    });
+  }
+
+  private void startClientWithCQ() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = lsRule.startClientVM(0, clientVersion,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      CQLISTENER0 = createAndExecuteCQ(ClusterStartupRule.getClientCache().getQueryService(), "CQ1",
+          "select * from /region");
+    });
+  }
+
+  private static EventsCqListner createAndExecuteCQ(QueryService queryService, String cqName,
+      String query)
+      throws CqExistsException, CqException, RegionNotFoundException {
+    CqAttributesFactory cqaf = new CqAttributesFactory();
+    EventsCqListner listenter = new EventsCqListner();
+    cqaf.addCqListener(listenter);
+
+    CqQuery cq = queryService.newCq(cqName, query, cqaf.create());
+    cq.execute();
+    return listenter;
+  }
+
+  private static class EventsCqListner implements CqListener {
+    private List<String> keys = new ArrayList<>();
+
+    @Override
+    public void onEvent(CqEvent aCqEvent) {
+      keys.add(aCqEvent.getKey().toString());
+    }
+
+    @Override
+    public void onError(CqEvent aCqEvent) {}
+
+    public List<String> getKeys() {
+      return keys;
+    }
   }
 }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
@@ -872,27 +872,6 @@ public class CqQueryDUnitTest extends JUnit4CacheTestCase {
     });
   }
 
-  private void validateCQError(VM vm, final String cqName, final int numError) {
-    vm.invoke(() -> {
-      QueryService cqService = getCache().getQueryService();
-      CqQuery cQuery = cqService.getCq(cqName);
-      assertThat(cQuery).describedAs("Failed to get CqQuery for CQ : " + cqName).isNotNull();
-
-      CqAttributes cqAttr = cQuery.getCqAttributes();
-      CqListener cqListener = cqAttr.getCqListener();
-      CqQueryTestListener listener = (CqQueryTestListener) cqListener;
-      listener.printInfo(false);
-
-      // Check for totalEvents count.
-      if (numError != noTest) {
-        // Result size validation.
-        listener.printInfo(true);
-        assertThat(listener.getErrorEventCount()).describedAs("Total Event Count mismatch")
-            .isEqualTo(numError);
-      }
-    });
-  }
-
   public void validateCQ(VM vm, final String cqName, final int resultSize, final int creates,
       final int updates, final int deletes) {
     validateCQ(vm, cqName, resultSize, creates, updates, deletes, noTest, noTest, noTest, noTest);

--- a/geode-dunit/src/main/java/org/apache/geode/cache/query/cq/dunit/CqQueryTestListener.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache/query/cq/dunit/CqQueryTestListener.java
@@ -15,19 +15,16 @@
 package org.apache.geode.cache.query.cq.dunit;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.apache.geode.LogWriter;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.query.CqEvent;
 import org.apache.geode.cache.query.CqStatusListener;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
-import org.apache.geode.test.dunit.WaitCriterion;
 
 public class CqQueryTestListener implements CqStatusListener {
   protected final LogWriter logger;
@@ -50,11 +47,11 @@ public class CqQueryTestListener implements CqStatusListener {
   protected volatile boolean eventRegionClear = false;
   protected volatile boolean eventRegionInvalidate = false;
 
-  public final Set destroys = Collections.synchronizedSet(new HashSet());
-  public final Set creates = Collections.synchronizedSet(new HashSet());
-  public final Set invalidates = Collections.synchronizedSet(new HashSet());
-  public final Set updates = Collections.synchronizedSet(new HashSet());
-  public final Set errors = Collections.synchronizedSet(new HashSet());
+  public final Set destroys = ConcurrentHashMap.newKeySet();
+  public final Set creates = ConcurrentHashMap.newKeySet();
+  public final Set invalidates = ConcurrentHashMap.newKeySet();
+  public final Set updates = ConcurrentHashMap.newKeySet();
+  public final Set errors = ConcurrentHashMap.newKeySet();
 
   private static final String WAIT_PROPERTY = "CqQueryTestListener.maxWaitTime";
 
@@ -213,197 +210,54 @@ public class CqQueryTestListener implements CqStatusListener {
 
   }
 
-  public boolean waitForCreated(final Object key) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return CqQueryTestListener.this.creates.contains(key);
-      }
-
-      @Override
-      public String description() {
-        return "never got create event for CQ " + CqQueryTestListener.this.cqName + " key " + key;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForCreated(final Object key) {
+    await().untilAsserted(() -> assertThat(CqQueryTestListener.this.creates).contains(key));
   }
 
 
-  public boolean waitForTotalEvents(final int total) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return (CqQueryTestListener.this.totalEventCount == total);
-      }
-
-      @Override
-      public String description() {
-        return "Did not receive expected number of events " + CqQueryTestListener.this.cqName
-            + " expected: " + total + " receieved: " + CqQueryTestListener.this.totalEventCount;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForTotalEvents(final int total) {
+    await()
+        .untilAsserted(() -> assertThat(CqQueryTestListener.this.totalEventCount).isEqualTo(total));
   }
 
-  public boolean waitForDestroyed(final Object key) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return CqQueryTestListener.this.destroys.contains(key);
-      }
-
-      @Override
-      public String description() {
-        return "never got destroy event for key " + key + " in CQ "
-            + CqQueryTestListener.this.cqName;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForDestroyed(final Object key) {
+    await().untilAsserted(() -> assertThat(CqQueryTestListener.this.destroys).contains(key));
   }
 
-  public boolean waitForInvalidated(final Object key) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return CqQueryTestListener.this.invalidates.contains(key);
-      }
-
-      @Override
-      public String description() {
-        return "never got invalidate event for CQ " + CqQueryTestListener.this.cqName;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForInvalidated(final Object key) {
+    await().untilAsserted(() -> assertThat(CqQueryTestListener.this.invalidates).contains(key));
   }
 
-  public boolean waitForUpdated(final Object key) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return CqQueryTestListener.this.updates.contains(key);
-      }
-
-      @Override
-      public String description() {
-        return "never got update event for CQ " + CqQueryTestListener.this.cqName;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForUpdated(final Object key) {
+    await().untilAsserted(() -> assertThat(CqQueryTestListener.this.updates).contains(key));
   }
 
-  public boolean waitForClose() {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return CqQueryTestListener.this.eventClose;
-      }
-
-      @Override
-      public String description() {
-        return "never got close event for CQ " + CqQueryTestListener.this.cqName;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForClose() {
+    await().untilAsserted(() -> assertThat(CqQueryTestListener.this.eventClose).isTrue());
   }
 
-  public boolean waitForRegionClear() {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return CqQueryTestListener.this.eventRegionClear;
-      }
-
-      @Override
-      public String description() {
-        return "never got region clear event for CQ " + CqQueryTestListener.this.cqName;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForRegionClear() {
+    await().untilAsserted(() -> assertThat(CqQueryTestListener.this.eventRegionClear).isTrue());
   }
 
-  public boolean waitForRegionInvalidate() {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return CqQueryTestListener.this.eventRegionInvalidate;
-      }
-
-      @Override
-      public String description() {
-        return "never got region invalidate event for CQ " + CqQueryTestListener.this.cqName;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForRegionInvalidate() {
+    await()
+        .untilAsserted(() -> assertThat(CqQueryTestListener.this.eventRegionInvalidate).isTrue());
   }
 
-  public boolean waitForError(final String expectedMessage) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        Iterator iterator = CqQueryTestListener.this.errors.iterator();
-        while (iterator.hasNext()) {
-          String errorMessage = (String) iterator.next();
-          if (errorMessage.equals(expectedMessage)) {
-            return true;
-          } else {
-            logger.fine("errors that exist:" + errorMessage);
-          }
-        }
-        return false;
-      }
-
-      @Override
-      public String description() {
-        return "never got create error for CQ " + CqQueryTestListener.this.cqName + " messaged "
-            + expectedMessage;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForError(final String expectedMessage) {
+    await()
+        .untilAsserted(() -> assertThat(CqQueryTestListener.this.errors).contains(expectedMessage));
   }
 
-  public boolean waitForCqsDisconnectedEvents(final int total) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return (CqQueryTestListener.this.cqsDisconnectedCount == total);
-      }
-
-      @Override
-      public String description() {
-        return "Did not receive expected number of calls to cqsDisconnected() "
-            + CqQueryTestListener.this.cqName + " expected: " + total + " received: "
-            + CqQueryTestListener.this.cqsDisconnectedCount;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForCqsDisconnectedEvents(final int total) {
+    await().untilAsserted(
+        () -> assertThat(CqQueryTestListener.this.cqsDisconnectedCount).isEqualTo(total));
   }
 
-  public boolean waitForCqsConnectedEvents(final int total) {
-    WaitCriterion ev = new WaitCriterion() {
-      @Override
-      public boolean done() {
-        return (CqQueryTestListener.this.cqsConnectedCount == total);
-      }
-
-      @Override
-      public String description() {
-        return "Did not receive expected number of calls to cqsConnected() "
-            + CqQueryTestListener.this.cqName + " expected: " + total + " receieved: "
-            + CqQueryTestListener.this.cqsConnectedCount;
-      }
-    };
-    GeodeAwaitility.await().untilAsserted(ev);
-    return true;
+  public void waitForCqsConnectedEvents(final int total) {
+    await().untilAsserted(
+        () -> assertThat(CqQueryTestListener.this.cqsConnectedCount).isEqualTo(total));
   }
 
   public void waitForEvents(final int creates, final int updates, final int deletes,

--- a/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -40,6 +41,15 @@ public class ExpirableSecurityManager extends SimpleSecurityManager implements S
       new ConcurrentHashMap<>();
   private final Map<String, List<String>> unauthorizedOps =
       new ConcurrentHashMap<>();
+
+  @Override
+  public Object authenticate(final Properties credentials) throws AuthenticationFailedException {
+    Object user = super.authenticate(credentials);
+    if (expired_users.contains((String) user)) {
+      throw new AuthenticationFailedException("User already expired.");
+    }
+    return user;
+  }
 
   @Override
   public boolean authorize(Object principal, ResourcePermission permission) {
@@ -75,7 +85,9 @@ public class ExpirableSecurityManager extends SimpleSecurityManager implements S
     if (list == null) {
       list = new ArrayList<>();
     }
-    list.add(permission.toString());
+    if (!list.contains(permission.toString())) {
+      list.add(permission.toString());
+    }
     maps.put(user.toString(), list);
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VersionManager.java
@@ -143,6 +143,14 @@ public class VersionManager {
     return unmodifiableList(testVersions);
   }
 
+  public List<String> getVersionsLaterThanAndEqualTo(String version) {
+    checkForLoadFailure();
+    List<String> result = new ArrayList<>(testVersions);
+    result.removeIf(s -> TestVersion.compare(s, version) < 0);
+    result.add(CURRENT_VERSION);
+    return result;
+  }
+
   /**
    * Returns a list of testable versions sorted from oldest to newest
    *

--- a/geode-old-client-support/src/main/java/com/gemstone/gemfire/OldClientSupportProvider.java
+++ b/geode-old-client-support/src/main/java/com/gemstone/gemfire/OldClientSupportProvider.java
@@ -25,6 +25,7 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.cache.CacheService;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.tier.sockets.ClientReAuthenticateMessage;
 import org.apache.geode.internal.cache.tier.sockets.OldClientSupportService;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.VersionedDataOutputStream;
@@ -129,7 +130,7 @@ public class OldClientSupportProvider implements OldClientSupportService {
     String className = theThrowable.getClass().getName();
 
     // backward compatibility for authentication expiration
-    if (clientVersion.isOlderThan(KnownVersion.GEODE_1_15_0)) {
+    if (clientVersion.isOlderThan(ClientReAuthenticateMessage.RE_AUTHENTICATION_START_VERSION)) {
       if (className.equals(AuthenticationExpiredException.class.getName())) {
         return new AuthenticationRequiredException(USER_NOT_FOUND);
       }

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
@@ -178,7 +178,7 @@ public interface DataSerializableFixedID extends SerializationVersions, BasicSer
   byte COLLECTION_TYPE_IMPL = -59;
   byte TX_LOCK_BATCH = -58;
   byte STORE_ALL_CACHED_DESERIALIZABLE = -57;
-  // -56 unused
+  byte CLIENT_RE_AUTHENTICATE = -56;
   byte MAP_TYPE_IMPL = -55;
   byte LOCATOR_LIST_REQUEST = -54;
   byte CLIENT_CONNECTION_REQUEST = -53;


### PR DESCRIPTION
GEODE-9453: clean up the old subject when new subject is authenticated.

* authorize the message before dispatching the message to the client
* add a new message type to be sent to the client for re-authentiate
* message dispatcher will wait for a certain time for client to reauthenticate before terminating the client
* when re-authenticate, the new subject will re-use the original uniqueId. Credentials will be sent to the user along with the old uniqueId if exists.
* old subject will be cleaned out when new subject re-authenticate back.
* re-auth multi-user mode in event dispatching is not supported (yet).

I will continue to write unit tests for those refactored classes
