### PR TITLE
GEODE-9611: fixed the incorrect spelling

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlPropertyResolver.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheXmlPropertyResolver.java
@@ -122,7 +122,7 @@ public class CacheXmlPropertyResolver implements PropertyResolver {
       if (ignoreUnresolvedProperties) {
         // Do Nothing
       } else {
-        logger.error("Format of the string {} used for perameterization is unresolvable",
+        logger.error("Format of the string {} used for parameterization is unresolvable",
             stringWithPrefixAndSuffix);
       }
     }


### PR DESCRIPTION
This PR fixes the spelling for one of the important error log messages for configuration settings coming from XML for parameterized attribute values. 

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
