### PR TITLE
GEODE-9561:  jmx-manager-ssl-enabled supersedes jmx-manager-ssl

### DIFF
--- a/geode-docs/managing/management/jmx_manager_operations.html.md.erb
+++ b/geode-docs/managing/management/jmx_manager_operations.html.md.erb
@@ -142,7 +142,7 @@ In the `gemfire.properties` file, you configure a JMX manager as follows.
 <td>1099</td>
 </tr>
 <tr>
-<td>jmx-manager-ssl</td>
+<td>jmx-manager-ssl-enabled</td>
 <td>If true and <code class="ph codeph">jmx-manager-port</code> is not zero, the JMX Manager accepts only SSL connections. The ssl-enabled property does not apply to the JMX Manager, but the other SSL properties do. This allows SSL to be configured for just the JMX Manager without needing to configure it for the other <%=vars.product_name%> connections. Ignored if <code class="ph codeph">jmx-manager</code> is false.</td>
 <td>false</td>
 </tr>


### PR DESCRIPTION
jmx-manager-ssl, which no longer exists, was superseded by jmx-manager-ssl-enabled, which does exist but has subsequently been deprecated.

For now, we’ll fix the small issue in front of us by updating the property to jmx-manager-ssl-enabled.