### PR TITLE
GEODE-9606: Fix flaky PubSubIntegrationTest.testPatternWithoutAGlob

### DIFF
--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/pubsub/AbstractPubSubIntegrationTest.java
@@ -757,10 +757,12 @@ public abstract class AbstractPubSubIntegrationTest implements RedisIntegrationT
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 2);
 
     mockSubscriber.prepareMessagesReceivedLatch(1);
+    mockSubscriber.preparePMessagesReceivedLatch(1);
     Long result = publisher.publish("salutations", "hello");
 
     assertThat(result).isEqualTo(2);
     mockSubscriber.awaitMessagesReceived();
+    mockSubscriber.awaitPMessagesReceived();
 
     mockSubscriber.punsubscribe("salutations");
     waitFor(() -> mockSubscriber.getSubscribedChannels() == 1);


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
