### PR TITLE
GEODE-9495: limit thread sleep in pub sub native redis acceptance test

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -45,7 +45,7 @@ public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTe
             new BufferedReader(new FileReader("/proc/sys/net/ipv4/tcp_fin_timeout"));
         String line = bufferedReader.readLine();
         if (line != null) {
-          socketTimeWaitMsec = Long.parseLong(line.trim());
+          socketTimeWaitMsec = 1000 * Long.parseLong(line.trim());
         }
       } catch (NumberFormatException | IOException ignored) {
       }

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -57,7 +57,6 @@ public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTe
         String[] parts = line.split(":");
         if (parts.length == 2) {
           socketTimeWaitMsec = 2 * Long.parseLong(parts[1].trim());
-          System.out.println("TIME_WAIT: " + socketTimeWaitMsec);
         }
       } catch (NumberFormatException | IOException ignored) {
       }

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -21,17 +21,13 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 
 import org.apache.commons.lang3.SystemUtils;
-import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
 import org.apache.geode.NativeRedisTestRule;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 
 public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTest {
-
-  private static final Logger logger = LogService.getLogger();
   private static long socketTimeWaitMsec = 90000;
 
   @ClassRule

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -61,16 +61,6 @@ public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTe
         }
       } catch (NumberFormatException | IOException ignored) {
       }
-    } else if (SystemUtils.IS_OS_WINDOWS) {
-      try {
-        process = Runtime.getRuntime().exec(
-            "reg query HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters /v TcpTimedWaitDelay");
-        BufferedReader reader = new BufferedReader(
-            new InputStreamReader(process.getInputStream()));
-        String line = reader.readLine();
-        socketTimeWaitMsec = Long.parseLong(line.trim());
-      } catch (NumberFormatException | IOException ignored) {
-      }
     }
     // Just leave timeout at the default if it's some other OS or there's a problem getting OS value
   }

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -46,8 +46,7 @@ public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTe
             new InputStreamReader(process.getInputStream()));
         String line = reader.readLine();
         socketTimeWaitMsec = Long.parseLong(line.trim());
-      } catch (NumberFormatException nfe) {
-      } catch (IOException ioe){
+      } catch (NumberFormatException | IOException ignored) {
       }
     } else if (SystemUtils.IS_OS_MAC) {
       try {
@@ -60,22 +59,20 @@ public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTe
           socketTimeWaitMsec = 2 * Long.parseLong(parts[1].trim());
           System.out.println("TIME_WAIT: " + socketTimeWaitMsec);
         }
-      } catch (NumberFormatException ignored) {
-      } catch (IOException ignored){
+      } catch (NumberFormatException | IOException ignored) {
       }
     } else if (SystemUtils.IS_OS_WINDOWS) {
-      // get Windows TIME_WAIT
       try {
-        process = Runtime.getRuntime().exec("reg query HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters /v TcpTimedWaitDelay");
+        process = Runtime.getRuntime().exec(
+            "reg query HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters /v TcpTimedWaitDelay");
         BufferedReader reader = new BufferedReader(
             new InputStreamReader(process.getInputStream()));
         String line = reader.readLine();
         socketTimeWaitMsec = Long.parseLong(line.trim());
-      } catch (NumberFormatException ignored) {
-      } catch (IOException ignored){
+      } catch (NumberFormatException | IOException ignored) {
       }
     }
-    // Just leave timeout at the default if it's some other OS
+    // Just leave timeout at the default if it's some other OS or there's a problem getting OS value
   }
 
 

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -38,22 +38,15 @@ public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTe
 
   @BeforeClass
   public static void runOnce() throws IOException {
-    Process process;
     if (SystemUtils.IS_OS_LINUX) {
       try {
-        process = Runtime.getRuntime().exec("cat /proc/sys/net/ipv4/tcp_fin_timeout");
-        BufferedReader reader = new BufferedReader(
-            new InputStreamReader(process.getInputStream()));
-        String line = reader.readLine();
+        String line = getCommandOutput("cat /proc/sys/net/ipv4/tcp_fin_timeout");
         socketTimeWaitMsec = Long.parseLong(line.trim());
       } catch (NumberFormatException | IOException ignored) {
       }
     } else if (SystemUtils.IS_OS_MAC) {
       try {
-        process = Runtime.getRuntime().exec("sysctl net.inet.tcp.msl");
-        BufferedReader reader = new BufferedReader(
-            new InputStreamReader(process.getInputStream()));
-        String line = reader.readLine();
+        String line = getCommandOutput("sysctl net.inet.tcp.msl");
         String[] parts = line.split(":");
         if (parts.length == 2) {
           socketTimeWaitMsec = 2 * Long.parseLong(parts[1].trim());
@@ -64,6 +57,12 @@ public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTe
     // Just leave timeout at the default if it's some other OS or there's a problem getting OS value
   }
 
+  private static String getCommandOutput(String commandString) throws IOException {
+    Process process = Runtime.getRuntime().exec(commandString);
+    BufferedReader reader = new BufferedReader(
+        new InputStreamReader(process.getInputStream()));
+    return reader.readLine();
+  }
 
   @AfterClass
   public static void cleanup() throws InterruptedException {

--- a/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/executor/pubsub/PubSubNativeRedisAcceptanceTest.java
@@ -81,10 +81,9 @@ public class PubSubNativeRedisAcceptanceTest extends AbstractPubSubIntegrationTe
     // This test consumes a lot of sockets and any subsequent tests may fail because of spurious
     // bind exceptions. Even though sockets are closed, they will remain in TIME_WAIT state so we
     // need to wait for that to clear up. It shouldn't take more than a minute or so.
-    // There will be a better solution for this from GEODE-9495, but for now a thread sleep is the
-    // simplest way to wait for the sockets to be out of the TIME_WAIT state. The timeout of 240 sec
-    // was chosen because that is the default duration for TIME_WAIT on Windows. The timeouts for
-    // both mac and linux are significantly shorter.
+    // For now a thread sleep is the simplest way to wait for the sockets to be out of the TIME_WAIT
+    // state. The default timeout of 240 sec was chosen because that is the default duration for
+    // TIME_WAIT on Windows. The timeouts for both mac and linux are significantly shorter.
     Thread.sleep(socketTimeWaitMsec);
   }
 


### PR DESCRIPTION
Update how we get and calculate the TIME_WAIT value on Linux, as well as reduce the default thread sleep to 90 seconds.