### PR TITLE
GEODE-9581: Fix possible sending of duplicate events

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderQueue.java
@@ -314,7 +314,8 @@ public class SerialGatewaySenderQueue implements RegionQueue {
     }
     boolean wasEmpty = lastDispatchedKey == lastDestroyedKey;
     Long key = peekedIds.remove();
-    if (!extraPeekedIds.remove(key)) {
+    boolean isExtraPeekedId = extraPeekedIds.contains(key);
+    if (!isExtraPeekedId) {
       updateHeadKey(key);
       lastDispatchedKey = key;
     } else {
@@ -338,12 +339,15 @@ public class SerialGatewaySenderQueue implements RegionQueue {
       }
     }
 
-    // Update head key and lastDispatchedKey with those extraPeekedIds removed
-    // that are consecutive to lastDispatchedKey so that they are not returned
-    // later by peekAhead given that they were already sent.
+    // For those extraPeekedIds removed that are consecutive to lastDispatchedKey:
+    // - Update lastDispatchedKey with them so that they are removed
+    // by the batch removal thread.
+    // - Update the head key with them.
+    // - Remove them from extraPeekedIds.
     long tmpKey = lastDispatchedKey;
     while (extraPeekedIdsRemovedButPreviousIdNotRemoved.contains(tmpKey = inc(tmpKey))) {
       extraPeekedIdsRemovedButPreviousIdNotRemoved.remove(tmpKey);
+      extraPeekedIds.remove(tmpKey);
       updateHeadKey(tmpKey);
       lastDispatchedKey = tmpKey;
     }


### PR DESCRIPTION
When group-transaction-events is set for a serial
gateway sender there is a small chance that duplicated
events are sent by the sender.

The reason behind is a bug in the serial gateway sender.

When the remove() method of the SerialGatewaySenderQueue
was invoked for an event that was peeked to complete
a transaction, it was also removed from the extraPeekedIds
structure.
This provoked that events already peeked, were peeked
again by SerialGatewaySenderQueue.peekAhead() when
they should not have been.

A change has been made in the remove() method so
that events that were peeked to complete a transaction
are only removed from the extraPeekedIds when a call
to remove() has been made previously for that event
(the events is in extraPeekedIdsRemovedButPreviousIdNotRemoved)
and the previous event is the lastDispatchedKey.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
