### PR TITLE
GEODE-9624: Fix 'status redundancy' result for empty regions

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImpl.java
@@ -53,7 +53,7 @@ public class SerializableRegionRedundancyStatusImpl extends
    * @param region The region for which the lowest redundancy should be calculated.
    * @return The redundancy of the least redundant bucket in the region.
    */
-  private int calculateLowestRedundancy(PartitionedRegion region) {
+  int calculateLowestRedundancy(PartitionedRegion region) {
     int numBuckets = region.getPartitionAttributes().getTotalNumBuckets();
     int minRedundancy = Integer.MAX_VALUE;
     for (int i = 0; i < numBuckets; i++) {
@@ -64,7 +64,7 @@ public class SerializableRegionRedundancyStatusImpl extends
         minRedundancy = bucketRedundancy;
       }
     }
-    return minRedundancy;
+    return minRedundancy == Integer.MAX_VALUE ? 0 : minRedundancy;
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImplTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.control;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.management.runtime.RegionRedundancyStatus;
+
+public class SerializableRegionRedundancyStatusImplTest {
+
+  SerializableRegionRedundancyStatusImpl redundancyStatus;
+  PartitionedRegion prMock;
+
+  @Before
+  public void setUp() {
+    prMock = mock(PartitionedRegion.class, RETURNS_DEEP_STUBS);
+  }
+
+  @Test
+  public void calculateLowestRedundancyReturnsZeroWhenRegionIsEmpty() {
+    redundancyStatus = new SerializableRegionRedundancyStatusImpl();
+    when(prMock.getPartitionAttributes().getTotalNumBuckets()).thenReturn(113);
+    when(prMock.getRegionAdvisor().getBucketRedundancy(anyInt())).thenReturn(-1);
+    assertThat(redundancyStatus.calculateLowestRedundancy(prMock)).isEqualTo(0);
+  }
+
+  @Test
+  public void redundancyStatusOfAnEmptyRegionIsEqualToNoRedundantCopies() {
+    when(prMock.getPartitionAttributes().getTotalNumBuckets()).thenReturn(113);
+    when(prMock.getRegionAdvisor().getBucketRedundancy(anyInt())).thenReturn(-1);
+    when(prMock.getRedundantCopies()).thenReturn(1);
+    redundancyStatus = new SerializableRegionRedundancyStatusImpl(prMock);
+    assertThat(redundancyStatus.getStatus())
+        .isEqualTo(RegionRedundancyStatus.RedundancyStatus.NO_REDUNDANT_COPIES);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/control/SerializableRegionRedundancyStatusImplTest.java
@@ -45,7 +45,7 @@ public class SerializableRegionRedundancyStatusImplTest {
   }
 
   @Test
-  public void redundancyStatusOfAnEmptyRegionIsEqualToNoRedundantCopies() {
+  public void redundancyStatusOfRegionWithNoBucketsCreatedIsEqualToNoRedundantCopies() {
     when(prMock.getPartitionAttributes().getTotalNumBuckets()).thenReturn(113);
     when(prMock.getRegionAdvisor().getBucketRedundancy(anyInt())).thenReturn(-1);
     when(prMock.getRedundantCopies()).thenReturn(1);

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StatusRedundancyCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/StatusRedundancyCommandDUnitTest.java
@@ -206,7 +206,7 @@ public class StatusRedundancyCommandDUnitTest {
   }
 
   @Test
-  public void statusRedundancyReturnsEmptyRegionStatusAsSatisfied() {
+  public void statusRedundancyReturnsEmptyRegionStatusCorrectly() {
     createRegion();
     doPutAndRemove();
     String command = new CommandStringBuilder(STATUS_REDUNDANCY).getCommandString();


### PR DESCRIPTION
When a partition redundant region is empty, `status redundancy` command shows a wrong redundancy value for that region.

```
gfsh>status redundancy
Number of regions with zero redundant copies = 0
Number of regions with partially satisfied redundancy = 1
Number of regions with fully satisfied redundancy = 0

Redundancy is partially satisfied for regions: 
  test redundancy status: NOT_SATISFIED. Desired redundancy is 1 and actual redundancy is 2147483647.
```

Problem is in `SerializableRegionRedundancyStatusImpl` class. The `calculateLowestRedundancy` initializes `minRedundancy` variable with `Integer.MAX_VALUE`. But for empty regions, all buckets have redundancy -1, so `minRedundancy` is not modified, and returned with that value.

I propose to check `minRedundancy` value before returning it. If its value is `Integer.MAX_VALUE`, the region is empty so I think the method should return `0`.

Notice that after this change, the redundancy status of an empty region will be reported as `RedundancyStatus.NO_REDUNDANT_COPIES` instead of `RedundancyStatus.NOT_SATISFIED`.



