### PR TITLE
fixGradleLint but without 'unused-dependencies' rule

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -16,11 +16,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-  <!-- This module was also published with a richer model, Gradle metadata,  -->
-  <!-- which should be used instead. Do not delete the following line which  -->
-  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-  <!-- that they should prefer consuming it instead. -->
-  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.geode</groupId>
   <artifactId>geode-all-bom</artifactId>
@@ -128,6 +123,11 @@
         <version>0.15.0</version>
       </dependency>
       <dependency>
+        <groupId>com.vaadin.external.google</groupId>
+        <artifactId>android-json</artifactId>
+        <version>0.0.20131108.vaadin1</version>
+      </dependency>
+      <dependency>
         <groupId>com.zaxxer</groupId>
         <artifactId>HikariCP</artifactId>
         <version>4.0.3</version>
@@ -228,6 +228,11 @@
         <version>1.0</version>
       </dependency>
       <dependency>
+        <groupId>javax.transaction</groupId>
+        <artifactId>javax.transaction-api</artifactId>
+        <version>1.3</version>
+      </dependency>
+      <dependency>
         <groupId>javax.ejb</groupId>
         <artifactId>ejb-api</artifactId>
         <version>3.0</version>
@@ -270,7 +275,7 @@
       <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
-        <version>5.1.46</version>
+        <version>8.0.26</version>
       </dependency>
       <dependency>
         <groupId>net.java.dev.jna</groupId>
@@ -358,19 +363,9 @@
         <version>4.1.0</version>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.cargo</groupId>
-        <artifactId>cargo-core-uberjar</artifactId>
-        <version>1.9.7</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-server</artifactId>
-        <version>9.4.43.v20210629</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-webapp</artifactId>
-        <version>9.4.43.v20210629</version>
+        <groupId>org.buildobjects</groupId>
+        <artifactId>jproc</artifactId>
+        <version>2.6.2</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.persistence</groupId>
@@ -391,6 +386,11 @@
         <groupId>org.jboss.modules</groupId>
         <artifactId>jboss-modules</artifactId>
         <version>1.11.0.Final</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jctools</groupId>
+        <artifactId>jctools-core</artifactId>
+        <version>3.3.0</version>
       </dependency>
       <dependency>
         <groupId>org.jgroups</groupId>
@@ -461,6 +461,16 @@
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>2.12.0</version>
+      </dependency>
+      <dependency>
+        <groupId>xerces</groupId>
+        <artifactId>xmlParserAPIs</artifactId>
+        <version>2.6.1</version>
+      </dependency>
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <version>1.4.01</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -578,6 +588,41 @@
         <version>6.6.6</version>
       </dependency>
       <dependency>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-core-api-container</artifactId>
+        <version>1.9.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-core-uberjar</artifactId>
+        <version>1.9.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.cargo</groupId>
+        <artifactId>cargo-core-api-generic</artifactId>
+        <version>1.9.7</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-server</artifactId>
+        <version>9.4.43.v20210629</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-webapp</artifactId>
+        <version>9.4.43.v20210629</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-http</artifactId>
+        <version>9.4.43.v20210629</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-util</artifactId>
+        <version>9.4.43.v20210629</version>
+      </dependency>
+      <dependency>
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest</artifactId>
         <version>2.2</version>
@@ -665,6 +710,11 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
+        <version>5.3.9</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-jcl</artifactId>
         <version>5.3.9</version>
       </dependency>
       <dependency>

--- a/boms/geode-client-bom/build.gradle
+++ b/boms/geode-client-bom/build.gradle
@@ -42,4 +42,3 @@ publishing {
     }
   }
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ plugins {
   id "eclipse"
   id "com.diffplug.spotless" version "5.14.3" apply false
   id "com.github.ben-manes.versions" version "0.39.0" apply false
-  id "nebula.lint" version "17.1.1" apply false
+  id "nebula.lint" version "17.2.1" apply false
   id "com.palantir.docker" version "0.28.0" apply false
   id "io.spring.dependency-management" version "1.0.11.RELEASE" apply false
   id "org.ajoberstar.grgit" version "4.1.0" apply false

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -99,6 +99,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2')
         api(group: 'com.sun.xml.bind', name: 'jaxb-impl', version: '2.3.2')
         api(group: 'com.tngtech.archunit', name:'archunit-junit4', version: '0.15.0')
+        api(group: 'com.vaadin.external.google', name: 'android-json', version: '0.0.20131108.vaadin1')
         api(group: 'com.zaxxer', name: 'HikariCP', version: '4.0.3')
         api(group: 'commons-beanutils', name: 'commons-beanutils', version: '1.9.4')
         api(group: 'commons-codec', name: 'commons-codec', version: '1.15')
@@ -120,6 +121,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'it.unimi.dsi', name: 'fastutil', version: get('fastutil.version'))
         api(group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2')
         api(group: 'javax.annotation', name: 'jsr250-api', version: '1.0')
+        api(group: 'javax.transaction', name: 'javax.transaction-api', version: get('javax.transaction-api.version'))
         api(group: 'javax.ejb', name: 'ejb-api', version: '3.0')
         api(group: 'javax.mail', name: 'javax.mail-api', version: '1.6.2')
         api(group: 'javax.resource', name: 'javax.resource-api', version: '1.7.1')
@@ -128,7 +130,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'joda-time', name: 'joda-time', version: '2.10.9')
         api(group: 'junit', name: 'junit', version: get('junit.version'))
         api(group: 'mx4j', name: 'mx4j-tools', version: '3.0.1')
-        api(group: 'mysql', name: 'mysql-connector-java', version: '5.1.46')
+        api(group: 'mysql', name: 'mysql-connector-java', version: '8.0.26')
         api(group: 'net.java.dev.jna', name: 'jna', version: '5.9.0')
         api(group: 'net.java.dev.jna', name: 'jna-platform', version: '5.9.0')
         api(group: 'net.minidev', name: 'json-smart', version: '2.4.7')
@@ -146,13 +148,12 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.apache.shiro', name: 'shiro-core', version: get('shiro.version'))
         api(group: 'org.assertj', name: 'assertj-core', version: '3.20.2')
         api(group: 'org.awaitility', name: 'awaitility', version: '4.1.0')
-        api(group: 'org.codehaus.cargo', name: 'cargo-core-uberjar', version: '1.9.7')
-        api(group: 'org.eclipse.jetty', name: 'jetty-server', version: get('jetty.version'))
-        api(group: 'org.eclipse.jetty', name: 'jetty-webapp', version: get('jetty.version'))
+        api(group: 'org.buildobjects', name: 'jproc', version: '2.6.2')
         api(group: 'org.eclipse.persistence', name: 'javax.persistence', version: '2.2.1')
         api(group: 'org.httpunit', name: 'httpunit', version: '1.7.3')
         api(group: 'org.iq80.snappy', name: 'snappy', version: '0.4')
         api(group: 'org.jboss.modules', name: 'jboss-modules', version: get('jboss-modules.version'))
+        api(group: 'org.jctools', name: 'jctools-core', version: '3.3.0')
         api(group: 'org.jgroups', name: 'jgroups', version: get('jgroups.version'))
         api(group: 'org.mockito', name: 'mockito-core', version: '3.12.4')
         api(group: 'org.mortbay.jetty', name: 'servlet-api', version: '3.0.20100224')
@@ -167,8 +168,11 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.0')
         api(group: 'redis.clients', name: 'jedis', version: '3.6.3')
         api(group: 'xerces', name: 'xercesImpl', version: '2.12.0')
+        api(group: 'xerces', name: 'xmlParserAPIs', version: '2.6.1')
+        api(group: 'xml-apis', name: 'xml-apis', version: '1.4.01')
       }
     }
+
 
     dependencySet(group: 'com.fasterxml.jackson.core', version: get('jackson.version')) {
       entry('jackson-annotations')
@@ -217,6 +221,19 @@ class DependencyConstraints implements Plugin<Project> {
       entry('lucene-test-framework')
     }
 
+    dependencySet(group: 'org.codehaus.cargo', version: '1.9.7') {
+      entry('cargo-core-api-container')
+      entry('cargo-core-uberjar')
+      entry('cargo-core-api-generic')
+    }
+
+    dependencySet(group: 'org.eclipse.jetty', version: get('jetty.version')) {
+      entry('jetty-server')
+      entry('jetty-webapp')
+      entry('jetty-http')
+      entry('jetty-util')
+    }
+
     dependencySet(group: 'org.hamcrest', version: '2.2') {
       entry('hamcrest')
     }
@@ -245,6 +262,7 @@ class DependencyConstraints implements Plugin<Project> {
       entry('spring-context')
       entry('spring-core')
       entry('spring-expression')
+      entry('spring-jcl')
       entry('spring-oxm')
       entry('spring-test')
       entry('spring-tx')

--- a/extensions/geode-modules-assembly/build.gradle
+++ b/extensions/geode-modules-assembly/build.gradle
@@ -236,7 +236,12 @@ tasks.register('distTcServer30', Zip) {
   configure(configureTcServer30Assembly)
 }
 
-task dist(type: Task, dependsOn: ['distTcServer', 'distTcServer30', 'distTomcat', 'distAppServer'])
+task dist(type: Task, dependsOn: [
+  'distTcServer',
+  'distTcServer30',
+  'distTomcat',
+  'distAppServer'
+])
 
 build.dependsOn dist
 

--- a/extensions/geode-modules-session-internal/build.gradle
+++ b/extensions/geode-modules-session-internal/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   // main
   implementation(platform(project(':boms:geode-all-bom')))
   implementation(project(':extensions:geode-modules'))
+  implementation('org.slf4j:slf4j-api')
 
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('javax.servlet:javax.servlet-api')

--- a/extensions/geode-modules-session/build.gradle
+++ b/extensions/geode-modules-session/build.gradle
@@ -42,8 +42,6 @@ dependencies {
   implementation('org.slf4j:slf4j-api')
 
   integrationTestImplementation('com.mockrunner:mockrunner-servlet') {
-    exclude group: 'jboss'
-    exclude group: 'xerces'
   }
   integrationTestImplementation('commons-io:commons-io')
   integrationTestImplementation('javax.servlet:javax.servlet-api')
@@ -56,11 +54,10 @@ dependencies {
   integrationTestImplementation('org.eclipse.jetty:jetty-servlet:' + DependencyConstraints.get('jetty.version'))
   integrationTestImplementation('org.eclipse.jetty:jetty-util')
   integrationTestImplementation('org.httpunit:httpunit') {
-    exclude group: 'javax.servlet'
     // this version of httpunit contains very outdated xercesImpl
-    exclude group: 'xerces'
   }
   integrationTestImplementation('org.slf4j:slf4j-api')
+  integrationTestImplementation('javax.servlet:servlet-api')
 
   integrationTestRuntimeOnly('xerces:xercesImpl')
 }

--- a/extensions/geode-modules-test/build.gradle
+++ b/extensions/geode-modules-test/build.gradle
@@ -20,15 +20,26 @@ import org.apache.geode.gradle.plugins.DependencyConstraints
 apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 
 dependencies {
+  api(project(':extensions:geode-modules'))
+
   // main
   implementation(platform(project(':boms:geode-all-bom')))
   implementation(project(':geode-dunit'))
   implementation('org.springframework:spring-core')
   implementation('org.httpunit:httpunit')
   implementation('pl.pragmatists:JUnitParams')
+  implementation('commons-io:commons-io')
+  implementation('javax.servlet:servlet-api')
+  implementation('junit:junit')
+  implementation('org.assertj:assertj-core')
+  implementation('org.mockito:mockito-core')
+  implementation('xerces:xmlParserAPIs')
+  implementation('xml-apis:xml-apis')
 
-  api(project(':extensions:geode-modules'))
 
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
+  compileOnly('org.apache.tomcat:catalina:' + DependencyConstraints.get('tomcat6.version'))
+  compileOnly('org.apache.tomcat:juli:' + DependencyConstraints.get('tomcat6.version'))
+  compileOnly('org.apache.tomcat:servlet-api:' + DependencyConstraints.get('tomcat6.version'))
 }

--- a/extensions/geode-modules-tomcat7/build.gradle
+++ b/extensions/geode-modules-tomcat7/build.gradle
@@ -32,6 +32,8 @@ dependencies {
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat7.version'))
   compileOnly('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat7.version'))
+  compileOnly('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat7.version'))
+  compileOnly('org.apache.tomcat:tomcat-servlet-api:' + DependencyConstraints.get('tomcat7.version'))
 
 
   // test
@@ -41,6 +43,8 @@ dependencies {
   testImplementation('org.mockito:mockito-core')
   testImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat7.version'))
   testImplementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat7.version'))
+  testImplementation('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat7.version'))
+  testImplementation('org.apache.tomcat:tomcat-servlet-api:' + DependencyConstraints.get('tomcat7.version'))
 
 
   // integrationTest
@@ -49,6 +53,8 @@ dependencies {
   integrationTestImplementation('org.httpunit:httpunit')
   integrationTestImplementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat7.version'))
   integrationTestImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat7.version'))
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.mockito:mockito-core')
 }
 
 sonarqube {

--- a/extensions/geode-modules-tomcat8/build.gradle
+++ b/extensions/geode-modules-tomcat8/build.gradle
@@ -32,7 +32,10 @@ dependencies {
 
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version'))
-
+  compileOnly('org.apache.tomcat:tomcat-coyote:'+ DependencyConstraints.get('tomcat8.version'))
+  compileOnly('org.apache.tomcat:tomcat-juli:'+ DependencyConstraints.get('tomcat8.version'))
+  compileOnly('org.apache.tomcat:tomcat-servlet-api:'+ DependencyConstraints.get('tomcat8.version'))
+  compileOnly('org.apache.tomcat:tomcat-util:'+ DependencyConstraints.get('tomcat8.version'))
 
   // test
   testImplementation(project(':extensions:geode-modules-test'))
@@ -40,12 +43,17 @@ dependencies {
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
   testImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version'))
-
+  testImplementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat8.version'))
+  testImplementation('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat8.version'))
+  testImplementation('org.apache.tomcat:tomcat-servlet-api:' + DependencyConstraints.get('tomcat8.version'))
+  testImplementation('org.apache.tomcat:tomcat-util:' + DependencyConstraints.get('tomcat8.version'))
 
   // integrationTest
   integrationTestImplementation(project(':extensions:geode-modules-test'))
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version'))
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.mockito:mockito-core')
 
 
   // distributedTest
@@ -54,6 +62,12 @@ dependencies {
   distributedTestImplementation(project(':geode-logging'))
   distributedTestImplementation('org.httpunit:httpunit')
   distributedTestImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat8.version'))
+  distributedTestImplementation('javax.servlet:servlet-api')
+  distributedTestImplementation('junit:junit')
+  distributedTestImplementation('org.apache.logging.log4j:log4j-api')
+  distributedTestImplementation('org.apache.tomcat:tomcat-jaspic-api')
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('org.awaitility:awaitility')
 }
 
 sonarqube {

--- a/extensions/geode-modules-tomcat9/build.gradle
+++ b/extensions/geode-modules-tomcat9/build.gradle
@@ -32,7 +32,9 @@ dependencies {
 
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat9.version'))
-
+  compileOnly('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat9.version'))
+  compileOnly('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat9.version'))
+  compileOnly('org.apache.tomcat:tomcat-servlet-api:' + DependencyConstraints.get('tomcat9.version'))
 
   // test
   testImplementation(project(':extensions:geode-modules-test'))
@@ -40,12 +42,17 @@ dependencies {
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
   testImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat9.version'))
+  testImplementation('org.apache.tomcat:tomcat-coyote:' + DependencyConstraints.get('tomcat9.version'))
+  testImplementation('org.apache.tomcat:tomcat-juli:' + DependencyConstraints.get('tomcat9.version'))
+  testImplementation('org.apache.tomcat:tomcat-servlet-api:' + DependencyConstraints.get('tomcat9.version'))
 
 
   // integrationTest
   integrationTestImplementation(project(':extensions:geode-modules-test'))
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation('org.apache.tomcat:tomcat-catalina:' + DependencyConstraints.get('tomcat9.version'))
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.mockito:mockito-core')
 }
 
 sonarqube {

--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -26,16 +26,20 @@ dependencies {
   // main
   implementation(platform(project(':boms:geode-all-bom')))
   api(project(':geode-logging'))
-  implementation(project(':geode-membership'))
   api(project(':geode-common'))
-  implementation(project(':geode-serialization'))
-  implementation('org.slf4j:slf4j-api')
-
   api(project(':geode-core'))
 
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('javax.servlet:javax.servlet-api')
   compileOnly('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
+  compileOnly('org.apache.tomcat:catalina:' + DependencyConstraints.get('tomcat6.version'))
+  compileOnly('org.apache.tomcat:juli:' + DependencyConstraints.get('tomcat6.version'))
+  compileOnly('org.apache.tomcat:servlet-api:' + DependencyConstraints.get('tomcat6.version'))
+
+
+  implementation(project(':geode-membership'))
+  implementation(project(':geode-serialization'))
+  implementation('org.slf4j:slf4j-api')
 
 
   // test
@@ -44,6 +48,9 @@ dependencies {
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
   testImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
+  testImplementation('org.apache.tomcat:catalina:' + DependencyConstraints.get('tomcat6.version'))
+  testImplementation('org.apache.tomcat:juli:' + DependencyConstraints.get('tomcat6.version'))
+  testImplementation('org.apache.tomcat:servlet-api:' + DependencyConstraints.get('tomcat6.version'))
 
 
   // integrationTest
@@ -51,11 +58,19 @@ dependencies {
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation('pl.pragmatists:JUnitParams')
   integrationTestImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.awaitility:awaitility')
+  integrationTestImplementation('org.mockito:mockito-core')
 
 
   // distributedTest
   distributedTestImplementation(project(':geode-dunit'))
   distributedTestImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))
+  distributedTestImplementation('junit:junit')
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('org.awaitility:awaitility')
+  distributedTestImplementation('org.mockito:mockito-core')
 }
 
 sonarqube {

--- a/extensions/session-testing-war/build.gradle
+++ b/extensions/session-testing-war/build.gradle
@@ -28,5 +28,5 @@ dependencies {
 }
 
 war {
-    archiveVersion = ''
+  archiveVersion = ''
 }

--- a/geode-apis-compatible-with-redis/build.gradle
+++ b/geode-apis-compatible-with-redis/build.gradle
@@ -43,6 +43,8 @@ dependencies {
   implementation('commons-codec:commons-codec')
   implementation('org.apache.commons:commons-lang3')
   implementation('it.unimi.dsi:fastutil')
+  implementation('it.unimi.dsi:fastutil-core')
+  implementation('org.apache.shiro:shiro-core')
 
   testImplementation(project(':geode-junit'))
   testImplementation('org.mockito:mockito-core')
@@ -50,12 +52,19 @@ dependencies {
   testImplementation('com.pholser:junit-quickcheck-core')
   testImplementation('com.pholser:junit-quickcheck-generators')
   testImplementation('pl.pragmatists:JUnitParams')
+  testImplementation('com.google.guava:guava')
+  testImplementation('org.awaitility:awaitility')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
 
   commonTestImplementation(project(':geode-junit'))
   commonTestImplementation(project(':geode-dunit'))
   commonTestImplementation('org.testcontainers:testcontainers')
   commonTestImplementation('redis.clients:jedis')
   commonTestImplementation('org.apache.logging.log4j:log4j-core')
+  commonTestImplementation('com.github.docker-java:docker-java-api')
+  commonTestImplementation('junit:junit')
+  commonTestImplementation('org.assertj:assertj-core')
 
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation(project(':geode-junit'))
@@ -64,8 +73,17 @@ dependencies {
   integrationTestImplementation('io.lettuce:lettuce-core')
   integrationTestImplementation('org.apache.logging.log4j:log4j-core')
   // This only exists for debugging PubSubNativeRedisAcceptanceTest
-  integrationTestImplementation('org.buildobjects:jproc:2.6.2')
+  integrationTestImplementation('org.buildobjects:jproc')
   integrationTestImplementation('pl.pragmatists:JUnitParams')
+  integrationTestImplementation('com.github.stefanbirkner:system-rules')
+  integrationTestImplementation('com.google.guava:guava')
+  integrationTestImplementation('io.netty:netty-transport')
+  integrationTestImplementation('org.mockito:mockito-core')
+  integrationTestImplementation('org.springframework.shell:spring-shell')
+  integrationTestImplementation('org.awaitility:awaitility')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
+
   integrationTestRuntimeOnly(project(':geode-log4j'))
 
   acceptanceTestImplementation(sourceSets.integrationTest.output)
@@ -77,16 +95,17 @@ dependencies {
   acceptanceTestImplementation('org.testcontainers:testcontainers')
   acceptanceTestRuntimeOnly(project(':geode-log4j'))
   acceptanceTestImplementation('org.springframework.boot:spring-boot-starter-web') {
-    exclude module: 'spring-boot-starter-logging'
-    exclude module: 'spring-boot-starter-tomcat'
+    exclude module: 'spring-boot-starter-logging' ; // avoid conflict between log4j-slf4j-impl and log4j-to-slf4j
+    //    exclude module: 'spring-boot-starter-tomcat'
   }
   acceptanceTestImplementation('org.springframework.session:spring-session-data-redis')
   acceptanceTestImplementation('org.apache.logging.log4j:log4j-core')
   // This only exists for debugging PubSubNativeRedisAcceptanceTest
-  acceptanceTestImplementation('org.buildobjects:jproc:2.6.2')
+  acceptanceTestImplementation('org.buildobjects:jproc')
   acceptanceTestImplementation('io.github.resilience4j:resilience4j-retry')
   acceptanceTestImplementation('io.lettuce:lettuce-core')
-  acceptanceTestRuntimeOnly('io.lettuce:lettuce-core')
+  acceptanceTestImplementation('junit:junit')
+  acceptanceTestImplementation('org.assertj:assertj-core')
 
   distributedTestCompileOnly(platform(project(':boms:geode-all-bom')))
   distributedTestCompileOnly('javax.servlet:javax.servlet-api')
@@ -97,10 +116,23 @@ dependencies {
   distributedTestImplementation('io.lettuce:lettuce-core')
   distributedTestImplementation('io.github.resilience4j:resilience4j-retry')
   distributedTestImplementation('org.springframework.boot:spring-boot-starter-web') {
-    exclude module: 'spring-boot-starter-logging'
-    exclude module: 'spring-boot-starter-tomcat'
+    exclude module: 'spring-boot-starter-logging' ; // avoid conflict between log4j-slf4j-impl and log4j-to-slf4j
+    //    exclude module: 'spring-boot-starter-tomcat'
   }
   distributedTestImplementation('org.springframework.session:spring-session-data-redis')
+  distributedTestImplementation('org.apache.tomcat.embed:tomcat-embed-core')
+  distributedTestImplementation('org.awaitility:awaitility')
+  distributedTestImplementation('org.springframework.boot:spring-boot-autoconfigure')
+  distributedTestImplementation('org.springframework.boot:spring-boot')
+  distributedTestImplementation('org.springframework.data:spring-data-redis')
+  distributedTestImplementation('org.springframework.session:spring-session-core')
+  distributedTestImplementation('org.springframework:spring-context')
+  distributedTestImplementation('org.springframework:spring-core')
+  distributedTestImplementation('org.springframework:spring-web')
+  distributedTestImplementation('org.springframework:spring-webmvc')
+  distributedTestImplementation('junit:junit')
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('io.netty:netty-handler')
 }
 
 acceptanceTest {

--- a/geode-apis-compatible-with-redis/src/test/resources/expected-pom.xml
+++ b/geode-apis-compatible-with-redis/src/test/resources/expected-pom.xml
@@ -16,11 +16,6 @@
   See the License for the specific language governing permissions and
   limitations under the License.
   -->
-  <!-- This module was also published with a richer model, Gradle metadata,  -->
-  <!-- which should be used instead. Do not delete the following line which  -->
-  <!-- is to indicate to Gradle or any Gradle module metadata file consumer  -->
-  <!-- that they should prefer consuming it instead. -->
-  <!-- do_not_remove: published-with-gradle-metadata -->
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.geode</groupId>
   <artifactId>geode-apis-compatible-with-redis</artifactId>
@@ -104,6 +99,16 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-core</artifactId>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -102,6 +102,14 @@ configurations {
   }
 }
 
+// geodeArchives is a direct reflection of what is contained in geode-dependencies.jar. To that
+// end only add _test_ dependencies to acceptanceTestCompile/Runtime. All other product
+// dependencies should be a part of geodeArchives and should not need to be added as individual
+// dependencies here.
+configurations.getByName("acceptanceTestImplementation") {
+  extendsFrom configurations.getByName("geodeArchives")
+}
+
 publishing {
   publications {
     maven(MavenPublication) {
@@ -186,6 +194,8 @@ dependencies {
     exclude module: 'geode-core'
   }
   testImplementation('org.assertj:assertj-core')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
 
   integrationTestImplementation(project(':geode-core'))
   integrationTestImplementation(project(':geode-membership'))
@@ -211,12 +221,25 @@ dependencies {
   integrationTestImplementation('org.springframework.security:spring-security-oauth2-jose')
   integrationTestImplementation('javax.annotation:javax.annotation-api')
   integrationTestImplementation('javax.servlet:javax.servlet-api')
-
+  integrationTestImplementation('com.fasterxml.jackson.core:jackson-core')
+  integrationTestImplementation('com.github.stefanbirkner:system-rules')
+  integrationTestImplementation('com.jayway.jsonpath:json-path')
+  integrationTestImplementation('org.mockito:mockito-core')
+  integrationTestImplementation('org.springframework:spring-core')
+  integrationTestImplementation('commons-io:commons-io')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.awaitility:awaitility')
+  integrationTestImplementation('com.fasterxml.jackson.core:jackson-databind')
+  integrationTestImplementation('org.apache.httpcomponents:httpcore')
+  integrationTestImplementation('org.hamcrest:hamcrest-core')
+  integrationTestImplementation('org.hamcrest:hamcrest')
 
   integrationTestRuntimeOnly('io.swagger:swagger-annotations')
   // these two modules are for testing only
   integrationTestRuntimeOnly('com.fasterxml.jackson.datatype:jackson-datatype-joda')
   integrationTestRuntimeOnly('joda-time:joda-time')
+
 
   distributedTestCompileOnly(platform(project(':boms:geode-all-bom')))
   distributedTestCompileOnly('io.swagger:swagger-annotations')
@@ -234,30 +257,45 @@ dependencies {
   }
   distributedTestImplementation(project(':extensions:session-testing-war'))
   distributedTestImplementation(project(':geode-assembly:geode-assembly-test'))
-  distributedTestImplementation('org.apache.httpcomponents:httpclient')
-  distributedTestImplementation('org.springframework:spring-web')
   distributedTestImplementation(project(':geode-management'))
   distributedTestImplementation(project(':geode-web-management'))
   distributedTestImplementation('com.arakelian:java-jq')
+  distributedTestImplementation('com.fasterxml.jackson.core:jackson-databind')
+  distributedTestImplementation('commons-io:commons-io')
   distributedTestImplementation('javax.servlet:javax.servlet-api')
+  distributedTestImplementation('junit:junit')
+  distributedTestImplementation('org.apache.commons:commons-lang3')
+  distributedTestImplementation('org.apache.httpcomponents:httpclient')
+  distributedTestImplementation('org.apache.httpcomponents:httpcore')
+  distributedTestImplementation('org.apache.logging.log4j:log4j-api')
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('org.awaitility:awaitility')
+  distributedTestImplementation('org.codehaus.cargo:cargo-core-api-container')
+  distributedTestImplementation('org.codehaus.cargo:cargo-core-uberjar')
+  distributedTestImplementation('org.hamcrest:hamcrest')
+  distributedTestImplementation('org.hamcrest:hamcrest-core')
+  distributedTestImplementation('org.springframework:spring-web')
 
   distributedTestRuntimeOnly(project(':extensions:geode-modules-session-internal')) {
     exclude group: 'org.apache.tomcat'
   }
-  distributedTestImplementation('org.codehaus.cargo:cargo-core-uberjar')
-
   distributedTestRuntimeOnly('io.swagger:swagger-annotations')
   distributedTestRuntimeOnly(project(':geode-wan'))
 
-  // geodeArchives is a direct reflection of what is contained in geode-dependencies.jar. To that
-  // end only add _test_ dependencies to acceptanceTestCompile/Runtime. All other product
-  // dependencies should be a part of geodeArchives and should not need to be added as individual
-  // dependencies here.
-  acceptanceTestImplementation(configurations.geodeArchives)
+
   acceptanceTestImplementation(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }
   acceptanceTestImplementation(project(':geode-assembly:geode-assembly-test'))
+  acceptanceTestImplementation('com.fasterxml.jackson.core:jackson-databind')
+  acceptanceTestImplementation('com.github.docker-java:docker-java-api')
+  acceptanceTestImplementation('commons-io:commons-io')
+  acceptanceTestImplementation('io.micrometer:micrometer-core')
+  acceptanceTestImplementation('junit:junit')
+  acceptanceTestImplementation('org.apache.commons:commons-lang3')
+  acceptanceTestImplementation('org.apache.logging.log4j:log4j-api')
+  acceptanceTestImplementation('org.assertj:assertj-core')
+  acceptanceTestImplementation('org.awaitility:awaitility')
 
   // This is used by 'gradle within gradle' tests. No need to bump this version; but if you do,
   // don't have it be the same version as the outer gradle version.
@@ -275,6 +313,8 @@ dependencies {
   uiTestImplementation('org.seleniumhq.selenium:selenium-api')
   uiTestImplementation('org.seleniumhq.selenium:selenium-remote-driver')
   uiTestImplementation('org.seleniumhq.selenium:selenium-support')
+  uiTestImplementation('org.assertj:assertj-core')
+  uiTestImplementation('junit:junit')
 
   uiTestRuntimeOnly(project(':geode-core'))
   uiTestRuntimeOnly('org.seleniumhq.selenium:selenium-chrome-driver')
@@ -287,8 +327,13 @@ dependencies {
     exclude module: 'geode-core'
   }
   upgradeTestImplementation(project(':geode-assembly:geode-assembly-test'))
-
   upgradeTestImplementation('org.apache.httpcomponents:httpclient')
+  upgradeTestImplementation('com.fasterxml.jackson.core:jackson-databind')
+  upgradeTestImplementation('org.apache.commons:commons-lang3')
+  upgradeTestImplementation('org.apache.httpcomponents:httpcore')
+  upgradeTestImplementation('com.fasterxml.jackson.core:jackson-core')
+  upgradeTestImplementation('org.assertj:assertj-core')
+  upgradeTestImplementation('junit:junit')
 
   upgradeTestCompileOnly(platform(project(':boms:geode-all-bom')))
   upgradeTestCompileOnly('io.swagger:swagger-annotations')
@@ -305,14 +350,12 @@ dependencies {
   webServerJetty('org.eclipse.jetty:jetty-distribution:' + DependencyConstraints.get('jetty.version') + '@zip')
 
   gfshDependencies ('org.springframework:spring-web') {
-    exclude module: 'spring-core'
-    exclude module: 'commons-logging'
   }
 }
 
 acceptanceTest {
-    // This is specifically used by GradleBuildWithGeodeCoreAcceptanceTest
-    systemProperty 'projectGroup', project.group
+  // This is specifically used by GradleBuildWithGeodeCoreAcceptanceTest
+  systemProperty 'projectGroup', project.group
 }
 
 tasks.register('defaultDistributionConfig', JavaExec) {
@@ -348,17 +391,18 @@ tasks.register('defaultCacheConfig', JavaExec) {
 def cp = {
   // first add all the dependent project jars
   def jars = configurations.geodeArchives.dependencies.collect { it.dependencyProject }
-    .findAll { !(it.name.contains('geode-web') || it.name.contains('geode-pulse')) }
-    .collect { it.jar.archiveName }
+  .findAll { !(it.name.contains('geode-web') || it.name.contains('geode-pulse')) }
+  .collect { it.jar.archiveName }
 
   // then add all the dependencies of the dependent jars
   def depJars = configurations.geodeArchives.dependencies.collect {
     it.dependencyProject.findAll {
       !(it.name.contains('geode-web') ||
-        it.name.contains('geode-pulse'))
+          it.name.contains('geode-pulse'))
     }.collect {
-      it.configurations.runtimeClasspath.collect { it.getName() }.findAll { !(
-          it.contains('geode-all-bom') ||
+      it.configurations.runtimeClasspath.collect { it.getName() }.findAll {
+        !(
+            it.contains('geode-all-bom') ||
 
             // exclude mx4j, once the deprecated code is deleted we can remove these entirely
             it.contains('commons-digester') ||
@@ -380,7 +424,7 @@ def cp = {
             it.contains('spring-context') ||
             it.contains('spring-expression') ||
             it.contains('spring-web')
-        )}
+            )}
     }
   }.flatten()
 
@@ -553,7 +597,8 @@ distributions {
 
       with copySpec {
         into('lib')
-        from { dependentProjectNames.collect {
+        from {
+          dependentProjectNames.collect {
             [
               project(':'.concat(it)).configurations.runtimeClasspath,
               project(':'.concat(it)).configurations.archives.allArtifacts.files
@@ -607,8 +652,9 @@ distributions {
 }
 // Distribution plugin does not allow configuring of the task, only the contents. So we set
 // compression and classifier here
-[tasks.named('distTar'),
- tasks.named('srcDistTar'),
+[
+  tasks.named('distTar'),
+  tasks.named('srcDistTar'),
 ]*.configure {
   compression Compression.GZIP
   archiveExtension='tgz'
@@ -621,10 +667,11 @@ tasks.named('srcDistTar').configure {
   classifier 'src'
 }
 
-[tasks.named('distZip'),
- tasks.named('srcDistZip'),
- tasks.named('dockerfileZip'),
- ]*.configure {
+[
+  tasks.named('distZip'),
+  tasks.named('srcDistZip'),
+  tasks.named('dockerfileZip'),
+]*.configure {
   enabled = false
 }
 
@@ -660,11 +707,11 @@ task dumpInstalledJars(dependsOn: installDist) {
 
     installDir.include("**/*.war").visit{ file ->
       if(!file.isDirectory()) {
-          FileTree warContents = zipTree(file.file)
-          println ""
-          println file.name
-          println("==========================")
-          printJars(warContents)
+        FileTree warContents = zipTree(file.file)
+        println ""
+        println file.name
+        println("==========================")
+        printJars(warContents)
       }
     }
   }

--- a/geode-assembly/geode-assembly-test/build.gradle
+++ b/geode-assembly/geode-assembly-test/build.gradle
@@ -30,6 +30,12 @@ dependencies {
   implementation(project(':geode-membership'))
   implementation('javax.servlet:javax.servlet-api')
   implementation('org.apache.commons:commons-lang3')
+  implementation('com.fasterxml.jackson.core:jackson-annotations')
+  implementation('org.apache.httpcomponents:httpcore')
+  implementation('org.codehaus.cargo:cargo-core-api-container')
+  implementation('org.codehaus.cargo:cargo-core-api-generic')
+  implementation('org.codehaus.cargo:cargo-core-api-util')
+
   compileOnly(project(':geode-tcp-server'))
   compileOnly('com.fasterxml.jackson.core:jackson-databind')
   compileOnly('commons-io:commons-io')
@@ -39,4 +45,3 @@ dependencies {
   compileOnly('org.assertj:assertj-core')
   compileOnly('org.codehaus.cargo:cargo-core-uberjar')
 }
-

--- a/geode-assembly/src/acceptanceTest/resources/gradle-test-projects/management/build.gradle
+++ b/geode-assembly/src/acceptanceTest/resources/gradle-test-projects/management/build.gradle
@@ -14,24 +14,24 @@
  */
 
 plugins {
-    id 'java'
-    id 'application'
+  id 'java'
+  id 'application'
 }
 
 repositories {
-    mavenLocal()
-    mavenCentral()
+  mavenLocal()
+  mavenCentral()
 }
 
 dependencies {
-    compile("${project.group}:geode-core:${project.version}")
-    runtime('org.apache.logging.log4j:log4j-slf4j-impl:2.12.0')
+  compile("${project.group}:geode-core:${project.version}")
+  runtime('org.apache.logging.log4j:log4j-slf4j-impl:2.12.0')
 }
 
 application {
-    mainClassName = 'ServerTestApp'
+  mainClassName = 'ServerTestApp'
 }
 
 run {
-    environment['GEODE_HOME'] = "${findProperty('geodeHome')}"
+  environment['GEODE_HOME'] = "${findProperty('geodeHome')}"
 }

--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -24,7 +24,10 @@ apply from: "${project.projectDir}/../gradle/jmh.gradle"
 dependencies {
   // main
   implementation(platform(project(':boms:geode-all-bom')))
+  implementation('com.fasterxml.jackson.core:jackson-annotations')
+  implementation('com.fasterxml.jackson.core:jackson-core')
   implementation('com.fasterxml.jackson.core:jackson-databind')
+
 
   // test
   testImplementation('junit:junit')

--- a/geode-common/src/test/resources/expected-pom.xml
+++ b/geode-common/src/test/resources/expected-pom.xml
@@ -48,6 +48,16 @@
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/geode-connectors/build.gradle
+++ b/geode-connectors/build.gradle
@@ -42,6 +42,7 @@ task downloadJdbcJars(type:Copy) {
 
 dependencies {
   api(platform(project(':boms:geode-all-bom')))
+  jdbcTestingJars(platform(project(':boms:geode-all-bom')))
 
   implementation(project(':geode-logging'))
   implementation(project(':geode-serialization'))
@@ -81,18 +82,15 @@ dependencies {
     ext.optional = true
   }
   implementation('org.springframework.shell:spring-shell') {
-    exclude module: 'aopalliance'
-    exclude module: 'asm'
-    exclude module: 'cglib'
-    exclude module: 'guava'
-    exclude module: 'spring-aop'
-    exclude module: 'spring-context-support'
-    exclude module: 'spring-core'
     ext.optional = true
   }
   implementation('com.healthmarketscience.rmiio:rmiio')
+  implementation('commons-io:commons-io')
 
   testImplementation('pl.pragmatists:JUnitParams')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('org.mockito:mockito-core')
 
   integrationTestImplementation('junit:junit')
   integrationTestImplementation('org.assertj:assertj-core')
@@ -105,7 +103,6 @@ dependencies {
   distributedTestRuntimeOnly('org.apache.derby:derby')
 
   acceptanceTestImplementation('com.github.stefanbirkner:system-rules') {
-    exclude module: 'junit-dep'
   }
   acceptanceTestImplementation('junit:junit')
   acceptanceTestImplementation('org.assertj:assertj-core')
@@ -118,7 +115,7 @@ dependencies {
   acceptanceTestRuntimeOnly('org.apache.derby:derby')
   acceptanceTestRuntimeOnly('org.postgresql:postgresql')
 
-  jdbcTestingJars('mysql:mysql-connector-java:8.0.26')
+  jdbcTestingJars('mysql:mysql-connector-java')
 }
 
 integrationTest.forkEvery 0

--- a/geode-connectors/src/test/resources/expected-pom.xml
+++ b/geode-connectors/src/test/resources/expected-pom.xml
@@ -106,41 +106,16 @@
       <groupId>org.springframework.shell</groupId>
       <artifactId>spring-shell</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>cglib</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-core</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>asm</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-aop</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>guava</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>aopalliance</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-context-support</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>com.healthmarketscience.rmiio</groupId>
       <artifactId>rmiio</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
       <scope>runtime</scope>
     </dependency>
   </dependencies>

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -24,95 +24,95 @@ apply from: "${project.projectDir}/../gradle/pmd.gradle"
 apply from: "${project.projectDir}/../gradle/jmh.gradle"
 
 sourceSets {
-    jca {
-        compileClasspath += configurations.compileClasspath
-        runtimeClasspath += configurations.runtimeClasspath
-    }
+  jca {
+    compileClasspath += configurations.compileClasspath
+    runtimeClasspath += configurations.runtimeClasspath
+  }
 }
 
 idea {
-    module {
-        testSourceDirs += project.tasks.generateIntegrationTestGrammarSource.outputs.files
-        testSourceDirs += project.tasks.generateDistributedTestGrammarSource.outputs.files
-        testSourceDirs += project.tasks.generatePerformanceTestGrammarSource.outputs.files
-        testSourceDirs += project.tasks.generateUpgradeTestGrammarSource.outputs.files
-    }
+  module {
+    testSourceDirs += project.tasks.generateIntegrationTestGrammarSource.outputs.files
+    testSourceDirs += project.tasks.generateDistributedTestGrammarSource.outputs.files
+    testSourceDirs += project.tasks.generatePerformanceTestGrammarSource.outputs.files
+    testSourceDirs += project.tasks.generateUpgradeTestGrammarSource.outputs.files
+  }
 }
 
 def generatedResources = "$buildDir/generated-resources/main"
 
 sourceSets {
-    main {
-        output.dir(generatedResources, builtBy: 'createVersionPropertiesFile')
-    }
-    test {
-        output.dir(generatedResources, builtBy: 'createVersionPropertiesFile')
-    }
+  main {
+    output.dir(generatedResources, builtBy: 'createVersionPropertiesFile')
+  }
+  test {
+    output.dir(generatedResources, builtBy: 'createVersionPropertiesFile')
+  }
 }
 
 sourceSets {
-// This works around resource-look up between integrationTest and test source-sets.
-// See GEODE-5803 / GEODE-5882
-    test.resources.srcDirs.each { testResourceSrc ->
-        integrationTest.resources.srcDir {
-            testResourceSrc
-        }
+  // This works around resource-look up between integrationTest and test source-sets.
+  // See GEODE-5803 / GEODE-5882
+  test.resources.srcDirs.each { testResourceSrc ->
+    integrationTest.resources.srcDir {
+      testResourceSrc
     }
+  }
 }
 
 
 // Creates the version properties file and writes it to the classes dir
 task createVersionPropertiesFile(dependsOn: ':writeBuildInfo') {
 
-    def propertiesFile = file(generatedResources + "/org/apache/geode/internal/GemFireVersion.properties")
-    def scmInfoFile = rootProject.tasks.writeBuildInfo.outputs.files
+  def propertiesFile = file(generatedResources + "/org/apache/geode/internal/GemFireVersion.properties")
+  def scmInfoFile = rootProject.tasks.writeBuildInfo.outputs.files
 
-    inputs.files {
-        scmInfoFile
+  inputs.files {
+    scmInfoFile
+  }
+  outputs.files {
+    propertiesFile
+  }
+
+  def props = [
+    "Product-Name"      : productName,
+    "Product-Version"   : version,
+    "Build-Id"          : "${System.env.USER} ${buildId}".toString(),
+    "Build-Platform"    : "${System.properties['os.name']} ${System.properties['os.version']} ${System.properties['os.arch']}".toString(),
+    "Build-Java-Vendor" : System.properties['java.vendor'],
+    "Build-Java-Version": System.properties['java.version']
+  ] as Properties
+
+  inputs.properties(props)
+
+  doLast {
+    def scmInfo = new Properties()
+    new FileInputStream(scmInfoFile.singleFile).withStream { fis ->
+      scmInfo.load(fis)
     }
-    outputs.files {
-        propertiesFile
+    props.putAll(scmInfo)
+
+    propertiesFile.getParentFile().mkdirs()
+    new FileOutputStream(propertiesFile).withStream { fos ->
+      props.store(fos, '')
     }
-
-    def props = [
-          "Product-Name"      : productName,
-          "Product-Version"   : version,
-          "Build-Id"          : "${System.env.USER} ${buildId}".toString(),
-          "Build-Platform"    : "${System.properties['os.name']} ${System.properties['os.version']} ${System.properties['os.arch']}".toString(),
-          "Build-Java-Vendor" : System.properties['java.vendor'],
-          "Build-Java-Version": System.properties['java.version']
-    ] as Properties
-
-    inputs.properties(props)
-
-    doLast {
-        def scmInfo = new Properties()
-        new FileInputStream(scmInfoFile.singleFile).withStream { fis ->
-            scmInfo.load(fis)
-        }
-        props.putAll(scmInfo)
-
-        propertiesFile.getParentFile().mkdirs()
-        new FileOutputStream(propertiesFile).withStream { fos ->
-            props.store(fos, '')
-        }
-    }
+  }
 }
 
 ext.moduleName = group + '.core'
 
 jar {
 
-    from sourceSets.main.output
-    from sourceSets.jca.output
+  from sourceSets.main.output
+  from sourceSets.jca.output
 
-    exclude 'org/apache/geode/internal/i18n/StringIdResourceBundle_ja.txt'
-    exclude 'org/apache/geode/admin/doc-files/ds4_0.dtd'
+  exclude 'org/apache/geode/internal/i18n/StringIdResourceBundle_ja.txt'
+  exclude 'org/apache/geode/admin/doc-files/ds4_0.dtd'
 
-    inputs.property("moduleName", moduleName)
-    manifest {
-        attributes('Automatic-Module-Name': moduleName)
-    }
+  inputs.property("moduleName", moduleName)
+  manifest {
+    attributes('Automatic-Module-Name': moduleName)
+  }
 
 }
 
@@ -127,281 +127,322 @@ repeatUpgradeTest {
 }
 
 task raJar(type: Jar, dependsOn: classes) {
-    description 'Assembles the jar archive that contains the JCA classes'
-    from sourceSets.jca.output
-    exclude 'org/apache/geode/ra/**'
-    archiveFileName='ra.jar'
+  description 'Assembles the jar archive that contains the JCA classes'
+  from sourceSets.jca.output
+  exclude 'org/apache/geode/ra/**'
+  archiveFileName='ra.jar'
 }
 
 task jcaJar(type: Jar, dependsOn: raJar) {
-    description 'Assembles the jar archive that contains the JCA bundle'
-    archiveBaseName='geode-jca'
-    archiveExtension='rar'
-    metaInf { from 'src/jca/ra.xml' }
-    from raJar.archivePath
+  description 'Assembles the jar archive that contains the JCA bundle'
+  archiveBaseName='geode-jca'
+  archiveExtension='rar'
+  metaInf { from 'src/jca/ra.xml' }
+  from raJar.archivePath
 }
 
 configurations {
-    //declaring new configuration that will be used to associate with artifacts
-    archives
+  //declaring new configuration that will be used to associate with artifacts
+  archives
 
-    classesOutput {
-        extendsFrom api
-        description 'a dependency that exposes the compiled classes'
-    }
+  classesOutput {
+    extendsFrom api
+    description 'a dependency that exposes the compiled classes'
+  }
 
-    jmh {
-        extendsFrom testImplementation
-    }
+  jmh {
+    extendsFrom testImplementation
+  }
 
-    raOutput
+  raOutput
 }
 
 artifacts {
-    raOutput raJar
+  raOutput raJar
 }
 
 dependencies {
 
-    //These bom dependencies are used to constrain the versions of the dependencies listed below
-    api(platform(project(':boms:geode-all-bom')))
-    compileOnly(platform(project(':boms:geode-all-bom')))
-    testCompileOnly(platform(project(':boms:geode-all-bom')))
-    // As plugin configurations that do not extend from compile,
-    // we must explicitly impose version constraints on these configurations.
-    antlr platform(project(':boms:geode-all-bom'))
-    jcaAnnotationProcessor(platform(project(':boms:geode-all-bom')))
+  //These bom dependencies are used to constrain the versions of the dependencies listed below
+  api(platform(project(':boms:geode-all-bom')))
+  compileOnly(platform(project(':boms:geode-all-bom')))
+  testCompileOnly(platform(project(':boms:geode-all-bom')))
+  // As plugin configurations that do not extend from compile,
+  // we must explicitly impose version constraints on these configurations.
+  antlr platform(project(':boms:geode-all-bom'))
+  jcaAnnotationProcessor(platform(project(':boms:geode-all-bom')))
 
-    //A dependency that contains the compiled output of the source. What is this for?
-    classesOutput sourceSets.main.output
-
-
-    // Source Dependencies
-    //------------------------------------------------------------
-
-    //  The antlr configuration is used by the antlr plugin, which compiles grammar
-    // files used by the query engine
-    antlr 'antlr:antlr'
-
-    // External
-    //------------------------------------------------------------
-
-    //Commons IO is used in persistence and management
-    api('commons-io:commons-io')
-
-    //tools.jar seems to be used by gfsh is some cases to control processes using
-    //the sun attach API? But this code path may not even be used?
-    compileOnly(files("${System.getProperty('java.home')}/../lib/tools.jar"))
-
-    //Find bugs is used in multiple places in the code to suppress findbugs warnings
-    compileOnly('com.github.stephenc.findbugs:findbugs-annotations')
-    testCompileOnly('com.github.stephenc.findbugs:findbugs-annotations')
-
-    //Spring web is used for SerializableObjectHttpMessageConverter
-    implementation('org.springframework:spring-web')
-    // find bugs leaks in from spring, needed to remove warnings.
-    compileOnly('com.google.code.findbugs:jsr305')
-
-    compileOnly('org.jetbrains:annotations')
-
-    //Jgroups is a core component of our membership system.
-    implementation('org.jgroups:jgroups')
-
-    //Antlr is used by the query engine.
-    implementation('antlr:antlr')
-
-    //Jackson annotations is used in gfsh
-    implementation('com.fasterxml.jackson.core:jackson-annotations')
-
-    //Jackson databind is used in gfsh, and also in pdx
-    implementation('com.fasterxml.jackson.core:jackson-databind')
-
-    //Commons validator is used to validate inet addresses in membership
-    implementation('commons-validator:commons-validator')
+  //A dependency that contains the compiled output of the source. What is this for?
+  classesOutput sourceSets.main.output
 
 
-    //jaxb is used by cluster configuration
-    implementation('javax.xml.bind:jaxb-api')
+  // Source Dependencies
+  //------------------------------------------------------------
 
-    //jaxb is used by cluster configuration
-    implementation('com.sun.xml.bind:jaxb-impl')
+  //  The antlr configuration is used by the antlr plugin, which compiles grammar
+  // files used by the query engine
+  antlr 'antlr:antlr'
 
-    //istack appears to be used only by jaxb, not in our code. jaxb doesn't
-    //declare this as required dependency though. It's unclear if this is needed
-    //Runtime
-    runtimeOnly('com.sun.istack:istack-commons-runtime') {
-        exclude group: '*'
-    }
+  // External
+  //------------------------------------------------------------
 
-    runtimeOnly(project(':geode-deployment:geode-deployment-legacy'))
+  //Commons IO is used in persistence and management
+  api('commons-io:commons-io')
 
-    //Commons lang is used in many different places in core
-    implementation('org.apache.commons:commons-lang3')
+  //tools.jar seems to be used by gfsh is some cases to control processes using
+  //the sun attach API? But this code path may not even be used?
+  compileOnly(files("${System.getProperty('java.home')}/../lib/tools.jar"))
 
-    //Commons modeler is used by the (deprecated) admin API
-    implementation('commons-modeler:commons-modeler') {
-        exclude module: 'commons-logging-api'
-        exclude module: 'mx4j-jmx'
-        exclude module: 'xml-apis'
-        ext.optional = true
-    }
+  //Find bugs is used in multiple places in the code to suppress findbugs warnings
+  compileOnly('com.github.stephenc.findbugs:findbugs-annotations')
+  testCompileOnly('com.github.stephenc.findbugs:findbugs-annotations')
 
-    //micrometer is used for micrometer based metrics from geode geode
-    api('io.micrometer:micrometer-core')
+  //Spring web is used for SerializableObjectHttpMessageConverter
+  implementation('org.springframework:spring-web')
+  // find bugs leaks in from spring, needed to remove warnings.
+  compileOnly('com.google.code.findbugs:jsr305')
 
+  compileOnly('org.jetbrains:annotations')
 
-    //FastUtil contains optimized collections that are used in multiple places in core
-    implementation('it.unimi.dsi:fastutil')
+  //Jgroups is a core component of our membership system.
+  implementation('org.jgroups:jgroups')
 
-    //Mail API is used by the deprecated admin API
-    implementation('javax.mail:javax.mail-api') {
-        ext.optional = true
-    }
+  //Antlr is used by the query engine.
+  implementation('antlr:antlr')
 
-    //The resource-API is used by the JCA support.
-    api('javax.resource:javax.resource-api')
+  //Jackson annotations is used in gfsh
+  implementation('com.fasterxml.jackson.core:jackson-annotations')
 
+  //Jackson databind is used in gfsh, and also in pdx
+  implementation('com.fasterxml.jackson.core:jackson-databind')
 
-    //MX4J is used by the old admin API
-    implementation('mx4j:mx4j') {
-        ext.optional = true
-    }
-
-    //MX4J remote is used by the old admin API
-    implementation('mx4j:mx4j-remote') {
-        ext.optional = true
-    }
-
-    //MX4J tools is used by the old admin API
-    implementation('mx4j:mx4j-tools') {
-        ext.optional = true
-    }
-
-    //JNA is used for locking memory and preallocating disk files.
-    implementation('net.java.dev.jna:jna')
-    implementation('net.java.dev.jna:jna-platform')
-
-    //JOptSimple is used by gfsh. A couple of usages have leaked into DiskStore
-    implementation('net.sf.jopt-simple:jopt-simple')
-
-    //Log4j is used everywhere
-    implementation('org.apache.logging.log4j:log4j-api')
+  //Commons validator is used to validate inet addresses in membership
+  implementation('commons-validator:commons-validator')
 
 
-    implementation('io.swagger:swagger-annotations') {
-        ext.optional = true
-    }
+  //jaxb is used by cluster configuration
+  implementation('javax.xml.bind:jaxb-api')
 
-    runtimeOnly(project(':geode-http-service')) {
-        ext.optional = true
-    }
+  //jaxb is used by cluster configuration
+  implementation('com.sun.xml.bind:jaxb-impl')
 
-    //Snappy is used for compressing values, if enabled
-    implementation('org.iq80.snappy:snappy') {
-        ext.optional = true
-    }
+  //istack appears to be used only by jaxb, not in our code. jaxb doesn't
+  //declare this as required dependency though. It's unclear if this is needed
+  //Runtime
+  runtimeOnly('com.sun.istack:istack-commons-runtime') {
+  }
 
-    //Shiro is used for security checks throughout geode-core
-    //API - Shiro is exposed in geode's ResourcePermission class
-    api('org.apache.shiro:shiro-core')
+  runtimeOnly(project(':geode-deployment:geode-deployment-legacy'))
 
-    //Classgraph is used by the gfsh cli, and also for function deployment (which happens in a server
-    //in response to a gfsh command)
-    implementation('io.github.classgraph:classgraph')
+  //Commons lang is used in many different places in core
+  implementation('org.apache.commons:commons-lang3')
 
-    //RMIIO is used for uploading jar files and copying them between locator an servers
-    implementation('com.healthmarketscience.rmiio:rmiio')
+  //Commons modeler is used by the (deprecated) admin API
+  implementation('commons-modeler:commons-modeler') {
+    ext.optional = true
+  }
 
-    //Geode-common has annotations and other pieces used geode-core
-    api(project(':geode-common'))
-    implementation(project(':geode-logging'))
-    implementation(project(':geode-membership'))
-    implementation(project(':geode-unsafe'))
-    implementation(project(':geode-serialization'))
-    implementation(project(':geode-tcp-server'))
-
-    //geode-management currently has pieces of the public API
-    //copied into it, so it is an API dependency
-    api(project(':geode-management'))
+  //micrometer is used for micrometer based metrics from geode geode
+  api('io.micrometer:micrometer-core')
 
 
-    jcaImplementation(sourceSets.main.output)
+  //FastUtil contains optimized collections that are used in multiple places in core
+  implementation('it.unimi.dsi:fastutil')
 
-    testImplementation(project(':geode-junit')) {
-        exclude module: 'geode-core'
-    }
-    testImplementation(project(':geode-concurrency-test'))
-    testImplementation('org.apache.bcel:bcel')
-    testImplementation('org.assertj:assertj-core')
-    testImplementation('org.mockito:mockito-core')
-    testImplementation('com.pholser:junit-quickcheck-core')
-    testImplementation('pl.pragmatists:JUnitParams')
-    testImplementation('com.tngtech.archunit:archunit-junit4')
-    testImplementation(project(path: ':geode-core', configuration: 'raOutput'))
+  //Mail API is used by the deprecated admin API
+  implementation('javax.mail:javax.mail-api') {
+    ext.optional = true
+  }
 
-    testImplementation(files("${System.getProperty('java.home')}/../lib/tools.jar"))
-
-    testRuntimeOnly('commons-collections:commons-collections')
-    testRuntimeOnly('commons-configuration:commons-configuration')
-    testRuntimeOnly('commons-io:commons-io')
-    testRuntimeOnly('commons-validator:commons-validator')
-    testRuntimeOnly('com.pholser:junit-quickcheck-generators')
-
-    // Needed for JDK8, not JDK11, after nebula.facet v7.0.9
-    integrationTestImplementation(files("${System.getProperty('java.home')}/../lib/tools.jar"))
-    integrationTestImplementation(project(':geode-gfsh'))
-    integrationTestImplementation(project(':geode-junit'))
-    integrationTestImplementation(project(':geode-dunit'))
-    integrationTestImplementation(project(':geode-log4j'))
-    integrationTestImplementation(project(':geode-concurrency-test'))
-    integrationTestImplementation('org.apache.bcel:bcel')
-    integrationTestImplementation('org.apache.logging.log4j:log4j-core')
-    integrationTestImplementation('pl.pragmatists:JUnitParams')
-    integrationTestImplementation('com.tngtech.archunit:archunit-junit4')
+  //The resource-API is used by the JCA support.
+  api('javax.resource:javax.resource-api')
 
 
-    integrationTestRuntimeOnly('org.apache.derby:derby')
-    integrationTestRuntimeOnly('xerces:xercesImpl')
-    integrationTestRuntimeOnly('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
+  //MX4J is used by the old admin API
+  implementation('mx4j:mx4j') {
+    ext.optional = true
+  }
 
-    distributedTestImplementation(project(':geode-gfsh'))
-    distributedTestImplementation(project(':geode-junit')) {
-        exclude module: 'geode-core'
-    }
-    distributedTestImplementation(project(':geode-dunit')) {
-        exclude module: 'geode-core'
-    }
-    distributedTestImplementation(project(':geode-log4j')) {
-        exclude module: 'geode-core'
-    }
-    distributedTestImplementation('pl.pragmatists:JUnitParams')
-    distributedTestImplementation('com.jayway.jsonpath:json-path-assert')
-    distributedTestImplementation('net.openhft:compiler')
+  //MX4J remote is used by the old admin API
+  implementation('mx4j:mx4j-remote') {
+    ext.optional = true
+  }
 
-    distributedTestRuntimeOnly('org.apache.derby:derby')
+  //MX4J tools is used by the old admin API
+  implementation('mx4j:mx4j-tools') {
+    ext.optional = true
+  }
+
+  //JNA is used for locking memory and preallocating disk files.
+  implementation('net.java.dev.jna:jna')
+  implementation('net.java.dev.jna:jna-platform')
+
+  //JOptSimple is used by gfsh. A couple of usages have leaked into DiskStore
+  implementation('net.sf.jopt-simple:jopt-simple')
+
+  //Log4j is used everywhere
+  implementation('org.apache.logging.log4j:log4j-api')
 
 
-    upgradeTestImplementation(project(':geode-dunit')) {
-        exclude module: 'geode-core'
-    }
+  implementation('io.swagger:swagger-annotations') {
+    ext.optional = true
+  }
 
-    upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
-    upgradeTestRuntimeOnly(project(':geode-log4j'))
-    upgradeTestRuntimeOnly(project(':geode-old-client-support'))
+  runtimeOnly(project(':geode-http-service')) {
+    ext.optional = true
+  }
 
-    performanceTestImplementation(project(':geode-junit')) {
-        exclude module: 'geode-core'
-    }
-    performanceTestImplementation(project(':geode-log4j'))
+  //Snappy is used for compressing values, if enabled
+  implementation('org.iq80.snappy:snappy') {
+    ext.optional = true
+  }
 
-    jmhImplementation('org.jctools:jctools-core:3.3.0')
+  //Shiro is used for security checks throughout geode-core
+  //API - Shiro is exposed in geode's ResourcePermission class
+  api('org.apache.shiro:shiro-core')
+
+  //Classgraph is used by the gfsh cli, and also for function deployment (which happens in a server
+  //in response to a gfsh command)
+  implementation('io.github.classgraph:classgraph')
+
+  //RMIIO is used for uploading jar files and copying them between locator an servers
+  implementation('com.healthmarketscience.rmiio:rmiio')
+
+  //Geode-common has annotations and other pieces used geode-core
+  api(project(':geode-common'))
+  implementation(project(':geode-logging'))
+  implementation(project(':geode-membership'))
+  implementation(project(':geode-unsafe'))
+  implementation(project(':geode-serialization'))
+  implementation(project(':geode-tcp-server'))
+  implementation('com.fasterxml.jackson.core:jackson-core')
+  implementation('commons-collections:commons-collections')
+  implementation('commons-logging:commons-logging-api')
+  implementation('commons-logging:commons-logging')
+  implementation('it.unimi.dsi:fastutil-core')
+  implementation('it.unimi.dsi:fastutil-extra')
+  implementation('javax.transaction:javax.transaction-api')
+  implementation('org.apache.shiro:shiro-cache')
+  implementation('org.apache.shiro:shiro-config-core')
+  implementation('org.apache.shiro:shiro-config-ogdl')
+  implementation('org.apache.shiro:shiro-lang')
+  implementation('org.springframework:spring-core')
+  implementation('org.springframework:spring-jcl')
+
+  //geode-management currently has pieces of the public API
+  //copied into it, so it is an API dependency
+  api(project(':geode-management'))
+
+
+  jcaImplementation(sourceSets.main.output)
+
+  testImplementation(project(':geode-junit')) {
+    exclude module: 'geode-core'
+  }
+  testImplementation(project(':geode-concurrency-test'))
+  testImplementation('org.apache.bcel:bcel')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('com.pholser:junit-quickcheck-core')
+  testImplementation('pl.pragmatists:JUnitParams')
+  testImplementation('com.tngtech.archunit:archunit-junit4')
+  testImplementation(project(path: ':geode-core', configuration: 'raOutput'))
+  testImplementation('com.google.code.findbugs:jsr305')
+  testImplementation(files("${System.getProperty('java.home')}/../lib/tools.jar"))
+  testImplementation('com.google.guava:guava')
+  testImplementation('org.awaitility:awaitility')
+  testImplementation('org.hamcrest:hamcrest-core:')
+  testImplementation('org.hamcrest:hamcrest')
+  testImplementation('com.github.stefanbirkner:system-rules')
+  testImplementation('com.tngtech.archunit:archunit')
+  testImplementation('junit:junit')
+
+  testRuntimeOnly('commons-collections:commons-collections')
+  testRuntimeOnly('commons-configuration:commons-configuration')
+  testRuntimeOnly('commons-io:commons-io')
+  testRuntimeOnly('commons-validator:commons-validator')
+  testRuntimeOnly('com.pholser:junit-quickcheck-generators')
+
+  // Needed for JDK8, not JDK11, after nebula.facet v7.0.9
+  integrationTestImplementation(files("${System.getProperty('java.home')}/../lib/tools.jar"))
+  integrationTestImplementation(project(':geode-gfsh'))
+  integrationTestImplementation(project(':geode-junit'))
+  integrationTestImplementation(project(':geode-dunit'))
+  integrationTestImplementation(project(':geode-log4j'))
+  integrationTestImplementation(project(':geode-concurrency-test'))
+  integrationTestImplementation('org.apache.bcel:bcel')
+  integrationTestImplementation('org.apache.logging.log4j:log4j-core')
+  integrationTestImplementation('pl.pragmatists:JUnitParams')
+  integrationTestImplementation('com.tngtech.archunit:archunit-junit4')
+  integrationTestImplementation('com.github.stefanbirkner:system-rules')
+  integrationTestImplementation('com.tngtech.archunit:archunit')
+  integrationTestImplementation('com.google.guava:guava')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.awaitility:awaitility')
+  integrationTestImplementation('org.hamcrest:hamcrest-core')
+  integrationTestImplementation('org.hamcrest:hamcrest')
+  integrationTestImplementation('org.mockito:mockito-core')
+
+  integrationTestRuntimeOnly('org.apache.derby:derby')
+  integrationTestRuntimeOnly('xerces:xercesImpl')
+  integrationTestRuntimeOnly('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
+
+  distributedTestImplementation(project(':geode-gfsh'))
+  distributedTestImplementation(project(':geode-junit')) {
+    exclude module: 'geode-core'
+  }
+  distributedTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-core'
+  }
+  distributedTestImplementation(project(':geode-log4j')) {
+    exclude module: 'geode-core'
+  }
+  distributedTestImplementation('pl.pragmatists:JUnitParams')
+  distributedTestImplementation('com.jayway.jsonpath:json-path-assert')
+  distributedTestImplementation('net.openhft:compiler')
+  distributedTestImplementation('com.google.guava:guava')
+  distributedTestImplementation('junit:junit')
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('org.awaitility:awaitility')
+  distributedTestImplementation('org.hamcrest:hamcrest-core')
+  distributedTestImplementation('org.hamcrest:hamcrest')
+  distributedTestImplementation('org.mockito:mockito-core')
+  distributedTestImplementation('org.springframework.shell:spring-shell')
+
+  distributedTestRuntimeOnly('org.apache.derby:derby')
+
+
+  upgradeTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-core'
+  }
+  upgradeTestImplementation('com.github.stefanbirkner:system-rules')
+  upgradeTestImplementation('org.assertj:assertj-core')
+  upgradeTestImplementation('org.mockito:mockito-core')
+  upgradeTestImplementation('org.awaitility:awaitility')
+  upgradeTestImplementation('org.hamcrest:hamcrest-core')
+  upgradeTestImplementation('org.hamcrest:hamcrest')
+  upgradeTestImplementation('junit:junit')
+
+  upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
+  upgradeTestRuntimeOnly(project(':geode-log4j'))
+  upgradeTestRuntimeOnly(project(':geode-old-client-support'))
+
+  performanceTestImplementation(project(':geode-junit')) {
+    exclude module: 'geode-core'
+  }
+  performanceTestImplementation(project(':geode-log4j'))
+  performanceTestImplementation('junit:junit')
+
+  jmhImplementation('org.jctools:jctools-core')
+  jmhImplementation('junit:junit')
 }
 
 tasks.eclipse.dependsOn(generateGrammarSource)
 
 distributedTest {
-    // Some tests have inner tests that should be ignored
-    exclude "**/*\$*.class"
+  // Some tests have inner tests that should be ignored
+  exclude "**/*\$*.class"
 }
 
 rootProject.generate.dependsOn(generateGrammarSource)

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -125,20 +125,6 @@
       <groupId>commons-modeler</groupId>
       <artifactId>commons-modeler</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>commons-logging-api</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>xml-apis</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>mx4j-jmx</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -238,15 +224,74 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil-extra</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>javax.transaction-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-cache</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-config-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-config-ogdl</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-lang</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jcl</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>com.sun.istack</groupId>
       <artifactId>istack-commons-runtime</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>*</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>

--- a/geode-cq/build.gradle
+++ b/geode-cq/build.gradle
@@ -30,12 +30,17 @@ dependencies {
 
 
   testImplementation(project(':geode-junit'))
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('org.mockito:mockito-core')
 
 
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation(project(':geode-junit'))
   integrationTestImplementation('junit:junit')
   integrationTestImplementation('org.awaitility:awaitility')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.mockito:mockito-core')
 
 
   distributedTestImplementation(project(':geode-gfsh'))
@@ -48,6 +53,9 @@ dependencies {
   distributedTestImplementation('org.awaitility:awaitility')
   distributedTestImplementation('org.hamcrest:hamcrest')
   distributedTestImplementation('pl.pragmatists:JUnitParams')
+  distributedTestImplementation('com.google.guava:guava')
+  distributedTestImplementation('org.hamcrest:hamcrest-core')
+  distributedTestImplementation('org.mockito:mockito-core')
 
 
   upgradeTestImplementation(project(':geode-dunit'))
@@ -55,6 +63,7 @@ dependencies {
   upgradeTestImplementation('junit:junit')
   upgradeTestImplementation('org.awaitility:awaitility')
   upgradeTestImplementation('org.mockito:mockito-core')
+  upgradeTestImplementation('org.assertj:assertj-core')
 
   upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
 }

--- a/geode-deployment/geode-deployment-legacy/build.gradle
+++ b/geode-deployment/geode-deployment-legacy/build.gradle
@@ -21,17 +21,27 @@ apply from: "${project.projectDir}/../../gradle/publish-java.gradle"
 apply from: "${project.projectDir}/../../gradle/warnings.gradle"
 
 dependencies {
-    implementation(platform(project(':boms:geode-all-bom')))
-    compileOnly(platform(project(':boms:geode-all-bom')))
+  implementation(platform(project(':boms:geode-all-bom')))
+  compileOnly(platform(project(':boms:geode-all-bom')))
 
-    implementation(project(':geode-core'))
-    implementation(project(':geode-common'))
-    implementation('io.swagger:swagger-annotations')
+  implementation(project(':geode-core'))
+  implementation(project(':geode-common'))
+  implementation('io.swagger:swagger-annotations')
+  implementation('commons-io:commons-io')
+  implementation('org.apache.logging.log4j:log4j-api')
 
-    compileOnly(project(':geode-logging'))
-    compileOnly('com.fasterxml.jackson.core:jackson-databind')
+  compileOnly(project(':geode-logging'))
+  compileOnly('com.fasterxml.jackson.core:jackson-databind')
 
-    testImplementation(project(':geode-junit'))
+  testImplementation(project(':geode-junit'))
+  testImplementation('org.awaitility:awaitility')
+  testImplementation('com.github.stefanbirkner:system-rules')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
 
-    integrationTestImplementation(project(':geode-junit'))
+  integrationTestImplementation(project(':geode-junit'))
+  integrationTestImplementation('com.github.stefanbirkner:system-rules')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.mockito:mockito-core')
 }

--- a/geode-deployment/geode-deployment-legacy/src/test/resources/expected-pom.xml
+++ b/geode-deployment/geode-deployment-legacy/src/test/resources/expected-pom.xml
@@ -61,5 +61,15 @@
       <artifactId>swagger-annotations</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-dunit/build.gradle
+++ b/geode-dunit/build.gradle
@@ -43,18 +43,10 @@ dependencies {
   implementation('commons-io:commons-io')
   implementation('org.apache.commons:commons-lang3')
   implementation('org.springframework.shell:spring-shell') {
-    exclude module: 'aopalliance'
-    exclude module: 'asm'
-    exclude module: 'cglib'
-    exclude module: 'guava'
-    exclude module: 'spring-aop'
-    exclude module: 'spring-context-support'
-    exclude module: 'spring-core'
     ext.optional = true
   }
   implementation('com.google.guava:guava')
   implementation('com.github.stefanbirkner:system-rules') {
-    exclude module: 'junit-dep'
   }
 
   implementation('org.assertj:assertj-core')
@@ -63,14 +55,17 @@ dependencies {
   implementation('pl.pragmatists:JUnitParams')
 
   implementation('junit:junit') {
-    exclude module: 'hamcrest'
   }
 
   upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
+  implementation('com.fasterxml.jackson.core:jackson-databind')
+  implementation('jline:jline')
+  implementation('org.apache.shiro:shiro-core')
+  implementation('org.hamcrest:hamcrest-core')
+  implementation('org.hamcrest:hamcrest')
 }
 
 distributedTest {
   // Some tests have inner tests that should be ignored
   exclude "**/*\$*.class"
 }
-

--- a/geode-dunit/src/test/resources/expected-pom.xml
+++ b/geode-dunit/src/test/resources/expected-pom.xml
@@ -132,36 +132,6 @@
       <groupId>org.springframework.shell</groupId>
       <artifactId>spring-shell</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>cglib</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-core</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>asm</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-aop</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>guava</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>aopalliance</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-context-support</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -173,12 +143,6 @@
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>junit-dep</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -204,12 +168,31 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>hamcrest</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>jline</groupId>
+      <artifactId>jline</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>runtime</scope>
     </dependency>
   </dependencies>
 </project>

--- a/geode-gfsh/build.gradle
+++ b/geode-gfsh/build.gradle
@@ -21,66 +21,95 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 apply from: "${project.projectDir}/../gradle/warnings.gradle"
 
 dependencies {
-    api(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
 
-    api(project(':geode-core'))
-    api(project(':geode-common'))
+  api(project(':geode-core'))
+  api(project(':geode-common'))
 
-    implementation(project(':geode-logging'))
-    implementation(project(':geode-membership'))
-    implementation(project(':geode-serialization'))
-    implementation(project(':geode-unsafe'))
-    implementation('org.springframework:spring-web')
-    implementation('org.apache.commons:commons-lang3')
-    implementation('com.healthmarketscience.rmiio:rmiio')
-    implementation('com.fasterxml.jackson.core:jackson-databind')
-    implementation('io.swagger:swagger-annotations')
+  implementation(project(':geode-logging'))
+  implementation(project(':geode-membership'))
+  implementation(project(':geode-serialization'))
+  implementation(project(':geode-unsafe'))
+  implementation('org.springframework:spring-web')
+  implementation('org.apache.commons:commons-lang3')
+  implementation('com.healthmarketscience.rmiio:rmiio')
+  implementation('com.fasterxml.jackson.core:jackson-databind')
+  implementation('io.swagger:swagger-annotations')
+  implementation('com.fasterxml.jackson.core:jackson-annotations')
+  implementation('com.fasterxml.jackson.core:jackson-core')
+  implementation('commons-collections:commons-collections')
+  implementation('commons-io:commons-io')
+  implementation('io.micrometer:micrometer-core')
+  implementation('jline:jline')
+  implementation('org.apache.shiro:shiro-core')
 
-//    //Find bugs is used in multiple places in the code to suppress findbugs warnings
-    testImplementation('com.github.stephenc.findbugs:findbugs-annotations')
-    testImplementation('org.springframework:spring-test')
-    testImplementation(project(':geode-junit'))
 
-    integrationTestImplementation(project(':geode-dunit'))
-    integrationTestImplementation('pl.pragmatists:JUnitParams')
-    integrationTestRuntimeOnly('org.apache.derby:derby')
-    
-    distributedTestImplementation(project(':geode-dunit'))
-    distributedTestImplementation('pl.pragmatists:JUnitParams')
-    distributedTestRuntimeOnly('org.apache.derby:derby')
+  testImplementation(project(':geode-junit'))
+  //    //Find bugs is used in multiple places in the code to suppress findbugs warnings
+  testImplementation('com.github.stephenc.findbugs:findbugs-annotations')
+  testImplementation('org.springframework:spring-test')
+  testImplementation('com.github.stefanbirkner:system-rules')
+  testImplementation('com.google.guava:guava')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
 
-    testCompileOnly(platform(project(':boms:geode-all-bom')))
-    testCompileOnly('io.swagger:swagger-annotations')
 
-    upgradeTestImplementation(project(':geode-junit'))
-    upgradeTestImplementation(project(':geode-dunit'))
+  integrationTestImplementation(project(':geode-dunit'))
+  integrationTestImplementation('pl.pragmatists:JUnitParams')
+  integrationTestImplementation('com.github.stefanbirkner:system-rules')
+  integrationTestImplementation('org.mockito:mockito-core')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
 
-    upgradeTestImplementation('org.awaitility:awaitility')
-    upgradeTestImplementation('org.assertj:assertj-core')
-    upgradeTestImplementation('junit:junit')
-    upgradeTestImplementation('xml-apis:xml-apis:2.0.2')
-    upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
+  integrationTestRuntimeOnly('org.apache.derby:derby')
 
-    implementation('net.sf.jopt-simple:jopt-simple')
 
-    //Log4j is used everywhere
-    implementation('org.apache.logging.log4j:log4j-api')
+  distributedTestImplementation(project(':geode-dunit'))
+  distributedTestImplementation('pl.pragmatists:JUnitParams')
+  distributedTestImplementation('com.google.guava:guava')
+  distributedTestImplementation('javax.resource:javax.resource-api')
+  distributedTestImplementation('junit:junit')
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('org.awaitility:awaitility')
+  distributedTestImplementation('org.hamcrest:hamcrest-core')
+  distributedTestImplementation('org.hamcrest:hamcrest')
 
-    //Spring core is used by the the gfsh cli
-    implementation('org.springframework:spring-core') {
-        ext.optional = true
-    }
+  distributedTestRuntimeOnly('org.apache.derby:derby')
 
-    //Spring shell is used by the gfsh cli. It's unclear why we can exclude
-    //So many transitive dependencies - are these really optional?
-    //GfshCommand is a public API class that depends on spring shell
-    api('org.springframework.shell:spring-shell') {
-        exclude module: 'aopalliance'
-        exclude module: 'asm'
-        exclude module: 'cglib'
-        exclude module: 'guava'
-        exclude module: 'spring-aop'
-        exclude module: 'spring-context-support'
-        exclude module: 'spring-core'
-    }
+
+  testCompileOnly(platform(project(':boms:geode-all-bom')))
+  testCompileOnly('io.swagger:swagger-annotations')
+
+
+  upgradeTestImplementation(project(':geode-junit'))
+  upgradeTestImplementation(project(':geode-dunit'))
+  upgradeTestImplementation('org.awaitility:awaitility')
+  upgradeTestImplementation('org.assertj:assertj-core')
+  upgradeTestImplementation('junit:junit')
+  upgradeTestRuntimeOnly('xerces:xmlParserAPIs')
+  upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
+
+  implementation('net.sf.jopt-simple:jopt-simple')
+
+  //Log4j is used everywhere
+  implementation('org.apache.logging.log4j:log4j-api')
+
+  //Spring core is used by the the gfsh cli
+  implementation('org.springframework:spring-core') {
+    ext.optional = true
+  }
+
+  //Spring shell is used by the gfsh cli. It's unclear why we can exclude
+  //So many transitive dependencies - are these really optional?
+  //GfshCommand is a public API class that depends on spring shell
+  api('org.springframework.shell:spring-shell') {
+    exclude module: 'aopalliance'
+    exclude module: 'asm'
+    exclude module: 'cglib'
+    exclude module: 'guava'
+    exclude module: 'spring-aop'
+    exclude module: 'spring-context-support'
+    exclude module: 'spring-core'
+  }
 }

--- a/geode-gfsh/src/test/resources/expected-pom.xml
+++ b/geode-gfsh/src/test/resources/expected-pom.xml
@@ -137,6 +137,41 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>jline</groupId>
+      <artifactId>jline</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>net.sf.jopt-simple</groupId>
       <artifactId>jopt-simple</artifactId>
       <scope>runtime</scope>

--- a/geode-http-service/build.gradle
+++ b/geode-http-service/build.gradle
@@ -28,7 +28,9 @@ dependencies {
   implementation('org.eclipse.jetty:jetty-webapp')
   implementation('org.eclipse.jetty:jetty-server')
   implementation('org.apache.commons:commons-lang3')
-  
+  implementation('org.eclipse.jetty:jetty-http')
+  implementation('org.eclipse.jetty:jetty-util')
+
   compileOnly(project(':geode-core'))
   compileOnly(project(':geode-common')) {
     exclude module: 'junit'
@@ -37,4 +39,7 @@ dependencies {
   testImplementation(project(':geode-core'))
   testImplementation(project(':geode-common'))
   testImplementation(project(':geode-junit'))
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('org.mockito:mockito-core')
 }

--- a/geode-http-service/src/test/resources/expected-pom.xml
+++ b/geode-http-service/src/test/resources/expected-pom.xml
@@ -71,5 +71,15 @@
       <artifactId>commons-lang3</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-jmh/build.gradle
+++ b/geode-jmh/build.gradle
@@ -34,17 +34,21 @@ dependencies {
 jar {
   manifest {
     attributes(
-            'Premain-Class': 'org.apache.geode.benchmark.jmh.profilers.ObjectSizeAgent'
-    )
+        'Premain-Class': 'org.apache.geode.benchmark.jmh.profilers.ObjectSizeAgent'
+        )
   }
 }
 
 test {
-  jvmArgs += ['-javaagent:' + jar.outputs.files.singleFile]
+  jvmArgs += [
+    '-javaagent:' + jar.outputs.files.singleFile
+  ]
   dependsOn jar
 }
 
 repeatUnitTest {
-  jvmArgs += ['-javaagent:' + jar.outputs.files.singleFile]
+  jvmArgs += [
+    '-javaagent:' + jar.outputs.files.singleFile
+  ]
   dependsOn jar
 }

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -27,7 +27,6 @@ compileJava {
 dependencies {
   api(platform(project(':boms:geode-all-bom')))
 
-  testImplementation(project(':geode-common'))
   compileOnly(project(':geode-core'))
   compileOnly(project(':geode-membership'))
   compileOnly(project(':geode-logging'))
@@ -35,8 +34,8 @@ dependencies {
   compileOnly(project(':geode-unsafe'))
   compileOnly(project(':geode-gfsh'))
 
+
   api('junit:junit') {
-    exclude module: 'hamcrest'
   }
   api('org.assertj:assertj-core')
   api('org.mockito:mockito-core')
@@ -45,22 +44,28 @@ dependencies {
   api('com.fasterxml.jackson.core:jackson-annotations')
   api('com.fasterxml.jackson.core:jackson-databind')
   api('com.github.stefanbirkner:system-rules') {
-    exclude module: 'junit-dep'
   }
   api('com.google.guava:guava')
   api('com.jayway.jsonpath:json-path')
   api('commons-io:commons-io')
-  
+
   api('org.apache.commons:commons-lang3')
   api('org.apache.logging.log4j:log4j-api')
-  
+
   api('org.awaitility:awaitility')
   api('org.hamcrest:hamcrest')
   api('io.micrometer:micrometer-core')
-  
+
   api('org.skyscreamer:jsonassert')
+  api('javax.transaction:javax.transaction-api')
+  api('org.apache.shiro:shiro-core')
+  api('org.hamcrest:hamcrest-core')
+  api('org.springframework.shell:spring-shell')
+
 
   testImplementation('pl.pragmatists:JUnitParams')
+  testImplementation(project(':geode-common'))
+
 
   integrationTestImplementation(project(':geode-core'))
   integrationTestImplementation(project(':geode-serialization'))

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -50,12 +50,6 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>hamcrest</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -86,12 +80,6 @@
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <scope>compile</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>junit-dep</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -136,6 +124,26 @@
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.transaction</groupId>
+      <artifactId>javax.transaction-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.shiro</groupId>
+      <artifactId>shiro-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.shell</groupId>
+      <artifactId>spring-shell</artifactId>
       <scope>compile</scope>
     </dependency>
   </dependencies>

--- a/geode-log4j/build.gradle
+++ b/geode-log4j/build.gradle
@@ -27,13 +27,12 @@ dependencies {
   implementation(project(':geode-core'))
   implementation(project(':geode-logging'))
   implementation('org.apache.commons:commons-lang3')
-
   implementation('org.apache.logging.log4j:log4j-api')
   implementation('org.apache.logging.log4j:log4j-core')
+  implementation('commons-io:commons-io')
 
   //This routes slf4j logs to log4j. Shiro and micrometer use slf4j
   runtimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
-    exclude module: 'slf4j-api'
     ext.optional = true
   }
   //This routes commons logging logs to log4j. Several apache commons dependencies use commons logging
@@ -58,6 +57,7 @@ dependencies {
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
+  testImplementation('com.github.stefanbirkner:system-rules')
 
   integrationTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-core'
@@ -66,6 +66,9 @@ dependencies {
   integrationTestImplementation('org.apache.logging.log4j:log4j-core::tests')
   integrationTestImplementation('org.apache.logging.log4j:log4j-core::test-sources')
   integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('com.github.stefanbirkner:system-rules')
+  integrationTestImplementation('org.awaitility:awaitility')
+  integrationTestImplementation('org.mockito:mockito-core')
 
   distributedTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-core'
@@ -79,4 +82,3 @@ dependencies {
   distributedTestImplementation('org.mockito:mockito-core')
   distributedTestImplementation('pl.pragmatists:JUnitParams')
 }
-

--- a/geode-log4j/src/test/resources/expected-pom.xml
+++ b/geode-log4j/src/test/resources/expected-pom.xml
@@ -72,15 +72,14 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>slf4j-api</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/geode-logging/build.gradle
+++ b/geode-logging/build.gradle
@@ -21,46 +21,43 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 apply from: "${project.projectDir}/../gradle/warnings.gradle"
 
 dependencies {
-    api(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
 
-    // Geode-common has annotations and other pieces used by geode-logging
-    api(project(':geode-common'))
+  // Geode-common has annotations and other pieces used by geode-logging
+  api(project(':geode-common'))
 
-    api('org.apache.logging.log4j:log4j-api')
+  api('org.apache.logging.log4j:log4j-api')
 
-    testImplementation(project(':geode-junit')) {
-        exclude module: 'geode-logging'
-    }
-    testImplementation(project(':geode-concurrency-test'))
+  testImplementation(project(':geode-junit')) {
+    exclude module: 'geode-logging'
+  }
+  testImplementation(project(':geode-concurrency-test'))
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('com.tngtech.archunit:archunit-junit4')
+  testImplementation('com.tngtech.archunit:archunit')
 
-    testImplementation('org.mockito:mockito-core')
-    testImplementation('junit:junit')
-    testImplementation('org.assertj:assertj-core')
 
-
-    integrationTestImplementation(project(':geode-junit')) {
-        exclude module: 'geode-logging'
-    }
-    integrationTestImplementation(project(':geode-dunit')) {
-        exclude module: 'geode-logging'
-    }
-    integrationTestImplementation('pl.pragmatists:JUnitParams')
-    distributedTestImplementation(project(':geode-junit')) {
-        exclude module: 'geode-logging'
-    }
-    distributedTestImplementation(project(':geode-dunit')) {
-        exclude module: 'geode-logging'
-    }
-    distributedTestImplementation('pl.pragmatists:JUnitParams')
-    upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
-
-    testImplementation('com.tngtech.archunit:archunit-junit4')
+  integrationTestImplementation(project(':geode-junit')) {
+    exclude module: 'geode-logging'
+  }
+  integrationTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-logging'
+  }
+  integrationTestImplementation('pl.pragmatists:JUnitParams')
+  distributedTestImplementation(project(':geode-junit')) {
+    exclude module: 'geode-logging'
+  }
+  distributedTestImplementation(project(':geode-dunit')) {
+    exclude module: 'geode-logging'
+  }
+  distributedTestImplementation('pl.pragmatists:JUnitParams')
+  upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
 
 }
 
 distributedTest {
-    // Some tests have inner tests that should be ignored
-    exclude "**/*\$*.class"
+  // Some tests have inner tests that should be ignored
+  exclude "**/*\$*.class"
 }
-
-

--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -32,11 +32,11 @@ dependencies {
   implementation(project(':geode-serialization'))
   implementation('org.apache.lucene:lucene-analyzers-common')
   implementation('org.apache.lucene:lucene-queryparser') {
-    exclude module: 'lucene-sandbox'
   }
   implementation('org.apache.commons:commons-lang3')
   implementation('mx4j:mx4j')
   implementation('org.apache.logging.log4j:log4j-api')
+  implementation('org.springframework.shell:spring-shell')
 
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('com.fasterxml.jackson.core:jackson-annotations')
@@ -51,6 +51,10 @@ dependencies {
   testImplementation('pl.pragmatists:JUnitParams')
   testImplementation('com.pholser:junit-quickcheck-core')
   testImplementation('com.carrotsearch.randomizedtesting:randomizedtesting-runner')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('org.awaitility:awaitility')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
 
 
   distributedTestImplementation(project(':geode-junit'))
@@ -58,21 +62,36 @@ dependencies {
   distributedTestImplementation(project(':geode-lucene:geode-lucene-test'))
   distributedTestImplementation('pl.pragmatists:JUnitParams')
   distributedTestImplementation('org.hamcrest:hamcrest')
+  distributedTestImplementation('junit:junit')
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('org.awaitility:awaitility')
+  distributedTestImplementation('org.hamcrest:hamcrest-core')
+  distributedTestImplementation('org.mockito:mockito-core')
 
 
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation(project(':geode-lucene:geode-lucene-test'))
   integrationTestImplementation('org.apache.lucene:lucene-analyzers-phonetic')
   integrationTestImplementation('pl.pragmatists:JUnitParams')
+  integrationTestImplementation('org.hamcrest:hamcrest')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.awaitility:awaitility')
+  integrationTestImplementation('org.hamcrest:hamcrest-core')
+  integrationTestImplementation('org.mockito:mockito-core')
 
 
   upgradeTestImplementation(project(':geode-dunit'))
   upgradeTestImplementation('commons-io:commons-io')
   upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
+  upgradeTestImplementation('org.assertj:assertj-core')
+  upgradeTestImplementation('org.awaitility:awaitility')
+  upgradeTestImplementation('junit:junit')
 
 
   performanceTestImplementation(project(':geode-junit'))
   performanceTestImplementation(project(':geode-lucene:geode-lucene-test'))
+  performanceTestImplementation('junit:junit')
 }
 
 //The lucene integration tests don't have any issues that requiring forking

--- a/geode-lucene/geode-lucene-test/build.gradle
+++ b/geode-lucene/geode-lucene-test/build.gradle
@@ -32,4 +32,3 @@ dependencies {
   implementation('org.apache.lucene:lucene-test-framework')
   implementation('org.mockito:mockito-core')
 }
-

--- a/geode-lucene/src/test/resources/expected-pom.xml
+++ b/geode-lucene/src/test/resources/expected-pom.xml
@@ -85,12 +85,6 @@
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-queryparser</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>lucene-sandbox</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -105,6 +99,11 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.shell</groupId>
+      <artifactId>spring-shell</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/geode-management/build.gradle
+++ b/geode-management/build.gradle
@@ -32,19 +32,25 @@ dependencies {
   implementation('com.fasterxml.jackson.core:jackson-annotations')
   implementation('org.springframework:spring-web')
   implementation('org.apache.httpcomponents:httpclient')
+  implementation('io.swagger:swagger-annotations')
+  implementation('org.apache.httpcomponents:httpcore')
+  implementation('org.springframework:spring-core')
 
   compileOnly(project(':geode-common')) {
     exclude module: 'junit'
   }
   compileOnly('io.springfox:springfox-swagger2') {
-    exclude module: 'slf4j-api'
-    exclude module: "jackson-annotations"
   }
 
   testImplementation(project(':geode-common'))
   testImplementation(project(':geode-junit')) {
     exclude module: 'geode-core'
   }
+  testImplementation('com.github.stefanbirkner:system-rules')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('org.awaitility:awaitility')
+  testImplementation('org.mockito:mockito-core')
 
   testCompileOnly(platform(project(':boms:geode-all-bom')))
   testCompileOnly('io.swagger:swagger-annotations')

--- a/geode-management/src/test/resources/expected-pom.xml
+++ b/geode-management/src/test/resources/expected-pom.xml
@@ -86,5 +86,20 @@
       <artifactId>httpclient</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>io.swagger</groupId>
+      <artifactId>swagger-annotations</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-membership/build.gradle
+++ b/geode-membership/build.gradle
@@ -20,57 +20,62 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 
 dependencies {
-    api(platform(project(':boms:geode-all-bom')))
-    compileOnly(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
+  compileOnly(platform(project(':boms:geode-all-bom')))
 
-    // Geode-common has annotations and other pieces used by geode-logging
-    api(project(':geode-common'))
+  // Geode-common has annotations and other pieces used by geode-logging
+  api(project(':geode-common'))
 
-    implementation(project(':geode-logging'))
-    implementation(project(':geode-serialization'))
-    implementation(project(':geode-tcp-server'))
+  implementation(project(':geode-logging'))
+  implementation(project(':geode-serialization'))
+  implementation(project(':geode-tcp-server'))
 
-    implementation('org.apache.logging.log4j:log4j-api')
-    implementation('org.jgroups:jgroups')
-    implementation('org.apache.commons:commons-lang3')
-    implementation('it.unimi.dsi:fastutil')
-    implementation('com.github.stephenc.findbugs:findbugs-annotations')
-    //Commons validator is used to validate inet addresses in membership
-    implementation('commons-validator:commons-validator')
-    //Jgroups is a core component of our membership system.
-    implementation('org.jgroups:jgroups')
+  implementation('org.apache.logging.log4j:log4j-api')
+  implementation('org.jgroups:jgroups')
+  implementation('org.apache.commons:commons-lang3')
+  implementation('it.unimi.dsi:fastutil')
+  implementation('com.github.stephenc.findbugs:findbugs-annotations')
+  //Commons validator is used to validate inet addresses in membership
+  implementation('commons-validator:commons-validator')
+  //Jgroups is a core component of our membership system.
+  implementation('org.jgroups:jgroups')
+  implementation('it.unimi.dsi:fastutil-core')
 
-    compileOnly('org.jetbrains:annotations')
-
-
-    testImplementation(project(':geode-junit'))
-    testImplementation(project(':geode-concurrency-test'))
-
-    testImplementation('org.mockito:mockito-core')
-    testImplementation('junit:junit')
-    testImplementation('org.assertj:assertj-core')
-    testImplementation('com.tngtech.archunit:archunit-junit4')
+  compileOnly('org.jetbrains:annotations')
 
 
+  testImplementation(project(':geode-junit'))
+  testImplementation(project(':geode-concurrency-test'))
 
-    integrationTestImplementation(project(':geode-junit'))
-    integrationTestImplementation('com.tngtech.archunit:archunit-junit4')
-    integrationTestImplementation('pl.pragmatists:JUnitParams')
-
-    integrationTestRuntimeOnly('org.apache.logging.log4j:log4j-core')
-
-
-    distributedTestImplementation(project(':geode-junit'))
-    distributedTestImplementation(project(':geode-dunit'))
-    distributedTestImplementation('pl.pragmatists:JUnitParams')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('com.tngtech.archunit:archunit-junit4')
 
 
+  integrationTestImplementation(project(':geode-junit'))
+  integrationTestImplementation('com.tngtech.archunit:archunit-junit4')
+  integrationTestImplementation('pl.pragmatists:JUnitParams')
+  integrationTestImplementation('com.tngtech.archunit:archunit')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.awaitility:awaitility')
+  integrationTestImplementation('org.hamcrest:hamcrest-core')
+  integrationTestImplementation('org.hamcrest:hamcrest')
+  integrationTestImplementation('org.mockito:mockito-core')
 
-    upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
+  integrationTestRuntimeOnly('org.apache.logging.log4j:log4j-core')
+
+
+  distributedTestImplementation(project(':geode-junit'))
+  distributedTestImplementation(project(':geode-dunit'))
+  distributedTestImplementation('pl.pragmatists:JUnitParams')
+
+
+  upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
 }
 
 distributedTest {
-    // Some tests have inner tests that should be ignored
-    exclude "**/*\$*.class"
+  // Some tests have inner tests that should be ignored
+  exclude "**/*\$*.class"
 }
-

--- a/geode-membership/src/test/resources/expected-pom.xml
+++ b/geode-membership/src/test/resources/expected-pom.xml
@@ -96,5 +96,10 @@
       <artifactId>commons-validator</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-memcached/build.gradle
+++ b/geode-memcached/build.gradle
@@ -37,6 +37,8 @@ dependencies {
   integrationTestImplementation(project(':geode-core'))
   integrationTestImplementation('net.spy:spymemcached')
   integrationTestImplementation(project(':geode-junit'))
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
 
   distributedTestImplementation(project(':geode-dunit'))
 }

--- a/geode-old-client-support/build.gradle
+++ b/geode-old-client-support/build.gradle
@@ -32,4 +32,3 @@ dependencies {
 
   distributedTestImplementation('junit:junit')
 }
-

--- a/geode-old-versions/build.gradle
+++ b/geode-old-versions/build.gradle
@@ -115,9 +115,9 @@ tasks.named('clean') {
 project.createGeodeClasspathsFile.mustRunAfter(clean)
 project.createGeodeClasspathsFile.inputs.files(getTasksByName('downloadAndUnzipFile', true))
 project.createGeodeClasspathsFile.inputs.files(getTasksByName('enumerateArchiveContents', true))
-tasks.named('build') {
-  dependsOn(tasks.named('createGeodeClasspathsFile'))
-}
+//tasks.named('build') {
+//  dependsOn(tasks.named('createGeodeClasspathsFile'))
+//}
 
 configurations {
   oldVersions

--- a/geode-pulse/build.gradle
+++ b/geode-pulse/build.gradle
@@ -64,31 +64,20 @@ dependencies {
   implementation('org.springframework.security:spring-security-oauth2-jose')
 
   implementation('org.springframework.security:spring-security-config') {
-    exclude module: 'aopalliance'
-    exclude module: 'spring-expression'
   }
   implementation('org.springframework.security:spring-security-ldap') {
-    exclude module: 'aopalliance'
-    exclude module: 'spring-asm'
-    exclude module: 'spring-expression'
-    exclude module: 'spring-jdbc'
   }
   implementation('org.springframework.security:spring-security-web') {
-    exclude module: 'aopalliance'
-    exclude module: 'spring-asm'
-    exclude module: 'spring-expression'
-    exclude module: 'spring-jdbc'
   }
   implementation('org.springframework:spring-context')
   implementation('org.springframework:spring-web')
   runtimeOnly('org.springframework:spring-webmvc') {
-    exclude module: 'aopalliance'
-    exclude module: 'aspectjweaver'
   }
   implementation('org.springframework:spring-tx')
   implementation('com.fasterxml.jackson.core:jackson-annotations')
   implementation('com.fasterxml.jackson.core:jackson-core')
   implementation('com.fasterxml.jackson.core:jackson-databind')
+  implementation('org.springframework.security:spring-security-crypto')
 
   compileOnly('org.mortbay.jetty:servlet-api')
 
@@ -107,6 +96,10 @@ dependencies {
     exclude module: 'geode-core'
   }
   testImplementation('org.springframework:spring-test')
+  testImplementation('com.github.stefanbirkner:system-rules')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('org.mockito:mockito-core')
 
 
   integrationTestImplementation(project(':geode-core'))
@@ -122,9 +115,12 @@ dependencies {
   integrationTestImplementation('org.springframework:spring-test')
   integrationTestImplementation('org.springframework:spring-webmvc')
   integrationTestImplementation('org.springframework.security:spring-security-test')
-
   integrationTestImplementation('junit:junit')
   integrationTestImplementation('org.hamcrest:hamcrest')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.hamcrest:hamcrest-core')
+  integrationTestImplementation('org.mockito:mockito-core')
+  integrationTestImplementation('org.springframework:spring-core')
 
   uiTestRuntimeOnly(project(':geode-core'))
   uiTestImplementation(project(':geode-junit')) {
@@ -135,6 +131,7 @@ dependencies {
   }
   uiTestImplementation(project(':geode-pulse:geode-pulse-test'))
   uiTestImplementation('org.seleniumhq.selenium:selenium-remote-driver')
+  uiTestImplementation('com.vaadin.external.google:android-json')
 }
 
 def generatedResources = "$buildDir/generated-resources/main"

--- a/geode-pulse/geode-pulse-test/build.gradle
+++ b/geode-pulse/geode-pulse-test/build.gradle
@@ -42,4 +42,3 @@ dependencies {
   implementation('org.seleniumhq.selenium:selenium-chrome-driver')
   implementation('org.seleniumhq.selenium:selenium-support')
 }
-

--- a/geode-rebalancer/build.gradle
+++ b/geode-rebalancer/build.gradle
@@ -32,9 +32,6 @@ dependencies {
 
   implementation('org.apache.logging.log4j:log4j-api')
   implementation('org.springframework:spring-context') {
-    exclude module: 'spring-beans'
-    exclude module: 'spring-expression'
-    exclude module: 'spring-aop'
   }
 
   testImplementation('junit:junit')
@@ -44,4 +41,5 @@ dependencies {
   integrationTestImplementation('junit:junit')
   integrationTestImplementation('org.awaitility:awaitility')
   integrationTestImplementation('org.hamcrest:hamcrest')
+  integrationTestImplementation('org.hamcrest:hamcrest-core')
 }

--- a/geode-rebalancer/src/test/resources/expected-pom.xml
+++ b/geode-rebalancer/src/test/resources/expected-pom.xml
@@ -70,20 +70,6 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
       <scope>runtime</scope>
-      <exclusions>
-        <exclusion>
-          <artifactId>spring-beans</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-expression</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-        <exclusion>
-          <artifactId>spring-aop</artifactId>
-          <groupId>*</groupId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/geode-serialization/build.gradle
+++ b/geode-serialization/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 
   //Log4j is used everywhere
   implementation('org.apache.logging.log4j:log4j-api')
+  implementation('it.unimi.dsi:fastutil-core')
 
   compileOnly(platform(project(':boms:geode-all-bom')))
   compileOnly('org.jetbrains:annotations')
@@ -39,12 +40,12 @@ dependencies {
     exclude module: 'geode-serialization'
   }
   testImplementation(project(':geode-concurrency-test'))
-
   testImplementation('com.tngtech.archunit:archunit-junit4')
   testImplementation('org.apache.bcel:bcel')
   testImplementation('org.mockito:mockito-core')
   testImplementation('junit:junit')
   testImplementation('org.assertj:assertj-core')
+  testImplementation('com.tngtech.archunit:archunit')
 
 
   integrationTestImplementation(project(':geode-junit')) {
@@ -54,6 +55,9 @@ dependencies {
     exclude module: 'geode-serialization'
   }
   integrationTestImplementation('pl.pragmatists:JUnitParams')
+  integrationTestImplementation('junit:junit')
+
+
   distributedTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-serialization'
   }
@@ -61,6 +65,8 @@ dependencies {
     exclude module: 'geode-serialization'
   }
   distributedTestImplementation('pl.pragmatists:JUnitParams')
+
+
   upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
 }
 
@@ -68,5 +74,3 @@ distributedTest {
   // Some tests have inner tests that should be ignored
   exclude "**/*\$*.class"
 }
-
-

--- a/geode-serialization/src/test/resources/expected-pom.xml
+++ b/geode-serialization/src/test/resources/expected-pom.xml
@@ -61,5 +61,10 @@
       <artifactId>log4j-api</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil-core</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-tcp-server/build.gradle
+++ b/geode-tcp-server/build.gradle
@@ -19,29 +19,34 @@ apply from: "${project.projectDir}/../gradle/publish-java.gradle"
 apply from: "${rootDir}/${scriptDir}/warnings.gradle"
 
 dependencies {
-    api(platform(project(':boms:geode-all-bom')))
+  api(platform(project(':boms:geode-all-bom')))
 
-    implementation(project(':geode-logging'))
-    implementation(project(':geode-serialization'))
+  implementation(project(':geode-logging'))
+  implementation(project(':geode-serialization'))
+  implementation('org.apache.logging.log4j:log4j-api')
+  //Commons validator is used to validate inet addresses
+  implementation('commons-validator:commons-validator')
 
-    implementation('org.apache.logging.log4j:log4j-api')
 
-    //Commons validator is used to validate inet addresses
-    implementation('commons-validator:commons-validator')
-    testImplementation(project(':geode-junit')) {
-        exclude module: 'geode-core'
-    }
-    testImplementation('org.assertj:assertj-core')
+  testImplementation(project(':geode-junit')) {
+    exclude module: 'geode-core'
+  }
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('com.tngtech.archunit:archunit-junit4')
+  testImplementation('com.tngtech.archunit:archunit')
+  testImplementation('junit:junit')
+  testImplementation('org.mockito:mockito-core')
 
-    testImplementation('com.tngtech.archunit:archunit-junit4')
+  integrationTestImplementation('com.tngtech.archunit:archunit-junit4')
+  integrationTestImplementation('org.mockito:mockito-core')
+  integrationTestImplementation(project(':geode-junit'))
 
-    integrationTestImplementation('com.tngtech.archunit:archunit-junit4')
-    integrationTestImplementation('org.mockito:mockito-core')
-    integrationTestImplementation(project(':geode-junit'))
+  upgradeTestImplementation(project(':geode-gfsh'))
+  upgradeTestImplementation(project(':geode-dunit'))
+  upgradeTestImplementation(project(':geode-membership'))
 
-    upgradeTestImplementation(project(':geode-gfsh'))
-    upgradeTestImplementation(project(':geode-dunit'))
-    upgradeTestImplementation(project(':geode-membership'))
-
-    upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
+  upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
+  upgradeTestImplementation('org.assertj:assertj-core')
+  upgradeTestImplementation('org.awaitility:awaitility')
+  upgradeTestImplementation('junit:junit')
 }

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -38,16 +38,19 @@ dependencies {
   testImplementation('org.assertj:assertj-core')
   testImplementation('junit:junit')
   testImplementation('org.mockito:mockito-core')
+  testImplementation('com.github.stefanbirkner:system-rules')
+  testImplementation('io.micrometer:micrometer-core')
+  testImplementation('org.awaitility:awaitility')
 
   integrationTestImplementation(project(':geode-junit'))
   integrationTestImplementation('org.assertj:assertj-core')
   integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.mockito:mockito-core')
 
 
   distributedTestImplementation(project(':geode-gfsh'))
   distributedTestImplementation(project(':geode-dunit'))
   distributedTestImplementation(project(':geode-junit'))
-
   distributedTestImplementation('mx4j:mx4j')
   distributedTestImplementation('org.awaitility:awaitility')
   distributedTestImplementation('junit:junit')
@@ -58,6 +61,7 @@ dependencies {
   distributedTestImplementation('commons-io:commons-io')
   distributedTestImplementation('org.assertj:assertj-core')
   distributedTestImplementation('pl.pragmatists:JUnitParams')
+  distributedTestImplementation('org.hamcrest:hamcrest-core')
 
 
   upgradeTestImplementation(project(':geode-gfsh'))
@@ -67,7 +71,7 @@ dependencies {
   upgradeTestImplementation('org.awaitility:awaitility')
   upgradeTestImplementation('org.assertj:assertj-core')
   upgradeTestImplementation('junit:junit')
-  upgradeTestImplementation('xml-apis:xml-apis:2.0.2')
+  upgradeTestRuntimeOnly('xerces:xercesImpl')
 
   upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
 }

--- a/geode-web-api/build.gradle
+++ b/geode-web-api/build.gradle
@@ -42,25 +42,19 @@ dependencies {
 
   implementation('org.apache.commons:commons-lang3')
   implementation('commons-fileupload:commons-fileupload') {
-    exclude module: 'commons-io'
   }
   // jackson-annotations must be accessed from the geode classloader and not the webapp
   compileOnly('com.fasterxml.jackson.core:jackson-annotations')
   implementation('com.fasterxml.jackson.core:jackson-core')
   implementation('com.fasterxml.jackson.core:jackson-databind'){
-    exclude module: 'jackson-annotations'
   }
 
   compileOnly('io.swagger:swagger-annotations')
 
   implementation('io.springfox:springfox-swagger2') {
-    exclude module: 'slf4j-api'
-    exclude module: 'jackson-annotations'
-    exclude module: 'swagger-annotations'
   }
 
   implementation('io.springfox:springfox-swagger-ui') {
-    exclude module: 'slf4j-api'
   }
 
   implementation('org.springframework:spring-beans')
@@ -70,22 +64,19 @@ dependencies {
   implementation('org.springframework:spring-web')
   implementation('org.springframework:spring-webmvc')
   implementation('org.springframework.hateoas:spring-hateoas') {
-    exclude module: 'aopalliance'
-    exclude module: 'commons-logging'
-    exclude module: 'objenesis'
-    exclude module: 'slf4j-api'
-    exclude module: 'spring-core'
-    exclude module: 'spring-plugin-core'
+    exclude module: 'spring-plugin-core' ;// inclusion of this transitive dependency breaks integration testing
   }
   implementation('org.springframework:spring-aspects') {
-    exclude module: 'aopalliance'
-    exclude module: 'aspectjweaver'
   }
   implementation('org.springframework:spring-oxm') {
-    exclude module: 'commons-logging'
-    exclude module: 'spring-core'
-    exclude module: 'spring-beans'
   }
+  implementation('com.google.guava:guava')
+  implementation('io.springfox:springfox-core')
+  implementation('io.springfox:springfox-spi')
+  implementation('io.springfox:springfox-spring-web')
+  implementation('org.apache.shiro:shiro-core')
+  implementation('org.springframework:spring-context')
+  implementation('org.springframework:spring-core')
   compileOnly('org.apache.logging.log4j:log4j-api')
 
 
@@ -94,10 +85,13 @@ dependencies {
   }
   testImplementation(project(':geode-core'))
   testImplementation('javax.servlet:javax.servlet-api')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
+
 
   integrationTestImplementation('org.springframework:spring-test')
   integrationTestImplementation('org.springframework.security:spring-security-test')
-
   integrationTestImplementation(project(':geode-core'))
   integrationTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-core'
@@ -105,6 +99,13 @@ dependencies {
   integrationTestImplementation(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }
+  integrationTestImplementation('com.jayway.jsonpath:json-path')
+  integrationTestImplementation('com.vaadin.external.google:android-json')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.hamcrest:hamcrest-core')
+  integrationTestImplementation('org.hamcrest:hamcrest')
+  integrationTestImplementation('org.skyscreamer:jsonassert')
 }
 
 sourceSets {

--- a/geode-web-management/build.gradle
+++ b/geode-web-management/build.gradle
@@ -61,22 +61,16 @@ dependencies {
 
   implementation('org.apache.commons:commons-lang3')
   implementation('commons-fileupload:commons-fileupload') {
-    exclude module: 'commons-io'
   }
   implementation('com.fasterxml.jackson.core:jackson-core')
   implementation('com.fasterxml.jackson.core:jackson-databind') {
-    exclude module: 'jackson-annotations'
   }
 
   compileOnly('io.swagger:swagger-annotations')
 
   implementation('io.springfox:springfox-swagger2') {
-    exclude module: 'slf4j-api'
-    exclude module: 'jackson-annotations'
-    exclude module: 'swagger-annotations'
   }
   implementation('io.springfox:springfox-swagger-ui') {
-    exclude module: 'slf4j-api'
   }
 
   implementation('org.springframework:spring-beans')
@@ -86,23 +80,22 @@ dependencies {
   implementation('org.springframework:spring-web')
   implementation('org.springframework:spring-webmvc')
   implementation('org.springframework.hateoas:spring-hateoas') {
-    exclude module: 'aopalliance'
-    exclude module: 'commons-logging'
-    exclude module: 'objenesis'
-    exclude module: 'slf4j-api'
-    exclude module: 'spring-core'
-    exclude module: 'spring-plugin-core'
+    exclude module: 'spring-plugin-core' ;// inclusion of this transitive dependency breaks integration testing
   }
   implementation('org.springframework:spring-aspects') {
-    exclude module: 'aopalliance'
-    exclude module: 'aspectjweaver'
   }
   implementation('org.springframework:spring-oxm') {
-    exclude module: 'commons-logging'
-    exclude module: 'spring-core'
-    exclude module: 'spring-beans'
   }
+  implementation('com.google.guava:guava')
+  implementation('io.springfox:springfox-core')
+  implementation('io.springfox:springfox-spi')
+  implementation('io.springfox:springfox-spring-web')
+  implementation('org.apache.shiro:shiro-core')
+  implementation('org.springframework:spring-context')
+  implementation('org.springframework:spring-core')
+  implementation('org.springframework:spring-jcl')
   compileOnly('org.apache.logging.log4j:log4j-api')
+
 
   commonTestImplementation(project(':geode-core'))
   commonTestImplementation(project(':geode-junit')) {
@@ -111,40 +104,48 @@ dependencies {
   commonTestImplementation(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }
+  commonTestImplementation(sourceSets.main.output)
   commonTestImplementation('org.springframework:spring-test')
   commonTestImplementation('org.springframework:spring-webmvc')
   commonTestImplementation('org.springframework.security:spring-security-test')
-  commonTestImplementation(project(':geode-web-management'))
+  commonTestImplementation('junit:junit')
+  commonTestImplementation('org.mockito:mockito-core')
+
 
   testImplementation(project(':geode-junit')) {
     exclude module: 'geode-core'
   }
   testImplementation(project(':geode-core'))
   testImplementation('javax.servlet:javax.servlet-api')
+  testImplementation('org.assertj:assertj-core')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
+
 
   integrationTestImplementation(sourceSets.commonTest.output)
-
   integrationTestImplementation(project(':geode-core'))
   integrationTestImplementation('org.springframework:spring-test')
   integrationTestImplementation('org.springframework:spring-webmvc')
   integrationTestImplementation('org.springframework.security:spring-security-test')
-
   integrationTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-core'
   }
   integrationTestImplementation(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }
+  integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestImplementation('org.hamcrest:hamcrest-core')
+  integrationTestImplementation('org.hamcrest:hamcrest')
+  integrationTestImplementation('org.mockito:mockito-core')
+  integrationTestImplementation('junit:junit:4.13.2')
   integrationTestRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
-    exclude module: 'slf4j-api'
   }
 
-  distributedTestImplementation(sourceSets.commonTest.output)
 
+  distributedTestImplementation(sourceSets.commonTest.output)
   distributedTestImplementation('org.springframework:spring-test')
   distributedTestImplementation('org.springframework:spring-webmvc')
   distributedTestImplementation('org.springframework.security:spring-security-test')
-
   distributedTestImplementation(project(':geode-core'))
   distributedTestImplementation(project(':geode-junit')) {
     exclude module: 'geode-core'
@@ -152,9 +153,13 @@ dependencies {
   distributedTestImplementation(project(':geode-dunit')) {
     exclude module: 'geode-core'
   }
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('org.awaitility:awaitility')
+  distributedTestImplementation('org.hamcrest:hamcrest-core')
+  distributedTestImplementation('org.hamcrest:hamcrest')
+  distributedTestImplementation('junit:junit')
 
   distributedTestRuntimeOnly('org.apache.logging.log4j:log4j-slf4j-impl') {
-    exclude module: 'slf4j-api'
   }
 }
 

--- a/geode-web/build.gradle
+++ b/geode-web/build.gradle
@@ -47,25 +47,43 @@ dependencies {
 
   implementation('org.springframework:spring-webmvc')
   implementation('org.apache.commons:commons-lang3')
+  implementation('commons-io:commons-io')
+  implementation('org.apache.shiro:shiro-core')
+  implementation('org.springframework:spring-beans')
+  implementation('org.springframework:spring-context')
+  implementation('org.springframework:spring-core')
+  implementation('org.springframework:spring-jcl')
+  implementation('org.springframework:spring-web')
 
   runtimeOnly('org.springframework:spring-aspects') {
-    exclude module: 'aspectjweaver'
   }
   runtimeOnly('org.springframework:spring-oxm')
   runtimeOnly('commons-fileupload:commons-fileupload')
 
+
   testImplementation(project(':geode-junit'))
   testImplementation('org.springframework:spring-test')
+  testImplementation('org.mockito:mockito-core')
+  testImplementation('junit:junit')
+  testImplementation('org.assertj:assertj-core')
 
   integrationTestImplementation(project(':geode-dunit'));
+  integrationTestImplementation('org.mockito:mockito-core')
+  integrationTestImplementation('junit:junit')
+  integrationTestImplementation('org.assertj:assertj-core')
 
   integrationTestRuntimeOnly(files(war.destinationDirectory))
+
 
   distributedTestImplementation(project(':geode-common'))
   distributedTestImplementation(project(':geode-dunit'))
   distributedTestImplementation('pl.pragmatists:JUnitParams')
+  distributedTestImplementation('junit:junit')
+  distributedTestImplementation('org.assertj:assertj-core')
+  distributedTestImplementation('org.awaitility:awaitility')
 
   distributedTestRuntimeOnly(files(war.destinationDirectory))
+
 
   upgradeTestImplementation(project(':geode-dunit')) {
   }

--- a/gradle/java.gradle
+++ b/gradle/java.gradle
@@ -124,7 +124,7 @@ gradle.taskGraph.whenReady({ graph ->
 
 configurations {
   testOutput {
-    extendsFrom testCompile
+    extendsFrom testImplementation
     description 'a dependency that exposes test artifacts'
   }
 }

--- a/gradle/lint.gradle
+++ b/gradle/lint.gradle
@@ -19,11 +19,18 @@ allprojects {
   apply plugin: 'nebula.lint'
   gradleLint.rules = []
   gradleLint.rules += 'overridden-dependency-version'
-  gradleLint.rules += 'unused-dependency'
+//  gradleLint.rules += 'unused-dependency' ; // broken due to Error from [com.netflix.nebula.lint.rule.GradleLintRule$1] processing source file [null]
   gradleLint.rules += 'unused-exclude-by-dep'
   gradleLint.rules += 'unused-exclude-by-conf'
+  gradleLint.rules += 'undeclared-dependency'
+  gradleLint.rules += 'archaic-wrapper'
+  gradleLint.rules += 'deprecated-dependency-configuration'
+  gradleLint.rules += 'deprecated-task-operator'
+  gradleLint.rules += 'empty-closure-rule'
+//  gradleLint.rules += 'duplicate-dependency-class' ; // broken due to Error from [com.netflix.nebula.lint.rule.GradleLintRule$1] processing source file [null]
 
   gradleLint.alwaysRun = false
   fixGradleLint.mustRunAfter(':combineReports')
+  fixLintGradle.mustRunAfter(':combineReports')
   lintGradle.mustRunAfter(':combineReports')
 }

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -131,21 +131,23 @@ spotless {
     // Spotless will not run on unchanged files unless this number changes.
     bumpThisNumberIfACustomStepChanges(project.ext.'spotless-file-hash')
 
+    greclipse()
+
     custom 'Use single-quote in project directives.', {
       it.replaceAll(/project\(":([^"]*)"\)$/, 'project(\':$1\')')
     }
 
     custom 'Use parenthesis in single-line gradle dependency declarations.', {
-      it.replaceAll(/\n(\s*\S*(?:[cC]ompile|[rR]untime)(?:Only)?) (?!\()([^{\n]*)\n/, { original, declaration, dep ->
+      it.replaceAll(/\n(\s*\S*(?:[cC]ompile|[rR]untime|[iI]mplementation|[tT]est)(?:Only)?) (?!\()([^{\n]*)\n/, { original, declaration, dep ->
         "\n${declaration}(${dep})\n"
       })
     }
 
     custom 'Do not pad spaces before parenthesis in gradle dependency declaration.', {
-      it.replaceAll(/\n(\s*\S*(?:[cC]ompile|[rR]untime)(?:Only)?) +\(/, '\n$1(')
+      it.replaceAll(/\n(\s*\S*(?:[cC]ompile|[rR]untime|[iI]mplementation|[tT]est)(?:Only)?) +\(/, '\n$1(')
     }
-
     indentWithSpaces(2)
+    endWithNewline()
   }
 }
 

--- a/static-analysis/pmd-rules/build.gradle
+++ b/static-analysis/pmd-rules/build.gradle
@@ -19,7 +19,10 @@ apply from: "${rootDir}/${scriptDir}/standard-subproject-configuration.gradle"
 apply from: "${rootDir}/${scriptDir}/warnings.gradle"
 
 dependencies {
-    implementation(platform(project(':boms:geode-all-bom')))
-    implementation('net.sourceforge.pmd:pmd-java')
-    testImplementation('net.sourceforge.pmd:pmd-test')
+  implementation(platform(project(':boms:geode-all-bom')))
+  implementation('net.sourceforge.pmd:pmd-java')
+  implementation('net.sourceforge.pmd:pmd-core')
+
+
+  testImplementation('net.sourceforge.pmd:pmd-test')
 }


### PR DESCRIPTION
Fixes dependencies and formatting in build.gradle files. 
* Pulls all used packages in as non-transitive dependencies.
* Drops unused-excludes. (testing may revert this part)
* Minor improvement to formatting of our dependency constraints


<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
