### PR TITLE
GEODE-4181: Migrate uses of JUnitParamsRunner

### DIFF
--- a/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractCommitSessionValveIntegrationTest.java
+++ b/extensions/geode-modules-test/src/main/java/org/apache/geode/modules/session/catalina/AbstractCommitSessionValveIntegrationTest.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 
 import javax.servlet.ServletException;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.catalina.Context;
 import org.apache.catalina.Manager;
@@ -38,8 +37,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AbstractCommitSessionValveIntegrationTest<CommitSessionValveT extends AbstractCommitSessionValve<CommitSessionValveT>>
     extends AbstractSessionValveIntegrationTest {
   protected Request request;

--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/JvmRouteBinderValveIntegrationTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/JvmRouteBinderValveIntegrationTest.java
@@ -29,7 +29,6 @@ import java.util.UUID;
 
 import javax.servlet.ServletException;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.catalina.Context;
 import org.apache.catalina.Manager;
@@ -40,8 +39,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class JvmRouteBinderValveIntegrationTest extends AbstractSessionValveIntegrationTest {
   private Request request;
   private Response response;

--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/callback/LocalSessionCacheLoaderIntegrationTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/callback/LocalSessionCacheLoaderIntegrationTest.java
@@ -21,7 +21,6 @@ import java.util.Enumeration;
 
 import javax.servlet.http.HttpSession;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -32,8 +31,9 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.modules.session.catalina.DeltaSession;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LocalSessionCacheLoaderIntegrationTest {
   private static final String SESSION_ID = "id";
   private static final String REGION_NAME = "sessions";

--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/callback/LocalSessionCacheWriterIntegrationTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/callback/LocalSessionCacheWriterIntegrationTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.servlet.http.HttpSession;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -37,8 +36,9 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.util.CacheWriterAdapter;
 import org.apache.geode.modules.session.catalina.DeltaSession;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LocalSessionCacheWriterIntegrationTest {
   private static final String SESSION_ID = "id";
   private static final String REGION_NAME = "sessions";

--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/callback/SessionExpirationCacheListenerIntegrationTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/callback/SessionExpirationCacheListenerIntegrationTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.servlet.http.HttpSession;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.juli.logging.Log;
 import org.junit.Before;
@@ -42,8 +41,9 @@ import org.apache.geode.modules.session.catalina.DeltaSession;
 import org.apache.geode.modules.session.catalina.DeltaSessionManager;
 import org.apache.geode.modules.session.catalina.SessionCache;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class SessionExpirationCacheListenerIntegrationTest {
   private static final String KEY = "key1";
   private static final String REGION_NAME = "sessions";

--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/internal/DeltaSessionAttributeEventBatchIntegrationTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/internal/DeltaSessionAttributeEventBatchIntegrationTest.java
@@ -21,14 +21,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DeltaSessionAttributeEventBatchIntegrationTest
     extends AbstractDeltaSessionIntegrationTest {
 

--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/internal/DeltaSessionDestroyAttributeEventIntegrationTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/internal/DeltaSessionDestroyAttributeEventIntegrationTest.java
@@ -18,15 +18,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.modules.session.catalina.DeltaSession;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DeltaSessionDestroyAttributeEventIntegrationTest
     extends AbstractDeltaSessionIntegrationTest {
 

--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/internal/DeltaSessionStatisticsIntegrationTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/internal/DeltaSessionStatisticsIntegrationTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.when;
 
 import javax.servlet.http.HttpSession;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
@@ -39,8 +38,9 @@ import org.apache.geode.modules.session.catalina.AbstractSessionCache;
 import org.apache.geode.modules.session.catalina.DeltaSession;
 import org.apache.geode.modules.session.catalina.SessionCache;
 import org.apache.geode.modules.session.catalina.callback.SessionExpirationCacheListener;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DeltaSessionStatisticsIntegrationTest extends AbstractDeltaSessionIntegrationTest {
   private DeltaSessionStatistics statistics;
 

--- a/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/internal/DeltaSessionUpdateAttributeEventIntegrationTest.java
+++ b/extensions/geode-modules/src/integrationTest/java/org/apache/geode/modules/session/catalina/internal/DeltaSessionUpdateAttributeEventIntegrationTest.java
@@ -18,15 +18,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.modules.session.catalina.DeltaSession;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DeltaSessionUpdateAttributeEventIntegrationTest
     extends AbstractDeltaSessionIntegrationTest {
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZLexCountIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZLexCountIntegrationTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.List;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
@@ -36,8 +35,9 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AbstractZLexCountIntegrationTest implements RedisIntegrationTest {
   public static final String KEY = "key";
   public static final int SCORE = 1;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
@@ -41,8 +40,9 @@ import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegrationTest {
   public static final String KEY = "key";
   public static final int SCORE = 1;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRemRangeByLexIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRemRangeByLexIntegrationTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.List;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
@@ -36,8 +35,9 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AbstractZRemRangeByLexIntegrationTest implements RedisIntegrationTest {
   public static final String KEY = "key";
   public static final int SCORE = 1;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRemRangeByRankIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRemRangeByRankIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CL
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Before;
@@ -32,8 +31,9 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AbstractZRemRangeByRankIntegrationTest implements RedisIntegrationTest {
   public static final String KEY = "key";
   public static final int BASE_SCORE = 1;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeByLexIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeByLexIntegrationTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.After;
@@ -41,8 +40,9 @@ import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AbstractZRevRangeByLexIntegrationTest implements RedisIntegrationTest {
   public static final String KEY = "key";
   public static final int SCORE = 1;

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -44,8 +43,9 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIntegrationTest {
   private static final String MEMBER_BASE_NAME = "member";
   private static final String KEY = "key";

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZRevRangeIntegrationTest.java
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -40,8 +39,9 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrationTest {
   private static final String MEMBER_BASE_NAME = "member";
   private static final String KEY = "key";

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -46,7 +46,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.BeforeClass;
@@ -69,8 +68,9 @@ import org.apache.geode.redis.internal.executor.sortedset.SortedSetLexRangeOptio
 import org.apache.geode.redis.internal.executor.sortedset.SortedSetRankRangeOptions;
 import org.apache.geode.redis.internal.executor.sortedset.ZAddOptions;
 import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class RedisSortedSetTest {
   private final ReflectionObjectSizer sizer = ReflectionObjectSizer.getInstance();
 

--- a/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-apis-compatible-with-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -34,12 +34,13 @@ import java.nio.charset.StandardCharsets;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-@RunWith(JUnitParamsRunner.class)
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
+
+@RunWith(GeodeParamsRunner.class)
 public class CoderTest {
   @Test
   @Parameters(method = "stringPairs")

--- a/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandForProxyRegionDUnitTest.java
+++ b/geode-connectors/src/distributedTest/java/org/apache/geode/connectors/jdbc/internal/cli/CreateMappingCommandForProxyRegionDUnitTest.java
@@ -39,7 +39,6 @@ import java.util.List;
 
 import javax.sql.DataSource;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Before;
@@ -75,9 +74,10 @@ import org.apache.geode.test.junit.categories.JDBCConnectorTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({JDBCConnectorTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class CreateMappingCommandForProxyRegionDUnitTest {
 
   private static final String TEST_REGION = "testRegion";

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlHandlerTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlHandlerTest.java
@@ -37,7 +37,6 @@ import java.util.Set;
 
 import javax.sql.DataSource;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -56,8 +55,9 @@ import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
 import org.apache.geode.pdx.internal.PdxInstanceImpl;
 import org.apache.geode.pdx.internal.PdxType;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class SqlHandlerTest {
   private static final String DATA_SOURCE_NAME = "dataSourceName";
   private static final String REGION_NAME = "testRegion";

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlToPdxInstanceCreatorTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlToPdxInstanceCreatorTest.java
@@ -22,7 +22,6 @@ import java.sql.JDBCType;
 import java.sql.SQLException;
 import java.util.Arrays;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
@@ -34,8 +33,9 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.pdx.FieldType;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.PdxInstanceFactory;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class SqlToPdxInstanceCreatorTest {
 
   private static final String COLUMN_NAME_1 = "columnName1";

--- a/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlToPdxInstanceTest.java
+++ b/geode-connectors/src/test/java/org/apache/geode/connectors/jdbc/internal/SqlToPdxInstanceTest.java
@@ -28,7 +28,6 @@ import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Date;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
@@ -38,8 +37,9 @@ import org.apache.geode.connectors.jdbc.JdbcConnectorException;
 import org.apache.geode.pdx.FieldType;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.pdx.WritablePdxInstance;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class SqlToPdxInstanceTest {
 
   private static final String COLUMN_NAME_1 = "columnName1";

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/CreateAndLocalDestroyInTXRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/CreateAndLocalDestroyInTXRegressionTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.verify;
 import java.io.Serializable;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -39,6 +38,7 @@ import org.apache.geode.cache.Region.Entry;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Create and LocalDestroy/LocalInvalidate should create event with NewValue
@@ -50,7 +50,7 @@ import org.apache.geode.test.dunit.rules.DistributedRule;
  * @since GemFire 5.0
  */
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class CreateAndLocalDestroyInTXRegressionTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/RegionExpirationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/RegionExpirationDistributedTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.timeout;
 import java.io.Serializable;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -39,6 +38,7 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Test Region expiration - both time-to-live and idle timeout.
@@ -51,7 +51,7 @@ import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
  *
  * @since GemFire 3.0
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class RegionExpirationDistributedTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
@@ -32,7 +32,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.assertj.core.api.ThrowableAssert;
@@ -66,8 +65,9 @@ import org.apache.geode.test.junit.categories.OQLQueryTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @Category({OQLQueryTest.class, SecurityTest.class})
 public class QueryConfigurationServiceConstraintsDistributedTest implements Serializable {
   private static final int ENTRIES = 500;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/aggregate/AggregateFunctionsQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/aggregate/AggregateFunctionsQueryDUnitTest.java
@@ -19,6 +19,7 @@ import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.cache.query.internal.aggregate.AbstractAggregator.downCast;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.runners.MethodSorters.NAME_ASCENDING;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -35,7 +36,6 @@ import java.util.function.Predicate;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -44,7 +44,6 @@ import org.junit.ClassRule;
 import org.junit.FixMethodOrder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.MethodSorters;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
@@ -62,9 +61,10 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.VMProvider;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+@RunWith(GeodeParamsRunner.class)
+@FixMethodOrder(NAME_ASCENDING)
 public class AggregateFunctionsQueryDUnitTest implements Serializable {
   private static final String regionName = "portfolio";
   private static MemberVM locator, server1, server2, server3, server4;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/InitializeIndexEntryDestroyQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/InitializeIndexEntryDestroyQueryDUnitTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.fail;
 import java.util.Arrays;
 import java.util.Properties;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.logging.log4j.Logger;
 import org.junit.Test;
@@ -52,6 +51,7 @@ import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Test creates a local region. Creates and removes index in a parallel running thread. Then
@@ -59,7 +59,7 @@ import org.apache.geode.test.junit.categories.OQLIndexTest;
  * and checks for UNDEFINED values in result set of the query.
  */
 @Category({OQLIndexTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class InitializeIndexEntryDestroyQueryDUnitTest extends JUnit4CacheTestCase {
   private static final Logger logger = LogService.getLogger();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientCachingProxyRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientCachingProxyRegionDistributedTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,8 +39,9 @@ import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ClientCachingProxyRegionDistributedTest implements Serializable {
   protected static final List<String> KEYS = Arrays.asList("Key1", "Key2");
   protected static final List<String> VALUES = Arrays.asList("Value1", "Value2");

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
@@ -29,7 +29,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,6 +56,7 @@ import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Client side deserialization should not throw EOFException when copy-on-read is true.
@@ -67,7 +67,7 @@ import org.apache.geode.test.junit.categories.ClientServerTest;
  * @since GemFire bugfix5.7
  */
 @Category({ClientServerTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerTestCase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DestroyRegionDuringGIIDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DestroyRegionDuringGIIDistributedTest.java
@@ -33,7 +33,6 @@ import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -64,8 +63,9 @@ import org.apache.geode.test.dunit.rules.CacheXmlRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class DestroyRegionDuringGIIDistributedTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryWithIndexAndPdxDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryWithIndexAndPdxDistributedTest.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -50,12 +49,13 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Extracted from {@link PRQueryDistributedTest}.
  */
 @Category(OQLIndexTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class PRQueryWithIndexAndPdxDistributedTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryWithIndexDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PRQueryWithIndexDistributedTest.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -47,12 +46,13 @@ import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Extracted from {@link PRQueryDistributedTest}.
  */
 @Category(OQLIndexTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class PRQueryWithIndexDistributedTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionCloseDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionCloseDistributedTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.Serializable;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -37,8 +36,9 @@ import org.apache.geode.internal.cache.partitioned.RegionAdvisor;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class PartitionedRegionCloseDistributedTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/backup/BackupDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/backup/BackupDistributedTest.java
@@ -45,7 +45,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.apache.commons.io.FileUtils;
@@ -89,6 +88,7 @@ import org.apache.geode.test.dunit.rules.DistributedDiskDirRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Additional tests to consider adding:
@@ -98,7 +98,7 @@ import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
  * <li>Test backing up and recovering while ops are in progress?
  * </ul>
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class BackupDistributedTest extends JUnit4DistributedTestCase implements Serializable {
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
@@ -31,7 +31,6 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.Logger;
@@ -51,13 +50,14 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * The purpose of RebalanceOperationComplexDistributedTest is to test rebalances
  * across zones and to ensure that enforceUniqueZone behavior of redundancy zones
  * is working correctly.
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class RebalanceOperationComplexDistributedTest implements Serializable {
   public static final int EXPECTED_BUCKET_COUNT = 113;
   public static final long TIMEOUT_SECONDS = GeodeAwaitility.getTimeout().getSeconds();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDistributedTest.java
@@ -56,7 +56,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -111,6 +110,7 @@ import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.cache.CacheTestCase;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 /**
@@ -119,7 +119,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
  * <p>
  * TODO test colocated regions where members aren't consistent in which regions they have
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class RebalanceOperationDistributedTest extends CacheTestCase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RestoreRedundancyOperationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RestoreRedundancyOperationDUnitTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -53,8 +52,9 @@ import org.apache.geode.management.runtime.RestoreRedundancyResults;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class RestoreRedundancyOperationDUnitTest {
   private List<MemberVM> servers;
   private static final int SERVERS_TO_START = 3;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ClientFunctionTimeoutRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/ClientFunctionTimeoutRegressionTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Before;
@@ -61,6 +60,7 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.categories.FunctionServiceTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Server should terminate client function execution when it times out. Client sends
@@ -71,7 +71,7 @@ import org.apache.geode.test.junit.categories.FunctionServiceTest;
  * gemfire.CLIENT_FUNCTION_TIMEOUT property is set
  */
 @Category(FunctionServiceTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class ClientFunctionTimeoutRegressionTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionOnRegionRetryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionOnRegionRetryDUnitTest.java
@@ -15,10 +15,8 @@
 package org.apache.geode.internal.cache.execute;
 
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Test;
@@ -26,9 +24,10 @@ import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class FunctionOnRegionRetryDUnitTest extends FunctionRetryTestBase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionOnServerRetryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionOnServerRetryDUnitTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.internal.cache.execute;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Test;
@@ -24,8 +23,9 @@ import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class FunctionOnServerRetryDUnitTest extends FunctionRetryTestBase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionOnServersRetryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionOnServersRetryDUnitTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.internal.cache.execute;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Test;
@@ -24,8 +23,9 @@ import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class FunctionOnServersRetryDUnitTest extends FunctionRetryTestBase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRSetOperationJTADUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRSetOperationJTADUnitTest.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import javax.naming.Context;
 import javax.transaction.UserTransaction;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.logging.log4j.Logger;
 import org.junit.Before;
@@ -52,10 +51,11 @@ import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class PRSetOperationJTADUnitTest extends JUnit4CacheTestCase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRSetOperationTXDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRSetOperationTXDUnitTest.java
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.logging.log4j.Logger;
 import org.junit.Before;
@@ -44,10 +43,11 @@ import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class PRSetOperationTXDUnitTest extends JUnit4CacheTestCase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDistributedTest.java
@@ -57,7 +57,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.apache.logging.log4j.Logger;
@@ -103,9 +102,10 @@ import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.categories.RegionsTest;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(RegionsTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class PersistentColocatedPartitionedRegionDistributedTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionDistributedTest.java
@@ -49,7 +49,6 @@ import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -102,11 +101,12 @@ import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.DistributedDiskDirRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Tests the basic use cases for PR persistence.
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial,unused")
 public class PersistentPartitionedRegionDistributedTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentPartitionedRegionWithRedundancyDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentPartitionedRegionWithRedundancyDUnitTest.java
@@ -29,7 +29,6 @@ import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -54,11 +53,12 @@ import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.DistributedDiskDirRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Tests the basic use cases for PR persistence.
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial,unused")
 public class PersistentPartitionedRegionWithRedundancyDUnitTest implements Serializable {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRVVRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRVVRecoveryDUnitTest.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -86,9 +85,10 @@ import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.rules.DistributedErrorCollector;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
 import org.apache.geode.test.junit.categories.PersistenceTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(PersistenceTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
@@ -55,7 +55,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.management.ObjectName;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -102,13 +101,14 @@ import org.apache.geode.test.dunit.rules.DistributedExecutorServiceRule;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 import org.apache.geode.test.junit.rules.serializable.SerializableErrorCollector;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * This is a test of how persistent distributed regions recover. This test makes sure that when
  * multiple VMs are persisting the same region, they recover with the latest data during recovery.
  */
 @Category(PersistenceTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class PersistentRecoveryOrderDUnitTest extends CacheTestCase {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/AsyncEventQueueEntrySynchronizationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/AsyncEventQueueEntrySynchronizationDUnitTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.internal.cache.wan;
 import static junitparams.JUnitParamsRunner.$;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,9 +39,10 @@ import org.apache.geode.internal.cache.versions.VersionSource;
 import org.apache.geode.internal.cache.versions.VersionTag;
 import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.junit.categories.AEQTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({AEQTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AsyncEventQueueEntrySynchronizationDUnitTest extends AsyncEventQueueTestBase {
 
   private static Object[] getRegionShortcuts() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/asyncqueue/SerialAsyncEventListenersDifferentPrimariesDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/asyncqueue/SerialAsyncEventListenersDifferentPrimariesDistributedTest.java
@@ -28,7 +28,6 @@ import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Rule;
@@ -57,10 +56,11 @@ import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.AEQTest;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(AEQTest.class)
 @SuppressWarnings("serial")
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class SerialAsyncEventListenersDifferentPrimariesDistributedTest implements Serializable {
 
   private MemberVM locator;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/CommonAsyncEventQueueDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/CommonAsyncEventQueueDUnitTest.java
@@ -20,7 +20,6 @@ import static org.junit.Assert.fail;
 
 import java.io.Serializable;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -36,9 +35,10 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.junit.categories.AEQTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({AEQTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class CommonAsyncEventQueueDUnitTest extends AsyncEventQueueTestBase {
 
   private static final long serialVersionUID = 1L;

--- a/geode-core/src/integrationTest/java/org/apache/geode/SetOperationTXJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/SetOperationTXJUnitTest.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -43,9 +42,10 @@ import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.cache.TXStateProxyImpl;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 import org.apache.geode.util.internal.GeodeGlossary;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class SetOperationTXJUnitTest {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/integrationTest/java/org/apache/geode/TXExpirationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/TXExpirationIntegrationTest.java
@@ -30,7 +30,6 @@ import static org.mockito.Mockito.verify;
 import java.util.Properties;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -55,13 +54,14 @@ import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.cache.TXStateProxy;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Tests transaction expiration functionality
  *
  * @since GemFire 4.0
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class TXExpirationIntegrationTest {
 
   private static final String REGION_NAME =

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/JoinQueriesIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/JoinQueriesIntegrationTest.java
@@ -21,7 +21,6 @@ import java.io.Serializable;
 import java.util.Calendar;
 import java.util.Date;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Rule;
@@ -36,9 +35,10 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.pdx.PdxInstance;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(OQLQueryTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class JoinQueriesIntegrationTest {
 
   @Rule

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/CompiledGroupBySelectIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/CompiledGroupBySelectIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.Arrays;
 import java.util.List;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,9 +33,10 @@ import org.apache.geode.cache.query.QueryInvalidException;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(OQLQueryTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class CompiledGroupBySelectIntegrationTest {
   private QueryService queryService;
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/DefaultQuerySecurityIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/DefaultQuerySecurityIntegrationTest.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -52,8 +51,9 @@ import org.apache.geode.security.query.data.QueryTestObject;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @Category({OQLQueryTest.class, SecurityTest.class})
 public class DefaultQuerySecurityIntegrationTest {
   private int entries = 500;

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/GroupJunctionIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/GroupJunctionIntegrationTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -42,10 +41,11 @@ import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 @Category(OQLQueryTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class GroupJunctionIntegrationTest {
   private static final int ENTRIES = 1000;
   private static final String REGION_NAME = "testRegion";

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/QueryServiceXmlIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/QueryServiceXmlIntegrationTest.java
@@ -25,7 +25,6 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.apache.commons.io.FileUtils;
@@ -42,8 +41,9 @@ import org.apache.geode.examples.SimpleSecurityManager;
 import org.apache.geode.management.internal.cli.util.TestMethodAuthorizer;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class QueryServiceXmlIntegrationTest {
 
   @Rule

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/AggregateFunctionQueryBaseIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/aggregate/AggregateFunctionQueryBaseIntegrationTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -35,10 +34,11 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 @Category(OQLQueryTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public abstract class AggregateFunctionQueryBaseIntegrationTest {
   static final String firstRegionName = "portfolio1";
   static final String secondRegionName = "portfolio2";

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexManagerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexManagerIntegrationTest.java
@@ -26,7 +26,6 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -49,9 +48,10 @@ import org.apache.geode.internal.cache.InternalRegion;
 import org.apache.geode.test.assertj.LogFileAssert;
 import org.apache.geode.test.junit.categories.OQLIndexTest;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(OQLIndexTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class IndexManagerIntegrationTest {
   private File logFile;
   private final int entries = 100;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -38,7 +38,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -50,8 +49,9 @@ import org.junit.runner.RunWith;
 
 import org.apache.geode.internal.lang.SystemUtils;
 import org.apache.geode.internal.membership.utils.AvailablePort;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AvailablePortHelperIntegrationTest {
 
   private Set<ServerSocket> serverSockets;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/backup/FileSystemBackupWriterTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/backup/FileSystemBackupWriterTest.java
@@ -31,7 +31,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.io.FileUtils;
 import org.junit.After;
@@ -46,8 +45,9 @@ import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.Oplog;
 import org.apache.geode.internal.cache.persistence.DiskStoreID;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class FileSystemBackupWriterTest {
   private static final Path RELATIVE_TARGET_DIR = Paths.get("backupTest");
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/event/DistributedEventTrackerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/event/DistributedEventTrackerIntegrationTest.java
@@ -33,7 +33,6 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.Properties;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Before;
@@ -56,9 +55,10 @@ import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.test.junit.categories.RegionsTest;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({RegionsTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DistributedEventTrackerIntegrationTest {
 
   @Rule

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/map/DestroyEntryDuringCloseIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/map/DestroyEntryDuringCloseIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Before;
@@ -34,12 +33,13 @@ import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * TestCase that emulates the conditions that entry destroy with concurrent destroy region or cache
  * close event will get expected Exception.
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DestroyEntryDuringCloseIntegrationTest {
 
   private static final String KEY = "KEY";

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/wan/asyncqueue/AsyncEventQueueValidationsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/wan/asyncqueue/AsyncEventQueueValidationsJUnitTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.fail;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.awaitility.core.ConditionTimeoutException;
 import org.junit.After;
@@ -46,9 +45,10 @@ import org.apache.geode.internal.cache.wan.AsyncEventQueueConfigurationException
 import org.apache.geode.internal.cache.wan.MyAsyncEventListener;
 import org.apache.geode.internal.cache.wan.MyGatewayEventFilter;
 import org.apache.geode.test.junit.categories.AEQTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({AEQTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AsyncEventQueueValidationsJUnitTest {
 
   private Cache cache;

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/jta/SetOperationJTAJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/jta/SetOperationJTAJUnitTest.java
@@ -29,7 +29,6 @@ import java.util.Map;
 import javax.naming.Context;
 import javax.transaction.UserTransaction;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -52,9 +51,10 @@ import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.cache.TXStateProxyImpl;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 import org.apache.geode.util.internal.GeodeGlossary;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class SetOperationJTAJUnitTest {
   private static final Logger logger = LogService.getLogger();
   private static final String REGION_NAME = "region1";

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/StatArchiveHandlerIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/statistics/StatArchiveHandlerIntegrationTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.mock;
 import java.io.File;
 import java.io.IOException;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -34,12 +33,13 @@ import org.junit.runner.RunWith;
 import org.apache.geode.internal.io.MainWithChildrenRollingFileHandler;
 import org.apache.geode.internal.io.RollingFileHandler;
 import org.apache.geode.test.junit.categories.StatisticsTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Tests behavior that interacts with file system.
  */
 @Category({StatisticsTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class StatArchiveHandlerIntegrationTest {
 
   private File dir;

--- a/geode-core/src/integrationTest/java/org/apache/geode/pdx/JSONFormatterBasicJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/pdx/JSONFormatterBasicJUnitTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.pdx;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -29,13 +28,14 @@ import org.junit.runner.RunWith;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.test.junit.categories.RestAPITest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * A test class to document and make clear what JSONFormatter will and won't parse as far as simple
  * examples.
  */
 @Category({RestAPITest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class JSONFormatterBasicJUnitTest {
   // This is needed because the JsonFormatter needs to access the PDX region, which requires a
   // running Cache.

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteFunctionOpRetryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteFunctionOpRetryTest.java
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Collection;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Test;
@@ -42,13 +41,14 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.internal.cache.execute.MemberMappedArgument;
 import org.apache.geode.internal.cache.execute.ServerFunctionExecutor;
 import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Test retry counts for onServer() function execution (via ExecuteFunctionOp).
  * Convince ourselves they aren't going to ever be infinite!
  */
 @Category({ClientServerTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ExecuteFunctionOpRetryTest {
 
   private static final boolean IS_FN_SERIALIZATION_REQUIRED = false;

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionOpImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionOpImplTest.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -34,13 +33,14 @@ import org.apache.geode.cache.execute.Function;
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.internal.cache.execute.ServerRegionFunctionExecutor;
 import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 
 /**
  * Test ExecutionRegionFunctionOpImpl class
  */
 @Category({ClientServerTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ExecuteRegionFunctionOpImplTest {
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionOpRetryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionOpRetryTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.when;
 import java.util.Collection;
 import java.util.Collections;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Test;
@@ -47,13 +46,14 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
 import org.apache.geode.internal.cache.execute.ServerRegionFunctionExecutor;
 import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Test retry counts on multi-hop on onRegion() function execution (via ExecuteRegionFunctionOp).
  * Ensure they are never infinite!
  */
 @Category({ClientServerTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ExecuteRegionFunctionOpRetryTest {
 
   private ExecuteFunctionTestSupport testSupport;

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionOpTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionOpTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.cache.client.internal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -26,12 +25,13 @@ import org.apache.geode.cache.execute.FunctionException;
 import org.apache.geode.cache.execute.FunctionInvocationTargetException;
 import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
 import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Test multi-hop on region function execution
  */
 @Category({ClientServerTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ExecuteRegionFunctionOpTest {
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionSingleHopOpRetryTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/ExecuteRegionFunctionSingleHopOpRetryTest.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Test;
@@ -44,6 +43,7 @@ import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.internal.cache.execute.ServerRegionFunctionExecutor;
 import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Test retry counts on single-hop onRegion() function execution (via
@@ -51,7 +51,7 @@ import org.apache.geode.test.junit.categories.ClientServerTest;
  * Ensure they are never infinite!
  */
 @Category({ClientServerTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 
 public class ExecuteRegionFunctionSingleHopOpRetryTest {
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/AbstractCompiledValueTestJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/AbstractCompiledValueTestJUnitTest.java
@@ -20,14 +20,14 @@ import static org.junit.Assert.assertTrue;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.query.internal.types.CollectionTypeImpl;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AbstractCompiledValueTestJUnitTest {
 
   private CompiledValue[] getCompiledValuesWhichDoNotImplementGetReceiver() {

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/AttributeDescriptorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/AttributeDescriptorTest.java
@@ -29,7 +29,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,8 +45,9 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.pdx.internal.TypeRegistry;
 import org.apache.geode.security.NotAuthorizedException;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AttributeDescriptorTest {
   private static final String PUBLIC_NO_ACCESSORS = "publicAttributeWithoutAccessors";
   private static final String PUBLIC_ACCESSOR_BY_NAME = "publicAttributeWithPublicAccessor";

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/QCompilerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/QCompilerTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Ignore;
@@ -39,9 +38,10 @@ import org.apache.geode.cache.query.internal.parse.OQLLexerTokenTypes;
 import org.apache.geode.cache.query.security.MethodInvocationAuthorizer;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.test.junit.categories.OQLQueryTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(OQLQueryTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class QCompilerTest {
   private QueryExecutionContext context;
 

--- a/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceImplTest.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -52,8 +51,9 @@ import org.apache.geode.cache.query.security.UnrestrictedMethodAuthorizer;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.management.internal.cli.util.TestMethodAuthorizer;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class QueryConfigurationServiceImplTest {
   private static final Set<String> EMPTY_SET = Collections.emptySet();
   private CqService mockCqService;

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/InternalConfigurationPersistenceServiceTest.java
@@ -35,7 +35,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,8 +55,9 @@ import org.apache.geode.internal.config.JAXBServiceTest.ElementTwo;
 import org.apache.geode.management.configuration.RegionType;
 import org.apache.geode.management.internal.configuration.domain.Configuration;
 import org.apache.geode.management.internal.configuration.utils.XmlUtils;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class InternalConfigurationPersistenceServiceTest {
 
   private InternalConfigurationPersistenceService service;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -55,8 +54,9 @@ import org.apache.geode.internal.cache.partitioned.PartitionedRegionRebalanceOp;
 import org.apache.geode.internal.cache.partitioned.PersistentBucketRecoverer;
 import org.apache.geode.internal.cache.partitioned.RegionAdvisor;
 import org.apache.geode.internal.cache.partitioned.rebalance.RebalanceDirector;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class PRHARedundancyProviderTest {
 
   private InternalCache cache;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -40,7 +40,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -70,8 +69,9 @@ import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
 import org.apache.geode.internal.cache.partitioned.colocation.ColocationLoggerFactory;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings({"deprecation", "unchecked", "unused"})
 public class PartitionedRegionTest {
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/RegionRedundancyStatusImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/RegionRedundancyStatusImplTest.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -35,8 +34,9 @@ import org.junit.runner.RunWith;
 
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.management.runtime.RegionRedundancyStatus;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class RegionRedundancyStatusImplTest {
 
   private PartitionedRegion mockRegion;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/PartitionedRegionLoadModelJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/rebalance/PartitionedRegionLoadModelJUnitTest.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -60,8 +59,9 @@ import org.apache.geode.internal.cache.partitioned.rebalance.model.Member;
 import org.apache.geode.internal.cache.partitioned.rebalance.model.PartitionedRegionLoadModel;
 import org.apache.geode.internal.cache.persistence.PersistentMemberID;
 import org.apache.geode.internal.inet.LocalHostUtil;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class PartitionedRegionLoadModelJUnitTest {
 
   private static final int MAX_MOVES = 5000;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/region/entry/RegionEntryFactoryBuilderJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/region/entry/RegionEntryFactoryBuilderJUnitTest.java
@@ -16,14 +16,15 @@ package org.apache.geode.internal.cache.region.entry;
 
 import static org.junit.Assert.assertEquals;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+
+@RunWith(GeodeParamsRunner.class)
 public class RegionEntryFactoryBuilderJUnitTest {
 
   private RegionEntryFactoryBuilder regionEntryFactoryBuilder;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/wan/GatewaySenderEventImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/wan/GatewaySenderEventImplTest.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -56,8 +55,9 @@ import org.apache.geode.internal.serialization.VersionedDataInputStream;
 import org.apache.geode.internal.serialization.VersionedDataOutputStream;
 import org.apache.geode.internal.util.BlobHelper;
 import org.apache.geode.test.fake.Fakes;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class GatewaySenderEventImplTest {
 
   private GemFireCacheImpl cache;

--- a/geode-core/src/test/java/org/apache/geode/internal/util/HostNameTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/util/HostNameTest.java
@@ -25,7 +25,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,8 +32,10 @@ import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.runner.RunWith;
 
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+
+@RunWith(GeodeParamsRunner.class)
 public class HostNameTest {
 
   private static final String EXPECTED_HOSTNAME = "expected-hostname";

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/DestroyPartitionedRegionMessageDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/DestroyPartitionedRegionMessageDUnitTest.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -48,8 +47,9 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 import org.apache.geode.test.junit.rules.VMProvider;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @Category(ClientSubscriptionTest.class)
 public class DestroyPartitionedRegionMessageDUnitTest implements Serializable {
   private MemberVM server1, server2;

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/InvalidatePartitionedRegionMessageDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/InvalidatePartitionedRegionMessageDUnitTest.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -47,8 +46,9 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 import org.apache.geode.test.junit.rules.VMProvider;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @Category(ClientSubscriptionTest.class)
 public class InvalidatePartitionedRegionMessageDUnitTest implements Serializable {
   private MemberVM server1, server2;

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/internal/QueryConfigurationServiceConstraintsDistributedTest.java
@@ -38,7 +38,6 @@ import java.util.function.Consumer;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.NamedParameters;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
@@ -73,9 +72,10 @@ import org.apache.geode.test.junit.categories.OQLQueryTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({OQLQueryTest.class, SecurityTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class QueryConfigurationServiceConstraintsDistributedTest implements Serializable {
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/PutAllClientServerDistributedTest.java
@@ -59,7 +59,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.After;
@@ -118,6 +117,7 @@ import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Tests putAll for c/s. Also tests removeAll
@@ -125,7 +125,7 @@ import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolde
  * @since GemFire 5.0.23
  */
 @Category({ClientServerTest.class, ClientSubscriptionTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial,NumericCastThatLosesPrecision")
 public class PutAllClientServerDistributedTest implements Serializable {
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandDistributedTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandDistributedTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.lang.reflect.Method;
 import java.util.Objects;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -45,8 +44,9 @@ import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AlterQueryServiceCommandDistributedTest {
   private static final String REPLICATE_REGION_NAME = "ReplicateRegion";
   private static final String PARTITION_REGION_NAME = "PartitionRegion";

--- a/geode-dunit/src/test/java/org/apache/geode/test/dunit/internal/VMEventNotifierTest.java
+++ b/geode-dunit/src/test/java/org/apache/geode/test/dunit/internal/VMEventNotifierTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Before;
@@ -37,11 +36,12 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.VMEventListener;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Unit tests for {@link VMEventNotifier};
  */
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class VMEventNotifierTest {
 
   private static final long TIMEOUT_MILLIS = GeodeAwaitility.getTimeout().toMillis();

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandWithSecurityDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterQueryServiceCommandWithSecurityDUnitTest.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import org.apache.commons.io.FileUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
@@ -59,8 +58,9 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.VMProvider;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AlterQueryServiceCommandWithSecurityDUnitTest {
   private static final Class<RestrictedMethodAuthorizer> DEFAULT_AUTHORIZER_CLASS =
       RestrictedMethodAuthorizer.class;

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterTimeToLiveExpirationOnProxyRegionDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterTimeToLiveExpirationOnProxyRegionDUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.Rule;
@@ -26,9 +25,10 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.EvictionTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({EvictionTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AlterTimeToLiveExpirationOnProxyRegionDUnitTest {
   @Rule
   public ClusterStartupRule clusterStartupRule = new ClusterStartupRule();

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DiskStoreCommandsDUnitTest.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
@@ -58,9 +57,10 @@ import org.apache.geode.test.junit.assertions.CommandResultAssert;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(PersistenceTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DiskStoreCommandsDUnitTest implements Serializable {
   private static final String GROUP = "GROUP1";
   private static final String GROUP2 = "GROUP2";

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ExportStackTraceCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ExportStackTraceCommandDUnitTest.java
@@ -23,7 +23,6 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -35,8 +34,9 @@ import org.junit.runner.RunWith;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ExportStackTraceCommandDUnitTest {
 
   @ClassRule

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ListMembersCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ListMembersCommandDUnitTest.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.junit.BeforeClass;
@@ -36,8 +35,9 @@ import org.apache.geode.management.internal.cli.result.CommandResult;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ListMembersCommandDUnitTest {
   private static MemberVM locator1, locator2;
   private Pattern pattern = Pattern.compile("(.*)locator-0(.*)\\[Coordinator]");

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/OfflineDiskStoreCommandsDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/OfflineDiskStoreCommandsDUnitTest.java
@@ -37,7 +37,6 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,8 +52,9 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class OfflineDiskStoreCommandsDUnitTest implements Serializable {
   private static final String REGION_NAME = "testRegion";
   private static final String DISK_STORE_ID = "testDisk";

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RebalanceMembersColocationTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RebalanceMembersColocationTest.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -36,10 +35,11 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 
 @Category(PersistenceTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class RebalanceMembersColocationTest {
 
   public static final String PARENT_REGION_NAME = "parentRegion";

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/VersionCommandJUnitTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/VersionCommandJUnitTest.java
@@ -24,7 +24,6 @@ import static org.apache.geode.internal.VersionDescription.SOURCE_REPOSITORY;
 import static org.apache.geode.internal.VersionDescription.SOURCE_REVISION;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -36,9 +35,10 @@ import org.apache.geode.internal.GemFireVersion;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.LocatorStarterRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({GfshTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class VersionCommandJUnitTest {
   private static final String[] EXPECTED_FULL_DATA =
       {BUILD_ID, BUILD_JAVA_VERSION, BUILD_PLATFORM, PRODUCT_NAME, PRODUCT_VERSION,

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -60,7 +60,7 @@ dependencies {
 
   api('org.skyscreamer:jsonassert')
 
-  testImplementation('pl.pragmatists:JUnitParams')
+  implementation('pl.pragmatists:JUnitParams')
 
   integrationTestImplementation(project(':geode-core'))
   integrationTestImplementation(project(':geode-serialization'))

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/runners/GeodeParamsRunner.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/runners/GeodeParamsRunner.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.runners;
+
+import junitparams.JUnitParamsRunner;
+import org.junit.runners.model.InitializationError;
+
+public class GeodeParamsRunner extends JUnitParamsRunner {
+  public GeodeParamsRunner(Class<?> testClass) throws InitializationError {
+    super(testClass);
+  }
+}

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.ComparisonFailure;
@@ -39,7 +38,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.MultipleFailureException;
 
-@RunWith(JUnitParamsRunner.class)
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
+
+@RunWith(GeodeParamsRunner.class)
 public class ConcurrencyRuleTest {
   private final AtomicBoolean invoked = new AtomicBoolean();
   private final AtomicBoolean retVal = new AtomicBoolean();

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -138,5 +138,10 @@
       <artifactId>jsonassert</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/EvictionDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/EvictionDUnitTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,10 +36,11 @@ import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.control.HeapMemoryMonitor;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class EvictionDUnitTest extends LuceneQueriesAccessorBase {
 
   protected static final float INITIAL_EVICTION_HEAP_PERCENTAGE = 50.9f;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/ExpirationDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/ExpirationDUnitTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.Collection;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,9 +32,10 @@ import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.Region;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ExpirationDUnitTest extends LuceneQueriesAccessorBase {
 
   protected static final int EXTRA_WAIT_TIME_SEC = 15;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneClientSecurityDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneClientSecurityDUnitTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,9 +46,10 @@ import org.apache.geode.security.NotAuthorizedException;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({SecurityTest.class, LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneClientSecurityDUnitTest extends LuceneQueriesAccessorBase {
 
   @Test

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneClientSecurityPostProcessingDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneClientSecurityPostProcessingDUnitTest.java
@@ -27,7 +27,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -53,9 +52,10 @@ import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.ClientCacheRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({SecurityTest.class, LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneClientSecurityPostProcessingDUnitTest extends LuceneQueriesAccessorBase {
 
   private VM accessor2;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneClientSecurityWithRegionCreatedBeforeIndexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneClientSecurityWithRegionCreatedBeforeIndexDUnitTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.cache.lucene;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.INDEX_NAME;
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -29,9 +28,10 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.lucene.internal.LuceneIndexFactoryImpl;
 import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({SecurityTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneClientSecurityWithRegionCreatedBeforeIndexDUnitTest
     extends LuceneClientSecurityDUnitTest {
 

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneCommandsSecurityDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneCommandsSecurityDUnitTest.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.Serializable;
 import java.util.Properties;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -43,9 +42,10 @@ import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({SecurityTest.class, LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneCommandsSecurityDUnitTest {
 
   @Rule

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneCommandsSecurityWithRegionCreatedBeforeIndexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneCommandsSecurityWithRegionCreatedBeforeIndexDUnitTest.java
@@ -15,8 +15,6 @@
 package org.apache.geode.cache.lucene;
 
 
-
-import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -27,9 +25,10 @@ import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({SecurityTest.class, LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneCommandsSecurityWithRegionCreatedBeforeIndexDUnitTest
     extends LuceneCommandsSecurityDUnitTest {
 

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationDUnitTest.java
@@ -39,7 +39,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
@@ -60,9 +59,10 @@ import org.apache.geode.cache.lucene.test.TestObject;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneIndexCreationDUnitTest extends LuceneDUnitTest {
 
   @Rule

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationOnFixedPRDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationOnFixedPRDUnitTest.java
@@ -17,15 +17,15 @@ package org.apache.geode.cache.lucene;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneIndexCreationOnFixedPRDUnitTest extends LuceneIndexCreationDUnitTest {
 
   @Override

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
@@ -29,7 +29,6 @@ import java.io.File;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -50,9 +49,10 @@ import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
 
   private static final String INDEX1_NAME = INDEX_NAME + "1";

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesClientDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesClientDUnitTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.cache.lucene;
 
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -28,9 +27,10 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.test.dunit.SerializableCallableIF;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesClientDUnitTest extends LuceneQueriesDUnitTest {
 
   @Override

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesDUnitTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.fail;
 
 import java.util.Properties;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.TermQuery;
@@ -42,6 +41,7 @@ import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * This test class is intended to contain basic integration tests of the lucene query class that
@@ -49,7 +49,7 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  *
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesDUnitTest extends LuceneQueriesAccessorBase {
 
   private static final long serialVersionUID = 1L;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexClientDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexClientDUnitTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.cache.lucene;
 
 import static org.apache.geode.cache.lucene.test.LuceneTestUtilities.REGION_NAME;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
@@ -28,6 +27,7 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.test.dunit.SerializableCallableIF;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * This test class is intended to contain basic integration tests of the lucene query class that
@@ -35,7 +35,7 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  *
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesReindexClientDUnitTest extends LuceneQueriesReindexDUnitTest {
 
   private static final long serialVersionUID = 1L;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,6 +32,7 @@ import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * This test class is intended to contain basic integration tests of the lucene query class that
@@ -40,7 +40,7 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  *
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
 
   private static final long serialVersionUID = 1L;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithRegionCreatedBeforeReindexClientDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithRegionCreatedBeforeReindexClientDUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.cache.lucene;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -24,9 +23,10 @@ import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesWithRegionCreatedBeforeReindexClientDUnitTest
     extends LuceneQueriesClientDUnitTest {
 

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithRegionCreatedBeforeReindexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithRegionCreatedBeforeReindexDUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.cache.lucene;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -24,6 +23,7 @@ import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * This test class is intended to contain basic integration tests of the lucene query class that
@@ -31,7 +31,7 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  *
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesWithRegionCreatedBeforeReindexDUnitTest extends LuceneQueriesDUnitTest {
 
   private static final long serialVersionUID = 1L;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithReindexFlagEnabledClientDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithReindexFlagEnabledClientDUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.cache.lucene;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -22,9 +21,10 @@ import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesWithReindexFlagEnabledClientDUnitTest
     extends LuceneQueriesClientDUnitTest {
 

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithReindexFlagEnabledDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithReindexFlagEnabledDUnitTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.cache.lucene;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -22,6 +21,7 @@ import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.lucene.internal.LuceneServiceImpl;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * This test class is intended to contain basic integration tests of the lucene query class that
@@ -29,7 +29,7 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  *
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesWithReindexFlagEnabledDUnitTest extends LuceneQueriesDUnitTest {
 
   private static final long serialVersionUID = 1L;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/MixedObjectIndexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/MixedObjectIndexDUnitTest.java
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,9 +36,10 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class MixedObjectIndexDUnitTest extends LuceneQueriesAccessorBase {
 
   protected RegionTestableType[] getPartitionRegionTypes() {

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/PaginationDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/PaginationDUnitTest.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -38,9 +37,10 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.test.dunit.Assert;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class PaginationDUnitTest extends LuceneQueriesAccessorBase {
   protected static final int PAGE_SIZE = 2;
   protected static final int FLUSH_WAIT_TIME_MS = 60000;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/RebalanceDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/RebalanceDUnitTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Test;
@@ -34,6 +33,7 @@ import org.apache.geode.cache.lucene.test.LuceneTestUtilities;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * This test class adds more basic tests of lucene functionality for partitioned regions. These
@@ -41,7 +41,7 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  *
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class RebalanceDUnitTest extends LuceneQueriesAccessorBase {
 
   protected static int NUM_BUCKETS = 10;

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/RebalanceWithRedundancyDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/RebalanceWithRedundancyDUnitTest.java
@@ -24,7 +24,6 @@ import java.io.Serializable;
 import java.util.concurrent.CountDownLatch;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.After;
 import org.junit.Test;
@@ -44,9 +43,10 @@ import org.apache.geode.internal.cache.InitialImageOperation.GIITestHookType;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class RebalanceWithRedundancyDUnitTest extends LuceneQueriesAccessorBase {
 
   @After

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/RebalanceWithRedundancyWithRegionCreatedBeforeReindexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/RebalanceWithRedundancyWithRegionCreatedBeforeReindexDUnitTest.java
@@ -21,7 +21,6 @@ import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import java.util.Set;
 import java.util.stream.IntStream;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.logging.log4j.Logger;
 import org.junit.After;
@@ -48,9 +47,10 @@ import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class RebalanceWithRedundancyWithRegionCreatedBeforeReindexDUnitTest
     extends LuceneQueriesAccessorBase {
 

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/internal/cli/DestroyLuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/internal/cli/DestroyLuceneIndexCommandsDUnitTest.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,9 +47,10 @@ import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.assertions.CommandResultAssert;
 import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(LuceneTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DestroyLuceneIndexCommandsDUnitTest implements Serializable {
 
   @Rule

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationIntegrationTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationIntegrationTest.java
@@ -37,7 +37,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
@@ -68,6 +67,7 @@ import org.apache.geode.internal.cache.BucketNotFoundException;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Tests of creating lucene indexes on regions. All tests of index creation use cases should be in
@@ -78,7 +78,7 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  * </ul>
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneIndexCreationIntegrationTest extends LuceneIntegrationTest {
 
   @Rule

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationPersistenceIntegrationTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationPersistenceIntegrationTest.java
@@ -40,7 +40,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.function.Consumer;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
@@ -57,12 +56,13 @@ import org.apache.geode.cache.lucene.test.TestObject;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Tests of lucene index creation that use persistence
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneIndexCreationPersistenceIntegrationTest extends LuceneIntegrationTest {
 
   @Rule

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/LuceneQueriesPersistenceIntegrationTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/LuceneQueriesPersistenceIntegrationTest.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotNull;
 import java.io.File;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -40,12 +39,13 @@ import org.apache.geode.internal.cache.EvictionAttributesImpl;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * Tests of lucene index creation that use persistence
  */
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneQueriesPersistenceIntegrationTest extends LuceneIntegrationTest {
 
   @Rule

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsIntegrationTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/internal/cli/LuceneIndexCommandsIntegrationTest.java
@@ -30,7 +30,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
@@ -62,9 +61,10 @@ import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.ServerStarterRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(LuceneTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 @SuppressWarnings("serial")
 public class LuceneIndexCommandsIntegrationTest {
 

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexCreationProfileJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneIndexCreationProfileJUnitTest.java
@@ -33,7 +33,6 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
@@ -51,9 +50,10 @@ import org.apache.geode.cache.lucene.test.LuceneTestUtilities;
 import org.apache.geode.internal.HeapDataOutputStream;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({LuceneTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneIndexCreationProfileJUnitTest {
 
   @Test

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/commands/LuceneIndexCommandsJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/cli/commands/LuceneIndexCommandsJUnitTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordAnalyzer;
@@ -78,6 +77,7 @@ import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.functions.CliFunctionResult;
 import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.test.junit.categories.LuceneTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * The LuceneIndexCommandsJUnitTest class is a test suite of test cases testing the contract and
@@ -90,7 +90,7 @@ import org.apache.geode.test.junit.categories.LuceneTest;
  * @see LuceneSearchIndexCommand
  */
 @Category(LuceneTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class LuceneIndexCommandsJUnitTest {
 
   private InternalCache mockCache;

--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSUtilTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/GMSUtilTest.java
@@ -22,15 +22,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.net.InetAddress;
 import java.util.List;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.apache.geode.distributed.internal.membership.api.MembershipConfigurationException;
 import org.apache.geode.distributed.internal.tcpserver.HostAndPort;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class GMSUtilTest {
 
   static final int PORT = 1234; // any old port--no need to have anything actually bound here

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/AsyncEventQueueOverflowMBeanAttributesDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/AsyncEventQueueOverflowMBeanAttributesDistributedTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -37,9 +36,10 @@ import org.apache.geode.internal.cache.wan.parallel.ParallelGatewaySenderQueue;
 import org.apache.geode.management.AsyncEventQueueMXBean;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({WanTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AsyncEventQueueOverflowMBeanAttributesDistributedTest extends AsyncEventQueueTestBase {
 
   @Test

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/GatewaySenderOverflowMBeanAttributesDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/GatewaySenderOverflowMBeanAttributesDistributedTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -35,9 +34,10 @@ import org.apache.geode.internal.cache.wan.parallel.ParallelGatewaySenderQueue;
 import org.apache.geode.management.GatewaySenderMXBean;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({WanTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class GatewaySenderOverflowMBeanAttributesDistributedTest extends WANTestBase {
 
   @Test

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationDUnitTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -49,9 +48,10 @@ import org.apache.geode.test.dunit.LogWriterUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({WanTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ParallelWANPropagationDUnitTest extends WANTestBase {
   private static final long serialVersionUID = 1L;
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/CreateGatewayReceiverCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/wancommand/CreateGatewayReceiverCommandDUnitTest.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -50,12 +49,13 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.WanTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 /**
  * DUnit tests for 'create gateway-receiver' command.
  */
 @Category(WanTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class CreateGatewayReceiverCommandDUnitTest {
 
   private static final String SERVER_1 = "server-1";

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigurationIndexWithFromClauseDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/configuration/ClusterConfigurationIndexWithFromClauseDUnitTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.management.internal.configuration;
 
 import static org.junit.Assert.assertTrue;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Before;
 import org.junit.Rule;
@@ -33,9 +32,10 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.WanTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({WanTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ClusterConfigurationIndexWithFromClauseDUnitTest {
 
   final String REGION_NAME = "region";

--- a/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeCommandDistributedTest.java
+++ b/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeCommandDistributedTest.java
@@ -36,7 +36,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
@@ -53,9 +52,10 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category(GfshTest.class)
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class AlterRuntimeCommandDistributedTest {
 
   @Rule

--- a/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommandDUnitTest.java
+++ b/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DescribeConfigCommandDUnitTest.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Properties;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,9 +36,10 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({GfshTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class DescribeConfigCommandDUnitTest {
   @Rule
   public ClusterStartupRule startupRule = new ClusterStartupRule().withLogFile();

--- a/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandDUnitTest.java
+++ b/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ExportConfigCommandDUnitTest.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.junit.Rule;
 import org.junit.Test;
@@ -35,9 +34,10 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.GfshTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({GfshTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class ExportConfigCommandDUnitTest {
 
   @Rule


### PR DESCRIPTION
Migrate all uses of `JUnitParamsRunner` to use a new runner that can be
made compatible with JUnit 5.

PROBLEM

We want to upgrade Geode to use JUnit 5. JUnit 5 includes a test engine
called JUnit Vintage, which it uses to run JUnit 4 tests. JUnit Vintage
interacts with test runners differently than JUnit 4 did.

`JUnitParamsRunner` is incompatible with JUnit Vintage in several ways:
- When `JUnitParamsRunner` describes parameterized tests, it discards
  the `@Category` annotation that JUnit Vintage uses to filter tests by
  category.
- When JUnit Vintage asks `JUnitParamsRunner` to filter tests by name,
  the runner fails to apply the filter to parameterized tests.

The net result is that when JUnit Vintage tries to filter tests by
category, `JUnitParamsRunner` runs every parameterized test, including
tests that lack the category. This affects the Windows Gfsh distributed
test job in particular, causing it to run 900 tests instead of the
desired 200. Numerous of the extra 700 tests fail on Windows.

This problem prevents us from upgrading to JUnit 5.

`JUnitParamsRunner` is no longer maintained. It will not be made
compatible with JUnit Vintage.

Approximately 140 test classes use `JUnitParamsRunner`. To upgrade to
JUnit 5, we will have to migrate all of these tests to use a runner
compatible with JUnit Vintage.

SOLUTION

The solution involves two steps:
1. Migrate every existing use of `JUnitParamsRunner` to instead use a
   new `GeodeParamsRunner` that behaves identically to
   `JUnitParamsRunner`.
2. Upgrade Geode to use JUnit 5.

This PR implements step 1. This PR implements a "dummy" version of
`GeodeParamsRunner` that behaves identically to `JUnitParamsRunner`. Its
only purpose is to allow migrating approximately 140 test classes to use
the new runner name.

I will implement step 2 in a later PR. This will include re-implementing
`GeodeParamsRunner` to be compatible with JUnit 5. (I have verified the
viability of this via a spike.)

Separating the "migrate the tests" and "upgrade JUnit" steps into
separate PRs makes each PR much more focused and much easier to review.
