### PR TITLE
GEODE-9547: Radish commands are authorized by the SecurityManager

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/connection/AuthNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/connection/AuthNativeRedisAcceptanceTest.java
@@ -43,10 +43,20 @@ public class AuthNativeRedisAcceptanceTest extends AbstractAuthIntegrationTest {
   }
 
   @Override
+  public String getUsername() {
+    return "default";
+  }
+
+  @Override
+  public String getPassword() {
+    return "default";
+  }
+
+  @Override
   public void setupCacheWithSecurity() {
     redisContainer =
         new GenericContainer<>(REDIS_DOCKER_IMAGE).withExposedPorts(6379)
-            .withCommand("redis-server --requirepass " + PASSWORD);
+            .withCommand("redis-server --requirepass " + getPassword());
     redisContainer.start();
     jedis = new Jedis("localhost", redisContainer.getFirstMappedPort(), REDIS_CLIENT_TIMEOUT);
   }

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/resources/0001-configure-redis-tests.patch
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/resources/0001-configure-redis-tests.patch
@@ -74,7 +74,7 @@ index 8978631e0..33c10eb15 100644
      } elseif {$opt eq {--port}} {
          set ::port $arg
 diff --git a/tests/unit/auth.tcl b/tests/unit/auth.tcl
-index 633cda95c..beaf711a4 100644
+index 633cda95c..5cb6dbab8 100644
 --- a/tests/unit/auth.tcl
 +++ b/tests/unit/auth.tcl
 @@ -1,15 +1,16 @@
@@ -101,6 +101,15 @@ index 633cda95c..beaf711a4 100644
  
      test {Arbitrary command gives an error when AUTH is required} {
          catch {r set foo bar} err
+@@ -17,7 +18,7 @@ start_server {tags {"auth"} overrides {requirepass foobar}} {
+     } {NOAUTH*}
+ 
+     test {AUTH succeeds when the right password is given} {
+-        r auth foobar
++        r auth dataWrite dataWrite
+     } {OK}
+ 
+     test {Once AUTH succeeded we can actually send commands to the server} {
 diff --git a/tests/unit/dump.tcl b/tests/unit/dump.tcl
 index 4c4e5d075..18bb694f2 100644
 --- a/tests/unit/dump.tcl

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractAuthIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractAuthIntegrationTest.java
@@ -107,7 +107,8 @@ public abstract class AbstractAuthIntegrationTest {
   public void givenSecurity_lettuceV6AuthClient_passes() throws Exception {
     setupCacheWithSecurity();
 
-    RedisURI uri = RedisURI.create(String.format("redis://%s@localhost:%d", getUsername(), getPort()));
+    RedisURI uri =
+        RedisURI.create(String.format("redis://%s@localhost:%d", getUsername(), getPort()));
     RedisClient client = RedisClient.create(uri);
 
     client.connect().sync().ping();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractAuthIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AbstractAuthIntegrationTest.java
@@ -87,6 +87,13 @@ public abstract class AbstractAuthIntegrationTest {
         .hasMessage("WRONGPASS invalid username-password pair or user is disabled.");
   }
 
+  /**
+   * Authentication and authorization is sometimes implemented and handled using thread locals.
+   * Our security implementation can do this but the way it's used here does not (and must not)
+   * since netty threads are shared between connections. This test should be using a single netty
+   * thread so that we can be sure that multiple connections will not inadvertently leak auth data
+   * between them.
+   */
   @Test
   public void givenSecurity_separateClientRequest_doNotInteract() throws Exception {
     setupCacheWithSecurity();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AuthIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AuthIntegrationTest.java
@@ -78,23 +78,25 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
      * setting this value.
      */
     System.setProperty("io.netty.eventLoopThreads", "1");
-    port = AvailablePortHelper.getRandomAvailableTCPPort();
-    CacheFactory cf = new CacheFactory();
-    cf.set(LOG_LEVEL, "error");
-    cf.set(MCAST_PORT, "0");
-    cf.set(LOCATORS, "");
-    if (username != null) {
-      cf.set(ConfigurationProperties.REDIS_USERNAME, username);
+    try {
+      port = AvailablePortHelper.getRandomAvailableTCPPort();
+      CacheFactory cf = new CacheFactory();
+      cf.set(LOG_LEVEL, "error");
+      cf.set(MCAST_PORT, "0");
+      cf.set(LOCATORS, "");
+      if (username != null) {
+        cf.set(ConfigurationProperties.REDIS_USERNAME, username);
+      }
+      if (withSecurityManager) {
+        cf.set(ConfigurationProperties.SECURITY_MANAGER, SimpleSecurityManager.class.getName());
+      }
+      cache = cf.create();
+      server = new GeodeRedisServer("localhost", port, (InternalCache) cache);
+      server.getRegionProvider().getSlotAdvisor().getBucketSlots();
+      this.jedis = new Jedis("localhost", port, 100000);
+    } finally {
+      System.clearProperty("io.netty.eventLoopThreads");
     }
-    if (withSecurityManager) {
-      cf.set(ConfigurationProperties.SECURITY_MANAGER, SimpleSecurityManager.class.getName());
-    }
-    cache = cf.create();
-    server = new GeodeRedisServer("localhost", port, (InternalCache) cache);
-    server.getRegionProvider().getSlotAdvisor().getBucketSlots();
-    this.jedis = new Jedis("localhost", port, 100000);
-
-    System.clearProperty("io.netty.eventLoopThreads");
   }
 
   @Test

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AuthIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AuthIntegrationTest.java
@@ -73,6 +73,10 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
   }
 
   private void setupCache(String username, boolean withSecurityManager) throws Exception {
+    /**
+     * See {@link #givenSecurity_separateClientRequest_doNotInteract} for some reasoning behind
+     * setting this value.
+     */
     System.setProperty("io.netty.eventLoopThreads", "1");
     port = AvailablePortHelper.getRandomAvailableTCPPort();
     CacheFactory cf = new CacheFactory();

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AuthIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/connection/AuthIntegrationTest.java
@@ -19,6 +19,7 @@ package org.apache.geode.redis.internal.executor.connection;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -53,22 +54,33 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     return port;
   }
 
+  @Override
+  public String getUsername() {
+    return "dataWrite";
+  }
+
+  @Override
+  public String getPassword() {
+    return "dataWrite";
+  }
+
   public void setupCacheWithSecurity() throws Exception {
-    setupCache(true, true);
+    setupCache(getUsername(), true);
   }
 
   public void setupCacheWithoutSecurity() throws Exception {
-    setupCache(false, false);
+    setupCache(null, false);
   }
 
-  private void setupCache(boolean withUsername, boolean withSecurityManager) throws Exception {
+  private void setupCache(String username, boolean withSecurityManager) throws Exception {
+    System.setProperty("io.netty.eventLoopThreads", "1");
     port = AvailablePortHelper.getRandomAvailableTCPPort();
     CacheFactory cf = new CacheFactory();
     cf.set(LOG_LEVEL, "error");
     cf.set(MCAST_PORT, "0");
     cf.set(LOCATORS, "");
-    if (withUsername) {
-      cf.set(ConfigurationProperties.REDIS_USERNAME, USERNAME);
+    if (username != null) {
+      cf.set(ConfigurationProperties.REDIS_USERNAME, username);
     }
     if (withSecurityManager) {
       cf.set(ConfigurationProperties.SECURITY_MANAGER, SimpleSecurityManager.class.getName());
@@ -77,13 +89,15 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     server = new GeodeRedisServer("localhost", port, (InternalCache) cache);
     server.getRegionProvider().getSlotAdvisor().getBucketSlots();
     this.jedis = new Jedis("localhost", port, 100000);
+
+    System.clearProperty("io.netty.eventLoopThreads");
   }
 
   @Test
   public void testAuthConfig() throws Exception {
     setupCacheWithSecurity();
     InternalDistributedSystem iD = (InternalDistributedSystem) cache.getDistributedSystem();
-    assertThat(iD.getConfig().getRedisUsername()).isEqualTo(USERNAME);
+    assertThat(iD.getConfig().getRedisUsername()).isEqualTo(getUsername());
   }
 
   @Test
@@ -100,6 +114,40 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
 
     assertThatThrownBy(() -> jedis.auth("username", "password"))
         .hasMessageContaining(RedisConstants.ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
+  }
+
+  @Test
+  public void givenSecurity_accessWithCorrectAuthorization_passes() throws Exception {
+    setupCacheWithSecurity();
+
+    jedis.auth("dataWrite", "dataWrite");
+
+    assertThat(jedis.set("foo", "bar")).isEqualTo("OK");
+  }
+
+  @Test
+  public void givenSecurity_multipleClientsConnectIndependently() throws Exception {
+    setupCacheWithSecurity();
+
+    jedis.auth("dataWrite", "dataWrite");
+    assertThat(jedis.set("foo", "bar")).isEqualTo("OK");
+
+    try (Jedis jedis2 = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT)) {
+      assertThatThrownBy(() -> jedis2.set("foo", "bar"))
+          .hasMessageContaining(RedisConstants.ERROR_NOT_AUTHENTICATED);
+    }
+  }
+
+  @Test
+  public void givenSecurity_accessWithIncorrectAuthorization_fails() throws Exception {
+    setupCacheWithSecurity();
+
+    // Authentication is successful
+    jedis.auth("dataWriteOther", "dataWriteOther");
+
+    // Permissions are incorrect
+    assertThatThrownBy(() -> jedis.set("foo", "bar"))
+        .hasMessageContaining(RedisConstants.ERROR_NOT_AUTHORIZED);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -29,7 +29,8 @@ public class RedisConstants {
   public static final String ERROR_UNKNOWN_COMMAND =
       "unknown command `%s`, with args beginning with: %s";
   public static final String ERROR_OUT_OF_RANGE = "The number provided is out of range";
-  public static final String ERROR_NOT_AUTH = "NOAUTH Authentication required.";
+  public static final String ERROR_NOT_AUTHENTICATED = "Authentication required.";
+  public static final String ERROR_NOT_AUTHORIZED = "Authorization failed.";
   public static final String ERROR_WRONG_TYPE =
       "Operation against a key holding the wrong kind of value";
   public static final String ERROR_NOT_INTEGER = "value is not an integer or out of range";

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
@@ -149,12 +149,12 @@ public class RedisResponse {
     return new RedisResponse((bba) -> Coder.getWrongpassResponse(bba, error));
   }
 
-  public static RedisResponse customError(String error) {
-    return new RedisResponse((buffer) -> Coder.getCustomErrorResponse(buffer, error));
-  }
-
   public static RedisResponse wrongType(String error) {
     return new RedisResponse((buffer) -> Coder.getWrongTypeResponse(buffer, error));
+  }
+
+  public static RedisResponse noAuth(String error) {
+    return new RedisResponse((buffer) -> Coder.getNoAuthResponse(buffer, error));
   }
 
   public static RedisResponse scan(int cursor, List<?> scanResult) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -34,6 +34,7 @@ import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINFINITY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMOVED;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNIL;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNOAUTH;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INFINITY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNaN;
@@ -225,6 +226,10 @@ public class Coder {
 
   public static ByteBuf getBusyKeyResponse(ByteBuf buffer, String error) {
     return getErrorResponse0(buffer, bBUSYKEY, error);
+  }
+
+  public static ByteBuf getNoAuthResponse(ByteBuf buffer, String error) {
+    return getErrorResponse0(buffer, bNOAUTH, error);
   }
 
   public static ByteBuf getCustomErrorResponse(ByteBuf buffer, String error) {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -232,14 +232,6 @@ public class Coder {
     return getErrorResponse0(buffer, bNOAUTH, error);
   }
 
-  public static ByteBuf getCustomErrorResponse(ByteBuf buffer, String error) {
-    byte[] errorAr = stringToBytes(error);
-    buffer.writeByte(ERROR_ID);
-    buffer.writeBytes(errorAr);
-    buffer.writeBytes(bCRLF);
-    return buffer;
-  }
-
   public static ByteBuf getIntegerResponse(ByteBuf buffer, int integer) {
     return getIntegerResponse(buffer, intToBytes(integer));
   }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -321,12 +321,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
   }
 
   public boolean isAuthorized() {
-    if (!securityService.isIntegratedSecurity()) {
-      return true;
-    }
-
     if (subject == null) {
-      return false;
+      return true;
     }
 
     try {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -89,10 +89,10 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
 
   static {
     String resourcePermission = System.getProperty("redis.resource-permission",
-            "DATA:WRITE:" + RegionProvider.REDIS_DATA_REGION);
+        "DATA:WRITE:" + RegionProvider.REDIS_DATA_REGION);
     String[] parts = resourcePermission.split(":");
     if (parts.length != 3) {
-      parts = new String[]{"DATA", "WRITE", RegionProvider.REDIS_DATA_REGION};
+      parts = new String[] {"DATA", "WRITE", RegionProvider.REDIS_DATA_REGION};
     }
 
     RESOURCE_PERMISSION = new ResourcePermission(parts[0], parts[1], parts[2]);

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -97,6 +97,9 @@ public class StringBytesGlossary {
   @MakeImmutable
   public static final byte[] bWRONGPASS = stringToBytes("WRONGPASS ");
 
+  @MakeImmutable
+  public static final byte[] bNOAUTH = stringToBytes("NOAUTH ");
+
   // ********** Redis Command constants **********
 
   // ClusterExecutor


### PR DESCRIPTION
- A default ResourcePermission of DATA:WRITE:REDIS_DATA is used. This
  can be overridden by setting the system property
  redis.resource-permission.
- If available, every request is authorized against the SecurityManager.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
