### PR TITLE
GEODE-9605: Allow use of character literals in Radish module

### DIFF
--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/KeyHashUtil.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/data/KeyHashUtil.java
@@ -15,8 +15,6 @@
 package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.LEFT_BRACE_ID;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.RIGHT_BRACE_ID;
 
 import org.apache.geode.redis.internal.executor.cluster.CRC16;
 
@@ -35,7 +33,7 @@ public class KeyHashUtil {
     int endHashtag;
 
     for (startHashtag = 0; startHashtag < key.length; startHashtag++) {
-      if (key[startHashtag] == LEFT_BRACE_ID) {
+      if (key[startHashtag] == (byte) '{') {
         break;
       }
     }
@@ -46,7 +44,7 @@ public class KeyHashUtil {
     }
 
     for (endHashtag = startHashtag + 1; endHashtag < key.length; endHashtag++) {
-      if (key[endHashtag] == RIGHT_BRACE_ID) {
+      if (key[endHashtag] == (byte) '}') {
         break;
       }
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/SelectExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/SelectExecutor.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.executor.connection;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SELECT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NUMBER_0_BYTE;
 
 import org.apache.geode.redis.internal.executor.AbstractExecutor;
 import org.apache.geode.redis.internal.executor.RedisResponse;
@@ -28,7 +27,7 @@ public class SelectExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     byte[] dbIndexBytes = command.getBytesKey();
-    if (dbIndexBytes.length == 1 && dbIndexBytes[0] == NUMBER_0_BYTE) {
+    if (dbIndexBytes.length == 1 && dbIndexBytes[0] == (byte) '0') {
       return RedisResponse.ok();
     }
     return RedisResponse.error(ERROR_SELECT);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetLexRangeOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetLexRangeOptions.java
@@ -20,10 +20,6 @@ import static org.apache.geode.redis.internal.data.RedisSortedSet.checkDummyMemb
 import static org.apache.geode.redis.internal.data.RedisSortedSet.javaImplementationOfAnsiCMemCmp;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGREATEST_MEMBER_NAME;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEAST_MEMBER_NAME;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEFT_PAREN;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEFT_SQUARE_BRACKET;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMINUS;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPLUS;
 
 import java.util.Arrays;
 import java.util.List;
@@ -50,25 +46,25 @@ public class SortedSetLexRangeOptions extends AbstractSortedSetRangeOptions<byte
     boolean isExclusive;
     byte[] value;
     if (bytes.length == 1) {
-      if (bytes[0] == bPLUS) {
+      if (bytes[0] == (byte) '+') {
         isExclusive = false;
         value = bGREATEST_MEMBER_NAME;
-      } else if (bytes[0] == bMINUS) {
+      } else if (bytes[0] == (byte) '-') {
         isExclusive = false;
         value = bLEAST_MEMBER_NAME;
-      } else if (bytes[0] == bLEFT_PAREN) {
+      } else if (bytes[0] == (byte) '(') {
         isExclusive = true;
         value = new byte[0];
-      } else if (bytes[0] == bLEFT_SQUARE_BRACKET) {
+      } else if (bytes[0] == (byte) '[') {
         isExclusive = false;
         value = new byte[0];
       } else {
         throw new RedisException(ERROR_MIN_MAX_NOT_A_VALID_STRING);
       }
-    } else if (bytes[0] == bLEFT_PAREN) {
+    } else if (bytes[0] == (byte) '(') {
       isExclusive = true;
       value = Arrays.copyOfRange(bytes, 1, bytes.length);
-    } else if (bytes[0] == bLEFT_SQUARE_BRACKET) {
+    } else if (bytes[0] == (byte) '[') {
       isExclusive = false;
       value = Arrays.copyOfRange(bytes, 1, bytes.length);
     } else {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetScoreRangeOptions.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetScoreRangeOptions.java
@@ -16,7 +16,6 @@ package org.apache.geode.redis.internal.executor.sortedset;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_MIN_MAX_NOT_A_FLOAT;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToDouble;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEFT_PAREN;
 
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +41,7 @@ public class SortedSetScoreRangeOptions extends AbstractSortedSetRangeOptions<Do
 
   private RangeLimit<Double> parseOneRangeArgument(byte[] bytes) {
     double score;
-    if (bytes[0] == bLEFT_PAREN) {
+    if (bytes[0] == (byte) '(') {
       // A value of "(" is equivalent to "(0"
       if (bytes.length == 1) {
         score = 0.0;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -21,7 +21,6 @@ import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ARRAY_ID
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.BULK_STRING_ID;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ERROR_ID;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INTEGER_ID;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NUMBER_0_BYTE;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.N_INF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.P_INF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.SIMPLE_STRING_ID;
@@ -33,9 +32,6 @@ import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bEMPTY_S
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bERR;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINFINITY;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLOWERCASE_A;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLOWERCASE_Z;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMINUS;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMOVED;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNIL;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INF;
@@ -43,7 +39,6 @@ import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INFIN
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNaN;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bOK;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bOOM;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPLUS;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bP_INF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bP_INFINITY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWRONGPASS;
@@ -361,7 +356,7 @@ public class Coder {
     boolean isNegative = false;
     long result = 0; // Accumulates negatively (avoid MIN_VALUE overflow).
     int i = 0;
-    if (bytes[0] == bMINUS) {
+    if (bytes[0] == (byte) '-') {
       isNegative = true;
       i++;
       if (length == 1) {
@@ -369,7 +364,7 @@ public class Coder {
       } else if (bytes[1] == digitToAscii(0)) {
         throw createNumberFormatException(bytes); // redis does not allow -0*
       }
-    } else if (bytes[0] == bPLUS) {
+    } else if (bytes[0] == (byte) '+') {
       throw createNumberFormatException(bytes); // redis does not allow +*
     }
     while (i < length) {
@@ -477,7 +472,7 @@ public class Coder {
   }
 
   private static boolean isLowerCase(byte value) {
-    return value >= bLOWERCASE_A && value <= bLOWERCASE_Z;
+    return value >= (byte) 'a' && value <= (byte) 'z';
   }
 
   public static boolean isInfinity(byte[] bytes) {
@@ -584,7 +579,7 @@ public class Coder {
     byte[] result = new byte[resultSize];
     int resultIdx = 0;
     if (negative) {
-      result[resultIdx++] = bMINUS;
+      result[resultIdx++] = (byte) '-';
     }
     if (quotient < 0) {
       result[resultIdx++] = digitToAscii(-quotient);
@@ -629,7 +624,7 @@ public class Coder {
       bytes[--bytePos] = digitToAscii(-intQuotient);
     }
     if (negative) {
-      bytes[--bytePos] = bMINUS;
+      bytes[--bytePos] = (byte) '-';
     }
     return bytes;
   }
@@ -666,12 +661,12 @@ public class Coder {
    * NOTE: the caller is responsible for ensuring that 'digit' is in the correct range.
    */
   public static byte digitToAscii(int digit) {
-    return (byte) (NUMBER_0_BYTE + digit);
+    return (byte) ((byte) '0' + digit);
   }
 
   public static int asciiToDigit(byte ascii) {
-    if (ascii >= NUMBER_0_BYTE && ascii <= NUMBER_0_BYTE + 9) {
-      return ascii - NUMBER_0_BYTE;
+    if (ascii >= (byte) '0' && ascii <= (byte) '0' + 9) {
+      return ascii - (byte) '0';
     }
     return -1;
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -20,13 +20,6 @@ import org.apache.geode.annotations.Immutable;
 import org.apache.geode.annotations.internal.MakeImmutable;
 import org.apache.geode.redis.internal.data.RedisSortedSet;
 
-/**
- * Important note
- * <p>
- * Do not use '' <-- java primitive chars. Redis uses {@link Coder#CHARSET} encoding so we should
- * not risk java handling char to byte conversions, rather just hard code {@link Coder#CHARSET}
- * chars as bytes
- */
 public class StringBytesGlossary {
 
   // ********** Single byte RedisResponse identifier constants **********
@@ -54,16 +47,6 @@ public class StringBytesGlossary {
    * byte identifier of an integer
    */
   public static final byte INTEGER_ID = ':';
-
-  /**
-   * byte identifier of an left paren
-   */
-  public static final byte LEFT_BRACE_ID = '{';
-
-  /**
-   * byte identifier of an right paren
-   */
-  public static final byte RIGHT_BRACE_ID = '}';
 
   // ********** RedisResponse constants **********
   /**
@@ -205,10 +188,6 @@ public class StringBytesGlossary {
   public static final byte[] bWITHSCORES = stringToBytes("WITHSCORES");
   @MakeImmutable
   public static final byte[] bLIMIT = stringToBytes("LIMIT");
-  public static final byte bPLUS = SIMPLE_STRING_ID; // +
-  public static final byte bMINUS = ERROR_ID; // -
-
-  public static final byte[] bZERO = stringToBytes("0");
 
   // ********** Constants for Double Infinity comparisons **********
   public static final String P_INF = "+inf";
@@ -241,25 +220,6 @@ public class StringBytesGlossary {
   public static final byte[] bNaN = stringToBytes(NaN);
 
   // ********** Miscellaneous constants for convenience **********
-  /**
-   * byte value of the number 0
-   */
-  public static final byte NUMBER_0_BYTE = '0';
-
-  /**
-   * byte value of the number 1
-   */
-  public static final byte NUMBER_1_BYTE = '1';
-
-  public static final byte bLOWERCASE_A = 'a';
-
-  public static final byte bLOWERCASE_Z = 'z';
-
-  public static final byte bLEFT_PAREN = '(';
-
-  public static final byte bLEFT_SQUARE_BRACKET = '[';
-
-  public static final byte bPERIOD = '.';
 
   public static final String PING_RESPONSE = "PONG";
 


### PR DESCRIPTION
Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
