### PR TITLE
GEODE-9554: Rebalancing a region with multiple redundancy zones can fail

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
@@ -40,6 +40,7 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.CacheTestCase;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.DistributedDiskDirRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 
 /**
@@ -75,6 +76,9 @@ public class RebalanceOperationComplexDistributedTest extends CacheTestCase {
 
   @Rule
   public ClusterStartupRule clusterStartupRule = new ClusterStartupRule(8);
+
+  @Rule
+  public DistributedDiskDirRule distributedDiskDirRule = new DistributedDiskDirRule();
 
   @Before
   public void setup() throws Exception {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
@@ -21,151 +21,162 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Stream;
 
 import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;
-import org.apache.geode.cache.control.RebalanceResults;
 import org.apache.geode.cache.control.ResourceManager;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.CacheTestCase;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 
 /**
- * TODO test colocated regions where buckets aren't created for all subregions
- *
- * <p>
- * TODO test colocated regions where members aren't consistent in which regions they have
+ * The purpose of RebalanceOperationComplexDistributedTest is to test rebalances
+ * across zones and to ensure that enforceUniqueZone behavior of redundancy zones
+ * is working correctly.
  */
 @RunWith(JUnitParamsRunner.class)
-@SuppressWarnings("serial")
 public class RebalanceOperationComplexDistributedTest extends CacheTestCase {
-
-  private static final long TIMEOUT_SECONDS = GeodeAwaitility.getTimeout().getValue();
-  public static final String CLIENT_XML =
-      "RebalanceOperationComplex-client.xml";
-  public static final String SERVER_XML =
-      "RebalanceOperationComplex-server.xml";
+  public static final int EXPECTED_BUCKET_COUNT = 113;
+  public static final long TIMEOUT_SECONDS = GeodeAwaitility.getTimeout().getValue();
+  public static final String CLIENT_XML = "RebalanceOperationComplex-client.xml";
+  public static final String SERVER_XML = "RebalanceOperationComplex-server.xml";
   public static final String REGION_NAME = "primary";
   public static final String COLOCATED_REGION_NAME = "colocated";
+
+  public static final String ZONE_A = "zoneA";
+  public static final String ZONE_B = "zoneB";
+
+  public int locatorPort;
+
+  // 6 servers distributed evenly across 2 zones
+  public static final Map<Integer, String> SERVER_ZONE_MAP = new HashMap<Integer, String>() {
+    {
+      put(1, ZONE_A);
+      put(2, ZONE_A);
+      put(3, ZONE_A);
+      put(4, ZONE_B);
+      put(5, ZONE_B);
+      put(6, ZONE_B);
+    }
+  };
 
   @Rule
   public ClusterStartupRule clusterStartupRule = new ClusterStartupRule(8);
 
-  private MemberVM startServer(int index, String zone, int locatorPort) {
-    return clusterStartupRule.startServerVM(index, s -> s.withProperty("cache-xml-file",
-        SERVER_XML)
-        .withProperty(REDUNDANCY_ZONE, zone)
-        .withConnectionToLocator(locatorPort));
+  @Before
+  public void setup() throws Exception {
+    MemberVM locatorVM = clusterStartupRule.startLocatorVM(0);
+    locatorPort = locatorVM.getPort();
+
+    // Startup the servers
+    for (Map.Entry<Integer, String> entry : SERVER_ZONE_MAP.entrySet()) {
+      startServerInRedundancyZone(entry.getKey(), entry.getValue());
+    }
+
+    // Startup a client to put all the data in the server regions
+    Properties properties2 = new Properties();
+    properties2.setProperty("cache-xml-file", CLIENT_XML);
+    ClientVM clientVM =
+        clusterStartupRule.startClientVM(7, properties2,
+            ccf -> ccf.addPoolLocator("localhost", locatorPort));
+
+    clientVM.invoke(() -> {
+      Map<Integer, String> putMap = new HashMap<>();
+      for (int i = 0; i < 1000; i++) {
+        putMap.put(i, "A");
+      }
+
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+
+      Stream.of(REGION_NAME, COLOCATED_REGION_NAME).forEach(regionName -> {
+        Region<Integer, String> region = clientCache.getRegion(regionName);
+        region.putAll(putMap);
+      });
+    });
   }
+
 
   /**
    * Test that we correctly use the redundancy-zone property to determine where to place redundant
    * copies of a buckets and doesn't allow cross redundancy zone deletes.
    */
   @Test
-  public void testEnforceZoneWithSixServersAndTwoZones() throws Exception {
-    MemberVM locatorVM = clusterStartupRule.startLocatorVM(0);
+  @Parameters({"1,2", "1,4", "4,1", "5,6"})
+  public void testEnforceZoneWithSixServersAndTwoZones(int rebalanceServer, int shutdownServer) {
 
-    // So startup six servers 3 in each redundancy zone
-    MemberVM server1 = startServer(1, "zoneA", locatorVM.getPort());
-    startServer(2, "zoneA", locatorVM.getPort());
-    startServer(3, "zoneA", locatorVM.getPort());
-    startServer(4, "zoneB", locatorVM.getPort());
-    startServer(5, "zoneB", locatorVM.getPort());
-    startServer(6, "zoneB", locatorVM.getPort());
-
-
-    // startup a client to put all the data.
-    Properties properties2 = new Properties();
-    properties2.setProperty("cache-xml-file",
-        CLIENT_XML);
-    ClientVM clientVM =
-        clusterStartupRule.startClientVM(7, properties2,
-            ccf -> ccf.addPoolLocator("localhost", locatorVM.getPort()));
-
-    clientVM.invoke(() -> {
-      ClientCache clientCache = ClusterStartupRule.getClientCache();
-      Map<Integer, String> map = new HashMap<>();
-      for (int i = 0; i < 1000; i++) {
-        map.put(i, "A");
-      }
-      Region<Integer, String> region =
-          clientCache.getRegion(REGION_NAME);
-      region.putAll(map);
-      Region<Integer, String> region2 =
-          clientCache.getRegion(COLOCATED_REGION_NAME);
-      region2.putAll(map);
-    });
+    VM rebalanceServerVM = clusterStartupRule.getVM(rebalanceServer);
 
     // Baseline rebalance with everything up
-    server1.invoke(() -> {
-      doRebalance(false, ClusterStartupRule.getCache().getResourceManager());
-    });
+    rebalanceServerVM.invoke(() -> doRebalance(ClusterStartupRule.getCache().getResourceManager()));
 
-    // knock server 2 offline
-    clusterStartupRule.stop(2);
+    // Take a server offline
+    clusterStartupRule.stop(shutdownServer);
 
-    // rebalance so that now all the buckets are one server 1 and server 3 reduncancy zone b servers
-    // should not be touched.
-    server1.invoke(() -> {
-      doRebalance(false, ClusterStartupRule.getCache().getResourceManager());
-    });
+    // Rebalance so that now all the buckets are on server 1 and server 3 redundancy.
+    // Zone b servers should not be touched.
+    rebalanceServerVM.invoke(() -> doRebalance(ClusterStartupRule.getCache().getResourceManager()));
 
-    // bring server 2 backonline
-    startServer(2, "zoneA", locatorVM.getPort());
+    // Restart the shutdownServer
+    startServerInRedundancyZone(shutdownServer, SERVER_ZONE_MAP.get(shutdownServer));
 
-    // do another rebalance to make sure all the buckets are distributed evenly(ish) and there is no
-    // cross redundancy zone bucket deletions.
-    server1.invoke(() -> {
-      doRebalance(false, ClusterStartupRule.getCache().getResourceManager());
-    });
+    // Do another rebalance to make sure all the buckets are distributed evenly(ish) and there are
+    // no cross redundancy zone bucket deletions.
+    rebalanceServerVM.invoke(() -> doRebalance(ClusterStartupRule.getCache().getResourceManager()));
 
     // Verify that all bucket counts add up to what they should
     compareZoneBucketCounts(COLOCATED_REGION_NAME);
     compareZoneBucketCounts(REGION_NAME);
   }
 
-  private void compareZoneBucketCounts(final String regionName) {
-    int zoneA = clusterStartupRule.getVM(1).invoke(() -> getBucketCount(regionName));
-    zoneA += clusterStartupRule.getVM(2).invoke(() -> getBucketCount(regionName));
-    zoneA += clusterStartupRule.getVM(3).invoke(() -> getBucketCount(regionName));
 
-    int zoneB = clusterStartupRule.getVM(4).invoke(() -> getBucketCount(regionName));
-    zoneB += clusterStartupRule.getVM(5).invoke(() -> getBucketCount(regionName));
-    zoneB += clusterStartupRule.getVM(6).invoke(() -> getBucketCount(regionName));
-
-    assertThat(zoneA).isEqualTo(zoneB).isEqualTo(113);
+  private void startServerInRedundancyZone(int index, final String zone) {
+    clusterStartupRule.startServerVM(index, s -> s.withProperty("cache-xml-file",
+        SERVER_XML)
+        .withProperty(REDUNDANCY_ZONE, zone)
+        .withConnectionToLocator(locatorPort));
   }
 
-  private RebalanceResults doRebalance(boolean simulate, ResourceManager manager)
-      throws TimeoutException, InterruptedException {
-    return doRebalance(simulate, manager, null, null);
-  }
 
-  private RebalanceResults doRebalance(boolean simulate, ResourceManager manager,
-      Set<String> includes, Set<String> excludes)
+  private void doRebalance(ResourceManager manager)
       throws TimeoutException, InterruptedException {
-    RebalanceResults results;
-    if (simulate) {
-      results = manager.createRebalanceFactory().includeRegions(includes).excludeRegions(excludes)
-          .simulate().getResults(TIMEOUT_SECONDS, SECONDS);
-    } else {
-      results = manager.createRebalanceFactory().includeRegions(includes).excludeRegions(excludes)
-          .start().getResults(TIMEOUT_SECONDS, SECONDS);
-    }
+    manager.createRebalanceFactory()
+        .start().getResults(TIMEOUT_SECONDS, SECONDS);
     assertThat(manager.getRebalanceOperations()).isEmpty();
-    return results;
   }
+
+
+  private void compareZoneBucketCounts(final String regionName) {
+    int zoneABucketCount = getZoneBucketCount(regionName, ZONE_A);
+    int zoneBBucketCount = getZoneBucketCount(regionName, ZONE_B);
+
+    assertThat(zoneABucketCount).isEqualTo(zoneBBucketCount).isEqualTo(EXPECTED_BUCKET_COUNT);
+  }
+
+
+  private int getZoneBucketCount(String regionName, String zoneName) {
+    int bucketCount = 0;
+    for (Map.Entry<Integer, String> entry : SERVER_ZONE_MAP.entrySet()) {
+      if (entry.getValue().compareTo(zoneName) == 0) {
+        bucketCount +=
+            clusterStartupRule.getVM(entry.getKey()).invoke(() -> getBucketCount(regionName));
+      }
+    }
+    return bucketCount;
+  }
+
 
   private int getBucketCount(String regionName) {
     PartitionedRegion region =

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.geode.distributed.ConfigurationProperties.REDUNDANCY_ZONE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+
+import junitparams.JUnitParamsRunner;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.control.RebalanceResults;
+import org.apache.geode.cache.control.ResourceManager;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.dunit.cache.CacheTestCase;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+
+/**
+ * TODO test colocated regions where buckets aren't created for all subregions
+ *
+ * <p>
+ * TODO test colocated regions where members aren't consistent in which regions they have
+ */
+@RunWith(JUnitParamsRunner.class)
+@SuppressWarnings("serial")
+public class RebalanceOperationComplexDistributedTest extends CacheTestCase {
+
+  private static final long TIMEOUT_SECONDS = GeodeAwaitility.getTimeout().getValue();
+  public static final String CLIENT_XML =
+      "RebalanceOperationComplex-client.xml";
+  public static final String SERVER_XML =
+      "RebalanceOperationComplex-server.xml";
+  public static final String REGION_NAME = "primary";
+  public static final String COLOCATED_REGION_NAME = "colocated";
+
+  @Rule
+  public ClusterStartupRule clusterStartupRule = new ClusterStartupRule(8);
+
+  private MemberVM startServer(int index, String zone, int locatorPort) {
+    return clusterStartupRule.startServerVM(index, s -> s.withProperty("cache-xml-file",
+        SERVER_XML)
+        .withProperty(REDUNDANCY_ZONE, zone)
+        .withConnectionToLocator(locatorPort));
+  }
+
+  /**
+   * Test that we correctly use the redundancy-zone property to determine where to place redundant
+   * copies of a buckets and doesn't allow cross redundancy zone deletes.
+   */
+  @Test
+  public void testEnforceZoneWithSixServersAndTwoZones() throws Exception {
+    MemberVM locatorVM = clusterStartupRule.startLocatorVM(0);
+
+    // So startup six servers 3 in each redundancy zone
+    MemberVM server1 = startServer(1, "zoneA", locatorVM.getPort());
+    startServer(2, "zoneA", locatorVM.getPort());
+    startServer(3, "zoneA", locatorVM.getPort());
+    startServer(4, "zoneB", locatorVM.getPort());
+    startServer(5, "zoneB", locatorVM.getPort());
+    startServer(6, "zoneB", locatorVM.getPort());
+
+
+    // startup a client to put all the data.
+    Properties properties2 = new Properties();
+    properties2.setProperty("cache-xml-file",
+        CLIENT_XML);
+    ClientVM clientVM =
+        clusterStartupRule.startClientVM(7, properties2,
+            ccf -> ccf.addPoolLocator("localhost", locatorVM.getPort()));
+
+    clientVM.invoke(() -> {
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Map<Integer, String> map = new HashMap<>();
+      for (int i = 0; i < 1000; i++) {
+        map.put(i, "A");
+      }
+      Region<Integer, String> region =
+          clientCache.getRegion(REGION_NAME);
+      region.putAll(map);
+      Region<Integer, String> region2 =
+          clientCache.getRegion(COLOCATED_REGION_NAME);
+      region2.putAll(map);
+    });
+
+    // Baseline rebalance with everything up
+    server1.invoke(() -> {
+      doRebalance(false, ClusterStartupRule.getCache().getResourceManager());
+    });
+
+    // knock server 2 offline
+    clusterStartupRule.stop(2);
+
+    // rebalance so that now all the buckets are one server 1 and server 3 reduncancy zone b servers
+    // should not be touched.
+    server1.invoke(() -> {
+      doRebalance(false, ClusterStartupRule.getCache().getResourceManager());
+    });
+
+    // bring server 2 backonline
+    startServer(2, "zoneA", locatorVM.getPort());
+
+    // do another rebalance to make sure all the buckets are distributed evenly(ish) and there is no
+    // cross redundancy zone bucket deletions.
+    server1.invoke(() -> {
+      doRebalance(false, ClusterStartupRule.getCache().getResourceManager());
+    });
+
+    // Verify that all bucket counts add up to what they should
+    compareZoneBucketCounts(COLOCATED_REGION_NAME);
+    compareZoneBucketCounts(REGION_NAME);
+  }
+
+  private void compareZoneBucketCounts(final String regionName) {
+    int zoneA = clusterStartupRule.getVM(1).invoke(() -> getBucketCount(regionName));
+    zoneA += clusterStartupRule.getVM(2).invoke(() -> getBucketCount(regionName));
+    zoneA += clusterStartupRule.getVM(3).invoke(() -> getBucketCount(regionName));
+
+    int zoneB = clusterStartupRule.getVM(4).invoke(() -> getBucketCount(regionName));
+    zoneB += clusterStartupRule.getVM(5).invoke(() -> getBucketCount(regionName));
+    zoneB += clusterStartupRule.getVM(6).invoke(() -> getBucketCount(regionName));
+
+    assertThat(zoneA).isEqualTo(zoneB).isEqualTo(113);
+  }
+
+  private RebalanceResults doRebalance(boolean simulate, ResourceManager manager)
+      throws TimeoutException, InterruptedException {
+    return doRebalance(simulate, manager, null, null);
+  }
+
+  private RebalanceResults doRebalance(boolean simulate, ResourceManager manager,
+      Set<String> includes, Set<String> excludes)
+      throws TimeoutException, InterruptedException {
+    RebalanceResults results;
+    if (simulate) {
+      results = manager.createRebalanceFactory().includeRegions(includes).excludeRegions(excludes)
+          .simulate().getResults(TIMEOUT_SECONDS, SECONDS);
+    } else {
+      results = manager.createRebalanceFactory().includeRegions(includes).excludeRegions(excludes)
+          .start().getResults(TIMEOUT_SECONDS, SECONDS);
+    }
+    assertThat(manager.getRebalanceOperations()).isEmpty();
+    return results;
+  }
+
+  private int getBucketCount(String regionName) {
+    PartitionedRegion region =
+        (PartitionedRegion) ClusterStartupRule.getCache().getRegion(regionName);
+    return region.getLocalBucketsListTestOnly().size();
+  }
+}

--- a/geode-core/src/distributedTest/resources/org/apache/geode/internal/cache/RebalanceOperationComplex-client.xml
+++ b/geode-core/src/distributedTest/resources/org/apache/geode/internal/cache/RebalanceOperationComplex-client.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE client-cache PUBLIC
+  "-//GemStone Systems, Inc.//GemFire Declarative Caching 7.0//EN"
+  "http://www.gemstone.com/dtd/cache7_0.dtd">
+  
+<client-cache>
+  <pdx read-serialized="true">
+    <pdx-serializer>
+      <class-name>org.apache.geode.pdx.ReflectionBasedAutoSerializer</class-name>
+      <parameter name="classes">
+        <string>.*</string>
+      </parameter>
+    </pdx-serializer>
+  </pdx>
+  <region name="primary" refid="PROXY"/>
+  <region name="colocated" refid="PROXY"/>
+</client-cache>

--- a/geode-core/src/distributedTest/resources/org/apache/geode/internal/cache/RebalanceOperationComplex-server.xml
+++ b/geode-core/src/distributedTest/resources/org/apache/geode/internal/cache/RebalanceOperationComplex-server.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<cache
+  xmlns="http://geode.apache.org/schema/cache"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://geode.apache.org/schema/cache
+                      http://geode.apache.org/schema/cache/cache-1.0.xsd"
+  version="1.0">
+  
+  <cache-server port="0"/>
+  
+  <pdx read-serialized="false" persistent="true">
+    <pdx-serializer>
+      <class-name>org.apache.geode.pdx.ReflectionBasedAutoSerializer</class-name>
+      <parameter name="classes">
+        <string>.*</string>
+      </parameter>
+    </pdx-serializer>
+  </pdx>
+
+  <region name="primary" refid="PARTITION_REDUNDANT_PERSISTENT">
+    <region-attributes>
+      <partition-attributes total-num-buckets="113" redundant-copies="1" recovery-delay="-1" startup-recovery-delay="-1"/>
+    </region-attributes>
+  </region>
+
+  <region name="colocated" refid="PARTITION_REDUNDANT_PERSISTENT">
+    <region-attributes>
+      <partition-attributes colocated-with="primary" total-num-buckets="113" redundant-copies="1" recovery-delay="-1" startup-recovery-delay="-1"/>
+    </region-attributes>
+  </region>
+
+</cache>

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -215,6 +215,26 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
             "RegionStats-partition-" + pr.getName(), pr.getCachePerfStats(), pr,
             pr.getCache().getMeterRegistry(), statisticsClock);
     this.keysOfInterest = new ConcurrentHashMap();
+    launchBucketIdsLogThread();
+  }
+
+  private void launchBucketIdsLogThread() {
+    new Thread(() -> logBucketIds()).start();
+  }
+
+  private void logBucketIds() {
+    List<Integer> previousBucketIdsList = Collections.emptyList(), currentBucketIdsList;
+    while (true) {
+      currentBucketIdsList = new ArrayList<>(getAllLocalBucketIds());
+      Collections.sort(currentBucketIdsList);
+      if (!currentBucketIdsList.equals(previousBucketIdsList)) {
+        previousBucketIdsList = currentBucketIdsList;
+      }
+      try {
+        Thread.sleep(2000);
+      } catch (Exception e) {
+      }
+    }
   }
 
   /**
@@ -793,6 +813,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
               .setPartitionedRegion(this.partitionedRegion)
               .setIndexes(getIndexes(rootRegion.getFullPath(), bucketRegionName)));
       this.partitionedRegion.getPrStats().incBucketCount(1);
+      // new Exception());
     } catch (RegionExistsException ex) {
       // Bucket Region is already created, so do nothing.
       if (logger.isDebugEnabled()) {
@@ -1644,6 +1665,7 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
       }
       this.localBucket2RegionMap.remove(Integer.valueOf(bucketId));
       this.partitionedRegion.getPrStats().incBucketCount(-1);
+      // new Exception());
       return true;
     } finally {
       lock.unlock();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegionDataStore.java
@@ -215,26 +215,6 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
             "RegionStats-partition-" + pr.getName(), pr.getCachePerfStats(), pr,
             pr.getCache().getMeterRegistry(), statisticsClock);
     this.keysOfInterest = new ConcurrentHashMap();
-    launchBucketIdsLogThread();
-  }
-
-  private void launchBucketIdsLogThread() {
-    new Thread(() -> logBucketIds()).start();
-  }
-
-  private void logBucketIds() {
-    List<Integer> previousBucketIdsList = Collections.emptyList(), currentBucketIdsList;
-    while (true) {
-      currentBucketIdsList = new ArrayList<>(getAllLocalBucketIds());
-      Collections.sort(currentBucketIdsList);
-      if (!currentBucketIdsList.equals(previousBucketIdsList)) {
-        previousBucketIdsList = currentBucketIdsList;
-      }
-      try {
-        Thread.sleep(2000);
-      } catch (Exception e) {
-      }
-    }
   }
 
   /**
@@ -813,7 +793,6 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
               .setPartitionedRegion(this.partitionedRegion)
               .setIndexes(getIndexes(rootRegion.getFullPath(), bucketRegionName)));
       this.partitionedRegion.getPrStats().incBucketCount(1);
-      // new Exception());
     } catch (RegionExistsException ex) {
       // Bucket Region is already created, so do nothing.
       if (logger.isDebugEnabled()) {
@@ -845,15 +824,6 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
       dumpBuckets();
       dumpBucket(bucketId, bucketRegion);
     }
-
-    // Iterator i = localRegion.entrySet().iterator();
-    // while (i.hasNext()) {
-    // try {
-    // NonTXEntry nte = (NonTXEntry) i.next();
-    // // updateBucket2Size(bucketId.longValue(), localRegion, null);
-    // // nte.getRegionEntry().getValueInVM();
-    // } catch (EntryDestroyedException ignore) {}
-    // }
 
     return bucketRegion;
   }
@@ -1665,7 +1635,6 @@ public class PartitionedRegionDataStore implements HasCachePerfStats {
       }
       this.localBucket2RegionMap.remove(Integer.valueOf(bucketId));
       this.partitionedRegion.getPrStats().incBucketCount(-1);
-      // new Exception());
       return true;
     } finally {
       lock.unlock();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/PartitionRebalanceDetailsImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/PartitionRebalanceDetailsImpl.java
@@ -47,6 +47,27 @@ public class PartitionRebalanceDetailsImpl
   private final transient PartitionedRegion region;
   private long time;
 
+  @Override
+  public String toString() {
+    return "PartitionRebalanceDetailsImpl{" +
+        "bucketCreateBytes=" + bucketCreateBytes +
+        ", bucketCreateTime=" + bucketCreateTime +
+        ", bucketCreatesCompleted=" + bucketCreatesCompleted +
+        ", bucketRemoveBytes=" + bucketRemoveBytes +
+        ", bucketRemoveTime=" + bucketRemoveTime +
+        ", bucketRemovesCompleted=" + bucketRemovesCompleted +
+        ", bucketTransferBytes=" + bucketTransferBytes +
+        ", bucketTransferTime=" + bucketTransferTime +
+        ", bucketTransfersCompleted=" + bucketTransfersCompleted +
+        ", partitionMemberDetailsAfter=" + partitionMemberDetailsAfter +
+        ", partitionMemberDetailsBefore=" + partitionMemberDetailsBefore +
+        ", primaryTransferTime=" + primaryTransferTime +
+        ", primaryTransfersCompleted=" + primaryTransfersCompleted +
+        ", region=" + region +
+        ", time=" + time +
+        '}';
+  }
+
   public PartitionRebalanceDetailsImpl(PartitionedRegion region) {
     this.region = region;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
@@ -210,7 +210,7 @@ public class PartitionedRegionRebalanceOp {
           membershipChange = false;
           // refetch the partitioned region details after
           // a membership change.
-          logger.debug("Rebalancing {} detected membership changes. Refetching details",
+          debug("Rebalancing {} detected membership changes. Refetching details",
               leaderRegion);
           if (this.stats != null) {
             this.stats.incRebalanceMembershipChanges(1);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
@@ -210,7 +210,8 @@ public class PartitionedRegionRebalanceOp {
           membershipChange = false;
           // refetch the partitioned region details after
           // a membership change.
-          debug("Rebalancing {} detected membership changes. Refetching details", leaderRegion);
+          logger.debug("Rebalancing {} detected membership changes. Refetching details",
+              leaderRegion);
           if (this.stats != null) {
             this.stats.incRebalanceMembershipChanges(1);
           }
@@ -283,9 +284,8 @@ public class PartitionedRegionRebalanceOp {
     // Early out of this VM doesn't have all of the regions that are
     // supposed to be colocated with this one.
     // TODO rebalance - there is a race here between this check and the
-    // earlier acquisition of the list
-    // of colocated regions. Really we should get a list of all colocated
-    // regions on all nodes.
+    // earlier acquisition of the list of colocated regions. Really we
+    // should get a list of all colocated regions on all nodes.
     if (!ColocationHelper.checkMembersColocation(leaderRegion,
         leaderRegion.getDistributionManager().getDistributionManagerId())) {
       return false;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
@@ -62,22 +62,19 @@ public class Member implements Comparable<Member> {
 
 
 
-  /**
-   * @param sourceMember the member we will be moving this bucket off of
-   * @param checkZone true if we should not put two copies of a bucket on two nodes with the same
-   */
-  public RefusalReason canDelete(Bucket bucket, InternalDistributedMember sourceMember,
-      boolean checkZone,
-      DistributionManager distributionManager) {
+  public RefusalReason canDelete(Bucket bucket, DistributionManager distributionManager) {
     if (distributionManager instanceof ClusterDistributionManager) {
       ClusterDistributionManager clusterDistributionManager =
           (ClusterDistributionManager) distributionManager;
       String myRedundancyZone = clusterDistributionManager.getRedundancyZone(memberId);
       boolean notLastMemberOfZone = false;
+
       for (Member member : bucket.getMembersHosting()) {
         if (!member.getMemberId().equals(this.getMemberId())) {
+
           String memberRedundancyZone =
               clusterDistributionManager.getRedundancyZone(member.memberId);
+
           if (memberRedundancyZone.equals(myRedundancyZone)) {
             notLastMemberOfZone = true;
           }
@@ -249,7 +246,7 @@ public class Member implements Comparable<Member> {
   }
 
   void changeTotalBytes(float change) {
-    totalBytes += (long) Math.round(change);
+    totalBytes += Math.round(change);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
@@ -60,6 +60,31 @@ public class Member implements Comparable<Member> {
    * @param checkZone true if we should not put two copies of a bucket on two nodes with the same
    *        IP address.
    */
+  public RefusalReason canDelete(Bucket bucket, InternalDistributedMember sourceMember,
+      boolean checkZone) {
+    // Check the ip address
+    if (checkZone) {
+      if (addressComparor.enforceUniqueZones()
+          && !addressComparor.areSameZone(getMemberId(), sourceMember)) {
+        logger.debug(
+            "Member {} would prefer not to delete {} because on {}",
+            getMemberId(), bucket, sourceMember);
+        return RefusalReason.DIFFERENT_ZONE;
+      } else {
+        logger.debug(
+            "Member {} will delete  {} because it is already on another member with the same redundancy zone",
+            this, bucket);
+      }
+    }
+    return RefusalReason.NONE;
+  }
+
+
+  /**
+   * @param sourceMember the member we will be moving this bucket off of
+   * @param checkZone true if we should not put two copies of a bucket on two nodes with the same
+   *        IP address.
+   */
   public RefusalReason willAcceptBucket(Bucket bucket, Member sourceMember, boolean checkZone) {
     // make sure this member is not already hosting this bucket
     if (getBuckets().contains(bucket)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
@@ -71,12 +71,15 @@ public class Member implements Comparable<Member> {
 
       for (Member member : bucket.getMembersHosting()) {
         if (!member.getMemberId().equals(this.getMemberId())) {
-
           String memberRedundancyZone =
               clusterDistributionManager.getRedundancyZone(member.memberId);
-
-          if (memberRedundancyZone.equals(myRedundancyZone)) {
-            notLastMemberOfZone = true;
+          if (memberRedundancyZone != null) {
+            if (memberRedundancyZone.equals(myRedundancyZone)) {
+              notLastMemberOfZone = true;
+            }
+          } else {
+            // Not using redundancy zones, so...
+            return RefusalReason.NONE;
           }
         }
       }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/Member.java
@@ -19,6 +19,7 @@ import java.util.TreeSet;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
@@ -40,7 +41,9 @@ public class Member implements Comparable<Member> {
   private final boolean isCritical;
   private final boolean enforceLocalMaxMemory;
 
-  Member(AddressComparor addressComparor, InternalDistributedMember memberId, boolean isCritical,
+  @VisibleForTesting
+  public Member(AddressComparor addressComparor, InternalDistributedMember memberId,
+      boolean isCritical,
       boolean enforceLocalMaxMemory) {
     this.addressComparor = addressComparor;
     this.memberId = memberId;
@@ -67,7 +70,7 @@ public class Member implements Comparable<Member> {
       if (addressComparor.enforceUniqueZones()
           && !addressComparor.areSameZone(getMemberId(), sourceMember)) {
         logger.debug(
-            "Member {} would prefer not to delete {} because on {}",
+            "Member {} cannot delete {} because it is in a different redundancy zone than {}",
             getMemberId(), bucket, sourceMember);
         return RefusalReason.DIFFERENT_ZONE;
       } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
@@ -297,7 +297,7 @@ public class PartitionedRegionLoadModel {
               new Object[] {memberRollup, this.allColocatedRegions,
                   memberRollup.getColocatedMembers().keySet(), memberRollup.getBuckets()});
         }
-        for (Bucket bucket : new HashSet<Bucket>(memberRollup.getBuckets())) {
+        for (Bucket bucket : new HashSet<>(memberRollup.getBuckets())) {
           bucket.removeMember(memberRollup);
         }
       }
@@ -475,8 +475,7 @@ public class PartitionedRegionLoadModel {
     Move bestMove = null;
 
     for (Member member : bucket.getMembersHosting()) {
-      if (member.canDelete(bucket, this.partitionedRegion.getMyId(), true,
-          partitionedRegion.getDistributionManager()).willAccept()) {
+      if (member.canDelete(bucket, partitionedRegion.getDistributionManager()).willAccept()) {
         float newLoad = (member.getTotalLoad() - bucket.getLoad()) / member.getWeight();
         if (newLoad > mostLoaded && !member.equals(bucket.getPrimary())) {
           Move move = new Move(null, member, bucket);
@@ -491,8 +490,8 @@ public class PartitionedRegionLoadModel {
   }
 
   public Move findBestTargetForFPR(Bucket bucket, boolean checkIPAddress) {
-    InternalDistributedMember targetMemberID = null;
-    Member targetMember = null;
+    InternalDistributedMember targetMemberID;
+    Member targetMember;
     List<FixedPartitionAttributesImpl> fpas =
         this.partitionedRegion.getFixedPartitionAttributesImpl();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
@@ -125,9 +125,13 @@ public class PartitionedRegionLoadModel {
   private final BucketOperator operator;
   private final int requiredRedundancy;
 
-  /** The average primary load on a member */
+  /**
+   * The average primary load on a member
+   */
   private float primaryAverage = -1;
-  /** The average bucket load on a member */
+  /**
+   * The average bucket load on a member
+   */
   private float averageLoad = -1;
   /**
    * The minimum improvement in variance that we'll consider worth moving a primary
@@ -151,7 +155,8 @@ public class PartitionedRegionLoadModel {
    * @param redundancyLevel The expected redundancy level for the region
    */
   public PartitionedRegionLoadModel(BucketOperator operator, int redundancyLevel, int numBuckets,
-      AddressComparor addressComparor, Set<InternalDistributedMember> criticalMembers,
+      AddressComparor addressComparor,
+      Set<InternalDistributedMember> criticalMembers,
       PartitionedRegion region) {
     this.operator = operator;
     this.requiredRedundancy = redundancyLevel;
@@ -360,8 +365,8 @@ public class PartitionedRegionLoadModel {
    *
    * This method will find the best node to create a redundant bucket and invoke the bucket operator
    * to create a bucket on that node. Because the bucket operator is asynchronous, the bucket may
-   * not be created immediately, but the model will be updated regardless. Invoke
-   * {@link #waitForOperations()} to wait for those operations to actually complete
+   * not be created immediately, but the model will be updated regardless. Invoke {@link
+   * #waitForOperations()} to wait for those operations to actually complete
    */
   public void createRedundantBucket(final BucketRollup bucket, final Member targetMember) {
     Map<String, Long> colocatedRegionSizes = getColocatedRegionSizes(bucket);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
@@ -470,12 +470,14 @@ public class PartitionedRegionLoadModel {
     Move bestMove = null;
 
     for (Member member : bucket.getMembersHosting()) {
-      float newLoad = (member.getTotalLoad() - bucket.getLoad()) / member.getWeight();
-      if (newLoad > mostLoaded && !member.equals(bucket.getPrimary())) {
-        Move move = new Move(null, member, bucket);
-        if (!this.attemptedBucketRemoves.contains(move)) {
-          mostLoaded = newLoad;
-          bestMove = move;
+      if (member.canDelete(bucket, this.partitionedRegion.getMyId(), true).willAccept()) {
+        float newLoad = (member.getTotalLoad() - bucket.getLoad()) / member.getWeight();
+        if (newLoad > mostLoaded && !member.equals(bucket.getPrimary())) {
+          Move move = new Move(null, member, bucket);
+          if (!this.attemptedBucketRemoves.contains(move)) {
+            mostLoaded = newLoad;
+            bestMove = move;
+          }
         }
       }
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/PartitionedRegionLoadModel.java
@@ -475,7 +475,8 @@ public class PartitionedRegionLoadModel {
     Move bestMove = null;
 
     for (Member member : bucket.getMembersHosting()) {
-      if (member.canDelete(bucket, this.partitionedRegion.getMyId(), true).willAccept()) {
+      if (member.canDelete(bucket, this.partitionedRegion.getMyId(), true,
+          partitionedRegion.getDistributionManager()).willAccept()) {
         float newLoad = (member.getTotalLoad() - bucket.getLoad()) / member.getWeight();
         if (newLoad > mostLoaded && !member.equals(bucket.getPrimary())) {
           Move move = new Move(null, member, bucket);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/RefusalReason.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/RefusalReason.java
@@ -15,7 +15,13 @@
 package org.apache.geode.internal.cache.partitioned.rebalance.model;
 
 public enum RefusalReason {
-  NONE, ALREADY_HOSTING, UNITIALIZED_MEMBER, SAME_ZONE, LOCAL_MAX_MEMORY_FULL, CRITICAL_HEAP;
+  NONE,
+  ALREADY_HOSTING,
+  UNITIALIZED_MEMBER,
+  SAME_ZONE,
+  DIFFERENT_ZONE,
+  LOCAL_MAX_MEMORY_FULL,
+  CRITICAL_HEAP;
 
   public boolean willAccept() {
     return this == NONE;
@@ -42,6 +48,11 @@ public enum RefusalReason {
       case CRITICAL_HEAP:
         return "Target member " + target.getMemberId()
             + " has reached its critical heap percentage, and cannot accept more data";
+      case DIFFERENT_ZONE:
+        return "Target member " + target.getMemberId()
+            + " is in a different redundancy zone than other members hosting bucket "
+            + bucket.getId()
+            + ": " + bucket.getMembersHosting();
       default:
         return this.toString();
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/RefusalReason.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/rebalance/model/RefusalReason.java
@@ -19,7 +19,7 @@ public enum RefusalReason {
   ALREADY_HOSTING,
   UNITIALIZED_MEMBER,
   SAME_ZONE,
-  DIFFERENT_ZONE,
+  LAST_MEMBER_IN_ZONE,
   LOCAL_MAX_MEMORY_FULL,
   CRITICAL_HEAP;
 
@@ -48,9 +48,9 @@ public enum RefusalReason {
       case CRITICAL_HEAP:
         return "Target member " + target.getMemberId()
             + " has reached its critical heap percentage, and cannot accept more data";
-      case DIFFERENT_ZONE:
+      case LAST_MEMBER_IN_ZONE:
         return "Target member " + target.getMemberId()
-            + " is in a different redundancy zone than other members hosting bucket "
+            + " is the last member of redundancy zone for the bucket "
             + bucket.getId()
             + ": " + bucket.getMembersHosting();
       default:

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/MemberTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/MemberTest.java
@@ -81,4 +81,27 @@ public class MemberTest {
         .isEqualTo(RefusalReason.LAST_MEMBER_IN_ZONE);
   }
 
+
+  @Test
+  public void testCanDeleteWhenNoZone() {
+    doReturn(true).when(addressComparor).enforceUniqueZones();
+    doReturn(true).when(addressComparor).areSameZone(
+        ArgumentMatchers.any(InternalDistributedMember.class),
+        ArgumentMatchers.any(InternalDistributedMember.class));
+    Set<Member> membersHostingBucket = new HashSet<>();
+    Bucket bucket = mock(Bucket.class);
+    ClusterDistributionManager clusterDistributionManager = mock(ClusterDistributionManager.class);
+    Member memberUnderTest = new Member(addressComparor, memberId, false, false);
+    Member otherMember = new Member(addressComparor, otherMemberId, false, false);
+    membersHostingBucket.add(memberUnderTest);
+    membersHostingBucket.add(otherMember);
+    when(bucket.getMembersHosting()).thenReturn(membersHostingBucket);
+
+    Mockito.when(clusterDistributionManager.getRedundancyZone(memberId)).thenReturn(null);
+    Mockito.when(clusterDistributionManager.getRedundancyZone(otherMemberId)).thenReturn(null);
+
+    assertThat(memberUnderTest.canDelete(bucket, clusterDistributionManager))
+        .isEqualTo(RefusalReason.NONE);
+  }
+
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/MemberTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/MemberTest.java
@@ -79,8 +79,8 @@ public class MemberTest {
         ArgumentMatchers.any(InternalDistributedMember.class),
         ArgumentMatchers.any(InternalDistributedMember.class));
     Bucket bucket = mock(Bucket.class);
-    Member memberUnderTest = new Member(addressComparor, memberId, true, true);
-    Member sourceMember = new Member(addressComparor, sourceId, true, true);
+    Member memberUnderTest = new Member(addressComparor, memberId, false, false);
+    Member sourceMember = new Member(addressComparor, sourceId, false, false);
 
     assertThat(memberUnderTest.willAcceptBucket(bucket, null, true)).isEqualTo(RefusalReason.NONE);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/MemberTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/MemberTest.java
@@ -53,7 +53,7 @@ public class MemberTest {
     Bucket bucket = mock(Bucket.class);
     Member memberUnderTest = new Member(addressComparor, memberId, false, false);
     assertThat(memberUnderTest.canDelete(bucket, sourceId, true))
-        .isEqualTo(RefusalReason.DIFFERENT_ZONE);
+        .isEqualTo(RefusalReason.LAST_MEMBER_IN_ZONE);
   }
 
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/MemberTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/MemberTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.partitioned.rebalance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+import org.mockito.ArgumentMatchers;
+
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.cache.partitioned.rebalance.model.AddressComparor;
+import org.apache.geode.internal.cache.partitioned.rebalance.model.Bucket;
+import org.apache.geode.internal.cache.partitioned.rebalance.model.Member;
+import org.apache.geode.internal.cache.partitioned.rebalance.model.RefusalReason;
+
+public class MemberTest {
+  AddressComparor addressComparor = mock(AddressComparor.class);
+  InternalDistributedMember memberId = mock(InternalDistributedMember.class);
+  InternalDistributedMember sourceId = mock(InternalDistributedMember.class);
+
+  @Test
+  public void testCanDeleteWhenInSameZone() {
+    doReturn(true).when(addressComparor).enforceUniqueZones();
+    doReturn(true).when(addressComparor).areSameZone(
+        ArgumentMatchers.any(InternalDistributedMember.class),
+        ArgumentMatchers.any(InternalDistributedMember.class));
+    Bucket bucket = mock(Bucket.class);
+    Member memberUnderTest = new Member(addressComparor, memberId, false, false);
+    assertThat(memberUnderTest.canDelete(bucket, sourceId, true)).isEqualTo(RefusalReason.NONE);
+  }
+
+
+  @Test
+  public void testCanDeleteWhenInDifferentZone() {
+    doReturn(true).when(addressComparor).enforceUniqueZones();
+    doReturn(false).when(addressComparor).areSameZone(
+        ArgumentMatchers.any(InternalDistributedMember.class),
+        ArgumentMatchers.any(InternalDistributedMember.class));
+    Bucket bucket = mock(Bucket.class);
+    Member memberUnderTest = new Member(addressComparor, memberId, false, false);
+    assertThat(memberUnderTest.canDelete(bucket, sourceId, true))
+        .isEqualTo(RefusalReason.DIFFERENT_ZONE);
+  }
+
+
+  @Test
+  public void testWillAcceptBucket() {
+    doReturn(true).when(addressComparor).enforceUniqueZones();
+    doReturn(true).when(addressComparor).areSameZone(
+        ArgumentMatchers.any(InternalDistributedMember.class),
+        ArgumentMatchers.any(InternalDistributedMember.class));
+    Bucket bucket = mock(Bucket.class);
+    Member memberUnderTest = new Member(addressComparor, memberId, false, false);
+    Member sourceMember = new Member(addressComparor, sourceId, false, false);
+
+    assertThat(memberUnderTest.willAcceptBucket(bucket, sourceMember, true))
+        .isEqualTo(RefusalReason.NONE);
+
+  }
+
+  @Test
+  public void testWillAcceptBucketWithNullSourceMember() {
+    doReturn(true).when(addressComparor).enforceUniqueZones();
+    doReturn(true).when(addressComparor).areSameZone(
+        ArgumentMatchers.any(InternalDistributedMember.class),
+        ArgumentMatchers.any(InternalDistributedMember.class));
+    Bucket bucket = mock(Bucket.class);
+    Member memberUnderTest = new Member(addressComparor, memberId, true, true);
+    Member sourceMember = new Member(addressComparor, sourceId, true, true);
+
+    assertThat(memberUnderTest.willAcceptBucket(bucket, null, true)).isEqualTo(RefusalReason.NONE);
+
+  }
+
+
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/RemoteDUnitVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/RemoteDUnitVM.java
@@ -49,13 +49,13 @@ class RemoteDUnitVM extends UnicastRemoteObject implements RemoteDUnitVMIF {
   }
 
   protected long start(String name) {
-    logger.info("Received method: {}", name);
+    logger.debug("Received method: {}", name);
     return System.nanoTime();
   }
 
   private void logDelta(String name, long start, MethodInvokerResult result) {
     long delta = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-    logger.info("Got result: {} from {} (took {} ms)", result, name, delta);
+    logger.debug("Got result: {} from {} (took {} ms)", result, name, delta);
   }
 
   /**

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/RemoteDUnitVM.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/RemoteDUnitVM.java
@@ -49,13 +49,13 @@ class RemoteDUnitVM extends UnicastRemoteObject implements RemoteDUnitVMIF {
   }
 
   protected long start(String name) {
-    logger.debug("Received method: {}", name);
+    logger.info("Received method: {}", name);
     return System.nanoTime();
   }
 
   private void logDelta(String name, long start, MethodInvokerResult result) {
     long delta = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
-    logger.debug("Got result: {} from {} (took {} ms)", result, name, delta);
+    logger.info("Got result: {} from {} (took {} ms)", result, name, delta);
   }
 
   /**


### PR DESCRIPTION
Fixed the issue, by not allowing the last member in a redundancy zone to be deleted during a rebase when deleting duplicate buckets.