### PR TITLE
GEODE-9582: make radish pattern match compatible with redis

### DIFF
--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractGlobPatternIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/AbstractGlobPatternIntegrationTest.java
@@ -252,4 +252,41 @@ public abstract class AbstractGlobPatternIntegrationTest implements RedisIntegra
 
     assertThat(jedis.keys("\\\\*")).containsExactlyInAnyOrder("\\", "\\!");
   }
+
+  @Test
+  public void escapedC_matchesVerbatim() {
+    jedis.set("\\C", "value");
+    jedis.set("\\Ca", "value");
+    jedis.set("b\\C", "value");
+
+    assertThat(jedis.keys("\\\\C")).containsExactlyInAnyOrder("\\C");
+  }
+
+  @Test
+  public void patternMatchIsCaseSensitive() {
+    jedis.set("a", "value");
+    jedis.set("A", "value");
+
+    assertThat(jedis.keys("A")).containsExactlyInAnyOrder("A");
+    assertThat(jedis.keys("a")).containsExactlyInAnyOrder("a");
+    assertThat(jedis.keys("[a-z]")).containsExactlyInAnyOrder("a");
+    assertThat(jedis.keys("[Z-A]")).containsExactlyInAnyOrder("A");
+    assertThat(jedis.keys("[aA]")).containsExactlyInAnyOrder("A", "a");
+  }
+
+  @Test
+  public void doubleQuote_matchesVerbatim() {
+    String key = "\"quotedKey\"";
+    jedis.set(key, "value");
+    assertThat(jedis.keys("quotedKey")).isEmpty();
+    assertThat(jedis.keys("\"*\"")).containsExactlyInAnyOrder(key);
+  }
+
+  @Test
+  public void embeddedWildCardMatches() {
+    jedis.set("foobar", "value");
+    jedis.set("foo123bar", "value");
+    jedis.set("foo123bar!", "value");
+    assertThat(jedis.keys("foo******bar")).containsExactlyInAnyOrder("foobar", "foo123bar");
+  }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
 
@@ -233,7 +232,8 @@ public class RedisHash extends AbstractRedisData {
     return result;
   }
 
-  public ImmutablePair<Integer, List<byte[]>> hscan(Pattern matchPattern, int count, int cursor) {
+  public ImmutablePair<Integer, List<byte[]>> hscan(GlobPattern matchPattern, int count,
+      int cursor) {
     // No need to allocate more space than it's possible to use given the size of the hash. We need
     // to add 1 to hlen() to ensure that if count > hash.size(), we return a cursor of 0
     long maximumCapacity = 2L * Math.min(count, hlen() + 1);
@@ -251,10 +251,10 @@ public class RedisHash extends AbstractRedisData {
     return new ImmutablePair<>(cursor, resultList);
   }
 
-  private void addIfMatching(Pattern matchPattern, List<byte[]> resultList, byte[] key,
+  private void addIfMatching(GlobPattern matchPattern, List<byte[]> resultList, byte[] key,
       byte[] value) {
     if (matchPattern != null) {
-      if (GlobPattern.matches(matchPattern, key)) {
+      if (matchPattern.matches(key)) {
         resultList.add(key);
         resultList.add(value);
       }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHashCommandsFunctionExecutor.java
@@ -19,11 +19,11 @@ package org.apache.geode.redis.internal.data;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.hash.RedisHashCommands;
 
 public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunctionExecutor implements
@@ -92,7 +92,7 @@ public class RedisHashCommandsFunctionExecutor extends RedisDataCommandsFunction
   }
 
   @Override
-  public Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern, int count,
+  public Pair<Integer, List<byte[]>> hscan(RedisKey key, GlobPattern matchPattern, int count,
       int cursor) {
     return stripedExecute(key,
         () -> getRedisHash(key, true)

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import it.unimi.dsi.fastutil.bytes.ByteArrays;
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -67,7 +66,7 @@ public class RedisSet extends AbstractRedisData {
    */
   public RedisSet() {}
 
-  Pair<BigInteger, List<Object>> sscan(Pattern matchPattern, int count, BigInteger cursor) {
+  Pair<BigInteger, List<Object>> sscan(GlobPattern matchPattern, int count, BigInteger cursor) {
     List<Object> returnList = new ArrayList<>();
     int size = members.size();
     BigInteger beforeCursor = new BigInteger("0");
@@ -81,7 +80,7 @@ public class RedisSet extends AbstractRedisData {
       }
 
       if (matchPattern != null) {
-        if (GlobPattern.matches(matchPattern, value)) {
+        if (matchPattern.matches(value)) {
           returnList.add(value);
           numElements++;
         }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSetCommandsFunctionExecutor.java
@@ -24,13 +24,13 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import it.unimi.dsi.fastutil.bytes.ByteArrays;
 import it.unimi.dsi.fastutil.objects.ObjectOpenCustomHashSet;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.set.RedisSetCommands;
 
 public class RedisSetCommandsFunctionExecutor extends RedisDataCommandsFunctionExecutor implements
@@ -104,7 +104,7 @@ public class RedisSetCommandsFunctionExecutor extends RedisDataCommandsFunctionE
   }
 
   @Override
-  public Pair<BigInteger, List<Object>> sscan(RedisKey key, Pattern matchPattern, int count,
+  public Pair<BigInteger, List<Object>> sscan(RedisKey key, GlobPattern matchPattern, int count,
       BigInteger cursor) {
     return stripedExecute(key, () -> getRedisSet(key, true).sscan(matchPattern, count, cursor));
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSetCommandsFunctionExecutor.java
@@ -20,11 +20,11 @@ package org.apache.geode.redis.internal.data;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.sortedset.RedisSortedSetCommands;
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetLexRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetRankRangeOptions;
@@ -150,7 +150,7 @@ public class RedisSortedSetCommandsFunctionExecutor extends RedisDataCommandsFun
   }
 
   @Override
-  public Pair<Integer, List<byte[]>> zscan(RedisKey key, Pattern matchPattern, int count,
+  public Pair<Integer, List<byte[]>> zscan(RedisKey key, GlobPattern matchPattern, int count,
       int cursor) {
     return stripedExecute(key,
         () -> getRedisSortedSet(key, true).zscan(matchPattern, count, cursor));

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HScanExecutor.java
@@ -17,12 +17,12 @@ package org.apache.geode.redis.internal.executor.hash;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_HASH;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.RedisDataType;
 import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -30,7 +30,7 @@ public class HScanExecutor extends AbstractScanExecutor {
 
   @Override
   protected Pair<Integer, List<byte[]>> executeScan(ExecutionHandlerContext context, RedisKey key,
-      Pattern pattern, int count, int cursor) {
+      GlobPattern pattern, int count, int cursor) {
     return context.getHashCommands().hscan(key, pattern, count, cursor);
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/RedisHashCommands.java
@@ -18,11 +18,11 @@ package org.apache.geode.redis.internal.executor.hash;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 
 public interface RedisHashCommands {
   int hset(RedisKey key, List<byte[]> fieldsToSet, boolean NX);
@@ -45,7 +45,7 @@ public interface RedisHashCommands {
 
   Collection<byte[]> hkeys(RedisKey key);
 
-  Pair<Integer, List<byte[]>> hscan(RedisKey key, Pattern matchPattern, int count, int cursor);
+  Pair<Integer, List<byte[]>> hscan(RedisKey key, GlobPattern matchPattern, int count, int cursor);
 
   byte[] hincrby(RedisKey key, byte[] field, long increment);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/KeysExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/key/KeysExecutor.java
@@ -19,8 +19,6 @@ package org.apache.geode.redis.internal.executor.key;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
 
 import org.apache.logging.log4j.Logger;
 
@@ -40,22 +38,14 @@ public class KeysExecutor extends AbstractExecutor {
     List<byte[]> commandElems = command.getProcessedCommand();
     byte[] glob = commandElems.get(1);
     Set<RedisKey> allKeys = getDataRegion(context).keySet();
-    List<RedisKey> matchingKeys = new ArrayList<>();
+    List<byte[]> matchingKeys = new ArrayList<>();
 
-    Pattern pattern;
-    try {
-      pattern = GlobPattern.createPattern(glob);
-    } catch (PatternSyntaxException e) {
-      logger.warn(
-          "Could not compile the pattern: '{}' due to the following exception: '{}'. KEYS will return an empty list.",
-          glob, e.getMessage());
-      return RedisResponse.emptyArray();
-    }
+    GlobPattern pattern = new GlobPattern(glob);
 
-    for (RedisKey bytesKey : allKeys) {
-      String key = bytesKey.toString();
-      if (pattern.matcher(key).matches()) {
-        matchingKeys.add(bytesKey);
+    for (RedisKey key : allKeys) {
+      byte[] keyBytes = key.toBytes();
+      if (pattern.matches(keyBytes)) {
+        matchingKeys.add(keyBytes);
       }
     }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/RedisSetCommands.java
@@ -19,11 +19,11 @@ import java.math.BigInteger;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 
 public interface RedisSetCommands {
 
@@ -43,7 +43,7 @@ public interface RedisSetCommands {
 
   Collection<byte[]> spop(RedisKey key, int popCount);
 
-  Pair<BigInteger, List<Object>> sscan(RedisKey key, Pattern matchPattern, int count,
+  Pair<BigInteger, List<Object>> sscan(RedisKey key, GlobPattern matchPattern, int count,
       BigInteger cursor);
 
   int sunionstore(RedisKey destination, List<RedisKey> setKeys);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/RedisSortedSetCommands.java
@@ -16,11 +16,11 @@
 package org.apache.geode.redis.internal.executor.sortedset;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 
 public interface RedisSortedSetCommands {
 
@@ -62,7 +62,7 @@ public interface RedisSortedSetCommands {
 
   long zrevrank(RedisKey key, byte[] member);
 
-  Pair<Integer, List<byte[]>> zscan(RedisKey key, Pattern matchPattern, int count, int cursor);
+  Pair<Integer, List<byte[]>> zscan(RedisKey key, GlobPattern matchPattern, int count, int cursor);
 
   byte[] zscore(RedisKey key, byte[] member);
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZScanExecutor.java
@@ -17,12 +17,12 @@ package org.apache.geode.redis.internal.executor.sortedset;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SORTED_SET;
 
 import java.util.List;
-import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.geode.redis.internal.data.RedisDataType;
 import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.key.AbstractScanExecutor;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -30,7 +30,7 @@ public class ZScanExecutor extends AbstractScanExecutor {
 
   @Override
   protected Pair<Integer, List<byte[]>> executeScan(ExecutionHandlerContext context, RedisKey key,
-      Pattern pattern, int count, int cursor) {
+      GlobPattern pattern, int count, int cursor) {
     return context.getSortedSetCommands().zscan(key, pattern, count, cursor);
   }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscriptionManager.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscriptionManager.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
 
 import org.apache.geode.annotations.Immutable;
 import org.apache.geode.redis.internal.executor.GlobPattern;
@@ -46,11 +45,11 @@ abstract class AbstractSubscriptionManager implements SubscriptionManager {
 
   @Override
   public List<byte[]> getIds(byte[] pattern) {
-    final Pattern globPattern = GlobPattern.createPattern(pattern);
+    final GlobPattern globPattern = new GlobPattern(pattern);
     final ArrayList<byte[]> result = new ArrayList<>();
     for (SubscriptionId key : clientManagers.keySet()) {
       byte[] idBytes = key.getSubscriptionIdBytes();
-      if (GlobPattern.matches(globPattern, idBytes)) {
+      if (globPattern.matches(idBytes)) {
         result.add(idBytes);
       }
     }
@@ -117,7 +116,7 @@ abstract class AbstractSubscriptionManager implements SubscriptionManager {
   private static final ClientSubscriptionManager EMPTY_CLIENT_MANAGER =
       new ClientSubscriptionManager() {
         @Override
-        public void forEachSubscription(byte[] subscriptionName, String channelToMatch,
+        public void forEachSubscription(byte[] subscriptionName, byte[] channelToMatch,
             Subscriptions.ForEachConsumer action) {}
 
         @Override
@@ -126,7 +125,7 @@ abstract class AbstractSubscriptionManager implements SubscriptionManager {
         }
 
         @Override
-        public int getSubscriptionCount(String channel) {
+        public int getSubscriptionCount(byte[] channel) {
           return 0;
         }
 

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelClientSubscriptionManager.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ChannelClientSubscriptionManager.java
@@ -43,12 +43,12 @@ class ChannelClientSubscriptionManager
   }
 
   @Override
-  public int getSubscriptionCount(String channel) {
+  public int getSubscriptionCount(byte[] channel) {
     return size.get();
   }
 
   @Override
-  public void forEachSubscription(byte[] subscriptionName, String channelToMatch,
+  public void forEachSubscription(byte[] subscriptionName, byte[] channelToMatch,
       ForEachConsumer action) {
     subscriptionMap
         .forEach((client, subscription) -> action.accept(subscriptionName, channelToMatch, client,

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ClientSubscriptionManager.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/ClientSubscriptionManager.java
@@ -36,7 +36,7 @@ interface ClientSubscriptionManager {
    * @param channelToMatch if non-null and the manager supports matching
    *        then only invoke action for subscriptions that match this.
    */
-  void forEachSubscription(byte[] subscriptionName, String channelToMatch, ForEachConsumer action);
+  void forEachSubscription(byte[] subscriptionName, byte[] channelToMatch, ForEachConsumer action);
 
   /**
    * return how many subscriptions this manager has.
@@ -50,7 +50,7 @@ interface ClientSubscriptionManager {
    * that the channel needs to match.
    * For managers without a pattern all subscriptions match.
    */
-  int getSubscriptionCount(String channel);
+  int getSubscriptionCount(byte[] channel);
 
   /**
    * Adds the given subscription for the given client to this manager.

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternClientSubscriptionManager.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternClientSubscriptionManager.java
@@ -15,7 +15,6 @@
  */
 package org.apache.geode.redis.internal.pubsub;
 
-import java.util.regex.Pattern;
 
 import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Client;
@@ -28,20 +27,20 @@ class PatternClientSubscriptionManager
    * have the same pattern, its compiled form is kept in this field
    * instead of on each PatternSubscription instance.
    */
-  private final Pattern pattern;
+  private final GlobPattern pattern;
 
   public PatternClientSubscriptionManager(Client client, byte[] patternBytes,
       Subscription subscription) {
     super(client, subscription);
-    pattern = GlobPattern.createPattern(patternBytes);
+    pattern = new GlobPattern(patternBytes);
   }
 
-  private boolean matches(String channel) {
-    return GlobPattern.matches(pattern, channel);
+  private boolean matches(byte[] channel) {
+    return pattern.matches(channel);
   }
 
   @Override
-  public int getSubscriptionCount(String channel) {
+  public int getSubscriptionCount(byte[] channel) {
     if (matches(channel)) {
       return getSubscriptionCount();
     }
@@ -49,7 +48,7 @@ class PatternClientSubscriptionManager
   }
 
   @Override
-  public void forEachSubscription(byte[] subscriptionName, String channelToMatch,
+  public void forEachSubscription(byte[] subscriptionName, byte[] channelToMatch,
       ForEachConsumer action) {
     if (matches(channelToMatch)) {
       super.forEachSubscription(subscriptionName, channelToMatch, action);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscriptionManager.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PatternSubscriptionManager.java
@@ -15,9 +15,7 @@
  */
 package org.apache.geode.redis.internal.pubsub;
 
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
-import java.util.regex.PatternSyntaxException;
 
 import org.apache.geode.redis.internal.netty.Client;
 import org.apache.geode.redis.internal.pubsub.Subscriptions.ForEachConsumer;
@@ -28,29 +26,22 @@ class PatternSubscriptionManager
   @Override
   protected ClientSubscriptionManager createClientManager(
       Client client, byte[] patternBytes, Subscription subscription) {
-    try {
-      return new PatternClientSubscriptionManager(client, patternBytes, subscription);
-    } catch (PatternSyntaxException ex) {
-      client.removePatternSubscription(patternBytes);
-      throw ex;
-    }
+    return new PatternClientSubscriptionManager(client, patternBytes, subscription);
   }
 
   @Override
   public int getSubscriptionCount(byte[] channel) {
     int result = 0;
-    final String channelString = bytesToString(channel);
     for (ClientSubscriptionManager manager : clientManagers.values()) {
-      result += manager.getSubscriptionCount(channelString);
+      result += manager.getSubscriptionCount(channel);
     }
     return result;
   }
 
   @Override
   public void foreachSubscription(byte[] channel, ForEachConsumer action) {
-    final String channelString = bytesToString(channel);
     clientManagers.forEach((id, manager) -> manager.forEachSubscription(id.getSubscriptionIdBytes(),
-        channelString, action));
+        channel, action));
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
@@ -63,7 +63,7 @@ public class Subscriptions {
   }
 
   public interface ForEachConsumer {
-    void accept(byte[] subscriptionName, String channelToMatch, Client client,
+    void accept(byte[] subscriptionName, byte[] channelToMatch, Client client,
         Subscription subscription);
   }
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisHashTest.java
@@ -35,7 +35,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
@@ -53,6 +52,7 @@ import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.size.ReflectionObjectSizer;
 import org.apache.geode.internal.size.ReflectionSingleObjectSizer;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.netty.Coder;
 
 public class RedisHashTest {
@@ -201,7 +201,8 @@ public class RedisHashTest {
   @Test
   public void hscanOnlyReturnsElementsMatchingPattern() {
     RedisHash hash = createRedisHash("ak1", "v1", "k2", "v2", "ak3", "v3", "k4", "v4");
-    ImmutablePair<Integer, List<byte[]>> result = hash.hscan(Pattern.compile("a.*"), 3, 0);
+    ImmutablePair<Integer, List<byte[]>> result =
+        hash.hscan(new GlobPattern(stringToBytes("a*")), 3, 0);
 
     List<String> fieldsAndValues =
         result.right.stream().map(Coder::bytesToString).collect(Collectors.toList());

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -44,7 +44,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import junitparams.JUnitParamsRunner;
@@ -65,6 +64,7 @@ import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.internal.size.ReflectionObjectSizer;
 import org.apache.geode.redis.internal.delta.RemsDeltaInfo;
+import org.apache.geode.redis.internal.executor.GlobPattern;
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetLexRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetRankRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
@@ -363,8 +363,9 @@ public class RedisSortedSetTest {
 
   @Test
   public void zscanOnlyReturnsElementsMatchingPattern() {
-    ImmutablePair<Integer, List<byte[]>> result = rangeSortedSet.zscan(Pattern.compile("member1.*"),
-        (int) rangeSortedSet.zcard(), 0);
+    ImmutablePair<Integer, List<byte[]>> result =
+        rangeSortedSet.zscan(new GlobPattern(stringToBytes("member1*")),
+            (int) rangeSortedSet.zcard(), 0);
 
     List<String> fieldsAndValues =
         result.right.stream().map(Coder::bytesToString).collect(Collectors.toList());

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/executor/GlobPatternTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/executor/GlobPatternTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.executor;
+
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class GlobPatternTest {
+  private GlobPattern createPattern(String pattern) {
+    return new GlobPattern(stringToBytes(pattern));
+  }
+
+  @Test
+  public void verifyEmptyInput() {
+    assertThat(createPattern("*").matches(stringToBytes(""))).isFalse();
+    assertThat(createPattern("**").matches(stringToBytes(""))).isFalse();
+    assertThat(createPattern("?").matches(stringToBytes(""))).isFalse();
+    assertThat(createPattern("").matches(stringToBytes(""))).isTrue();
+  }
+
+  @Test
+  public void verifyOneByteInput() {
+    assertThat(createPattern("*").matches(stringToBytes("a"))).isTrue();
+    assertThat(createPattern("**").matches(stringToBytes("b"))).isTrue();
+    assertThat(createPattern("?").matches(stringToBytes("@"))).isTrue();
+    assertThat(createPattern("").matches(stringToBytes("a"))).isFalse();
+  }
+
+  @Test
+  public void patternThatEndsWithWildcards() {
+    assertThat(createPattern("foo****").matches(stringToBytes("foo"))).isTrue();
+    assertThat(createPattern("foo****").matches(stringToBytes("foo1"))).isTrue();
+    assertThat(createPattern("foo****").matches(stringToBytes("foo11111111111"))).isTrue();
+    assertThat(createPattern("foo****").matches(stringToBytes("fo11111111111"))).isFalse();
+  }
+
+  @Test
+  public void patternsWithEmbeddedWildcards() {
+    assertThat(createPattern("foo****bar").matches(stringToBytes("foobar"))).isTrue();
+    assertThat(createPattern("foo****bar").matches(stringToBytes("foo123bar"))).isTrue();
+    assertThat(createPattern("foo****bar").matches(stringToBytes("foo123bar!"))).isFalse();
+    assertThat(createPattern("*bar*").matches(stringToBytes("foobarbaz"))).isTrue();
+    assertThat(createPattern("*bar*joe").matches(stringToBytes("foorbarbazjoe"))).isTrue();
+    assertThat(createPattern("*bar*joe").matches(stringToBytes("foorbarbazjoey"))).isFalse();
+  }
+
+  @Test
+  public void caseSensitive() {
+    assertThat(createPattern("foo****").matches(stringToBytes("Foo"))).isFalse();
+    assertThat(createPattern("foo****").matches(stringToBytes("foo"))).isTrue();
+    assertThat(createPattern("[a-z]oo").matches(stringToBytes("Foo"))).isFalse();
+    assertThat(createPattern("[a-z]oo").matches(stringToBytes("goo"))).isTrue();
+  }
+
+  @Test
+  public void escapeMakesSpecialsLiteral() {
+    assertThat(createPattern("b\\*r").matches(stringToBytes("b*r"))).isTrue();
+    assertThat(createPattern("b\\*r").matches(stringToBytes("bar"))).isFalse();
+    assertThat(createPattern("b\\").matches(stringToBytes("b\\"))).isTrue();
+  }
+
+  @Test
+  public void charSets() {
+    assertThat(createPattern("[^a-z]").matches(stringToBytes("A"))).isTrue();
+    assertThat(createPattern("[z-a]").matches(stringToBytes("z"))).isTrue();
+    assertThat(createPattern("[z-a]").matches(stringToBytes("a"))).isTrue();
+    assertThat(createPattern("[z-a]").matches(stringToBytes("m"))).isTrue();
+    assertThat(createPattern("[^a-a]").matches(stringToBytes("a"))).isFalse();
+    assertThat(createPattern("[a-a]").matches(stringToBytes("a"))).isTrue();
+    assertThat(createPattern("[a-a]").matches(stringToBytes("b"))).isFalse();
+    assertThat(createPattern("[a\\-z]").matches(stringToBytes("-"))).isTrue();
+    assertThat(createPattern("[a").matches(stringToBytes("a"))).isTrue();
+  }
+}

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/ChannelClientSubscriptionManagerTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/ChannelClientSubscriptionManagerTest.java
@@ -40,7 +40,7 @@ public class ChannelClientSubscriptionManagerTest {
   @Test
   public void newManagerHasOneSubscription() {
     assertThat(createManager().getSubscriptionCount()).isOne();
-    assertThat(createManager().getSubscriptionCount("channel")).isOne();
+    assertThat(createManager().getSubscriptionCount(stringToBytes("channel"))).isOne();
   }
 
   @Test
@@ -52,9 +52,9 @@ public class ChannelClientSubscriptionManagerTest {
     manager.remove(client);
 
     assertThat(manager.getSubscriptionCount()).isZero();
-    assertThat(manager.getSubscriptionCount("channel")).isZero();
+    assertThat(manager.getSubscriptionCount(stringToBytes("channel"))).isZero();
     Collection<Collection<Object>> foreachResults = new ArrayList<>();
-    manager.forEachSubscription(null, "channel",
+    manager.forEachSubscription(null, stringToBytes("channel"),
         (subName, toMatch, c, sub) -> foreachResults.add(asList(subName, toMatch, c, sub)));
     assertThat(foreachResults).isEmpty();
   }
@@ -71,11 +71,12 @@ public class ChannelClientSubscriptionManagerTest {
     assertThat(removeResult).isFalse();
     assertThat(addResult).isFalse();
     assertThat(manager.getSubscriptionCount()).isZero();
-    assertThat(manager.getSubscriptionCount("channel")).isZero();
+    assertThat(manager.getSubscriptionCount(stringToBytes("channel"))).isZero();
   }
 
   @Test
   public void secondAddReturnsTrue() {
+    byte[] channel = stringToBytes("channel");
     Client client = mock(Client.class);
     Subscription subscription = mock(Subscription.class);
     ClientSubscriptionManager manager = createManager(client, stringToBytes("*"), subscription);
@@ -86,14 +87,14 @@ public class ChannelClientSubscriptionManagerTest {
 
     assertThat(result).isTrue();
     assertThat(manager.getSubscriptionCount()).isEqualTo(2);
-    assertThat(manager.getSubscriptionCount("channel")).isEqualTo(2);
+    assertThat(manager.getSubscriptionCount(channel)).isEqualTo(2);
     Collection<Collection<Object>> foreachResults = new ArrayList<>();
     byte[] subName = stringToBytes("subName");
-    manager.forEachSubscription(subName, "channel",
+    manager.forEachSubscription(subName, channel,
         (sn, toMatch, c, sub) -> foreachResults.add(asList(sn, toMatch, c, sub)));
     assertThat(foreachResults).containsExactlyInAnyOrder(
-        asList(subName, "channel", client, subscription),
-        asList(subName, "channel", client2, subscription2));
+        asList(subName, channel, client, subscription),
+        asList(subName, channel, client2, subscription2));
   }
 
   @Test
@@ -112,13 +113,14 @@ public class ChannelClientSubscriptionManagerTest {
     assertThat(removeResult).isTrue();
     assertThat(addResult).isTrue();
     assertThat(manager.getSubscriptionCount()).isEqualTo(2);
-    assertThat(manager.getSubscriptionCount("channel")).isEqualTo(2);
+    byte[] channel = stringToBytes("channel");
+    assertThat(manager.getSubscriptionCount(channel)).isEqualTo(2);
     Collection<Collection<Object>> foreachResults = new ArrayList<>();
     byte[] subName = stringToBytes("subName");
-    manager.forEachSubscription(subName, "channel",
+    manager.forEachSubscription(subName, channel,
         (sn, toMatch, c, sub) -> foreachResults.add(asList(sn, toMatch, c, sub)));
     assertThat(foreachResults).containsExactlyInAnyOrder(
-        asList(subName, "channel", client, subscription),
-        asList(subName, "channel", client2, subscription2));
+        asList(subName, channel, client, subscription),
+        asList(subName, channel, client2, subscription2));
   }
 }

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
@@ -24,14 +24,12 @@ import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPUNSUBSCRIBE;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bUNSUBSCRIBE;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.regex.PatternSyntaxException;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -147,17 +145,6 @@ public class SubscriptionsJUnitTest {
     assertThat(result.getSubscription()).isNull();
     assertThat(client.getSubscriptionCount()).isOne();
     assertThat(client.getPatternSubscriptions()).containsExactlyInAnyOrder(pattern);
-  }
-
-  @Test
-  public void psubscribeCleanUpAfterFailedSubscribe() {
-    Client client = createClient();
-    final byte[] pattern = stringToBytes("\\C");
-
-    assertThatThrownBy(() -> subscriptions.psubscribe(pattern, client))
-        .isInstanceOf(PatternSyntaxException.class);
-
-    assertThat(client.getSubscriptionCount()).isZero();
   }
 
   @Test


### PR DESCRIPTION
GlobPattern now uses code derived from native redis's glob matching.
It should be completely compatible with native redis unless I broke something
in the conversion to java. This has the benefit of being able to do the match with
a byte array (the jdk matcher required a conversion to a String).
This also cleaned up some of our other code that handled the exception
thrown from the jdk when compiling a pattern.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
