### PR TITLE
GEODE-9585: adding support for the KEYSLOT command

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/cluster/ClusterSlotsAndNodesDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/cluster/ClusterSlotsAndNodesDUnitTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.executor.cluster;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_REGION_BUCKETS;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.data.redis.connection.ClusterSlotHashUtil.calculateSlot;
 
 import java.util.BitSet;
 import java.util.List;
@@ -293,6 +294,13 @@ public class ClusterSlotsAndNodesDUnitTest {
         ClusterNodes.parseClusterNodes(jedis1.clusterNodes()).getNodes();
 
     assertThat(nodesFromSlots).containsExactlyInAnyOrderElementsOf(nodesFromNodes);
+  }
+
+  @Test
+  public void keySlotOnServerMatchesClientSideHashing() {
+    assertThat(jedis1.clusterKeySlot("somekey")).isEqualTo(calculateSlot("somekey"));
+    assertThat(jedis1.clusterKeySlot("otherkey")).isEqualTo(calculateSlot("otherkey"));
+    assertThat(jedis1.clusterKeySlot("key{with}hash")).isEqualTo(calculateSlot("key{with}hash"));
   }
 
   private static void rebalanceAllRegions(MemberVM vm) {

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/cluster/AbstractClusterIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/cluster/AbstractClusterIntegrationTest.java
@@ -76,6 +76,7 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
     assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("with{borked{hashes}"))
         .isEqualTo(1058);
     assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("with{unmatched")).isEqualTo(10479);
+    assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("aaa}bbb{tag}ccc")).isEqualTo(8338);
     assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("withunmatchedright}"))
         .isEqualTo(10331);
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/cluster/AbstractClusterIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/cluster/AbstractClusterIntegrationTest.java
@@ -15,19 +15,25 @@
 
 package org.apache.geode.redis.internal.executor.cluster;
 
+import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 
 public abstract class AbstractClusterIntegrationTest implements RedisIntegrationTest {
+  private static final int NUM_KEYS_TO_TEST = 1000;
+  private static final int MAX_KEY_LENGTH = 255;
 
   private JedisCluster jedis;
 
@@ -43,26 +49,27 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
 
   @Test
   public void testCluster_givenWrongNumberOfArguments() {
-    assertThatThrownBy(() -> jedis.getConnectionFromSlot(0).sendCommand(Protocol.Command.CLUSTER))
+    final Jedis connection = jedis.getConnectionFromSlot(0);
+    assertThatThrownBy(() -> connection.sendCommand(Protocol.Command.CLUSTER))
         .hasMessage("ERR wrong number of arguments for 'cluster' command");
     assertThatThrownBy(
-        () -> jedis.getConnectionFromSlot(0).sendCommand(Protocol.Command.CLUSTER, "1", "2"))
+        () -> connection.sendCommand(Protocol.Command.CLUSTER, "1", "2"))
             .hasMessage(
                 "ERR Unknown subcommand or wrong number of arguments for '1'. Try CLUSTER HELP.");
     assertThatThrownBy(
-        () -> jedis.getConnectionFromSlot(0).sendCommand(Protocol.Command.CLUSTER, "SLOTS", "1"))
+        () -> connection.sendCommand(Protocol.Command.CLUSTER, "SLOTS", "1"))
             .hasMessage(
                 "ERR Unknown subcommand or wrong number of arguments for 'SLOTS'. Try CLUSTER HELP.");
     assertThatThrownBy(
-        () -> jedis.getConnectionFromSlot(0).sendCommand(Protocol.Command.CLUSTER, "NOTACOMMAND"))
+        () -> connection.sendCommand(Protocol.Command.CLUSTER, "NOTACOMMAND"))
             .hasMessage(
                 "ERR Unknown subcommand or wrong number of arguments for 'NOTACOMMAND'. Try CLUSTER HELP.");
     assertThatThrownBy(
-        () -> jedis.getConnectionFromSlot(0).sendCommand(Protocol.Command.CLUSTER, "KEYSLOT"))
+        () -> connection.sendCommand(Protocol.Command.CLUSTER, "KEYSLOT"))
             .hasMessage(
                 "ERR Unknown subcommand or wrong number of arguments for 'KEYSLOT'. Try CLUSTER HELP.");
     assertThatThrownBy(
-        () -> jedis.getConnectionFromSlot(0).sendCommand(Protocol.Command.CLUSTER, "KEYSLOT",
+        () -> connection.sendCommand(Protocol.Command.CLUSTER, "KEYSLOT",
             "blah", "fo"))
                 .hasMessage(
                     "ERR Unknown subcommand or wrong number of arguments for 'KEYSLOT'. Try CLUSTER HELP.");
@@ -70,14 +77,24 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
 
   @Test
   public void keyslot_ReturnsCorrectSlot() {
-    assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("nohash")).isEqualTo(9072);
-    assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("with{hash}")).isEqualTo(238);
-    assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("with{two}{hashes}")).isEqualTo(2127);
-    assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("with{borked{hashes}"))
-        .isEqualTo(1058);
-    assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("with{unmatched")).isEqualTo(10479);
-    assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("aaa}bbb{tag}ccc")).isEqualTo(8338);
-    assertThat(jedis.getConnectionFromSlot(0).clusterKeySlot("withunmatchedright}"))
-        .isEqualTo(10331);
+    final Jedis connection = jedis.getConnectionFromSlot(0);
+    assertThat(connection.clusterKeySlot("nohash")).isEqualTo(9072);
+    assertThat(connection.clusterKeySlot("with{hash}")).isEqualTo(238);
+    assertThat(connection.clusterKeySlot("with{two}{hashes}")).isEqualTo(2127);
+    assertThat(connection.clusterKeySlot("with{borked{hashes}")).isEqualTo(1058);
+    assertThat(connection.clusterKeySlot("with{unmatched")).isEqualTo(10479);
+    assertThat(connection.clusterKeySlot("aaa}bbb{tag}ccc")).isEqualTo(8338);
+    assertThat(connection.clusterKeySlot("withunmatchedright}")).isEqualTo(10331);
+    assertThat(connection.clusterKeySlot("somekey")).isEqualTo(11058L);
+    assertThat(connection.clusterKeySlot("foo{hash_tag}")).isEqualTo(2515L);
+    assertThat(connection.clusterKeySlot("bar{hash_tag}")).isEqualTo(2515L);
+    assertThat(connection.clusterKeySlot("hash_tag")).isEqualTo(2515L);
+
+    for (int i = 0; i < NUM_KEYS_TO_TEST; i++) {
+      String key = RandomStringUtils.random(i % MAX_KEY_LENGTH + 1);
+      assertThat(connection.clusterKeySlot(key))
+          .withFailMessage("Failure for key %s", key)
+          .isEqualTo(JedisClusterCRC16.getCRC16(key) % (long) REDIS_SLOTS);
+    }
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -15,7 +15,7 @@ toData,15
 fromData,58
 
 org/apache/geode/redis/internal/data/RedisKey,2
-fromData,22
+fromData,19
 toData,19
 
 org/apache/geode/redis/internal/data/RedisSet,2

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -206,7 +206,7 @@ public class RegionProvider {
 
   private RedisDataMovedException createRedisDataMovedException(RedisKey key) {
     RedisMemberInfo memberInfo = getRedisMemberInfo(key);
-    Integer slot = key.getSlot();
+    int slot = key.getSlot();
     return new RedisDataMovedException(slot, memberInfo.getHostAddress(),
         memberInfo.getRedisPort());
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -206,7 +206,7 @@ public class RegionProvider {
 
   private RedisDataMovedException createRedisDataMovedException(RedisKey key) {
     RedisMemberInfo memberInfo = getRedisMemberInfo(key);
-    Integer slot = key.getCrc16() & (REDIS_SLOTS - 1);
+    Integer slot = key.getSlot();
     return new RedisDataMovedException(slot, memberInfo.getHostAddress(),
         memberInfo.getRedisPort());
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/KeyHashUtil.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/KeyHashUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.data;
+
+import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
+
+import org.apache.geode.redis.internal.executor.cluster.CRC16;
+
+/**
+ * Utility for parsing the hashtags in a redis key and computing the redis slot of the key.
+ */
+public class KeyHashUtil {
+
+  /**
+   * Compute the slot of a given redis key
+   *
+   * @return the slot, a value between 0 and 16K.
+   */
+  public static int slotForKey(byte[] value) {
+    int startHashtag = Integer.MAX_VALUE;
+    int endHashtag = 0;
+
+    for (int i = 0; i < value.length; i++) {
+      if (value[i] == '{' && startHashtag == Integer.MAX_VALUE) {
+        startHashtag = i;
+      } else if (value[i] == '}') {
+        endHashtag = i;
+        break;
+      }
+    }
+
+    if (endHashtag - startHashtag <= 1) {
+      startHashtag = -1;
+      endHashtag = value.length;
+    }
+
+    return CRC16.calculate(value, startHashtag + 1, endHashtag) & (REDIS_SLOTS - 1);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
@@ -32,7 +32,7 @@ import org.apache.geode.redis.internal.executor.cluster.RedisPartitionResolver;
 
 public class RedisKey implements DataSerializableFixedID {
 
-  private int slot;
+  private short slot;
   private byte[] value;
 
   public RedisKey() {}
@@ -43,7 +43,6 @@ public class RedisKey implements DataSerializableFixedID {
   }
 
   public int getBucketId() {
-    // & (REDIS_SLOTS - 1) is equivalent to % REDIS_SLOTS but supposedly faster
     return getSlot() / REDIS_SLOTS_PER_BUCKET;
   }
 
@@ -81,7 +80,7 @@ public class RedisKey implements DataSerializableFixedID {
   public void fromData(DataInput in, DeserializationContext context)
       throws IOException {
     // Need to convert a signed short to unsigned
-    slot = in.readShort() & 0xffff;
+    slot = in.readShort();
     value = DataSerializer.readByteArray(in);
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
@@ -79,7 +79,6 @@ public class RedisKey implements DataSerializableFixedID {
   @Override
   public void fromData(DataInput in, DeserializationContext context)
       throws IOException {
-    // Need to convert a signed short to unsigned
     slot = in.readShort();
     value = DataSerializer.readByteArray(in);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisKey.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.redis.internal.data;
 
-import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
@@ -29,41 +28,23 @@ import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.SerializationContext;
-import org.apache.geode.redis.internal.executor.cluster.CRC16;
 import org.apache.geode.redis.internal.executor.cluster.RedisPartitionResolver;
 
 public class RedisKey implements DataSerializableFixedID {
 
-  private int crc16;
+  private int slot;
   private byte[] value;
 
   public RedisKey() {}
 
   public RedisKey(byte[] value) {
     this.value = value;
-    int startHashtag = Integer.MAX_VALUE;
-    int endHashtag = 0;
-
-    for (int i = 0; i < value.length; i++) {
-      if (value[i] == '{' && startHashtag == Integer.MAX_VALUE) {
-        startHashtag = i;
-      } else if (value[i] == '}') {
-        endHashtag = i;
-        break;
-      }
-    }
-
-    if (endHashtag - startHashtag <= 1) {
-      startHashtag = -1;
-      endHashtag = value.length;
-    }
-
-    crc16 = CRC16.calculate(value, startHashtag + 1, endHashtag);
+    slot = KeyHashUtil.slotForKey(value);
   }
 
   public int getBucketId() {
     // & (REDIS_SLOTS - 1) is equivalent to % REDIS_SLOTS but supposedly faster
-    return (getCrc16() & (REDIS_SLOTS - 1)) / REDIS_SLOTS_PER_BUCKET;
+    return getSlot() / REDIS_SLOTS_PER_BUCKET;
   }
 
   /**
@@ -92,7 +73,7 @@ public class RedisKey implements DataSerializableFixedID {
 
   @Override
   public void toData(DataOutput out, SerializationContext context) throws IOException {
-    out.writeShort(crc16);
+    out.writeShort(slot);
     DataSerializer.writeByteArray(value, out);
   }
 
@@ -100,7 +81,7 @@ public class RedisKey implements DataSerializableFixedID {
   public void fromData(DataInput in, DeserializationContext context)
       throws IOException {
     // Need to convert a signed short to unsigned
-    crc16 = in.readShort() & 0xffff;
+    slot = in.readShort() & 0xffff;
     value = DataSerializer.readByteArray(in);
   }
 
@@ -121,7 +102,7 @@ public class RedisKey implements DataSerializableFixedID {
   /**
    * Used by the {@link RedisPartitionResolver} to map slots to buckets
    */
-  public int getCrc16() {
-    return crc16;
+  public int getSlot() {
+    return slot;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
@@ -21,6 +21,7 @@ import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUC
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINFO;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bKEYSLOT;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNODES;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSLOTS;
 
@@ -36,6 +37,7 @@ import org.apache.geode.cache.partition.PartitionMemberInfo;
 import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.cache.partition.PartitionRegionInfo;
 import org.apache.geode.redis.internal.SlotAdvisor;
+import org.apache.geode.redis.internal.data.KeyHashUtil;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
@@ -58,6 +60,8 @@ public class ClusterExecutor extends AbstractExecutor {
       return getNodes(context);
     } else if (equalsIgnoreCaseBytes(bytes, bSLOTS)) {
       return getSlots(context);
+    } else if (equalsIgnoreCaseBytes(bytes, bKEYSLOT)) {
+      return RedisResponse.integer(KeyHashUtil.slotForKey(args.get(2)));
     } else {
       return RedisResponse.error(
           String.format(ERROR_UNKNOWN_CLUSTER_SUBCOMMAND, bytesToString(bytes)));

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -109,6 +109,8 @@ public class StringBytesGlossary {
   public static final byte[] bSLOTS = stringToBytes("SLOTS");
   @MakeImmutable
   public static final byte[] bNODES = stringToBytes("NODES");
+  @MakeImmutable
+  public static final byte[] bKEYSLOT = stringToBytes("KEYSLOT");
 
   // ScanExecutor, HScanExecutor and SScanExecutor
   @MakeImmutable

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -32,27 +32,37 @@ public class StringBytesGlossary {
   /**
    * byte identifier of a bulk string
    */
-  public static final byte BULK_STRING_ID = 36; // '$'
+  public static final byte BULK_STRING_ID = '$';
 
   /**
    * byte identifier of an array
    */
-  public static final byte ARRAY_ID = 42; // '*'
+  public static final byte ARRAY_ID = '*';
 
   /**
    * byte identifier of a simple string
    */
-  public static final byte SIMPLE_STRING_ID = 43; // '+'
+  public static final byte SIMPLE_STRING_ID = '+';
 
   /**
    * byte identifier of an error
    */
-  public static final byte ERROR_ID = 45; // '-'
+  public static final byte ERROR_ID = '-';
 
   /**
    * byte identifier of an integer
    */
-  public static final byte INTEGER_ID = 58; // ':'
+  public static final byte INTEGER_ID = ':';
+
+  /**
+   * byte identifier of an left paren
+   */
+  public static final byte LEFT_BRACE_ID = '{';
+
+  /**
+   * byte identifier of an right paren
+   */
+  public static final byte RIGHT_BRACE_ID = '}';
 
   // ********** RedisResponse constants **********
   /**

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -240,22 +240,22 @@ public class StringBytesGlossary {
   /**
    * byte value of the number 0
    */
-  public static final byte NUMBER_0_BYTE = 48; // '0'
+  public static final byte NUMBER_0_BYTE = '0';
 
   /**
    * byte value of the number 1
    */
-  public static final byte NUMBER_1_BYTE = 49; // '1'
+  public static final byte NUMBER_1_BYTE = '1';
 
-  public static final byte bLOWERCASE_A = 97; // a
+  public static final byte bLOWERCASE_A = 'a';
 
-  public static final byte bLOWERCASE_Z = 122; // z
+  public static final byte bLOWERCASE_Z = 'z';
 
-  public static final byte bLEFT_PAREN = 40; // (
+  public static final byte bLEFT_PAREN = '(';
 
-  public static final byte bLEFT_SQUARE_BRACKET = 91; // [
+  public static final byte bLEFT_SQUARE_BRACKET = '[';
 
-  public static final byte bPERIOD = 46; // .
+  public static final byte bPERIOD = '.';
 
   public static final String PING_RESPONSE = "PONG";
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/parameters/ClusterParameterRequirements.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/parameters/ClusterParameterRequirements.java
@@ -27,7 +27,7 @@ public class ClusterParameterRequirements implements ParameterRequirements {
 
     if (numberOfArguments < 2) {
       throw new RedisParametersMismatchException(command.wrongNumberOfArgumentsErrorMessage());
-    } else if (numberOfArguments > 2) {
+    } else if (numberOfArguments > 3) {
       throw new RedisParametersMismatchException(
           String.format(ERROR_UNKNOWN_CLUSTER_SUBCOMMAND, command.getStringKey()));
     }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/KeyHashUtilTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/KeyHashUtilTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.generator.Size;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+import redis.clients.jedis.util.JedisClusterCRC16;
+
+import org.apache.geode.redis.internal.netty.Coder;
+
+@RunWith(JUnitQuickcheck.class)
+public class KeyHashUtilTest {
+
+  @Property
+  public void geodeAndJedisGenerateSameSlotWithHardcodedExamples() {
+    compareHashes("nohash");
+    compareHashes("with{hash}");
+    compareHashes("with{two}{hashes}");
+    compareHashes("with{borked{hashes}");
+    compareHashes("with{unmatched");
+    compareHashes("aaa}bbb{tag}ccc");
+    compareHashes("withunmatchedright}");
+    compareHashes("empty{}hash");
+    compareHashes("nested{some{hash}or}hash");
+
+    compareHashes("name{user1000}");
+    compareHashes("{user1000");
+    compareHashes("}user1000{");
+    compareHashes("user{}1000");
+    compareHashes("user}{1000");
+    compareHashes("{user1000}}bar");
+    compareHashes("foo{user1000}{bar}");
+    compareHashes("foo{}{user1000}");
+    compareHashes("{}{user1000}");
+    compareHashes("foo{{user1000}}bar");
+    compareHashes("");
+  }
+
+  @Property
+  public void geodeAndJedisGenerateSameSlot(String key,
+      @Size(min = 0, max = 2) Set<@InRange(minInt = 0, maxInt = 10) Integer> leftParenLocations,
+      @Size(min = 0, max = 2) Set<@InRange(minInt = 0, maxInt = 10) Integer> rightParenLocations) {
+    byte[] keyBytes = Coder.stringToBytes(key);
+    leftParenLocations.stream()
+        .filter(location -> location < keyBytes.length)
+        .forEach(location -> keyBytes[location] = '{');
+    rightParenLocations.stream()
+        .filter(location -> location < keyBytes.length)
+        .forEach(location -> keyBytes[location] = '}');
+
+    compareHashes(Coder.bytesToString(keyBytes));
+  }
+
+  private static void compareHashes(String key) {
+    int jedisSlot = JedisClusterCRC16.getSlot(key);
+    short geodeSlot = KeyHashUtil.slotForKey(Coder.stringToBytes(key));
+    assertThat(geodeSlot)
+        .withFailMessage("Slot did not match for key %s", key)
+        .isEqualTo((short) jedisSlot);
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisKeyJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisKeyJUnitTest.java
@@ -38,7 +38,6 @@ public class RedisKeyJUnitTest {
   @Test
   public void testSerialization() throws Exception {
     RedisKey keyOut = new RedisKey(stringToBytes("012345"));
-    assertThat((short) keyOut.getSlot()).isPositive();
 
     HeapDataOutputStream out = new HeapDataOutputStream(100);
     DataSerializer.writeObject(keyOut, out);

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisKeyJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisKeyJUnitTest.java
@@ -26,8 +26,6 @@ import org.apache.geode.internal.HeapDataOutputStream;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
-import org.apache.geode.redis.internal.RegionProvider;
-import org.apache.geode.redis.internal.executor.cluster.CRC16;
 
 public class RedisKeyJUnitTest {
 
@@ -38,45 +36,7 @@ public class RedisKeyJUnitTest {
   }
 
   @Test
-  public void testRoutingId_withHashtags() {
-    RedisKey key = new RedisKey(stringToBytes("name{user1000}"));
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("user1000") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("{user1000"));
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("{user1000") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("}user1000{"));
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("}user1000{") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("user{}1000"));
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("user{}1000") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("user}{1000"));
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("user}{1000") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("{user1000}}bar"));
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("user1000") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("foo{user1000}{bar}"));
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("user1000") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("foo{}{user1000}"));
-    assertThat(key.getSlot())
-        .isEqualTo(CRC16.calculate("foo{}{user1000}") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("{}{user1000}"));
-    assertThat(key.getSlot())
-        .isEqualTo(CRC16.calculate("{}{user1000}") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(stringToBytes("foo{{user1000}}bar"));
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("{user1000") % RegionProvider.REDIS_SLOTS);
-
-    key = new RedisKey(new byte[] {});
-    assertThat(key.getSlot()).isEqualTo(CRC16.calculate("") % RegionProvider.REDIS_SLOTS);
-  }
-
-  @Test
-  public void testSerialization_withPositiveSignedShortCRC16() throws Exception {
+  public void testSerialization() throws Exception {
     RedisKey keyOut = new RedisKey(stringToBytes("012345"));
     assertThat((short) keyOut.getSlot()).isPositive();
 


### PR DESCRIPTION
Adding support for the keyslot command. refactoring the RedisKey code a little
bit to move the slot calculation into a static method that can be used and
tested separately. Changing RedisKey.crc16 to slot, because that is only thing
we are using the crc16 field for.

Thank you for submitting a contribution to Apache Geode.

In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken:

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

### Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
