### PR TITLE
GEODE-9516: add ZINTERSTORE command

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZInterStoreNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/sortedset/ZInterStoreNativeRedisAcceptanceTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.NativeRedisClusterTestRule;
+
+public class ZInterStoreNativeRedisAcceptanceTest extends AbstractZInterStoreIntegrationTest {
+
+  @ClassRule
+  public static NativeRedisClusterTestRule server = new NativeRedisClusterTestRule();
+
+  @Override
+  public int getPort() {
+    return server.getExposedPorts().get(0);
+  }
+
+  @Override
+  public void flushAll() {
+    server.flushAll();
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -275,6 +275,12 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   }
 
   @Test
+  public void testZInterStore() {
+    runCommandAndAssertNoStatUpdates(SORTED_SET_KEY,
+        k -> jedis.zinterstore(k, new ZParams().weights(1, 2), k, k));
+  }
+
+  @Test
   public void testZLexCount() {
     runCommandAndAssertHitsAndMisses(SORTED_SET_KEY, k -> jedis.zlexcount(k, "-", "+"));
   }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -702,15 +702,48 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     return tuples;
   }
 
+  @Test
+  public void test_assertThatActualScoresAreVeryCloseToExpectedScores() {
+    Set<Tuple> actualResult = new HashSet<>(3);
+    Set<Tuple> expectedResult = new HashSet<>(2);
+
+    actualResult.add(new Tuple("element1", 1.0));
+    expectedResult.add(new Tuple("element1", 1.0));
+
+    actualResult.add(new Tuple("element2", 2.0));
+    expectedResult.add(new Tuple("element2", 2.0));
+
+    actualResult.add(new Tuple("element3", 3.0));
+
+    // actual has more elements than expected
+    assertThatThrownBy(
+        () -> assertThatActualScoresAreVeryCloseToExpectedScores(expectedResult, actualResult))
+            .isInstanceOf(AssertionError.class);
+
+    expectedResult.add(new Tuple("element3", 3.0));
+    expectedResult.add(new Tuple("element4", 4.0));
+
+    // actual has fewer elements than expected
+    assertThatThrownBy(
+        () -> assertThatActualScoresAreVeryCloseToExpectedScores(expectedResult, actualResult))
+            .isInstanceOf(AssertionError.class);
+  }
+
   private void assertThatActualScoresAreVeryCloseToExpectedScores(
       Set<Tuple> expectedResults, Set<Tuple> results) {
+    assertThat(expectedResults.size()).isEqualTo(results.size());
+
     for (Tuple expectedResult : expectedResults) {
+      boolean resultFound = false;
       for (Tuple actualResult : results) {
         if (Objects.equals(actualResult.getElement(), expectedResult.getElement())) {
           assertThat(actualResult.getScore()).isCloseTo(expectedResult.getScore(),
               Offset.offset(0.0001D));
+          resultFound = true;
+          break;
         }
       }
+      assertThat(resultFound).isTrue();
     }
   }
 }

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -175,6 +175,14 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
   }
 
   @Test
+  public void shouldError_givenWeightsFollowedByCorrectNumberOfArgumentsIncludingAggregate() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "3",
+            KEY1, KEY2, KEY3, "WEIGHTS", "1", "AGGREGATE", "SUM"))
+                .hasMessage("ERR " + RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT);
+  }
+
+  @Test
   public void shouldStoreIntersection_givenWeightOfOne_andOneRedisSortedSet() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
     Set<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> value);
@@ -592,6 +600,16 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     Set<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expectedResults, results);
+  }
+
+  @Test
+  public void shouldNotError_givenKeysNamedWeightsOrAggregate() {
+    String weights = "WEIGHTS";
+    jedis.zadd(weights, 1, "member");
+    String aggregate = "AGGREGATE";
+    jedis.zadd(aggregate, 1, "member");
+    jedis.zinterstore(weights, weights, weights);
+    jedis.zinterstore(aggregate, aggregate, aggregate);
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -183,6 +183,13 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
   }
 
   @Test
+  public void shouldError_givenNumKeysNotAnInteger() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "fish", KEY1, KEY2))
+            .hasMessage("ERR " + RedisConstants.ERROR_NOT_INTEGER);
+  }
+
+  @Test
   public void shouldStoreIntersection_givenWeightOfOne_andOneRedisSortedSet() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
     Set<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> value);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -115,7 +115,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
   }
 
   @Test
-  public void shouldError_givenWeightNotANumber() {
+  public void shouldError_givenWeightNotAFloat() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
             KEY1, "WEIGHTS", "not-a-number"))
@@ -502,7 +502,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
     Set<Tuple> expected = new HashSet<>();
     for (int i = 6; i <= 10; i++) {
-      expected.add(tupleMaxOfScores("player" + i, scores1, scores2, scores3));
+      expected.add(new Tuple("player" + i, score));
     }
 
     Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -1,0 +1,735 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.function.BiFunction;
+
+import org.assertj.core.data.Offset;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Protocol;
+import redis.clients.jedis.Tuple;
+import redis.clients.jedis.ZParams;
+
+import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.redis.internal.RedisConstants;
+
+public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegrationTest {
+
+  private static final String NEW_SET = "{user1}new";
+  private static final String KEY1 = "{user1}sset1";
+  private static final String KEY2 = "{user1}sset2";
+  private static final String KEY3 = "{user1}sset3";
+
+  private JedisCluster jedis;
+
+  @Before
+  public void setUp() {
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void shouldError_givenTooFewArguments() {
+    assertAtLeastNArgs(jedis, Protocol.Command.ZINTERSTORE, 3);
+  }
+
+  @Test
+  public void shouldError_givenWrongKeyType() {
+    final String STRING_KEY = "{user1}stringKey";
+    jedis.set(STRING_KEY, "value");
+    assertThatThrownBy(() -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2",
+        STRING_KEY, KEY1)).hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
+  }
+
+  @Test
+  public void shouldError_givenSetsCrossSlots() {
+    final String WRONG_KEY = "{user2}another";
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2", WRONG_KEY,
+            KEY1)).hasMessage("CROSSSLOT " + RedisConstants.ERROR_WRONG_SLOT);
+  }
+
+  @Test
+  public void shouldError_givenNumkeysTooLarge() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2", KEY1))
+            .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenNumkeysTooSmall() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1", KEY1, KEY2))
+            .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenTooManyWeights() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
+            KEY1, "WEIGHTS", "2", "3")).hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenTooFewWeights() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2",
+            KEY1, KEY2, "WEIGHTS", "1")).hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenWeightNotANumber() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
+            KEY1, "WEIGHTS", "not-a-number"))
+                .hasMessage("ERR " + RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT);
+  }
+
+  @Test
+  public void shouldError_givenWeightsWithoutAnyValues() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
+            KEY1, "WEIGHTS")).hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenMultipleWeightKeywords() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
+            KEY1, "WEIGHT", "1.0", "WEIGHT", "2.0"))
+                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenUnknownAggregate() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
+            KEY1, "AGGREGATE", "UNKNOWN", "WEIGHTS", "1"))
+                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenAggregateKeywordWithoutValue() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
+            KEY1, "AGGREGATE")).hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldError_givenMultipleAggregates() {
+    assertThatThrownBy(
+        () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
+            KEY1, "WEIGHTS", "1", "AGGREGATE", "SUM", "MIN"))
+                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenWeightOfOne_andOneRedisSortedSet() {
+    Map<String, Double> scores = buildMapOfMembersAndScores();
+    Set<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> value);
+    jedis.zadd(KEY1, scores);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1), KEY1))
+        .isEqualTo(expectedResults.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenWeightOfZero_andOneRedisSortedSet() {
+    Map<String, Double> scores = buildMapOfMembersAndScores();
+    Set<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> 0D);
+    jedis.zadd(KEY1, scores);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(0), KEY1))
+        .isEqualTo(scores.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenWeightOfPositiveInfinity_andOneRedisSortedSet() {
+    Map<String, Double> scores = buildMapOfMembersAndScores();
+    Set<Tuple> expectedResults =
+        convertToTuples(scores, (ignore, value) -> value > 0 ? Double.POSITIVE_INFINITY : value);
+    jedis.zadd(KEY1, scores);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(Double.POSITIVE_INFINITY),
+        KEY1)).isEqualTo(scores.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenWeightOfNegativeInfinity_andOneRedisSortedSet() {
+    Map<String, Double> scores = buildMapOfMembersAndScores();
+    jedis.zadd(KEY1, scores);
+
+    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    expectedResults.add(new Tuple("player1", Double.POSITIVE_INFINITY));
+    expectedResults.add(new Tuple("player2", 0D));
+    expectedResults.add(new Tuple("player3", Double.NEGATIVE_INFINITY));
+    expectedResults.add(new Tuple("player4", Double.NEGATIVE_INFINITY));
+    expectedResults.add(new Tuple("player5", Double.NEGATIVE_INFINITY));
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(Double.NEGATIVE_INFINITY),
+        KEY1)).isEqualTo(scores.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenWeightOfN_andOneRedisSortedSet() {
+    Map<String, Double> scores = buildMapOfMembersAndScores();
+    jedis.zadd(KEY1, scores);
+
+    double multiplier = 2.71D;
+
+    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
+    expectedResults.add(new Tuple("player2", 0D));
+    expectedResults.add(new Tuple("player3", multiplier));
+    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
+    expectedResults.add(new Tuple("player5", 3.2D * multiplier));
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(multiplier), KEY1))
+        .isEqualTo(scores.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenMultipleRedisSortedSets() {
+    Map<String, Double> scores = buildMapOfMembersAndScores();
+    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
+    expectedResults.add(new Tuple("player2", 0D));
+    expectedResults.add(new Tuple("player3", 2D));
+    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
+    expectedResults.add(new Tuple("player5", 3.2D * 2));
+
+    jedis.zadd(KEY1, scores);
+    jedis.zadd(KEY2, scores);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams(), KEY1, KEY2))
+        .isEqualTo(expectedResults.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenTwoRedisSortedSets_withDifferentWeights() {
+    Map<String, Double> scores = buildMapOfMembersAndScores();
+    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
+    expectedResults.add(new Tuple("player2", 0D));
+    expectedResults.add(new Tuple("player3", 3D));
+    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
+    expectedResults.add(new Tuple("player5", 3.2D * 3));
+
+    jedis.zadd(KEY1, scores);
+    jedis.zadd(KEY2, scores);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1, 2), KEY1, KEY2))
+        .isEqualTo(expectedResults.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenMultipleIdenticalRedisSortedSets_withDifferentPositiveWeights() {
+    Map<String, Double> scores = buildMapOfMembersAndScores();
+    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
+    expectedResults.add(new Tuple("player2", 0D));
+    expectedResults.add(new Tuple("player3", 4.5D));
+    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
+    expectedResults.add(new Tuple("player5", 3.2D * 4.5D));
+
+    jedis.zadd(KEY1, scores);
+    jedis.zadd(KEY2, scores);
+    jedis.zadd(KEY3, scores);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1D, 2D, 1.5D), KEY1, KEY2, KEY3))
+        .isEqualTo(expectedResults.size());
+
+    Set<Tuple> actualResults = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThatActualScoresAreVeryCloseToExpectedScores(expectedResults, actualResults);
+  }
+
+  @Test
+  public void shouldStoreIntersection_givenOneSetDoesNotExist() {
+    Map<String, Double> scores = buildMapOfMembersAndScores(1, 10);
+    Set<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x);
+    jedis.zadd(KEY1, scores);
+
+    assertThat(jedis.zinterstore(NEW_SET, KEY1, KEY2)).isEqualTo(scores.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expectedResults, results);
+  }
+
+  @Test
+  public void shouldStoreNothingAtDestinationKey_givenTwoNonIntersectingSets() {
+    Map<String, Double> scores = buildMapOfMembersAndScores(1, 5);
+    Map<String, Double> nonIntersectionScores = buildMapOfMembersAndScores(6, 10);
+    jedis.zadd(KEY1, scores);
+    jedis.zadd(KEY2, nonIntersectionScores);
+
+    assertThat(jedis.zinterstore(NEW_SET, KEY1, KEY2)).isZero();
+
+    assertThat(jedis.zrangeWithScores(NEW_SET, 0, 10)).isEmpty();
+  }
+
+  @Test
+  public void shouldStoreSumOfIntersection_givenThreePartiallyOverlappingSets() {
+    Map<String, Double> scores1 = buildMapOfMembersAndScores(1, 10);
+    Map<String, Double> scores2 = buildMapOfMembersAndScores(6, 13);
+    Map<String, Double> scores3 = buildMapOfMembersAndScores(4, 11);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.SUM),
+        KEY1, KEY2, KEY3)).isEqualTo(5);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 6; i <= 10; i++) {
+      expected.add(tupleSumOfScores("player" + i, scores1, scores2, scores3));
+    }
+
+    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
+  }
+
+  @Test
+  public void shouldStoreMaxOfIntersection_givenThreePartiallyOverlappingSets() {
+    Map<String, Double> scores1 = buildMapOfMembersAndScores(1, 10);
+    Map<String, Double> scores2 = buildMapOfMembersAndScores(6, 13);
+    Map<String, Double> scores3 = buildMapOfMembersAndScores(4, 11);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MAX),
+        KEY1, KEY2, KEY3)).isEqualTo(5);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 6; i <= 10; i++) {
+      expected.add(tupleMaxOfScores("player" + i, scores1, scores2, scores3));
+    }
+
+    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
+  }
+
+  @Test
+  public void shouldStoreMinOfIntersection_givenThreePartiallyOverlappingSets() {
+    Map<String, Double> scores1 = buildMapOfMembersAndScores(1, 10);
+    Map<String, Double> scores2 = buildMapOfMembersAndScores(6, 13);
+    Map<String, Double> scores3 = buildMapOfMembersAndScores(4, 11);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    assertThat(jedis.zinterstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MIN),
+        KEY1, KEY2, KEY3)).isEqualTo(5);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 6; i <= 10; i++) {
+      expected.add(tupleMinOfScores("player" + i, scores1, scores2, scores3));
+    }
+
+    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
+  }
+
+  @Test
+  public void shouldStoreSumOfIntersection_givenThreePartiallyOverlappingSets_andWeights() {
+    double weight1 = 0D;
+    double weight2 = 42D;
+    double weight3 = -7.3D;
+
+    Map<String, Double> scores1 = buildMapOfMembersAndScores(1, 10);
+    Map<String, Double> scores2 = buildMapOfMembersAndScores(6, 13);
+    Map<String, Double> scores3 = buildMapOfMembersAndScores(4, 11);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    ZParams zParams = new ZParams().aggregate(ZParams.Aggregate.SUM)
+        .weights(weight1, weight2, weight3);
+
+    assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 6; i <= 10; i++) {
+      expected.add(tupleSumOfScoresWithWeights("player" + i, scores1, scores2, scores3, weight1,
+          weight2, weight3));
+    }
+
+    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
+  }
+
+  @Test
+  public void shouldStoreMaxOfIntersection_givenThreePartiallyOverlappingSets_andWeights() {
+    double weight1 = 0D;
+    double weight2 = 42D;
+    double weight3 = -7.3D;
+
+    Map<String, Double> scores1 = buildMapOfMembersAndScores(1, 10);
+    Map<String, Double> scores2 = buildMapOfMembersAndScores(6, 13);
+    Map<String, Double> scores3 = buildMapOfMembersAndScores(4, 11);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    ZParams zParams = new ZParams().aggregate(ZParams.Aggregate.MAX)
+        .weights(weight1, weight2, weight3);
+
+    assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 6; i <= 10; i++) {
+      expected.add(tupleMaxOfScoresWithWeights("player" + i, scores1, scores2, scores3, weight1,
+          weight2, weight3));
+    }
+
+    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
+  }
+
+  @Test
+  public void shouldStoreMinOfIntersection_givenThreePartiallyOverlappingSets_andWeights() {
+    double weight1 = 0D;
+    double weight2 = 42D;
+    double weight3 = -7.3D;
+
+    Map<String, Double> scores1 = buildMapOfMembersAndScores(1, 10);
+    Map<String, Double> scores2 = buildMapOfMembersAndScores(6, 13);
+    Map<String, Double> scores3 = buildMapOfMembersAndScores(4, 11);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    ZParams zParams = new ZParams().aggregate(ZParams.Aggregate.MIN)
+        .weights(weight1, weight2, weight3);
+
+    assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 6; i <= 10; i++) {
+      expected.add(tupleMinOfScoresWithWeights("player" + i, scores1, scores2, scores3, weight1,
+          weight2, weight3));
+    }
+
+    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
+  }
+
+  @Test
+  public void shouldStoreMaxOfIntersection_givenThreePartiallyOverlappingSetsWithIdenticalScores() {
+    double score = 3.141592;
+    Map<String, Double> scores1 = buildMapOfMembersAndIdenticalScores(1, 10, score);
+    Map<String, Double> scores2 = buildMapOfMembersAndIdenticalScores(6, 13, score);
+    Map<String, Double> scores3 = buildMapOfMembersAndIdenticalScores(4, 11, score);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    ZParams zParams = new ZParams().aggregate(ZParams.Aggregate.MAX);
+
+    assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 6; i <= 10; i++) {
+      expected.add(tupleMaxOfScores("player" + i, scores1, scores2, scores3));
+    }
+
+    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
+  }
+
+  @Test
+  public void shouldStoreMinOfIntersection_givenThreePartiallyOverlappingSetsWithIdenticalScores() {
+    double score = 3.141592;
+    Map<String, Double> scores1 = buildMapOfMembersAndIdenticalScores(1, 10, score);
+    Map<String, Double> scores2 = buildMapOfMembersAndIdenticalScores(6, 13, score);
+    Map<String, Double> scores3 = buildMapOfMembersAndIdenticalScores(4, 11, score);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    ZParams zParams = new ZParams().aggregate(ZParams.Aggregate.MAX);
+
+    assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 6; i <= 10; i++) {
+      expected.add(new Tuple("player" + i, score));
+    }
+
+    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
+  }
+
+  @Test
+  public void shouldStoreIntersectionUsingLastAggregate_givenMultipleAggregateKeywords() {
+    Map<String, Double> scores1 = buildMapOfMembersAndScores(1, 15);
+    Map<String, Double> scores2 = buildMapOfMembersAndScores(9, 13);
+    Map<String, Double> scores3 = buildMapOfMembersAndScores(12, 18);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    Set<Tuple> expected = new HashSet<>();
+    for (int i = 12; i <= 13; i++) {
+      expected.add(tupleMaxOfScores("player" + i, scores1, scores2, scores3));
+    }
+
+    jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "3",
+        KEY1, KEY2, KEY3, "AGGREGATE", "MIN", "AGGREGATE", "MAX");
+
+    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expected, results);
+  }
+
+  @Test
+  public void shouldStoreIntersection_whenTargetExistsAndSetsAreDuplicated() {
+    Map<String, Double> scores = buildMapOfMembersAndScores(0, 10);
+    jedis.zadd(KEY1, scores);
+    jedis.zadd(KEY2, scores);
+
+    Set<Tuple> expectedResults = convertToTuples(scores, (ignore, score) -> score * 2);
+
+    // destination key is a key that exists
+    assertThat(jedis.zinterstore(KEY1, KEY1, KEY2)).isEqualTo(scores.size());
+
+    Set<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
+
+    assertThatActualScoresAreVeryCloseToExpectedScores(expectedResults, results);
+  }
+
+  @Test
+  public void ensureSetConsistency_whenRunningConcurrently() {
+    int scoreCount = 1000;
+    Map<String, Double> scores1 = buildMapOfMembersAndScores(1, 15);
+    Map<String, Double> scores2 = buildMapOfMembersAndScores(3, 18);
+    Map<String, Double> scores3 = buildMapOfMembersAndScores(4, 14);
+
+    jedis.zadd(KEY1, scores1);
+    jedis.zadd(KEY2, scores2);
+    jedis.zadd(KEY3, scores3);
+
+    Set<Tuple> expectedMinScores = new HashSet<>();
+    Set<Tuple> expectedMaxScores = new HashSet<>();
+    for (int i = 4; i <= 14; i++) {
+      expectedMinScores.add(tupleMinOfScores("player" + i, scores1, scores2, scores3));
+      expectedMaxScores.add(tupleMaxOfScores("player" + i, scores1, scores2, scores3));
+    }
+
+    // new ConcurrentLoopingThreads(1000,
+    // i -> jedis.zadd(KEY1, (double) i, "member-" + i),
+    // i -> jedis.zadd(KEY2, (double) i, "member-" + i),
+    // i -> jedis.zadd(KEY3, (double) i, "member-" + i),
+    // i -> jedis.zinterstore("maxSet", new ZParams().aggregate(ZParams.Aggregate.MAX),
+    jedis.zinterstore("maxSet", new ZParams().aggregate(ZParams.Aggregate.MAX),
+        KEY1, KEY2, KEY3);
+    // This ensures that the lock ordering for keys is working
+    // i -> jedis.zinterstore("minSet", new ZParams().aggregate(ZParams.Aggregate.MIN),
+    jedis.zinterstore("minSet", new ZParams().aggregate(ZParams.Aggregate.MIN),
+        KEY1, KEY2, KEY3);// )
+    // .runWithAction(() -> {
+    Set<Tuple> maxSet = jedis.zrangeWithScores("maxSet", 0, scoreCount);
+    Set<Tuple> minSet = jedis.zrangeWithScores("minSet", 0, scoreCount);
+    assertThat(maxSet).hasSize(scoreCount);
+    assertThat(minSet).hasSize(scoreCount);
+    assertThatActualScoresAreVeryCloseToExpectedScores(expectedMaxScores, maxSet);
+    assertThatActualScoresAreVeryCloseToExpectedScores(expectedMinScores, minSet);
+    // });
+  }
+
+  @Test
+  public void ensureSetConsistency_andNoExceptions_whenRunningConcurrently() {
+    int scoreCount = 1000;
+    jedis.zadd("{A}ones", buildMapOfMembersAndScores(0, scoreCount - 1));
+
+    jedis.zadd("{A}scores1", buildMapOfMembersAndScores(0, scoreCount - 1));
+    jedis.zadd("{A}scores2", buildMapOfMembersAndScores(0, scoreCount - 1));
+    jedis.zadd("{A}scores3", buildMapOfMembersAndScores(0, scoreCount - 1));
+
+    new ConcurrentLoopingThreads(1000,
+        i -> jedis.zadd("{A}scores1", (double) i, "player" + i),
+        i -> jedis.zadd("{A}scores2", (double) i, "player" + i),
+        i -> jedis.zadd("{A}scores3", (double) i, "player" + i),
+        i -> jedis.zinterstore("{A}maxSet", new ZParams().aggregate(ZParams.Aggregate.MAX),
+            "{A}scores1", "{A}scores2", "{A}scores3"),
+        // This ensures that the lock ordering for keys is working
+        i -> jedis.zinterstore("{A}minSet", new ZParams().aggregate(ZParams.Aggregate.MIN),
+            "{A}scores1", "{A}scores2", "{A}scores3"))
+                .runWithAction(() -> {
+                  assertThat(jedis.zrangeWithScores("{A}maxSet", 0, scoreCount))
+                      .hasSize(scoreCount);
+                  assertThat(jedis.zrangeWithScores("{A}minSet", 0, scoreCount))
+                      .hasSize(scoreCount);
+                });
+  }
+
+  /************* Helper Methods *************/
+
+  private Map<String, Double> buildMapOfMembersAndScores() {
+    Map<String, Double> scores = new LinkedHashMap<>();
+    scores.put("player1", Double.NEGATIVE_INFINITY);
+    scores.put("player2", 0D);
+    scores.put("player3", 1D);
+    scores.put("player4", Double.POSITIVE_INFINITY);
+    scores.put("player5", 3.2D);
+    return scores;
+  }
+
+  private Map<String, Double> buildMapOfMembersAndScores(int start, int end) {
+    Map<String, Double> scores = new LinkedHashMap<>();
+    Random random = new Random();
+
+    for (int i = start; i <= end; i++) {
+      scores.put("player" + i, random.nextDouble());
+    }
+
+    return scores;
+  }
+
+  private Map<String, Double> buildMapOfMembersAndIdenticalScores(int start, int end,
+      double score) {
+    Map<String, Double> scores = new LinkedHashMap<>();
+
+    for (int i = start; i <= end; i++) {
+      scores.put("player" + i, score);
+    }
+
+    return scores;
+  }
+
+  Tuple tupleSumOfScores(String memberName, Map<String, Double> scores1,
+      Map<String, Double> scores2, Map<String, Double> scores3) {
+    return tupleSumOfScoresWithWeights(memberName, scores1, scores2, scores3, 1, 1, 1);
+  }
+
+  Tuple tupleSumOfScoresWithWeights(String memberName, Map<String, Double> scores1,
+      Map<String, Double> scores2, Map<String, Double> scores3, double weight1, double weight2,
+      double weight3) {
+    return new Tuple(memberName, scores1.get(memberName) * weight1
+        + scores2.get(memberName) * weight2
+        + scores3.get(memberName) * weight3);
+  }
+
+  Tuple tupleMaxOfScores(String memberName, Map<String, Double> scores1,
+      Map<String, Double> scores2, Map<String, Double> scores3) {
+    return tupleMaxOfScoresWithWeights(memberName, scores1, scores2, scores3, 1, 1, 1);
+  }
+
+  Tuple tupleMaxOfScoresWithWeights(String memberName, Map<String, Double> scores1,
+      Map<String, Double> scores2, Map<String, Double> scores3, double weight1, double weight2,
+      double weight3) {
+    return new Tuple(memberName, max(max(scores1.get(memberName) * weight1,
+        scores2.get(memberName) * weight2), scores3.get(memberName) * weight3));
+  }
+
+  Tuple tupleMinOfScores(String memberName, Map<String, Double> scores1,
+      Map<String, Double> scores2, Map<String, Double> scores3) {
+    return tupleMinOfScoresWithWeights(memberName, scores1, scores2, scores3, 1, 1, 1);
+  }
+
+  Tuple tupleMinOfScoresWithWeights(String memberName, Map<String, Double> scores1,
+      Map<String, Double> scores2, Map<String, Double> scores3, double weight1, double weight2,
+      double weight3) {
+    return new Tuple(memberName, min(min(scores1.get(memberName) * weight1,
+        scores2.get(memberName) * weight2), scores3.get(memberName) * weight3));
+  }
+
+  private Set<Tuple> convertToTuples(Map<String, Double> map,
+      BiFunction<Integer, Double, Double> function) {
+    Set<Tuple> tuples = new LinkedHashSet<>();
+    int x = 0;
+    for (Map.Entry<String, Double> e : map.entrySet()) {
+      tuples.add(new Tuple(e.getKey().getBytes(), function.apply(x++, e.getValue())));
+    }
+
+    return tuples;
+  }
+
+  private void assertThatActualScoresAreVeryCloseToExpectedScores(
+      Set<Tuple> expectedResults, Set<Tuple> results) {
+    for (Tuple expectedResult : expectedResults) {
+      for (Tuple actualResult : results) {
+        if (Objects.equals(actualResult.getElement(), expectedResult.getElement())) {
+          assertThat(actualResult.getScore()).isCloseTo(expectedResult.getScore(),
+              Offset.offset(0.0001D));
+        }
+      }
+    }
+  }
+}

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
@@ -410,8 +410,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (double) (i * 10));
 
     jedis.zunionstore(KEY1,
-        new ZParams().weights(1, 10).aggregate(ZParams.Aggregate.MAX), KEY1,
-        KEY2);
+        new ZParams().weights(1, 10).aggregate(ZParams.Aggregate.MAX), KEY1, KEY2);
 
     Set<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 20);
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZInterStoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/ZInterStoreIntegrationTest.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+
+public class ZInterStoreIntegrationTest extends AbstractZInterStoreIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -90,6 +90,7 @@ import org.apache.geode.redis.internal.executor.sortedset.ZAddExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZCardExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZCountExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZIncrByExecutor;
+import org.apache.geode.redis.internal.executor.sortedset.ZInterStoreExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZLexCountExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZPopMaxExecutor;
 import org.apache.geode.redis.internal.executor.sortedset.ZPopMinExecutor;
@@ -231,6 +232,7 @@ public enum RedisCommandType {
   ZCARD(new ZCardExecutor(), SUPPORTED, new ExactParameterRequirements(2)),
   ZCOUNT(new ZCountExecutor(), SUPPORTED, new ExactParameterRequirements(4)),
   ZINCRBY(new ZIncrByExecutor(), SUPPORTED, new ExactParameterRequirements(4)),
+  ZINTERSTORE(new ZInterStoreExecutor(), SUPPORTED, new MinimumParameterRequirements(4)),
   ZLEXCOUNT(new ZLexCountExecutor(), SUPPORTED, new ExactParameterRequirements(4)),
   ZPOPMAX(new ZPopMaxExecutor(), SUPPORTED, new MinimumParameterRequirements(2)
       .and(new MaximumParameterRequirements(3, ERROR_SYNTAX))),

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -71,5 +71,4 @@ public class RedisConstants {
       "AUTH called without a Security Manager configured.";
   public static final String ERROR_KEY_REQUIRED =
       "at least 1 input key is needed for ZUNIONSTORE/ZINTERSTORE";
-  public static final String ERROR_NEGATIVE_LENGTH = "negative length";
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -69,4 +69,7 @@ public class RedisConstants {
       "invalid username-password pair or user is disabled.";
   public static final String ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED =
       "AUTH called without a Security Manager configured.";
+  public static final String ERROR_KEY_REQUIRED =
+      "at least 1 input key is needed for ZUNIONSTORE/ZINTERSTORE";
+  public static final String ERROR_NEGATIVE_LENGTH = "negative length";
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -346,14 +346,6 @@ public class RegionProvider {
   }
 
   /**
-   * A means to consistently order multiple keys for locking to avoid typical deadlock situations.
-   * Note that the list of keys is sorted in place.
-   */
-  public void orderForLocking(List<RedisKey> keys) {
-    keys.sort(stripedCoordinator::compareStripes);
-  }
-
-  /**
    * Check if a key would be stored locally (in a primary bucket on this server). Otherwise throw a
    * {@link RedisDataMovedException}. Note that this will not check for the actual existence of the
    * key.

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -346,6 +346,14 @@ public class RegionProvider {
   }
 
   /**
+   * A means to consistently order multiple keys for locking to avoid typical deadlock situations.
+   * Note that the list of keys is sorted in place.
+   */
+  public void orderForLocking(List<RedisKey> keys) {
+    keys.sort(stripedCoordinator::compareStripes);
+  }
+
+  /**
    * Check if a key would be stored locally (in a primary bucket on this server). Otherwise throw a
    * {@link RedisDataMovedException}. Note that this will not check for the actual existence of the
    * key.

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisSortedSet.java
@@ -18,7 +18,6 @@ package org.apache.geode.redis.internal.data;
 
 import static java.util.Collections.singletonList;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -32,7 +31,7 @@ import org.apache.geode.redis.internal.netty.Coder;
 class NullRedisSortedSet extends RedisSortedSet {
 
   NullRedisSortedSet() {
-    super(new ArrayList<>(), new double[0]);
+    super(0);
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -721,10 +721,10 @@ public class RedisSortedSet extends AbstractRedisData {
   private Double getMaxScoreForMember(List<RedisSortedSet> sets, byte[] member) {
     double runningMax = Double.MIN_VALUE;
     for (RedisSortedSet set : sets) {
-      if (set.members.containsKey(member)) {
-        double newScore = set.members.get(member).getScore();
-        if (newScore > runningMax) {
-          runningMax = newScore;
+      OrderedSetEntry m;
+      if ((m = set.members.get(member)) != null) {
+        if (m.getScore() > runningMax) {
+          runningMax = m.getScore();
         }
       } else {
         return null;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -350,37 +350,6 @@ public class RedisSortedSet extends AbstractRedisData {
     return getSortedSetSize();
   }
 
-
-
-  // double weight = keyWeight.getWeight();
-  // RedisSortedSet weightedSet = new RedisSortedSet(keyWeights.size());
-  //
-  // for (AbstractOrderedSetEntry entry : set.members.values()) {
-  // double score;
-  // // Redis math and Java math are different when handling infinity. Specifically:
-  // // Java: INFINITY * 0 = NaN
-  // // Redis: INFINITY * 0 = 0
-  // if (weight == 0) {
-  // score = 0;
-  // } else if (weight == 1) {
-  // score = entry.getScore();
-  // } else if (Double.isInfinite(weight) && entry.getScore() == 0D) {
-  // score = 0D;
-  // } else {
-  // score = entry.getScore() * weight;
-  // }
-  // weightedSet.memberAdd(entry.getMember(), score);
-  // }
-  // sets.add(weightedSet);
-  // }
-  //
-  // computeIntersection(sets, aggregator);
-  //
-  // regionProvider.getLocalDataRegion().put(key, this);
-  //
-  // return this.getSortedSetSize();
-  // }
-
   long zlexcount(SortedSetLexRangeOptions lexOptions) {
     int minIndex = lexOptions.getRangeIndex(scoreSet, true);
     if (minIndex >= scoreSet.size()) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -737,8 +737,8 @@ public class RedisSortedSet extends AbstractRedisData {
   public abstract static class AbstractOrderedSetEntry
       implements Comparable<AbstractOrderedSetEntry>,
       Sizeable {
-    protected byte[] member;
-    protected double score = 0D;
+    byte[] member;
+    double score = 0D;
 
     private AbstractOrderedSetEntry() {}
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -18,7 +18,6 @@ package org.apache.geode.redis.internal.data;
 
 import static java.lang.Double.compare;
 import static org.apache.geode.internal.JvmSizeUtils.memoryOverhead;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_OPERATION_PRODUCED_NAN;
 import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_SORTED_SET;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SORTED_SET;
@@ -301,10 +300,10 @@ public class RedisSortedSet extends AbstractRedisData {
       }
 
       double weight = keyWeight.getWeight();
-      RedisSortedSet weightedSet = new RedisSortedSet();
+      RedisSortedSet weightedSet = new RedisSortedSet(Collections.emptyList(), new double[] {});
 
       for (AbstractOrderedSetEntry entry : set.members.values()) {
-        OrderedSetEntry existingValue = members.get(entry.member);
+        OrderedSetEntry existingValue = members.get(entry.getMember());
         if (existingValue == null) {
           double score;
           // Redis math and Java math are different when handling infinity. Specifically:
@@ -318,9 +317,6 @@ public class RedisSortedSet extends AbstractRedisData {
             score = 0D;
           } else {
             score = entry.score * weight;
-            if (Double.isNaN(score)) {
-              throw new ArithmeticException(ERROR_OPERATION_PRODUCED_NAN);
-            }
           }
           weightedSet.memberAdd(entry.member, score);
         }
@@ -655,7 +651,7 @@ public class RedisSortedSet extends AbstractRedisData {
   }
 
   private RedisSortedSet getIntersection(List<RedisSortedSet> sets, ZAggregator aggregator) {
-    RedisSortedSet retVal = new RedisSortedSet();
+    RedisSortedSet retVal = new RedisSortedSet(Collections.emptyList(), new double[] {});
     RedisSortedSet smallestSet = sets.get(0);
 
     for (RedisSortedSet set : sets) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -70,7 +70,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   @Override
   public long zinterstore(RedisKey destinationKey, List<ZKeyWeight> keyWeights,
       ZAggregator aggregator) {
-    List<RedisKey> keysToLock = lockKeys(destinationKey, keyWeights);
+    List<RedisKey> keysToLock = getKeysToLock(destinationKey, keyWeights);
 
     return stripedExecute(destinationKey, keysToLock,
         () -> new RedisSortedSet(Collections.emptyList(), new double[] {})
@@ -174,7 +174,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   @Override
   public long zunionstore(RedisKey destinationKey, List<ZKeyWeight> keyWeights,
       ZAggregator aggregator) {
-    List<RedisKey> keysToLock = lockKeys(destinationKey, keyWeights);
+    List<RedisKey> keysToLock = getKeysToLock(destinationKey, keyWeights);
     for (ZKeyWeight kw : keyWeights) {
       getRegionProvider().ensureKeyIsLocal(kw.getKey());
       keysToLock.add(kw.getKey());
@@ -183,12 +183,12 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
     keysToLock.add(destinationKey);
 
     return stripedExecute(destinationKey, keysToLock,
-        () -> new RedisSortedSet(Collections.emptyList(), new double[0])
+        () -> new RedisSortedSet(0)
             .zunionstore(getRegionProvider(), destinationKey, keyWeights, aggregator));
   }
 
   /************* Helper Methods *************/
-  private List<RedisKey> lockKeys(RedisKey destinationKey, List<ZKeyWeight> keyWeights) {
+  private List<RedisKey> getKeysToLock(RedisKey destinationKey, List<ZKeyWeight> keyWeights) {
     List<RedisKey> keysToLock = new ArrayList<>(keyWeights.size());
     for (ZKeyWeight kw : keyWeights) {
       getRegionProvider().ensureKeyIsLocal(kw.getKey());

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -175,9 +175,6 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
       ZAggregator aggregator) {
     List<RedisKey> keysToLock = getKeysToLock(destinationKey, keyWeights);
 
-    getRegionProvider().ensureKeyIsLocal(destinationKey);
-    keysToLock.add(destinationKey);
-
     return stripedExecute(destinationKey, keysToLock,
         () -> new RedisSortedSet(0)
             .zunionstore(getRegionProvider(), destinationKey, keyWeights, aggregator));

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -73,7 +73,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
     List<RedisKey> keysToLock = lockKeys(destinationKey, keyWeights);
 
     return stripedExecute(destinationKey, keysToLock,
-        () -> new RedisSortedSet()
+        () -> new RedisSortedSet(Collections.emptyList(), new double[] {})
             .zinterstore(getRegionProvider(), destinationKey, keyWeights, aggregator));
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -18,7 +18,6 @@ package org.apache.geode.redis.internal.data;
 
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.tuple.Pair;
@@ -73,8 +72,8 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
     List<RedisKey> keysToLock = getKeysToLock(destinationKey, keyWeights);
 
     return stripedExecute(destinationKey, keysToLock,
-        () -> new RedisSortedSet(Collections.emptyList(), new double[] {})
-            .zinterstore(getRegionProvider(), destinationKey, keyWeights, aggregator));
+        () -> new RedisSortedSet(0))
+            .zinterstore(getRegionProvider(), destinationKey, keyWeights, aggregator);
   }
 
   @Override
@@ -175,10 +174,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   public long zunionstore(RedisKey destinationKey, List<ZKeyWeight> keyWeights,
       ZAggregator aggregator) {
     List<RedisKey> keysToLock = getKeysToLock(destinationKey, keyWeights);
-    for (ZKeyWeight kw : keyWeights) {
-      getRegionProvider().ensureKeyIsLocal(kw.getKey());
-      keysToLock.add(kw.getKey());
-    }
+
     getRegionProvider().ensureKeyIsLocal(destinationKey);
     keysToLock.add(destinationKey);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -197,7 +197,6 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
     getRegionProvider().ensureKeyIsLocal(destinationKey);
     keysToLock.add(destinationKey);
 
-    getRegionProvider().orderForLocking(keysToLock);
     return keysToLock;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -81,7 +81,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
     getRegionProvider().orderForLocking(keysToLock);
 
     return stripedExecute(destinationKey, keysToLock,
-        () -> new RedisSortedSet(Collections.emptyList())
+        () -> new RedisSortedSet()
             .zinterstore(getRegionProvider(), destinationKey, keyWeights, aggregator));
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -32,6 +32,8 @@ public interface RedisSortedSetCommands {
 
   byte[] zincrby(RedisKey key, double increment, byte[] member);
 
+  long zinterstore(RedisKey destinationKey, List<ZKeyWeight> keyWeights, ZAggregator aggregator);
+
   long zlexcount(RedisKey key, SortedSetLexRangeOptions rangeOptions);
 
   List<byte[]> zpopmax(RedisKey key, int count);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAggregator.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAggregator.java
@@ -23,7 +23,15 @@ import java.util.function.BiFunction;
  */
 public enum ZAggregator {
 
-  SUM(Double::sum),
+  SUM((score1, score2) -> {
+    // in native redis, adding -inf and +inf results in 0. java math returns NaN
+    if (score1.isInfinite() && score2.isInfinite()) {
+      if (score1 == -score2) {
+        return 0D;
+      }
+    }
+    return Double.sum(score1, score2);
+  }),
   MIN(Math::min),
   MAX(Math::max);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZInterStoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZInterStoreExecutor.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
+import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bAGGREGATE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWEIGHTS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.AbstractExecutor;
+import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.redis.internal.netty.Command;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+
+public class ZInterStoreExecutor extends AbstractExecutor {
+
+  @Override
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
+    List<byte[]> commandElements = command.getProcessedCommand();
+
+    Iterator<byte[]> argIterator = commandElements.iterator();
+    // Skip command and destination key
+    argIterator.next();
+    argIterator.next();
+
+    long numKeys;
+    try {
+      numKeys = Coder.bytesToLong(argIterator.next());
+    } catch (NumberFormatException ex) {
+      return RedisResponse.error(ERROR_SYNTAX);
+    }
+
+    // Rough validation so that we can use numKeys to initialize the array sizes below.
+    if (numKeys > commandElements.size()) {
+      return RedisResponse.error(ERROR_SYNTAX);
+    }
+
+    List<RedisKey> sourceKeys = new ArrayList<>((int) numKeys);
+    List<Double> weights = new ArrayList<>((int) numKeys);
+    ZAggregator aggregator = ZAggregator.SUM;
+
+    while (argIterator.hasNext()) {
+      byte[] arg = argIterator.next();
+
+      if (sourceKeys.size() < numKeys) {
+        sourceKeys.add(new RedisKey(arg));
+        continue;
+      }
+
+      arg = toUpperCaseBytes(arg);
+      if (Arrays.equals(arg, bWEIGHTS)) {
+        if (!weights.isEmpty()) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+        for (int i = 0; i < numKeys; i++) {
+          if (!argIterator.hasNext()) {
+            return RedisResponse.error(ERROR_SYNTAX);
+          }
+          try {
+            weights.add(Coder.bytesToDouble(argIterator.next()));
+          } catch (NumberFormatException nex) {
+            return RedisResponse.error(ERROR_WEIGHT_NOT_A_FLOAT);
+          }
+        }
+        continue;
+      }
+
+      if (Arrays.equals(arg, bAGGREGATE)) {
+        try {
+          aggregator = ZAggregator.valueOf(Coder.bytesToString(argIterator.next()));
+        } catch (IllegalArgumentException | NoSuchElementException e) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+        continue;
+      }
+
+      // End up here if we have more keys than weights
+      return RedisResponse.error(ERROR_SYNTAX);
+    }
+
+    if (sourceKeys.size() != numKeys) {
+      return RedisResponse.error(ERROR_SYNTAX);
+    }
+
+    int bucket = command.getKey().getBucketId();
+    for (RedisKey key : sourceKeys) {
+      if (key.getBucketId() != bucket) {
+        return RedisResponse.crossSlot(ERROR_WRONG_SLOT);
+      }
+    }
+
+    List<ZKeyWeight> keyWeights = new ArrayList<>();
+    for (int i = 0; i < sourceKeys.size(); i++) {
+      double weight = weights.isEmpty() ? 1 : weights.get(i);
+      keyWeights.add(new ZKeyWeight(sourceKeys.get(i), weight));
+    }
+
+    long result = context.getSortedSetCommands()
+        .zinterstore(command.getKey(), keyWeights, aggregator);
+
+    return RedisResponse.integer(result);
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZInterStoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZInterStoreExecutor.java
@@ -14,113 +14,17 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
-import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bAGGREGATE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWEIGHTS;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 
-import org.apache.geode.redis.internal.data.RedisKey;
-import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ZInterStoreExecutor extends AbstractExecutor {
-
+public class ZInterStoreExecutor extends ZStoreExecutor {
   @Override
-  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    List<byte[]> commandElements = command.getProcessedCommand();
-
-    Iterator<byte[]> argIterator = commandElements.iterator();
-    // Skip command and destination key
-    argIterator.next();
-    argIterator.next();
-
-    long numKeys;
-    try {
-      numKeys = Coder.bytesToLong(argIterator.next());
-    } catch (NumberFormatException ex) {
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
-
-    // Rough validation so that we can use numKeys to initialize the array sizes below.
-    if (numKeys > commandElements.size()) {
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
-
-    List<RedisKey> sourceKeys = new ArrayList<>((int) numKeys);
-    List<Double> weights = new ArrayList<>((int) numKeys);
-    ZAggregator aggregator = ZAggregator.SUM;
-
-    while (argIterator.hasNext()) {
-      byte[] arg = argIterator.next();
-
-      if (sourceKeys.size() < numKeys) {
-        sourceKeys.add(new RedisKey(arg));
-        continue;
-      }
-
-      arg = toUpperCaseBytes(arg);
-      if (Arrays.equals(arg, bWEIGHTS)) {
-        if (!weights.isEmpty()) {
-          return RedisResponse.error(ERROR_SYNTAX);
-        }
-        for (int i = 0; i < numKeys; i++) {
-          if (!argIterator.hasNext()) {
-            return RedisResponse.error(ERROR_SYNTAX);
-          }
-          try {
-            weights.add(Coder.bytesToDouble(argIterator.next()));
-          } catch (NumberFormatException nex) {
-            return RedisResponse.error(ERROR_WEIGHT_NOT_A_FLOAT);
-          }
-        }
-        continue;
-      }
-
-      if (Arrays.equals(arg, bAGGREGATE)) {
-        try {
-          aggregator = ZAggregator.valueOf(Coder.bytesToString(argIterator.next()));
-        } catch (IllegalArgumentException | NoSuchElementException e) {
-          return RedisResponse.error(ERROR_SYNTAX);
-        }
-        continue;
-      }
-
-      // End up here if we have more keys than weights
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
-
-    if (sourceKeys.size() != numKeys) {
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
-
-    int bucket = command.getKey().getBucketId();
-    for (RedisKey key : sourceKeys) {
-      if (key.getBucketId() != bucket) {
-        return RedisResponse.crossSlot(ERROR_WRONG_SLOT);
-      }
-    }
-
-    List<ZKeyWeight> keyWeights = new ArrayList<>();
-    for (int i = 0; i < sourceKeys.size(); i++) {
-      double weight = weights.isEmpty() ? 1 : weights.get(i);
-      keyWeights.add(new ZKeyWeight(sourceKeys.get(i), weight));
-    }
-
-    long result = context.getSortedSetCommands()
-        .zinterstore(command.getKey(), keyWeights, aggregator);
-
-    return RedisResponse.integer(result);
+  public long getResult(ExecutionHandlerContext context, Command command,
+      List<ZKeyWeight> keyWeights, ZAggregator aggregator) {
+    return context.getSortedSetCommands().zinterstore(command.getKey(), keyWeights, aggregator);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZKeyWeight.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZKeyWeight.java
@@ -23,7 +23,7 @@ import org.apache.geode.redis.internal.data.RedisKey;
  */
 public class ZKeyWeight {
   private final RedisKey key;
-  private final double weight;
+  private double weight;
 
   public ZKeyWeight(RedisKey key, double weight) {
     this.key = key;
@@ -36,5 +36,9 @@ public class ZKeyWeight {
 
   public double getWeight() {
     return weight;
+  }
+
+  public void setWeight(double weight) {
+    this.weight = weight;
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor.sortedset;
+
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
+import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bAGGREGATE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWEIGHTS;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.AbstractExecutor;
+import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.redis.internal.netty.Command;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+
+public abstract class ZStoreExecutor extends AbstractExecutor {
+
+  @Override
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
+    List<byte[]> commandElements = command.getProcessedCommand();
+
+    Iterator<byte[]> argIterator = commandElements.iterator();
+    // Skip command and destination key
+    argIterator.next();
+    argIterator.next();
+
+    long numKeys;
+    try {
+      numKeys = Coder.bytesToLong(argIterator.next());
+    } catch (NumberFormatException ex) {
+      return RedisResponse.error(ERROR_SYNTAX);
+    }
+
+    // Rough validation so that we can use numKeys to initialize the array sizes below.
+    if (numKeys > commandElements.size()) {
+      return RedisResponse.error(ERROR_SYNTAX);
+    }
+
+    List<RedisKey> sourceKeys = new ArrayList<>((int) numKeys);
+    List<Double> weights = new ArrayList<>((int) numKeys);
+    ZAggregator aggregator = ZAggregator.SUM;
+
+    while (argIterator.hasNext()) {
+      byte[] arg = argIterator.next();
+
+      if (sourceKeys.size() < numKeys) {
+        sourceKeys.add(new RedisKey(arg));
+        continue;
+      }
+
+      arg = toUpperCaseBytes(arg);
+      if (Arrays.equals(arg, bWEIGHTS)) {
+        if (!weights.isEmpty()) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+        for (int i = 0; i < numKeys; i++) {
+          if (!argIterator.hasNext()) {
+            return RedisResponse.error(ERROR_SYNTAX);
+          }
+          try {
+            weights.add(Coder.bytesToDouble(argIterator.next()));
+          } catch (NumberFormatException nex) {
+            return RedisResponse.error(ERROR_WEIGHT_NOT_A_FLOAT);
+          }
+        }
+        continue;
+      }
+
+      if (Arrays.equals(arg, bAGGREGATE)) {
+        try {
+          aggregator = ZAggregator.valueOf(Coder.bytesToString(argIterator.next()));
+        } catch (IllegalArgumentException | NoSuchElementException e) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+        continue;
+      }
+
+      // End up here if we have more keys than weights
+      return RedisResponse.error(ERROR_SYNTAX);
+    }
+
+    if (sourceKeys.size() != numKeys) {
+      return RedisResponse.error(ERROR_SYNTAX);
+    }
+
+    int bucket = command.getKey().getBucketId();
+    for (RedisKey key : sourceKeys) {
+      if (key.getBucketId() != bucket) {
+        return RedisResponse.crossSlot(ERROR_WRONG_SLOT);
+      }
+    }
+
+    List<ZKeyWeight> keyWeights = new ArrayList<>((int) numKeys);
+    for (int i = 0; i < sourceKeys.size(); i++) {
+      double weight = weights.isEmpty() ? 1 : weights.get(i);
+      keyWeights.add(new ZKeyWeight(sourceKeys.get(i), weight));
+    }
+
+    long result = getResult(context, command, keyWeights, aggregator);
+
+    return RedisResponse.integer(result);
+  }
+
+  public abstract long getResult(ExecutionHandlerContext context, Command command,
+      List<ZKeyWeight> keyWeights, ZAggregator aggregator);
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
@@ -70,10 +70,6 @@ public abstract class ZStoreExecutor extends AbstractExecutor {
         return syntaxErrorResponse;
       }
       argument = argIterator.next();
-      if (Arrays.equals(toUpperCaseBytes(argument), bWEIGHTS)
-          || Arrays.equals(toUpperCaseBytes(argument), bAGGREGATE)) {
-        return syntaxErrorResponse;
-      }
       keyWeights.add(new ZKeyWeight(new RedisKey(argument), 1D));
     }
 
@@ -85,9 +81,6 @@ public abstract class ZStoreExecutor extends AbstractExecutor {
           return syntaxErrorResponse;
         }
         argument = argIterator.next();
-        if (Arrays.equals(toUpperCaseBytes(argument), bWEIGHTS)) {
-          return syntaxErrorResponse; // there must be an aggregate between 'AGGREGATE' & 'WEIGHTS'
-        }
         try {
           aggregator = ZAggregator.valueOf(Coder.bytesToString(toUpperCaseBytes(argument)));
         } catch (IllegalArgumentException e) {
@@ -100,9 +93,6 @@ public abstract class ZStoreExecutor extends AbstractExecutor {
             return syntaxErrorResponse;
           }
           argument = argIterator.next();
-          if (Arrays.equals(toUpperCaseBytes(argument), bAGGREGATE)) {
-            return syntaxErrorResponse; // there must be # weights between 'WEIGHTS' & 'AGGREGATE'
-          }
           try {
             keyWeights.get(i).setWeight(Coder.bytesToDouble(argument));
           } catch (NumberFormatException e) {
@@ -112,10 +102,6 @@ public abstract class ZStoreExecutor extends AbstractExecutor {
       } else {
         return syntaxErrorResponse;
       }
-    }
-
-    if (keyWeights.size() != numKeys) {
-      return syntaxErrorResponse;
     }
 
     int slot = command.getKey().getSlot();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.executor.sortedset;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_KEY_REQUIRED;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
@@ -57,7 +58,7 @@ public abstract class ZStoreExecutor extends AbstractExecutor {
         return RedisResponse.error(ERROR_KEY_REQUIRED);
       }
     } catch (NumberFormatException ex) {
-      return syntaxErrorResponse;
+      return RedisResponse.error(ERROR_NOT_INTEGER);
     }
 
     List<ZKeyWeight> keyWeights = new ArrayList<>(numKeys);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
@@ -14,18 +14,19 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_KEY_REQUIRED;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
+import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bAGGREGATE;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWEIGHTS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
+import java.util.ListIterator;
 
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
@@ -39,89 +40,181 @@ public abstract class ZStoreExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<byte[]> commandElements = command.getProcessedCommand();
+    boolean weightsFound = false;
 
-    Iterator<byte[]> argIterator = commandElements.iterator();
+    ListIterator<byte[]> argIterator = commandElements.listIterator();
     // Skip command and destination key
     argIterator.next();
     argIterator.next();
 
-    long numKeys;
+    int numKeys;
     try {
-      numKeys = Coder.bytesToLong(argIterator.next());
+      numKeys = narrowLongToInt(Coder.bytesToLong(argIterator.next()));
     } catch (NumberFormatException ex) {
       return RedisResponse.error(ERROR_SYNTAX);
     }
 
     // Rough validation so that we can use numKeys to initialize the array sizes below.
-    if (numKeys > commandElements.size()) {
+    if (numKeys > commandElements.size() - 2) {
       return RedisResponse.error(ERROR_SYNTAX);
     }
 
-    List<ZKeyWeight> keyWeights = new ArrayList<>((int) numKeys);
+    if (numKeys <= 0) {
+      return RedisResponse.error(ERROR_KEY_REQUIRED);
+    }
+
+    List<ZKeyWeight> keyWeights = new ArrayList<>(numKeys);
     ZAggregator aggregator = ZAggregator.SUM;
+    byte[] argument;
+    boolean aggOrWeightFound = false;
+    boolean aggregateFound = false;
 
-    while (argIterator.hasNext()) {
-      byte[] arg = argIterator.next();
+    do {
+      int numWeights = 0;
+      argument = argIterator.next();
 
-      if (keyWeights.size() < numKeys) {
-        keyWeights.add(new ZKeyWeight(new RedisKey(arg), 1D));
-        continue;
-      }
+      if (Arrays.equals(toUpperCaseBytes(argument), bWEIGHTS)) {
+        aggOrWeightFound = true;
 
-      arg = toUpperCaseBytes(arg);
-      if (Arrays.equals(arg, bWEIGHTS)) {
-        if (!allWeightsAreOne(keyWeights)) {
+        if (!argIterator.hasNext()) {
           return RedisResponse.error(ERROR_SYNTAX);
         }
-        for (int i = 0; i < numKeys; i++) {
-          if (!argIterator.hasNext()) {
+
+        // start parsing weights
+        for (int i = 0; argIterator.hasNext(); i++) {
+          argument = argIterator.next();
+
+          if (Arrays.equals(toUpperCaseBytes(argument), bAGGREGATE)) {
+            if (numWeights == numKeys) {
+              break;
+            } else {
+              return RedisResponse.error(ERROR_SYNTAX);
+            }
+          }
+
+          if (keyWeights.size() > numKeys || i >= numKeys) {
             return RedisResponse.error(ERROR_SYNTAX);
           }
           try {
-            keyWeights.get(i).setWeight(Coder.bytesToDouble(argIterator.next()));
-          } catch (NumberFormatException nex) {
+            double arg = Coder.bytesToDouble(argument);
+            keyWeights.get(i).setWeight(arg);
+            numWeights++;
+          } catch (NumberFormatException e) {
             return RedisResponse.error(ERROR_WEIGHT_NOT_A_FLOAT);
           }
         }
-        continue;
-      }
 
-      if (Arrays.equals(arg, bAGGREGATE)) {
-        try {
-          aggregator = ZAggregator.valueOf(Coder.bytesToString(argIterator.next()));
-        } catch (IllegalArgumentException | NoSuchElementException e) {
+        if (numWeights != numKeys) {
           return RedisResponse.error(ERROR_SYNTAX);
         }
-        continue;
+
+
+      } else if (Arrays.equals(toUpperCaseBytes(argument), bAGGREGATE)) {
+        aggOrWeightFound = true;
+
+        // the iterator must have at least one more, and we must have the expected number of keys
+        if (!argIterator.hasNext() || keyWeights.size() != numKeys) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+
+        // start parsing aggregates
+        argument = argIterator.next();
+        if (Arrays.equals(toUpperCaseBytes(argument), bWEIGHTS)) {
+          // if we've found at least one aggregate before the weights keyword then we're good
+          if (aggregateFound) {
+            break;
+          } else {
+            return RedisResponse.error(ERROR_SYNTAX);
+          }
+        }
+
+        try {
+          aggregator = ZAggregator.valueOf(Coder.bytesToString(toUpperCaseBytes(argument)));
+        } catch (IllegalArgumentException e) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+        aggregateFound = true;
+
+      } else {
+        // otherwise it's a key
+        if (aggOrWeightFound || keyWeights.size() > numKeys) {
+          return RedisResponse.error(ERROR_SYNTAX);
+        }
+        keyWeights.add(new ZKeyWeight(new RedisKey(argument), 1D));
       }
 
-      // End up here if we have more keys than weights
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
+    } while (argIterator.hasNext());
 
     if (keyWeights.size() != numKeys) {
       return RedisResponse.error(ERROR_SYNTAX);
     }
 
-    int bucket = command.getKey().getBucketId();
+    int slot = command.getKey().getSlot();
     for (ZKeyWeight keyWeight : keyWeights) {
-      if (keyWeight.getKey().getBucketId() != bucket) {
+      if (keyWeight.getKey().getSlot() != slot) {
         return RedisResponse.crossSlot(ERROR_WRONG_SLOT);
       }
     }
 
-    long result = getResult(context, command, keyWeights, aggregator);
+    return RedisResponse.integer(getResult(context, command, keyWeights, aggregator));
 
-    return RedisResponse.integer(result);
-  }
 
-  private boolean allWeightsAreOne(List<ZKeyWeight> keyWeights) {
-    for (ZKeyWeight key : keyWeights) {
-      if (key.getWeight() != 1D) {
-        return false;
-      }
-    }
-    return true;
+    //
+    //
+    // while (argIterator.hasNext()) {
+    // byte[] arg = argIterator.next();
+    //
+    // if (keyWeights.size() < numKeys) {
+    // keyWeights.add(new ZKeyWeight(new RedisKey(arg), 1D));
+    // continue;
+    // }
+    //
+    // arg = toUpperCaseBytes(arg);
+    // if (Arrays.equals(arg, bWEIGHTS)) {
+    // if (weightsFound) {
+    // return RedisResponse.error(ERROR_SYNTAX);
+    // } else {
+    // weightsFound = true;
+    // }
+    // for (int i = 0; i < numKeys; i++) {
+    // if (!argIterator.hasNext()) {
+    // return RedisResponse.error(ERROR_SYNTAX);
+    // }
+    // try {
+    // keyWeights.get(i).setWeight(Coder.bytesToDouble(argIterator.next()));
+    // } catch (NumberFormatException nex) {
+    // return RedisResponse.error(ERROR_WEIGHT_NOT_A_FLOAT);
+    // }
+    // }
+    // continue;
+    // }
+    //
+    // if (Arrays.equals(arg, bAGGREGATE)) {
+    // try {
+    // aggregator = ZAggregator.valueOf(Coder.bytesToString(argIterator.next()));
+    // } catch (IllegalArgumentException | NoSuchElementException e) {
+    // return RedisResponse.error(ERROR_SYNTAX);
+    // }
+    // continue;
+    // }
+    //
+    // // End up here if we have finished parsing keys and encounter another option other than
+    // // WEIGHTS and AGGREGATE
+    // return RedisResponse.error(ERROR_SYNTAX);
+    // }
+    //
+    // if (keyWeights.size() != numKeys) {
+    // return RedisResponse.error(ERROR_SYNTAX);
+    // }
+    //
+    // int slot = command.getKey().getSlot();
+    // for (ZKeyWeight keyWeight : keyWeights) {
+    // if (keyWeight.getKey().getSlot() != slot) {
+    // return RedisResponse.crossSlot(ERROR_WRONG_SLOT);
+    // }
+    // }
+    //
+    // return RedisResponse.integer(getResult(context, command, keyWeights, aggregator));
   }
 
   public abstract long getResult(ExecutionHandlerContext context, Command command,

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZUnionStoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZUnionStoreExecutor.java
@@ -14,113 +14,16 @@
  */
 package org.apache.geode.redis.internal.executor.sortedset;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
-import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bAGGREGATE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWEIGHTS;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 
-import org.apache.geode.redis.internal.data.RedisKey;
-import org.apache.geode.redis.internal.executor.AbstractExecutor;
-import org.apache.geode.redis.internal.executor.RedisResponse;
-import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
-public class ZUnionStoreExecutor extends AbstractExecutor {
-
+public class ZUnionStoreExecutor extends ZStoreExecutor {
   @Override
-  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
-    List<byte[]> commandElements = command.getProcessedCommand();
-
-    Iterator<byte[]> argIterator = commandElements.iterator();
-    // Skip command and destination key
-    argIterator.next();
-    argIterator.next();
-
-    long numKeys;
-    try {
-      numKeys = Coder.bytesToLong(argIterator.next());
-    } catch (NumberFormatException nex) {
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
-
-    // Rough validation so that we can use numKeys to initialize the array sizes below.
-    if (numKeys > commandElements.size()) {
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
-
-    List<RedisKey> sourceKeys = new ArrayList<>((int) numKeys);
-    List<Double> weights = new ArrayList<>((int) numKeys);
-    ZAggregator aggregator = ZAggregator.SUM;
-
-    while (argIterator.hasNext()) {
-      byte[] arg = argIterator.next();
-
-      if (sourceKeys.size() < numKeys) {
-        sourceKeys.add(new RedisKey(arg));
-        continue;
-      }
-
-      arg = toUpperCaseBytes(arg);
-      if (Arrays.equals(arg, bWEIGHTS)) {
-        if (!weights.isEmpty()) {
-          return RedisResponse.error(ERROR_SYNTAX);
-        }
-        for (int i = 0; i < numKeys; i++) {
-          if (!argIterator.hasNext()) {
-            return RedisResponse.error(ERROR_SYNTAX);
-          }
-          try {
-            weights.add(Coder.bytesToDouble(argIterator.next()));
-          } catch (NumberFormatException nex) {
-            return RedisResponse.error(ERROR_WEIGHT_NOT_A_FLOAT);
-          }
-        }
-        continue;
-      }
-
-      if (Arrays.equals(arg, bAGGREGATE)) {
-        try {
-          aggregator = ZAggregator.valueOf(Coder.bytesToString(argIterator.next()));
-        } catch (IllegalArgumentException | NoSuchElementException e) {
-          return RedisResponse.error(ERROR_SYNTAX);
-        }
-        continue;
-      }
-
-      // End up here if we have more keys than weights
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
-
-    if (sourceKeys.size() != numKeys) {
-      return RedisResponse.error(ERROR_SYNTAX);
-    }
-
-    int bucket = command.getKey().getBucketId();
-    for (RedisKey key : sourceKeys) {
-      if (key.getBucketId() != bucket) {
-        return RedisResponse.crossSlot(ERROR_WRONG_SLOT);
-      }
-    }
-
-    List<ZKeyWeight> keyWeights = new ArrayList<>();
-    for (int i = 0; i < sourceKeys.size(); i++) {
-      double weight = weights.isEmpty() ? 1 : weights.get(i);
-      keyWeights.add(new ZKeyWeight(sourceKeys.get(i), weight));
-    }
-
-    long result = context.getSortedSetCommands()
-        .zunionstore(command.getKey(), keyWeights, aggregator);
-
-    return RedisResponse.integer(result);
+  public long getResult(ExecutionHandlerContext context, Command command,
+      List<ZKeyWeight> keyWeights, ZAggregator aggregator) {
+    return context.getSortedSetCommands().zunionstore(command.getKey(), keyWeights, aggregator);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -376,7 +376,7 @@ public class RedisSortedSetTest {
 
   @Test
   public void zscanThrowsWhenReturnedArrayListLengthWouldExceedVMLimit() {
-    RedisSortedSet sortedSet = spy(new RedisSortedSet());
+    RedisSortedSet sortedSet = spy(new RedisSortedSet(Collections.emptyList(), new double[] {}));
     doReturn(Integer.MAX_VALUE - 10L).when(sortedSet).zcard();
 
     assertThatThrownBy(() -> sortedSet.zscan(null, Integer.MAX_VALUE - 10, 0))


### PR DESCRIPTION
ZINTERSTORE command takes the intersection of N sorted sets and stores
the results, either summing, taking the max, or taking the min of all
the scores for each member. The provided destination key will be
overridden if it already exists.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
