### PR TITLE
GEODE-9619: [documentation] Align contents section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 
 ## Contents
 1. [Overview](#overview)
-2. [How to Get Apache Geode](#obtaining)
-3. [Main Concepts and Components](#concepts)
-4. [Location of Directions for Building from Source](#building)
-5. [Geode in 5 minutes](#started)
-6. [Application Development](#development)
-7. [Documentation](https://geode.apache.org/docs/)
-8. [Wiki](https://cwiki.apache.org/confluence/display/GEODE/Index)
-9. [How to Contribute](https://cwiki.apache.org/confluence/display/GEODE/How+to+Contribute)
-10.[Export Control](#export)
+1. [How to Get Apache Geode](#obtaining)
+1. [Main Concepts and Components](#concepts)
+1. [Location of Directions for Building from Source](#building)
+1. [Geode in 5 minutes](#started)
+1. [Application Development](#development)
+1. [Documentation](https://geode.apache.org/docs/)
+1. [Wiki](https://cwiki.apache.org/confluence/display/GEODE/Index)
+1. [How to Contribute](https://cwiki.apache.org/confluence/display/GEODE/How+bto+Contribute)
+1. [Export Control](#export)
 
 ## <a name="overview"></a>Overview
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 1. [Application Development](#development)
 1. [Documentation](https://geode.apache.org/docs/)
 1. [Wiki](https://cwiki.apache.org/confluence/display/GEODE/Index)
-1. [How to Contribute](https://cwiki.apache.org/confluence/display/GEODE/How+bto+Contribute)
+1. [How to Contribute](https://cwiki.apache.org/confluence/display/GEODE/How+to+Contribute)
 1. [Export Control](#export)
 
 ## <a name="overview"></a>Overview


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->
Jira ticket: https://issues.apache.org/jira/projects/GEODE/issues/GEODE-9619

Came here from ApacheCon, saw this and thought I'll start my contributions here 😄 

This PR adds changes to format the contents section of the README in a way that the 9th and 10th list element are not rendered on to the same line. I've also changed the numbering from 1,2,3,4 to 1,1,1,1 so that Markdown can figure out the numbering (lesser chance of missing a number in the list)

### Before:
![image](https://user-images.githubusercontent.com/37668193/134190142-4e304930-99b7-425e-813e-5545aac8622a.png)

### After:
![image](https://user-images.githubusercontent.com/37668193/134190264-0e6f91d5-5c0a-40cf-8729-9811a95266bc.png)

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
