### PR TITLE
GEODE-9532: Register LongWrapperSerializer before Region.put() (#6799)

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
@@ -3814,6 +3814,19 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
         createRegion(name);
       });
 
+      // Make sure vm0 and vm1 have both registered the LongWrapperSerializer after vm2 reconnects
+      // and before vm2 puts any instance of LongWrapper in the region
+      // This is to avoid async disk store FlusherThread serializing any instance of LongWrapper
+      // before the LongWrapperSerializer is registered
+      vm0.invoke(() -> {
+        waitForLongWrapperSerializerRegistration();
+      });
+
+      vm1.invoke(() -> {
+        // see the comments in "get" CacheSerializableRunnable above
+        waitForLongWrapperSerializerRegistration();
+      });
+
       vm2.invoke("Put long", () -> {
         Region<Object, Object> region = getRootRegion().getSubregion(name);
         region.put(key2, new LongWrapper(longValue));
@@ -3845,6 +3858,18 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
     } finally {
       Wait.pause(1500);
       unregisterAllSerializers();
+    }
+  }
+
+  private void waitForLongWrapperSerializerRegistration() {
+    // see the comments in "get" CacheSerializableRunnable in testNoDataSerializer()
+    final int savVal = InternalDataSerializer.GetMarker.WAIT_MS;
+    InternalDataSerializer.GetMarker.WAIT_MS = 1;
+    try {
+      await("DataSerializer with id 121 was never registered")
+          .until(() -> InternalDataSerializer.getSerializer((byte) 121) != null);
+    } finally {
+      InternalDataSerializer.GetMarker.WAIT_MS = savVal;
     }
   }
 


### PR DESCRIPTION
(cherry picked from commit 10abff6cb6722a56b03305251076c9c78e948dd3)

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
