### PR TITLE
GEODE-9607: prevent pubsub from running server out of memory

### DIFF
--- a/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-apis-compatible-with-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -36,6 +36,7 @@ import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.exceptions.JedisException;
 
+import org.apache.geode.redis.mocks.MockSubscriber;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
@@ -103,7 +104,51 @@ public class OutOfMemoryDUnitTest {
     fillMemory(jedis, false);
 
     assertThatThrownBy(
-        () -> jedis.set("{key}oneMoreKey", makeLongStringValue(2 * LARGE_VALUE_SIZE)))
+        () -> jedis.set("{key}oneMoreKey", "value"))
+            .hasMessageContaining("OOM");
+
+    memoryPressureThread.interrupt();
+    memoryPressureThread.join();
+  }
+
+  @Test
+  public void shouldReturnOOMError_forSubscribe_whenThresholdReached()
+      throws InterruptedException {
+    IgnoredException.addIgnoredException(expectedEx);
+    IgnoredException.addIgnoredException("LowMemoryException");
+    MockSubscriber mockSubscriber = new MockSubscriber();
+    int redisServerPort1 = clusterStartUp.getRedisPort(1);
+    JedisCluster subJedis =
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), REDIS_CLIENT_TIMEOUT);
+
+    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
+    memoryPressureThread.start();
+
+    fillMemory(jedis, false);
+
+    assertThatThrownBy(
+        () -> subJedis.subscribe(mockSubscriber, "channel"))
+            .hasMessageContaining("OOM");
+
+    subJedis.close();
+
+    memoryPressureThread.interrupt();
+    memoryPressureThread.join();
+  }
+
+  @Test
+  public void shouldReturnOOMError_forPublish_whenThresholdReached()
+      throws InterruptedException {
+    IgnoredException.addIgnoredException(expectedEx);
+    IgnoredException.addIgnoredException("LowMemoryException");
+
+    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
+    memoryPressureThread.start();
+
+    fillMemory(jedis, false);
+
+    assertThatThrownBy(
+        () -> jedis.publish("channel", "message"))
             .hasMessageContaining("OOM");
 
     memoryPressureThread.interrupt();
@@ -136,9 +181,7 @@ public class OutOfMemoryDUnitTest {
 
     fillMemory(jedis, true);
 
-    await().untilAsserted(() -> {
-      assertThat(jedis.ttl(FILLER_KEY + 1)).isEqualTo(-2);
-    });
+    await().untilAsserted(() -> assertThat(jedis.ttl(FILLER_KEY + 1)).isEqualTo(-2));
 
     memoryPressureThread.interrupt();
     memoryPressureThread.join();
@@ -195,7 +238,7 @@ public class OutOfMemoryDUnitTest {
   private static Runnable makeMemoryPressureRunnable() {
     return new Runnable() {
       boolean running = true;
-      String pressureValue = makeLongStringValue(PRESSURE_VALUE_SIZE);
+      final String pressureValue = makeLongStringValue(PRESSURE_VALUE_SIZE);
 
       @Override
       public void run() {

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -13,5 +13,5 @@ org/apache/geode/redis/internal/data/RedisSet$MemberSet
 org/apache/geode/redis/internal/data/RedisSetCommandsFunctionExecutor$SetOp
 org/apache/geode/redis/internal/data/RedisSortedSet$MemberMap
 org/apache/geode/redis/internal/data/RedisStringCommandsFunctionExecutor$BitOp
-org/apache/geode/redis/internal/pubsub/PubSubImpl$PublishFunction
+org/apache/geode/redis/internal/pubsub/Publisher$PublishFunction
 org/apache/geode/redis/internal/services/StripedExecutorService$State

--- a/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-apis-compatible-with-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -41,3 +41,7 @@ toData,27
 org/apache/geode/redis/internal/executor/string/SetOptions,2
 fromData,27
 toData,27
+
+org/apache/geode/redis/internal/pubsub/Publisher$PublishRequest,2
+fromData,17
+toData,17

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -74,12 +74,12 @@ public class GeodeRedisServer {
 
     unsupportedCommandsEnabled = Boolean.getBoolean(ENABLE_UNSUPPORTED_COMMANDS_PARAM);
 
-    pubSub = new PubSubImpl(new Subscriptions());
     redisStats = createStats(cache);
     StripedCoordinator stripedCoordinator = new SynchronizedStripedCoordinator();
     RedisMemberInfoRetrievalFunction infoFunction = RedisMemberInfoRetrievalFunction.register();
 
     regionProvider = new RegionProvider(cache, stripedCoordinator, redisStats);
+    pubSub = new PubSubImpl(new Subscriptions(), regionProvider);
 
     passiveExpirationManager = new PassiveExpirationManager(regionProvider);
 
@@ -139,6 +139,7 @@ public class GeodeRedisServer {
   public synchronized void shutdown() {
     if (!shutdown) {
       logger.info("GeodeRedisServer shutting down");
+      pubSub.close();
       passiveExpirationManager.stop();
       nettyRedisServer.stop();
       redisStats.close();

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisService.java
@@ -36,6 +36,7 @@ import org.apache.geode.redis.internal.data.RedisSortedSet;
 import org.apache.geode.redis.internal.data.RedisString;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
 import org.apache.geode.redis.internal.executor.string.SetOptions;
+import org.apache.geode.redis.internal.pubsub.Publisher;
 
 public class GeodeRedisService implements CacheService, ResourceEventsListener {
   private static final Logger logger = LogService.getLogger();
@@ -59,6 +60,9 @@ public class GeodeRedisService implements CacheService, ResourceEventsListener {
     InternalDataSerializer.getDSFIDSerializer().registerDSFID(
         DataSerializableFixedID.REDIS_KEY,
         RedisKey.class);
+    InternalDataSerializer.getDSFIDSerializer().registerDSFID(
+        DataSerializableFixedID.PUBLISH_REQUEST,
+        Publisher.PublishRequest.class);
     InternalDataSerializer.getDSFIDSerializer().registerDSFID(
         DataSerializableFixedID.REDIS_SET_ID,
         RedisSet.class);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractExecutor.java
@@ -15,9 +15,13 @@
 package org.apache.geode.redis.internal.executor;
 
 import java.util.Collection;
+import java.util.Set;
 
+import org.apache.geode.cache.LowMemoryException;
 import org.apache.geode.cache.Region;
+import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.redis.internal.GeodeRedisServer;
+import org.apache.geode.redis.internal.RedisCommandType;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
@@ -39,5 +43,16 @@ public abstract class AbstractExecutor implements Executor {
 
   protected Region<RedisKey, RedisData> getDataRegion(ExecutionHandlerContext context) {
     return context.getRegionProvider().getLocalDataRegion();
+  }
+
+  protected void checkForLowMemory(RedisCommandType commandType, ExecutionHandlerContext context) {
+    Set<DistributedMember> criticalMembers = context.getRegionProvider().getCriticalMembers();
+    if (!criticalMembers.isEmpty()) {
+      throw new LowMemoryException(
+          String.format(
+              "%s cannot be executed because the members %s are running low on memory",
+              commandType.toString(), criticalMembers),
+          criticalMembers);
+    }
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PublishExecutor.java
@@ -27,12 +27,13 @@ public class PublishExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
+    checkForLowMemory(command.getCommandType(), context);
 
     List<byte[]> args = command.getCommandArguments();
     byte[] channelName = args.get(0);
     byte[] message = args.get(1);
     long publishCount = context.getPubSub()
-        .publish(context.getRegionProvider(), channelName, message, context.getClient());
+        .publish(channelName, message, context.getClient());
 
     return RedisResponse.integer(publishCount);
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
@@ -33,6 +33,7 @@ public class SubscribeExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
+    checkForLowMemory(command.getCommandType(), context);
 
     Collection<SubscribeResult> results = new ArrayList<>(command.getCommandArguments().size());
     for (byte[] channelName : command.getCommandArguments()) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSub.java
@@ -19,7 +19,6 @@ package org.apache.geode.redis.internal.pubsub;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.netty.Client;
 
 /**
@@ -42,7 +41,7 @@ public interface PubSub {
    * @return the number of subscribers to this channel that are connected to the server on which
    *         the command is executed.
    */
-  long publish(RegionProvider regionProvider, byte[] channel, byte[] message, Client client);
+  long publish(byte[] channel, byte[] message, Client client);
 
   /**
    * Subscribe to a channel
@@ -111,4 +110,6 @@ public interface PubSub {
    * Should be called when the given client disconnects from the server.
    */
   void clientDisconnect(Client client);
+
+  void close();
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/PubSubImpl.java
@@ -16,33 +16,13 @@
 
 package org.apache.geode.redis.internal.pubsub;
 
-import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadFactory;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
-import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.VisibleForTesting;
-import org.apache.geode.cache.execute.FunctionContext;
-import org.apache.geode.cache.execute.FunctionService;
-import org.apache.geode.cache.execute.ResultCollector;
-import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.cache.execute.InternalFunction;
-import org.apache.geode.logging.internal.executors.LoggingThreadFactory;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.redis.internal.netty.Client;
-import org.apache.geode.redis.internal.services.StripedExecutorService;
-import org.apache.geode.redis.internal.services.StripedRunnable;
 
 /**
  * Concrete class that manages publish and subscribe functionality. Since Redis subscriptions
@@ -50,58 +30,17 @@ import org.apache.geode.redis.internal.services.StripedRunnable;
  * expecting to receive published messages.
  */
 public class PubSubImpl implements PubSub {
-  private static final int MAX_PUBLISH_THREAD_COUNT =
-      Integer.getInteger("redis.max-publish-thread-count", 10);
-
-  private static final Logger logger = LogService.getLogger();
-
   private final Subscriptions subscriptions;
-  private final ExecutorService executor;
+  private final Publisher publisher;
 
-  /**
-   * Inner class to wrap the publish action and pass it to the {@link StripedExecutorService}.
-   */
-  private static class PublishingRunnable implements StripedRunnable {
-
-    private final Runnable runnable;
-    private final Client client;
-
-    public PublishingRunnable(Runnable runnable, Client client) {
-      this.runnable = runnable;
-      this.client = client;
-    }
-
-    @Override
-    public Object getStripe() {
-      return client;
-    }
-
-    @Override
-    public void run() {
-      runnable.run();
-    }
-  }
-
-  public PubSubImpl(Subscriptions subscriptions) {
-    this.subscriptions = subscriptions;
-    executor = createExecutorService();
-    registerPublishFunction();
+  public PubSubImpl(Subscriptions subscriptions, RegionProvider regionProvider) {
+    this(subscriptions, new Publisher(regionProvider, subscriptions));
   }
 
   @VisibleForTesting
-  PubSubImpl(Subscriptions subscriptions, ExecutorService executorService) {
+  PubSubImpl(Subscriptions subscriptions, Publisher publisher) {
     this.subscriptions = subscriptions;
-    executor = executorService;
-    // since this is used for unit testing, do not call registerPublishFunction
-  }
-
-  private static ExecutorService createExecutorService() {
-    ThreadFactory threadFactory = new LoggingThreadFactory("GeodeRedisServer-Publish-", true);
-    BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<>();
-    ExecutorService innerPublishExecutor = new ThreadPoolExecutor(1, MAX_PUBLISH_THREAD_COUNT,
-        60, TimeUnit.SECONDS, workQueue, threadFactory);
-
-    return new StripedExecutorService(innerPublishExecutor);
+    this.publisher = publisher;
   }
 
   @VisibleForTesting
@@ -110,44 +49,9 @@ public class PubSubImpl implements PubSub {
   }
 
   @Override
-  public long publish(RegionProvider regionProvider, byte[] channel, byte[] message,
-      Client client) {
-    executor.submit(
-        new PublishingRunnable(() -> internalPublish(regionProvider, channel, message), client));
-
+  public long publish(byte[] channel, byte[] message, Client client) {
+    publisher.publish(client, channel, message);
     return subscriptions.getAllSubscriptionCount(channel);
-  }
-
-  @SuppressWarnings("unchecked")
-  private void internalPublish(RegionProvider regionProvider, byte[] channel, byte[] message) {
-    Set<DistributedMember> remoteMembers = regionProvider.getRemoteRegionMembers();
-    try {
-      ResultCollector<?, ?> resultCollector = null;
-      try {
-        if (!remoteMembers.isEmpty()) {
-          // send function to remotes
-          resultCollector = FunctionService
-              .onMembers(remoteMembers)
-              .setArguments(new byte[][] {channel, message})
-              .execute(PublishFunction.ID);
-        }
-      } finally {
-        // execute it locally
-        publishMessageToLocalSubscribers(channel, message);
-        if (resultCollector != null) {
-          // block until remote execute completes
-          resultCollector.getResult();
-        }
-      }
-    } catch (Exception e) {
-      // the onMembers contract is for execute to throw an exception
-      // if one of the members goes down.
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "Exception executing publish function on channel {}. If a server departed during the publish then an exception is expected.",
-            bytesToString(channel), e);
-      }
-    }
   }
 
   @Override
@@ -158,10 +62,6 @@ public class PubSubImpl implements PubSub {
   @Override
   public SubscribeResult psubscribe(byte[] pattern, Client client) {
     return subscriptions.psubscribe(pattern, client);
-  }
-
-  private void registerPublishFunction() {
-    FunctionService.registerFunction(new PublishFunction(this));
   }
 
   @Override
@@ -201,57 +101,12 @@ public class PubSubImpl implements PubSub {
 
   @Override
   public void clientDisconnect(Client client) {
+    publisher.disconnect(client);
     subscriptions.remove(client);
   }
 
-  @VisibleForTesting
-  void publishMessageToLocalSubscribers(byte[] channel, byte[] message) {
-    subscriptions.forEachSubscription(channel,
-        (subscriptionName, channelToMatch, client, subscription) -> subscription.publishMessage(
-            channelToMatch != null, subscriptionName,
-            client, channel, message));
-  }
-
-  private static class PublishFunction implements InternalFunction<byte[][]> {
-    public static final String ID = "redisPubSubFunctionID";
-    /**
-     * this class is never serialized (since it implemented getId)
-     * but make tools happy by setting its serialVersionUID.
-     */
-    private static final long serialVersionUID = -1L;
-
-    private final PubSubImpl pubSub;
-
-    public PublishFunction(PubSubImpl pubSub) {
-      this.pubSub = pubSub;
-    }
-
-    @Override
-    public String getId() {
-      return ID;
-    }
-
-    @Override
-    public void execute(FunctionContext<byte[][]> context) {
-      byte[][] publishMessage = context.getArguments();
-      pubSub.publishMessageToLocalSubscribers(publishMessage[0], publishMessage[1]);
-      context.getResultSender().lastResult(true);
-    }
-
-    /**
-     * Since the publish process uses an onMembers function call, we don't want to re-publish
-     * to members if one fails.
-     * TODO: Revisit this in the event that we instead use an onMember call against individual
-     * members.
-     */
-    @Override
-    public boolean isHA() {
-      return false;
-    }
-
-    @Override
-    public boolean hasResult() {
-      return true; // this is needed to preserve ordering
-    }
+  @Override
+  public void close() {
+    publisher.close();
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Publisher.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Publisher.java
@@ -1,0 +1,330 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.geode.redis.internal.pubsub;
+
+import static org.apache.geode.logging.internal.executors.LoggingExecutors.newCachedThreadPool;
+import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Logger;
+
+import org.apache.geode.DataSerializer;
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.cache.execute.ResultCollector;
+import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.internal.cache.execute.InternalFunction;
+import org.apache.geode.internal.serialization.DataSerializableFixedID;
+import org.apache.geode.internal.serialization.DeserializationContext;
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.netty.Client;
+
+/**
+ * This class deals with doing a redis pubsub publish operation.
+ * Since publish requests from the same client must have order
+ * preserved, and since publish requests myst be done in a thread
+ * other than the one the request arrived from, this class has an
+ * instance of ClientPublisher for any Client that does a publish.
+ * The ClientPublisher maintains an ordered queue of requests
+ * and is careful to process them in the order they arrived.
+ * It supports batching them which can be a significant win as
+ * soon as a second geode server is added to the cluster.
+ * WARNING: The queue on the ClientPublisher is unbounded
+ * which can cause the server to run out of memory if the
+ * client keeps sending publish requests faster than the server
+ * can process them. It would be nice for this queue to have
+ * a bound but that could cause a hang because of the way
+ * we use Netty.
+ */
+public class Publisher {
+  private static final Logger logger = LogService.getLogger();
+
+  private final ExecutorService executor;
+  private final RegionProvider regionProvider;
+  private final Subscriptions subscriptions;
+  private final Map<Client, ClientPublisher> clientPublishers = new ConcurrentHashMap<>();
+
+  public Publisher(RegionProvider regionProvider, Subscriptions subscriptions) {
+    this.executor = createExecutorService();
+    this.regionProvider = regionProvider;
+    this.subscriptions = subscriptions;
+    registerPublishFunction();
+  }
+
+  @VisibleForTesting
+  Publisher(RegionProvider regionProvider, Subscriptions subscriptions, ExecutorService executor) {
+    this.executor = executor;
+    this.regionProvider = regionProvider;
+    this.subscriptions = subscriptions;
+    // no need to register function in unit tests
+  }
+
+  public void publish(Client client, byte[] channel, byte[] message) {
+    ClientPublisher clientPublisher =
+        clientPublishers.computeIfAbsent(client, key -> new ClientPublisher());
+    clientPublisher.publish(channel, message);
+  }
+
+  public void disconnect(Client client) {
+    clientPublishers.remove(client);
+  }
+
+  public void close() {
+    executor.shutdown();
+    try {
+      if (!executor.awaitTermination(1, TimeUnit.MINUTES)) {
+        logger.warn("Timed out waiting for queued publish requests to be sent.");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  @VisibleForTesting
+  int getClientCount() {
+    return clientPublishers.size();
+  }
+
+
+  private static ExecutorService createExecutorService() {
+    return newCachedThreadPool("GeodeRedisServer-Publish-", true);
+  }
+
+  private void registerPublishFunction() {
+    FunctionService.registerFunction(new PublishFunction(this));
+  }
+
+  @SuppressWarnings("unchecked")
+  private void internalPublish(List<PublishRequest> batch) {
+    Set<DistributedMember> remoteMembers = regionProvider.getRemoteRegionMembers();
+    try {
+      ResultCollector<?, ?> resultCollector = null;
+      try {
+        if (!remoteMembers.isEmpty()) {
+          // send function to remotes
+          resultCollector = FunctionService
+              .onMembers(remoteMembers)
+              .setArguments(batch)
+              .execute(PublishFunction.ID);
+        }
+      } finally {
+        // execute it locally
+        publishBatchToLocalSubscribers(batch);
+        if (resultCollector != null) {
+          // block until remote execute completes
+          resultCollector.getResult();
+        }
+      }
+    } catch (Exception e) {
+      // the onMembers contract is for execute to throw an exception
+      // if one of the members goes down.
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "Exception executing publish function on batch {}. If a server departed during the publish then an exception is expected.",
+            batch, e);
+      }
+    }
+  }
+
+  private void publishBatchToLocalSubscribers(List<PublishRequest> batch) {
+    batch.forEach(request -> subscriptions.forEachSubscription(request.getChannel(),
+        (subscriptionName, channelToMatch, client, subscription) -> subscription.publishMessage(
+            channelToMatch != null, subscriptionName,
+            client, request.getChannel(), request.getMessage())));
+  }
+
+  public static class PublishRequest implements DataSerializableFixedID {
+    // note final can not be used because of DataSerializableFixedID
+    private byte[] channel;
+    private byte[] message;
+
+    public PublishRequest(byte[] channel, byte[] message) {
+      this.channel = channel;
+      this.message = message;
+    }
+
+    @SuppressWarnings("unused")
+    public PublishRequest() {
+      // needed for DataSerializableFixedID
+    }
+
+    public byte[] getChannel() {
+      return channel;
+    }
+
+    public byte[] getMessage() {
+      return message;
+    }
+
+    @Override
+    public int getDSFID() {
+      return PUBLISH_REQUEST;
+    }
+
+    @Override
+    public void toData(DataOutput out, SerializationContext context) throws IOException {
+      DataSerializer.writeByteArray(getChannel(), out);
+      DataSerializer.writeByteArray(getMessage(), out);
+    }
+
+    @Override
+    public void fromData(DataInput in, DeserializationContext context)
+        throws IOException, ClassNotFoundException {
+      channel = DataSerializer.readByteArray(in);
+      message = DataSerializer.readByteArray(in);
+    }
+
+    @Override
+    public KnownVersion[] getSerializationVersions() {
+      return null;
+    }
+
+    @Override
+    public String toString() {
+      return "PublishRequest{" +
+          "channel=" + bytesToString(channel) +
+          ", message=" + bytesToString(message) +
+          '}';
+    }
+  }
+
+  /**
+   * Manages all the publish requests from a particular client.
+   * The order of these requests is maintained, and they will be
+   * delivered to subscribers in that order.
+   * Since the delivery to subscribers can be slower than the rate
+   * at which publish requests arrive, this publisher supports
+   * batching so allow multiple requests to be sent with a single
+   * function call.
+   */
+  private class ClientPublisher {
+    /**
+     * The queue of incoming publish requests from a particular client.
+     */
+    private final BlockingQueue<PublishRequest> requests = new LinkedBlockingQueue<>();
+    private static final int MAX_BATCH_SIZE = 256;
+    /**
+     * Requests are removed from the "requests" queue and put into this batch.
+     * The batch will contain up to MAX_BATCH_SIZE requests but could contain
+     * any number less than that. All the requests added to this batch will be
+     * sent to subscribers before an attempt is made to fill it again.
+     */
+    private final List<PublishRequest> batch = new ArrayList<>(MAX_BATCH_SIZE);
+    /**
+     * True if an executor thread is currently working on our queue.
+     * Any use of this field must be protected by synchronization.
+     * Note that currently only a single executor thread will be working on
+     * a given ClientPublisher.
+     */
+    private boolean active;
+
+    public void publish(byte[] channel, byte[] message) {
+      // Only one thread for a given Client will call this method
+      // and this is the only place that adds to the queue.
+      // But one of the executor threads can be concurrently
+      // removing items from the queue.
+      requests.add(new PublishRequest(channel, message));
+      fillBatchIfNeeded();
+    }
+
+    private synchronized void fillBatchIfNeeded() {
+      // if active then the executor is already working on our batch
+      if (!active) {
+        // This should only happen when our queue is empty,
+        // and we add a request to it.
+        fillBatch();
+      }
+    }
+
+    private synchronized void fillBatch() {
+      batch.clear();
+      if (requests.drainTo(batch, MAX_BATCH_SIZE) > 0) {
+        active = true;
+        publishBatch();
+      } else {
+        active = false;
+      }
+    }
+
+    private void publishBatch() {
+      executor.execute(() -> {
+        try {
+          internalPublish(batch);
+        } finally {
+          fillBatch();
+        }
+      });
+    }
+  }
+
+  private static class PublishFunction implements InternalFunction<List<PublishRequest>> {
+    public static final String ID = "redisPubSubFunctionID";
+    /**
+     * this class is never serialized (since it implemented getId)
+     * but make tools happy by setting its serialVersionUID.
+     */
+    private static final long serialVersionUID = -1L;
+
+    private final Publisher publisher;
+
+    public PublishFunction(Publisher publisher) {
+      this.publisher = publisher;
+    }
+
+    @Override
+    public String getId() {
+      return ID;
+    }
+
+    @Override
+    public void execute(FunctionContext<List<PublishRequest>> context) {
+      publisher.publishBatchToLocalSubscribers(context.getArguments());
+      context.getResultSender().lastResult(true);
+    }
+
+    /**
+     * Since the publish process uses an onMembers function call, we don't want to re-publish
+     * to members if one fails.
+     * TODO: Revisit this in the event that we instead use an onMember call against individual
+     * members.
+     */
+    @Override
+    public boolean isHA() {
+      return false;
+    }
+
+    @Override
+    public boolean hasResult() {
+      return true; // this is needed to preserve ordering
+    }
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Publisher.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Publisher.java
@@ -198,7 +198,7 @@ public class Publisher {
 
     @Override
     public void fromData(DataInput in, DeserializationContext context)
-        throws IOException, ClassNotFoundException {
+        throws IOException {
       channel = DataSerializer.readByteArray(in);
       message = DataSerializer.readByteArray(in);
     }
@@ -223,7 +223,7 @@ public class Publisher {
    * delivered to subscribers in that order.
    * Since the delivery to subscribers can be slower than the rate
    * at which publish requests arrive, this publisher supports
-   * batching so allow multiple requests to be sent with a single
+   * batching to allow multiple requests to be sent with a single
    * function call.
    */
   private class ClientPublisher {

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PubSubImplTest.java
@@ -23,14 +23,13 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 
 import org.junit.Test;
 
 public class PubSubImplTest {
   private final Subscriptions subscriptions = mock(Subscriptions.class);
-  private final ExecutorService executor = mock(ExecutorService.class);
-  private final PubSubImpl pubsub = new PubSubImpl(subscriptions, executor);
+  private final Publisher publisher = mock(Publisher.class);
+  private final PubSubImpl pubsub = new PubSubImpl(subscriptions, publisher);
 
   @Test
   public void findNumberOfSubscribersPerChannel_handlesEmptyList() {

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PublisherTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PublisherTest.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.geode.redis.internal.pubsub;
+
+import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.apache.geode.redis.internal.RegionProvider;
+import org.apache.geode.redis.internal.netty.Client;
+
+public class PublisherTest {
+  private final RegionProvider regionProvider = mock(RegionProvider.class);
+  private final Subscriptions subscriptions = mock(Subscriptions.class);
+  private final ExecutorService executorService = createExecutorService();
+  private final Publisher publisher = new Publisher(regionProvider, subscriptions, executorService);
+
+  private ExecutorService createExecutorService() {
+    // This service will do synchronous executioo
+    // in the calling thread when execute is called.
+    ExecutorService executorService = new ExecutorService() {
+      @Override
+      public void execute(Runnable command) {
+        command.run();
+      }
+
+      @Override
+      public void shutdown() {
+
+      }
+
+      @Override
+      public List<Runnable> shutdownNow() {
+        return null;
+      }
+
+      @Override
+      public boolean isShutdown() {
+        return false;
+      }
+
+      @Override
+      public boolean isTerminated() {
+        return false;
+      }
+
+      @Override
+      public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return false;
+      }
+
+      @Override
+      public <T> Future<T> submit(Callable<T> task) {
+        return null;
+      }
+
+      @Override
+      public <T> Future<T> submit(Runnable task, T result) {
+        return null;
+      }
+
+      @Override
+      public Future<?> submit(Runnable task) {
+        return null;
+      }
+
+      @Override
+      public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+          throws InterruptedException {
+        return null;
+      }
+
+      @Override
+      public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout,
+          TimeUnit unit) throws InterruptedException {
+        return null;
+      }
+
+      @Override
+      public <T> T invokeAny(Collection<? extends Callable<T>> tasks)
+          throws InterruptedException, ExecutionException {
+        return null;
+      }
+
+      @Override
+      public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+          throws InterruptedException, ExecutionException, TimeoutException {
+        return null;
+      }
+    };
+    return executorService;
+  }
+
+  @Test
+  public void defaultPublisherHasNoClients() {
+    assertThat(publisher.getClientCount()).isZero();
+  }
+
+  @Test
+  public void doingPublishAddsOneClient() {
+    Client client = mock(Client.class);
+    byte[] channel = stringToBytes("channel");
+    byte[] message = stringToBytes("message");
+
+    publisher.publish(client, channel, message);
+
+    assertThat(publisher.getClientCount()).isOne();
+  }
+
+  @Test
+  public void doingTwoPublishesFromSameClientAddsOne() {
+    Client client = mock(Client.class);
+    byte[] channel = stringToBytes("channel");
+    byte[] message = stringToBytes("message");
+
+    publisher.publish(client, channel, message);
+    publisher.publish(client, channel, message);
+
+    assertThat(publisher.getClientCount()).isOne();
+  }
+
+  @Test
+  public void doingTwoPublishesFromDifferentClientsAddsBoth() {
+    Client client1 = mock(Client.class);
+    Client client2 = mock(Client.class);
+    byte[] channel = stringToBytes("channel");
+    byte[] message = stringToBytes("message");
+
+    publisher.publish(client1, channel, message);
+    publisher.publish(client2, channel, message);
+
+    assertThat(publisher.getClientCount()).isEqualTo(2);
+  }
+
+  @Test
+  public void disconnectingClientsThatPublishedSetCountToZero() {
+    Client client1 = mock(Client.class);
+    Client client2 = mock(Client.class);
+    byte[] channel = stringToBytes("channel");
+    byte[] message = stringToBytes("message");
+
+    publisher.publish(client1, channel, message);
+    publisher.publish(client2, channel, message);
+    publisher.disconnect(client1);
+    publisher.disconnect(client2);
+
+    assertThat(publisher.getClientCount()).isZero();
+  }
+
+  @Test
+  public void closingPublisherDoesNotFail() {
+    Client client1 = mock(Client.class);
+    Client client2 = mock(Client.class);
+    byte[] channel = stringToBytes("channel");
+    byte[] message = stringToBytes("message");
+
+    publisher.publish(client1, channel, message);
+    publisher.publish(client2, channel, message);
+    publisher.close();
+  }
+
+
+  @Test
+  public void publishesCallSubscriptionsInCorrectOrder() {
+    Client client = mock(Client.class);
+    byte[] channel1 = stringToBytes("channel1");
+    byte[] message = stringToBytes("message");
+    byte[] channel2 = stringToBytes("channel2");
+    byte[] channel3 = stringToBytes("channel3");
+
+    publisher.publish(client, channel1, message);
+    publisher.publish(client, channel2, message);
+    publisher.publish(client, channel3, message);
+
+    ArgumentCaptor<byte[]> channelCaptor = ArgumentCaptor.forClass(byte[].class);
+    verify(subscriptions, times(3)).forEachSubscription(channelCaptor.capture(), any());
+    assertThat(channelCaptor.getAllValues()).containsExactly(channel1, channel2, channel3);
+  }
+}

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PublisherTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PublisherTest.java
@@ -44,7 +44,7 @@ public class PublisherTest {
   private final Publisher publisher = new Publisher(regionProvider, subscriptions, executorService);
 
   private ExecutorService createExecutorService() {
-    // This service will do synchronous executioo
+    // This service will do synchronous execution
     // in the calling thread when execute is called.
     ExecutorService executorService = new ExecutorService() {
       @Override
@@ -53,9 +53,7 @@ public class PublisherTest {
       }
 
       @Override
-      public void shutdown() {
-
-      }
+      public void shutdown() {}
 
       @Override
       public List<Runnable> shutdownNow() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -37,6 +37,7 @@ import org.apache.geode.CancelException;
 import org.apache.geode.Statistics;
 import org.apache.geode.SystemFailure;
 import org.apache.geode.annotations.Immutable;
+import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.LowMemoryException;
@@ -682,7 +683,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
     });
   }
 
-  protected Set<DistributedMember> getHeapCriticalMembersFrom(
+  public Set<DistributedMember> getHeapCriticalMembersFrom(
       Set<? extends DistributedMember> members) {
     Set<DistributedMember> criticalMembers = getCriticalMembers();
     criticalMembers.retainAll(members);
@@ -750,6 +751,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
     return mostRecentEvent;
   }
 
+  @VisibleForTesting
   protected HeapMemoryMonitor setMostRecentEvent(
       MemoryEvent mostRecentEvent) {
     this.mostRecentEvent = mostRecentEvent;

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/DataSerializableFixedID.java
@@ -463,8 +463,9 @@ public interface DataSerializableFixedID extends SerializationVersions, BasicSer
   short PR_UPDATE_ENTRY_VERSION_MESSAGE = 159;
 
   short REDIS_KEY = 160;
+  short PUBLISH_REQUEST = 161;
 
-  // 161 through 164 unused
+  // 162 through 164 unused
 
   short PR_FETCH_BULK_ENTRIES_MESSAGE = 165;
   short PR_FETCH_BULK_ENTRIES_REPLY_MESSAGE = 166;


### PR DESCRIPTION
Moved all of the publish code from PubSubImpl to Publisher.
This new class is able to batch the publish requests instead
of always sending them one at a time to other servers.

Also the ExecutorService used for publishing is now correctly configured (thanks to Jens for figuring this out) so that it can use more than one thread for publishing.

Both the publish and subscribe executor now do a critical memory check and will throw a  LowMemoryException

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
