### PR TITLE
GEODE-9575: improve how publish executes a function

### DIFF
--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -13,4 +13,5 @@ org/apache/geode/redis/internal/data/RedisSet$MemberSet
 org/apache/geode/redis/internal/data/RedisSetCommandsFunctionExecutor$SetOp
 org/apache/geode/redis/internal/data/RedisSortedSet$MemberMap
 org/apache/geode/redis/internal/data/RedisStringCommandsFunctionExecutor$BitOp
+org/apache/geode/redis/internal/pubsub/PubSubImpl$PublishFunction
 org/apache/geode/redis/internal/services/StripedExecutorService$State

--- a/geode-apis-compatible-with-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-apis-compatible-with-redis-serializables.txt
+++ b/geode-apis-compatible-with-redis/src/main/resources/org/apache/geode/redis/internal/sanctioned-geode-apis-compatible-with-redis-serializables.txt
@@ -7,4 +7,3 @@ org/apache/geode/redis/internal/executor/BaseSetOptions$Exists,false
 org/apache/geode/redis/internal/netty/CoderException,true,4707944288714910949
 org/apache/geode/redis/internal/netty/RedisCommandParserException,true,4707944288714910949
 org/apache/geode/redis/internal/parameters/RedisParametersMismatchException,true,-643700717871858072
-org/apache/geode/redis/internal/pubsub/PubSubImpl$1,false,this$0:org/apache/geode/redis/internal/pubsub/PubSubImpl


### PR DESCRIPTION
- getRegionMembers now uses the advisor to compute
the set of members hosting the redis region.
- PubSubImpl now has a PublishFunction in place of the old
anonymous inner class.
- PubSubDUnitTest had a timing issue after killing a server.
The next test would fail due to the state left around by
the test that did the kill. Now this test gives each test
method a new clean slate and is passing consistently.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
