### PR TITLE
GEODE-9595: Exclude circular integrationTest classpath dependencies

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -233,7 +233,9 @@ dependencies {
         exclude group: '*'
     }
 
-    runtimeOnly(project(':geode-deployment:geode-deployment-legacy'))
+    runtimeOnly(project(':geode-deployment:geode-deployment-legacy')) {
+        exclude module: 'geode-core'
+    }
 
     //Commons lang is used in many different places in core
     implementation('org.apache.commons:commons-lang3')
@@ -349,10 +351,18 @@ dependencies {
 
     // Needed for JDK8, not JDK11, after nebula.facet v7.0.9
     integrationTestImplementation(files("${System.getProperty('java.home')}/../lib/tools.jar"))
-    integrationTestImplementation(project(':geode-gfsh'))
-    integrationTestImplementation(project(':geode-junit'))
-    integrationTestImplementation(project(':geode-dunit'))
-    integrationTestImplementation(project(':geode-log4j'))
+    integrationTestImplementation(project(':geode-gfsh')) {
+        exclude module: 'geode-core'
+    }
+    integrationTestImplementation(project(':geode-junit')) {
+        exclude module: 'geode-core'
+    }
+    integrationTestImplementation(project(':geode-dunit')) {
+        exclude module: 'geode-core'
+    }
+    integrationTestImplementation(project(':geode-log4j')) {
+        exclude module: 'geode-core'
+    }
     integrationTestImplementation(project(':geode-concurrency-test'))
     integrationTestImplementation('org.apache.bcel:bcel')
     integrationTestImplementation('org.apache.logging.log4j:log4j-core')
@@ -364,7 +374,9 @@ dependencies {
     integrationTestRuntimeOnly('xerces:xercesImpl')
     integrationTestRuntimeOnly('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
 
-    distributedTestImplementation(project(':geode-gfsh'))
+    distributedTestImplementation(project(':geode-gfsh')) {
+        exclude module: 'geode-core'
+    }
     distributedTestImplementation(project(':geode-junit')) {
         exclude module: 'geode-core'
     }

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -252,6 +252,12 @@
       <groupId>org.apache.geode</groupId>
       <artifactId>geode-deployment-legacy</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>geode-core</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>

--- a/geode-cq/build.gradle
+++ b/geode-cq/build.gradle
@@ -32,7 +32,9 @@ dependencies {
   testImplementation(project(':geode-junit'))
 
 
-  integrationTestImplementation(project(':geode-dunit'))
+  integrationTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-cq'
+  }
   integrationTestImplementation(project(':geode-junit'))
   integrationTestImplementation('junit:junit')
   integrationTestImplementation('org.awaitility:awaitility')
@@ -40,7 +42,9 @@ dependencies {
 
   distributedTestImplementation(project(':geode-gfsh'))
   distributedTestImplementation(project(':geode-junit'))
-  distributedTestImplementation(project(':geode-dunit'))
+  distributedTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-cq'
+  }
   distributedTestImplementation('org.apache.commons:commons-lang3')
   distributedTestImplementation('junit:junit')
   distributedTestImplementation('mx4j:mx4j')
@@ -50,7 +54,9 @@ dependencies {
   distributedTestImplementation('pl.pragmatists:JUnitParams')
 
 
-  upgradeTestImplementation(project(':geode-dunit'))
+  upgradeTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-cq'
+  }
   upgradeTestImplementation(project(':geode-junit'))
   upgradeTestImplementation('junit:junit')
   upgradeTestImplementation('org.awaitility:awaitility')

--- a/geode-gfsh/build.gradle
+++ b/geode-gfsh/build.gradle
@@ -41,11 +41,15 @@ dependencies {
     testImplementation('org.springframework:spring-test')
     testImplementation(project(':geode-junit'))
 
-    integrationTestImplementation(project(':geode-dunit'))
+    integrationTestImplementation(project(':geode-dunit')) {
+        exclude module: 'geode-gfsh'
+    }
     integrationTestImplementation('pl.pragmatists:JUnitParams')
     integrationTestRuntimeOnly('org.apache.derby:derby')
     
-    distributedTestImplementation(project(':geode-dunit'))
+    distributedTestImplementation(project(':geode-dunit')) {
+        exclude module: 'geode-gfsh'
+    }
     distributedTestImplementation('pl.pragmatists:JUnitParams')
     distributedTestRuntimeOnly('org.apache.derby:derby')
 
@@ -53,7 +57,9 @@ dependencies {
     testCompileOnly('io.swagger:swagger-annotations')
 
     upgradeTestImplementation(project(':geode-junit'))
-    upgradeTestImplementation(project(':geode-dunit'))
+    upgradeTestImplementation(project(':geode-dunit')) {
+        exclude module: 'geode-gfsh'
+    }
 
     upgradeTestImplementation('org.awaitility:awaitility')
     upgradeTestImplementation('org.assertj:assertj-core')

--- a/geode-management/build.gradle
+++ b/geode-management/build.gradle
@@ -49,7 +49,9 @@ dependencies {
   testCompileOnly(platform(project(':boms:geode-all-bom')))
   testCompileOnly('io.swagger:swagger-annotations')
 
-  integrationTestImplementation(project(':geode-dunit'))
+  integrationTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-management'
+  }
   integrationTestImplementation(project(':geode-junit'))
   integrationTestImplementation('junit:junit')
   integrationTestImplementation('org.awaitility:awaitility')

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -45,7 +45,9 @@ dependencies {
 
 
   distributedTestImplementation(project(':geode-gfsh'))
-  distributedTestImplementation(project(':geode-dunit'))
+  distributedTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-wan'
+  }
   distributedTestImplementation(project(':geode-junit'))
 
   distributedTestImplementation('mx4j:mx4j')
@@ -62,7 +64,9 @@ dependencies {
 
   upgradeTestImplementation(project(':geode-gfsh'))
   upgradeTestImplementation(project(':geode-junit'))
-  upgradeTestImplementation(project(':geode-dunit'))
+  upgradeTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-wan'
+  }
 
   upgradeTestImplementation('org.awaitility:awaitility')
   upgradeTestImplementation('org.assertj:assertj-core')

--- a/geode-web-api/build.gradle
+++ b/geode-web-api/build.gradle
@@ -104,6 +104,7 @@ dependencies {
   }
   integrationTestImplementation(project(':geode-dunit')) {
     exclude module: 'geode-core'
+    exclude module: 'geode-web-api'
   }
 }
 


### PR DESCRIPTION
The bug GEODE-9595 results in Analyze*Module*SerializablesIntegrationTests failing with the following when an actual serializable is missing from the sanctioned serializables and the excluded list:
```
java.nio.file.FileSystemNotFoundException
	at com.sun.nio.zipfs.ZipFileSystemProvider.getFileSystem(ZipFileSystemProvider.java:171)
	at com.sun.nio.zipfs.ZipFileSystemProvider.getPath(ZipFileSystemProvider.java:157)
	at java.nio.file.Paths.get(Paths.java:143)
	at org.apache.geode.codeAnalysis.AnalyzeDataSerializablesJUnitTestBase.mainResourceToSourcePath(AnalyzeDataSerializablesJUnitTestBase.java:260)
	at org.apache.geode.codeAnalysis.AnalyzeSerializablesJUnitTestBase.testSerializables(AnalyzeSerializablesJUnitTestBase.java:102)
```
Debugging reveals that the above is caused by the integrationTest classpath loading classes and resources from geode-*module*/build/libs/geode-*module*.jar instead of from geode-*module*/build/classes and geode-*module*/build/resources.

Example in geode-core:

Execute `$ ./gradlew geode-core:dependencies --configuration integrationTestRuntimeClasspath | less`

Search for `geode-core` and note that the following dependencies will add the geode-core jar file as a dependency. Integration tests will then load classes and resources from that jar file instead of the filesystem which is incorrect behavior unless a testing target is specifically written to use the jars:
```
+--- project :geode-gfsh
|    +--- <snip>
|    +--- project :geode-core (*)
```
```
+--- project :geode-dunit
|    +--- <snip>
|    +--- project :geode-core (*)
|    +--- <snip>
|    +--- project :geode-cq
|    |    +--- <snip>
|    |    +--- project :geode-core (*)
|    +--- project :geode-log4j
|    |    +--- <snip>
|    |    +--- project :geode-core (*)
```
```
+--- project :geode-deployment:geode-deployment-legacy
|    +--- <snip>
|    +--- project :geode-core (*)
```
The fix involves excluding `geode-core` from the above identified integrationTestImplementation dependencies:
```
    integrationTestImplementation(project(':geode-gfsh')) {
        exclude module: 'geode-core'
    }
    integrationTestImplementation(project(':geode-junit')) {
        exclude module: 'geode-core'
    }
    integrationTestImplementation(project(':geode-dunit')) {
        exclude module: 'geode-core'
    }
    integrationTestImplementation(project(':geode-log4j')) {
        exclude module: 'geode-core'
    }
```
This PR fixes the circular dependencies that add geode-*module*.jars to the classpath of tests in modules:
- geode-core
- geode-cq
- geode-gfsh
- geode-maangement
- geode-wan
- geode-web-api
