### PR TITLE
GEODE-9596: Avoid creating multiple cq maps in ClientUpdateMessage

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -1569,7 +1569,8 @@ public class HARegionQueueJUnitTest {
     regionQueue.putEntryConditionallyIntoHAContainer(mockHAEventWrapper);
     regionQueue.putEntryConditionallyIntoHAContainer(mockHAEventWrapper);
 
-    verify(mockClientUpdateMessage).setClientCqs(mockClientCqConcurrentMap);
+    verify(mockClientUpdateMessage).addOrSetClientCqs(mockClientProxyMembershipId,
+        mockClientCqConcurrentMap);
     verify(mockClientUpdateMessage).addClientInterestList(mockClientProxyMembershipId,
         true);
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -1569,9 +1569,8 @@ public class HARegionQueueJUnitTest {
     regionQueue.putEntryConditionallyIntoHAContainer(mockHAEventWrapper);
     regionQueue.putEntryConditionallyIntoHAContainer(mockHAEventWrapper);
 
-    verify(mockClientUpdateMessage, times(1)).addClientCqs(mockClientProxyMembershipId,
-        mockCqNameToOp);
-    verify(mockClientUpdateMessage, times(1)).addClientInterestList(mockClientProxyMembershipId,
+    verify(mockClientUpdateMessage).setClientCqs(mockClientCqConcurrentMap);
+    verify(mockClientUpdateMessage).addClientInterestList(mockClientProxyMembershipId,
         true);
 
     // Mock that the ClientUpdateMessage is only interested in invalidates, then do another put

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
@@ -3494,7 +3494,7 @@ public class HARegionQueue implements RegionQueue {
       if (haEventWrapper.getClientCqs() != null) {
         CqNameToOp clientCQ = haEventWrapper.getClientCqs().get(proxyID);
         if (clientCQ != null) {
-          msg.setClientCqs(haEventWrapper.getClientCqs());
+          msg.addOrSetClientCqs(proxyID, haEventWrapper.getClientCqs());
         }
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
@@ -3494,7 +3494,7 @@ public class HARegionQueue implements RegionQueue {
       if (haEventWrapper.getClientCqs() != null) {
         CqNameToOp clientCQ = haEventWrapper.getClientCqs().get(proxyID);
         if (clientCQ != null) {
-          msg.addClientCqs(proxyID, clientCQ);
+          msg.setClientCqs(haEventWrapper.getClientCqs());
         }
       }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
@@ -589,6 +589,14 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
     return _clientCqs;
   }
 
+  public void addOrSetClientCqs(ClientProxyMembershipID proxyID, ClientCqConcurrentMap clientCqs) {
+    if (_clientCqs == null) {
+      _clientCqs = clientCqs;
+    } else {
+      _clientCqs.put(proxyID, clientCqs.get(proxyID));
+    }
+  }
+
   synchronized void addClientCq(ClientProxyMembershipID clientId, String cqName, Integer cqEvent) {
     if (_clientCqs == null) {
       _clientCqs = new ClientCqConcurrentMap();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImpl.java
@@ -589,19 +589,7 @@ public class ClientUpdateMessageImpl implements ClientUpdateMessage, Sizeable, N
     return _clientCqs;
   }
 
-  /**
-   * Add cqs for the given client.
-   *
-   */
-  public void addClientCqs(ClientProxyMembershipID clientId, CqNameToOp filteredCqs) {
-    if (_clientCqs == null) {
-      _clientCqs = new ClientCqConcurrentMap();
-      _hasCqs = true;
-    }
-    _clientCqs.put(clientId, filteredCqs);
-  }
-
-  void addClientCq(ClientProxyMembershipID clientId, String cqName, Integer cqEvent) {
+  synchronized void addClientCq(ClientProxyMembershipID clientId, String cqName, Integer cqEvent) {
     if (_clientCqs == null) {
       _clientCqs = new ClientCqConcurrentMap();
       _hasCqs = true;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImplTest.java
@@ -148,7 +148,7 @@ public class ClientUpdateMessageImplTest implements Serializable {
 
     addClientCqConcurrently(clientUpdateMessageImpl, numOfEvents, cqEvents, cqNames, clients);
 
-    assertThat(clientUpdateMessageImpl.getClientCqs().size()).isEqualTo(2);
+    assertThat(clientUpdateMessageImpl.getClientCqs()).hasSize(2);
     assertThat(clientUpdateMessageImpl.getClientCqs().get(client1)).isInstanceOf(
         ClientUpdateMessageImpl.CqNameToOpHashMap.class);
     ClientUpdateMessageImpl.CqNameToOpHashMap client1Cqs =
@@ -212,7 +212,7 @@ public class ClientUpdateMessageImplTest implements Serializable {
 
     clientUpdateMessageImpl.addOrSetClientCqs(client1, clientCqs);
 
-    assertThat(clientUpdateMessageImpl.getClientCqs().size()).isEqualTo(2);
+    assertThat(clientUpdateMessageImpl.getClientCqs()).hasSize(2);
     assertThat(clientUpdateMessageImpl.getClientCqs().get(client1)).isInstanceOf(
         ClientUpdateMessageImpl.CqNameToOpHashMap.class);
     ClientUpdateMessageImpl.CqNameToOpHashMap client1Cqs =

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUpdateMessageImplTest.java
@@ -22,7 +22,11 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Future;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.geode.CopyHelper;
@@ -32,8 +36,15 @@ import org.apache.geode.internal.cache.EnumListenerEvent;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.test.fake.Fakes;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
 public class ClientUpdateMessageImplTest implements Serializable {
+  private final ClientProxyMembershipID client1 = mock(ClientProxyMembershipID.class);
+  private final ClientProxyMembershipID client2 = mock(ClientProxyMembershipID.class);
+
+  @Rule
+  public ExecutorServiceRule executorService = new ExecutorServiceRule();
+
   @Test
   public void addInterestedClientTest() {
     ClientUpdateMessageImpl clientUpdateMessageImpl = new ClientUpdateMessageImpl();
@@ -109,4 +120,64 @@ public class ClientUpdateMessageImplTest implements Serializable {
     when(localRegion.getName()).thenReturn(regionName);
     return new ClientUpdateMessageImpl(EnumListenerEvent.AFTER_CREATE, null, null);
   }
+
+  @Test
+  public void addClientCqCanBeExecutedConcurrently() throws Exception {
+    ClientUpdateMessageImpl clientUpdateMessageImpl = new ClientUpdateMessageImpl();
+
+    int numOfEvents = 4;
+    int[] cqEvents = new int[numOfEvents];
+    String[] cqNames = new String[numOfEvents];
+    ClientProxyMembershipID[] clients = new ClientProxyMembershipID[numOfEvents];
+    prepareCqInfo(numOfEvents, cqEvents, cqNames, clients);
+
+    addClientCqConcurrently(clientUpdateMessageImpl, numOfEvents, cqEvents, cqNames, clients);
+
+    assertThat(clientUpdateMessageImpl.getClientCqs().size()).isEqualTo(2);
+    assertThat(clientUpdateMessageImpl.getClientCqs().get(client1)).isInstanceOf(
+        ClientUpdateMessageImpl.CqNameToOpHashMap.class);
+    ClientUpdateMessageImpl.CqNameToOpHashMap client1Cqs =
+        (ClientUpdateMessageImpl.CqNameToOpHashMap) clientUpdateMessageImpl.getClientCqs()
+            .get(client1);
+    for (int i = 0; i < 3; i++) {
+      assertThat(client1Cqs.get("cqName" + i)).isEqualTo(i);
+    }
+
+    assertThat(clientUpdateMessageImpl.getClientCqs().get(client2)).isInstanceOf(
+        ClientUpdateMessageImpl.CqNameToOpSingleEntry.class);
+    ClientUpdateMessageImpl.CqNameToOpSingleEntry client2Cqs =
+        (ClientUpdateMessageImpl.CqNameToOpSingleEntry) clientUpdateMessageImpl.getClientCqs()
+            .get(client2);
+    assertThat(client2Cqs.isEmpty()).isFalse();
+  }
+
+  private void prepareCqInfo(int numOfEvents, int[] cqEvents, String[] cqNames,
+      ClientProxyMembershipID[] clients) {
+    for (int i = 0; i < numOfEvents; i++) {
+      cqEvents[i] = i;
+      cqNames[i] = "cqName" + i;
+      if (i < 3) {
+        clients[i] = client1;
+      } else {
+        clients[i] = client2;
+      }
+    }
+  }
+
+  private void addClientCqConcurrently(ClientUpdateMessageImpl clientUpdateMessageImpl,
+      int numOfEvents, int[] cqEvents, String[] cqNames, ClientProxyMembershipID[] clients)
+      throws InterruptedException, java.util.concurrent.ExecutionException {
+    List<Future<Void>> futures = new ArrayList<>();
+    for (int i = 0; i < numOfEvents; i++) {
+      ClientProxyMembershipID client = clients[i];
+      String cqName = cqNames[i];
+      int cqEvent = cqEvents[i];
+      futures.add(executorService
+          .submit(() -> clientUpdateMessageImpl.addClientCq(client, cqName, cqEvent)));
+    }
+    for (Future<Void> future : futures) {
+      future.get();
+    }
+  }
+
 }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDUnitTest.java
@@ -14,11 +14,11 @@
  */
 package org.apache.geode.cache.query.cq.dunit;
 
-import static junit.framework.TestCase.assertEquals;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.VM.getHostName;
 import static org.apache.geode.test.dunit.VM.getVM;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -134,7 +134,7 @@ public class CqDUnitTest implements Serializable {
       QueryService cqService = clientCacheRule.getClientCache().getQueryService();
       CqListener cqListener = cqService.getCq(cqName).getCqAttributes().getCqListener();
 
-      assertEquals(totalCQInvocations, ((TestCqListener) cqListener).numEvents.get());
+      assertThat(totalCQInvocations).isEqualTo(((TestCqListener) cqListener).numEvents.get());
     });
   }
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDUnitTest.java
@@ -1,0 +1,229 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.cq.dunit;
+
+import static junit.framework.TestCase.assertEquals;
+import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.VM.getHostName;
+import static org.apache.geode.test.dunit.VM.getVM;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionFactory;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.client.Pool;
+import org.apache.geode.cache.client.PoolManager;
+import org.apache.geode.cache.query.CqAttributes;
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqListener;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.data.Portfolio;
+import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.cache.server.ClientSubscriptionConfig;
+import org.apache.geode.internal.cache.DiskStoreAttributes;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.CacheRule;
+import org.apache.geode.test.dunit.rules.ClientCacheRule;
+import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+public class CqDUnitTest implements Serializable {
+  private static final int VM_COUNT = 8;
+
+  private final String REGION_NAME = "region";
+
+  private String hostName;
+  private VM[] clients;
+  private int serverPort;
+  private TestCqListener[] testListener;
+  private int totalPut;
+  private int totalCQInvocations;
+  private final String cqName = "cqName";
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule(VM_COUNT);
+
+  @Rule
+  public CacheRule cacheRule = new CacheRule(VM_COUNT);
+
+  @Rule
+  public ClientCacheRule clientCacheRule = new ClientCacheRule(VM_COUNT);
+
+  @Rule
+  public SerializableTemporaryFolder tempDir = new SerializableTemporaryFolder();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  @Rule
+  public DistributedRestoreSystemProperties restoreSystemProperties =
+      new DistributedRestoreSystemProperties();
+
+  @Before
+  public void setUp() {
+    hostName = getHostName();
+    VM server = getVM(0);
+    getVM(0).invoke(() -> cacheRule.createCache());
+    testListener = new TestCqListener[VM_COUNT - 1];
+
+    clients = new VM[VM_COUNT - 1];
+    for (int i = 0; i < VM_COUNT - 1; i++) {
+      clients[i] = getVM(i + 1);
+      clients[i].invoke(() -> clientCacheRule.createClientCache());
+      testListener[i] = new TestCqListener();
+    }
+
+    serverPort = server.invoke(() -> createSubscriptionServer(cacheRule.getCache()));
+
+    for (VM client : clients) {
+      client.invoke(this::createRegionOnClient);
+    }
+
+    totalPut = 500;
+    totalCQInvocations = totalPut * clients.length;
+  }
+
+  @Test
+  public void clientCanInvokeCQListenersWhenHAContainerEnablesEviction() throws Exception {
+    registerCqs();
+
+    AsyncInvocation<?>[] asyncInvocations = new AsyncInvocation[VM_COUNT - 1];
+    for (int i = 0; i < VM_COUNT - 1; i++) {
+      asyncInvocations[i] = clients[i].invokeAsync(this::doPuts);
+    }
+
+    for (int i = 0; i < VM_COUNT - 1; i++) {
+      asyncInvocations[i].await();
+    }
+
+    for (int i = 0; i < VM_COUNT - 1; i++) {
+      clients[i].invoke(this::verifyCQListenerInvocations);
+    }
+  }
+
+  private void verifyCQListenerInvocations() {
+    await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+      QueryService cqService = clientCacheRule.getClientCache().getQueryService();
+      CqListener cqListener = cqService.getCq(cqName).getCqAttributes().getCqListener();
+
+      assertEquals(totalCQInvocations, ((TestCqListener) cqListener).numEvents.get());
+    });
+  }
+
+  private void registerCqs() {
+    for (int i = 0; i < VM_COUNT - 1; i++) {
+      registerCq(clients[i]);
+    }
+  }
+
+  private void registerCq(VM client) {
+    client.invoke(() -> {
+      ClientCache clientCache = clientCacheRule.getClientCache();
+
+      QueryService queryService = clientCache.getQueryService();
+      CqAttributesFactory cqaf = new CqAttributesFactory();
+
+      int i = client.getId() - 1;
+      cqaf.addCqListener(testListener[i]);
+      CqAttributes cqAttributes = cqaf.create();
+
+      queryService.newCq(cqName, "Select * from " + SEPARATOR + REGION_NAME + " where ID > 0",
+          cqAttributes)
+          .executeWithInitialResults();
+    });
+  }
+
+  private void doPuts() {
+    ClientCache clientCache = clientCacheRule.getClientCache();
+    Region<Object, Object> region = clientCache.getRegion(REGION_NAME);
+
+
+    for (int i = totalPut; i > 0; i--) {
+      doPut(region, i);
+    }
+  }
+
+  private void doPut(Region<Object, Object> region, int i) {
+    region.put(i, new Portfolio(i));
+  }
+
+  private static class TestCqListener implements CqListener, Serializable {
+    AtomicInteger numEvents = new AtomicInteger();
+
+    @Override
+    public void onEvent(CqEvent aCqEvent) {
+      numEvents.incrementAndGet();
+    }
+
+    @Override
+    public void onError(CqEvent aCqEvent) {}
+  }
+
+  private void createRegionOnClient() {
+    Pool pool = PoolManager.createFactory().addServer(hostName, serverPort)
+        .setSubscriptionEnabled(true).create("poolName");
+
+    ClientRegionFactory<Object, Object> crf =
+        clientCacheRule.getClientCache().createClientRegionFactory(ClientRegionShortcut.PROXY);
+    crf.setPoolName(pool.getName());
+    crf.create(REGION_NAME);
+  }
+
+  private int createSubscriptionServer(InternalCache cache) throws IOException {
+    initializeDiskStore(cache);
+    createRegionOnServer(cache);
+    return initializeCacheServerWithSubscription(cache);
+  }
+
+  private void initializeDiskStore(InternalCache cache) throws IOException {
+    DiskStoreAttributes diskStoreAttributes = new DiskStoreAttributes();
+    diskStoreAttributes.name = "clientQueueDS";
+    diskStoreAttributes.diskDirs = new File[] {tempDir.newFolder(testName + "_dir")};
+    cache.createDiskStoreFactory(diskStoreAttributes).create("clientQueueDS");
+  }
+
+  private void createRegionOnServer(InternalCache cache) {
+    cache.createRegionFactory(RegionShortcut.REPLICATE).create(REGION_NAME);
+  }
+
+  private int initializeCacheServerWithSubscription(InternalCache cache) throws IOException {
+    CacheServer cacheServer = cache.addCacheServer();
+    ClientSubscriptionConfig clientSubscriptionConfig = cacheServer.getClientSubscriptionConfig();
+    clientSubscriptionConfig.setEvictionPolicy("entry");
+    clientSubscriptionConfig.setCapacity(1);
+    clientSubscriptionConfig.setDiskStoreName("clientQueueDS");
+    cacheServer.setPort(0);
+    cacheServer.setHostnameForClients(hostName);
+    cacheServer.start();
+    return cacheServer.getPort();
+  }
+}

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDUnitTest.java
@@ -23,7 +23,6 @@ import static org.apache.geode.test.dunit.VM.getVM;
 import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
@@ -131,7 +130,7 @@ public class CqDUnitTest implements Serializable {
   }
 
   private void verifyCQListenerInvocations() {
-    await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+    await().untilAsserted(() -> {
       QueryService cqService = clientCacheRule.getClientCache().getQueryService();
       CqListener cqListener = cqService.getCq(cqName).getCqAttributes().getCqListener();
 


### PR DESCRIPTION
  * This can occur if HAContainer enables eviction.
  * Also addClientCq can be accessed concurrently by intialization threads during queue registration.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
