### PR TITLE
Revert "GEODE-7309: uplift lucene to 7.1.0 (#6351)"

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -555,32 +555,27 @@
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-analyzers-common</artifactId>
-        <version>7.1.0</version>
+        <version>6.6.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-analyzers-phonetic</artifactId>
-        <version>7.1.0</version>
+        <version>6.6.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-core</artifactId>
-        <version>7.1.0</version>
+        <version>6.6.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-queryparser</artifactId>
-        <version>7.1.0</version>
+        <version>6.6.6</version>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>
         <artifactId>lucene-test-framework</artifactId>
-        <version>7.1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.lucene</groupId>
-        <artifactId>lucene-backward-codecs</artifactId>
-        <version>7.1.0</version>
+        <version>6.6.6</version>
       </dependency>
       <dependency>
         <groupId>org.hamcrest</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -209,13 +209,12 @@ class DependencyConstraints implements Plugin<Project> {
       entry('log4j-slf4j-impl')
     }
 
-    dependencySet(group: 'org.apache.lucene', version: '7.1.0') {
+    dependencySet(group: 'org.apache.lucene', version: '6.6.6') {
       entry('lucene-analyzers-common')
       entry('lucene-analyzers-phonetic')
       entry('lucene-core')
       entry('lucene-queryparser')
       entry('lucene-test-framework')
-      entry('lucene-backward-codecs')
     }
 
     dependencySet(group: 'org.hamcrest', version: '2.2') {

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1036,11 +1036,11 @@ lib/log4j-core-2.14.1.jar
 lib/log4j-jcl-2.14.1.jar
 lib/log4j-jul-2.14.1.jar
 lib/log4j-slf4j-impl-2.14.1.jar
-lib/lucene-analyzers-common-7.1.0.jar
-lib/lucene-analyzers-phonetic-7.1.0.jar
-lib/lucene-core-7.1.0.jar
-lib/lucene-queries-7.1.0.jar
-lib/lucene-queryparser-7.1.0.jar
+lib/lucene-analyzers-common-6.6.6.jar
+lib/lucene-analyzers-phonetic-6.6.6.jar
+lib/lucene-core-6.6.6.jar
+lib/lucene-queries-6.6.6.jar
+lib/lucene-queryparser-6.6.6.jar
 lib/micrometer-core-1.7.3.jar
 lib/mx4j-3.0.2.jar
 lib/mx4j-remote-3.0.2.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -81,10 +81,10 @@ jetty-util-9.4.43.v20210629.jar
 log4j-slf4j-impl-2.14.1.jar
 log4j-core-2.14.1.jar
 log4j-jul-2.14.1.jar
-lucene-analyzers-phonetic-7.1.0.jar
-lucene-analyzers-common-7.1.0.jar
-lucene-queryparser-7.1.0.jar
-lucene-core-7.1.0.jar
-lucene-queries-7.1.0.jar
+lucene-analyzers-phonetic-6.6.6.jar
+lucene-analyzers-common-6.6.6.jar
+lucene-queryparser-6.6.6.jar
+lucene-core-6.6.6.jar
+lucene-queries-6.6.6.jar
 geo-0.7.7.jar
 netty-all-4.1.67.Final.jar

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/GemFireCacheImpl.java
@@ -4118,14 +4118,6 @@ public class GemFireCacheImpl implements InternalCache, InternalClientCache, Has
   }
 
   @Override
-  public boolean hasMemberOlderThan(KnownVersion version) {
-    return getMembers().stream()
-        .map(InternalDistributedMember.class::cast)
-        .map(InternalDistributedMember::getVersion)
-        .anyMatch(v -> v.compareTo(version) < 0);
-  }
-
-  @Override
   public JSONFormatter getJsonFormatter() {
     // only ProxyCache implementation needs a JSONFormatter that has reference to userAttributes
     return new JSONFormatter();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -66,7 +66,6 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
-import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.statistics.StatisticsClockSupplier;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.pdx.PdxInstanceFactory;
@@ -587,6 +586,4 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime, Inte
   void lockDiskStore(String diskStoreName);
 
   void unlockDiskStore(String diskStoreName);
-
-  boolean hasMemberOlderThan(KnownVersion version);
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -94,7 +94,6 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
-import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
 import org.apache.geode.management.internal.RestAgent;
@@ -1224,11 +1223,6 @@ public class InternalCacheForClientAccess implements InternalCache {
   @Override
   public void unlockDiskStore(String diskStoreName) {
 
-  }
-
-  @Override
-  public boolean hasMemberOlderThan(KnownVersion version) {
-    return delegate.hasMemberOlderThan(version);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -168,7 +168,6 @@ import org.apache.geode.internal.logging.LocalLogWriter;
 import org.apache.geode.internal.offheap.MemoryAllocator;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.security.SecurityServiceFactory;
-import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.management.internal.JmxManagerAdvisor;
@@ -1114,11 +1113,6 @@ public class CacheCreation implements InternalCache {
   @Override
   public void unlockDiskStore(String diskStoreName) {
 
-  }
-
-  @Override
-  public boolean hasMemberOlderThan(KnownVersion version) {
-    return false;
   }
 
   public QueryConfigurationServiceCreation getQueryConfigurationServiceCreation() {

--- a/geode-docs/tools_modules/lucene_integration.html.md.erb
+++ b/geode-docs/tools_modules/lucene_integration.html.md.erb
@@ -334,7 +334,6 @@ Lucene indexes created for all members.
 # <a id="LuceneRandC" class="no-quick-link"></a>Requirements and Caveats
 
 - Join queries between regions are not supported.
-- All cluster members must be running the same major Lucene version in order to execute Lucene queries.
 - Lucene indexes are stored in on-heap memory only.
 - Lucene queries from within transactions are not supported.
 On an attempt to query from within a transaction,

--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -68,7 +68,6 @@ dependencies {
 
   upgradeTestImplementation(project(':geode-dunit'))
   upgradeTestImplementation('commons-io:commons-io')
-  upgradeTestImplementation('org.apache.lucene:lucene-backward-codecs')
   upgradeTestRuntimeOnly(project(path: ':geode-old-versions', configuration: 'classpathsOutput'))
 
 

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/internal/repository/IndexRepositoryImplJUnitTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/cache/lucene/internal/repository/IndexRepositoryImplJUnitTest.java
@@ -200,7 +200,7 @@ public class IndexRepositoryImplJUnitTest {
     repo.commit();
     checkQuery("Cream", "s", "key2", "key4");
     verify(stats, times(1)).startRepositoryQuery();
-    verify(stats, times(1)).endRepositoryQuery(anyLong(), eq(2l));
+    verify(stats, times(1)).endRepositoryQuery(anyLong(), eq(2));
   }
 
   @Test

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactory.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactory.java
@@ -38,7 +38,6 @@ import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionRegionConfig;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionHelper;
-import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 public class IndexRepositoryFactory {
@@ -103,13 +102,6 @@ public class IndexRepositoryFactory {
     if (oldRepository != null) {
       oldRepository.cleanup();
     }
-
-    if (userRegion.getCache() != null
-        && userRegion.getCache().hasMemberOlderThan(KnownVersion.GEODE_1_15_0)) {
-      logger.info("Some members are older than " + KnownVersion.GEODE_1_15_0.getName());
-      return null;
-    }
-
     DistributedLockService lockService = getLockService();
     String lockName = getLockName(fileAndChunkBucket);
     while (!lockService.lock(lockName, 100, -1)) {

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneEventListener.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneEventListener.java
@@ -36,7 +36,6 @@ import org.apache.geode.internal.cache.BucketNotFoundException;
 import org.apache.geode.internal.cache.EntrySnapshot;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PrimaryBucketException;
-import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
@@ -81,11 +80,6 @@ public class LuceneEventListener implements AsyncEventListener {
     // Try to get a PDX instance if possible, rather than a deserialized object
     Boolean initialPdxReadSerialized = this.cache.getPdxReadSerializedOverride();
     cache.setPdxReadSerializedOverride(true);
-
-    if (cache.hasMemberOlderThan(KnownVersion.GEODE_1_15_0)) {
-      logger.info("Some members are older than " + KnownVersion.GEODE_1_15_0.getName());
-      return false;
-    }
 
     Set<IndexRepository> affectedRepos = new HashSet<>();
 

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexStats.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/LuceneIndexStats.java
@@ -120,7 +120,7 @@ public class LuceneIndexStats {
   /**
    * @param start the timestamp taken when the operation started
    */
-  public void endRepositoryQuery(long start, final long totalHits) {
+  public void endRepositoryQuery(long start, final int totalHits) {
     stats.incLong(repositoryQueryExecutionTimeId, getStatTime() - start);
     stats.incInt(repositoryQueryExecutionsInProgressId, -1);
     stats.incInt(repositoryQueryExecutionsId, 1);

--- a/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/repository/IndexRepositoryImpl.java
+++ b/geode-lucene/src/main/java/org/apache/geode/cache/lucene/internal/repository/IndexRepositoryImpl.java
@@ -29,9 +29,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.TopDocs;
-import org.apache.lucene.search.similarities.TFIDFSimilarity;
 import org.apache.lucene.store.AlreadyClosedException;
-import org.apache.lucene.util.BytesRef;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.lucene.LuceneIndex;
@@ -145,9 +143,8 @@ public class IndexRepositoryImpl implements IndexRepository {
   @Override
   public void query(Query query, int limit, IndexResultCollector collector) throws IOException {
     long start = stats.startRepositoryQuery();
-    long totalHits = 0;
+    int totalHits = 0;
     IndexSearcher searcher = searcherManager.acquire();
-    searcher.setSimilarity(new LuceneSimilarity());
     try {
       TopDocs docs = searcher.search(query, limit);
       totalHits = docs.totalHits;
@@ -228,33 +225,6 @@ public class IndexRepositoryImpl implements IndexRepository {
         // ignore
         return 0;
       }
-    }
-  }
-
-  private static class LuceneSimilarity extends TFIDFSimilarity {
-    @Override
-    public float tf(float freq) {
-      return (float) Math.sqrt(freq);
-    }
-
-    @Override
-    public float idf(long docFreq, long docCount) {
-      return (float) Math.sqrt((docCount) / (1 + docFreq) + 1);
-    }
-
-    @Override
-    public float lengthNorm(int length) {
-      return (float) (1 / Math.sqrt(length));
-    }
-
-    @Override
-    public float sloppyFreq(int distance) {
-      return 0;
-    }
-
-    @Override
-    public float scorePayload(int doc, int start, int end, BytesRef payload) {
-      return 1;
     }
   }
 }

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactoryTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/IndexRepositoryFactoryTest.java
@@ -41,7 +41,6 @@ import org.apache.geode.internal.cache.BucketAdvisor;
 import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
-import org.apache.geode.internal.serialization.KnownVersion;
 
 public class IndexRepositoryFactoryTest {
   private Integer bucketId;
@@ -120,15 +119,6 @@ public class IndexRepositoryFactoryTest {
     when(oldRepository.isClosed()).thenReturn(true);
     when(fileAndChunkBucketAdvisor.isPrimary()).thenReturn(true).thenReturn(false);
     when(distributedLockService.lock(any(), anyLong(), anyLong())).thenReturn(false);
-
-    IndexRepository indexRepository = indexRepositoryFactory.finishComputingRepository(0,
-        serializer, userRegion, oldRepository, luceneIndex);
-    assertThat(indexRepository).isNull();
-  }
-
-  @Test
-  public void finishComputingRepositoryShouldReturnNullWhenThereIsOlderMember() throws IOException {
-    when(userRegion.getCache().hasMemberOlderThan(KnownVersion.GEODE_1_15_0)).thenReturn(false);
 
     IndexRepository indexRepository = indexRepositoryFactory.finishComputingRepository(0,
         serializer, userRegion, oldRepository, luceneIndex);

--- a/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneServiceImplJUnitTest.java
+++ b/geode-lucene/src/test/java/org/apache/geode/cache/lucene/internal/LuceneServiceImplJUnitTest.java
@@ -172,7 +172,8 @@ public class LuceneServiceImplJUnitTest {
     }
 
     @Override
-    protected void validateAllMembersAreTheSameVersion(PartitionedRegion region) {}
+    protected void validateAllMembersAreTheSameVersion(PartitionedRegion region) {
 
+    }
   }
 }

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeDUnit.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeDUnit.java
@@ -135,49 +135,37 @@ public abstract class LuceneSearchWithRollingUpgradeDUnit
             server3);
       }
       int expectedRegionSize = 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 0,
+      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName, expectedRegionSize, 0,
           10, server2, server3);
       locator = rollLocatorToCurrent(locator, hostName, locatorPorts[0], getTestMethodName(),
           locatorString);
 
       server1 = rollServerToCurrentCreateLuceneIndexAndCreateRegion(server1, regionType,
           testingDirs[0], shortcutName, regionName, locatorPorts, reindex);
+      verifyLuceneQueryResultInEachVM(regionName, expectedRegionSize, server1);
       expectedRegionSize += 5;
-      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 5,
+      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName, expectedRegionSize, 5,
           15, server2, server3);
       expectedRegionSize += 5;
-      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 10,
+      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName, expectedRegionSize, 10,
           20, server1, server3);
 
       server2 = rollServerToCurrentCreateLuceneIndexAndCreateRegion(server2, regionType,
           testingDirs[1], shortcutName, regionName, locatorPorts, reindex);
+      verifyLuceneQueryResultInEachVM(regionName, expectedRegionSize, server2);
       expectedRegionSize += 5;
-      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 15,
+      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName, expectedRegionSize, 15,
           25, server1, server3);
       expectedRegionSize += 5;
-      putSerializableObjectAndVerifyLuceneQueryResult(server3, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 20,
+      putSerializableObjectAndVerifyLuceneQueryResult(server3, regionName, expectedRegionSize, 20,
           30, server2, server3);
 
       server3 = rollServerToCurrentCreateLuceneIndexAndCreateRegion(server3, regionType,
           testingDirs[2], shortcutName, regionName, locatorPorts, reindex);
       verifyLuceneQueryResultInEachVM(regionName, expectedRegionSize, server3);
-      putSerializableObjectAndVerifyLuceneQueryResult(server3, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 15,
+      putSerializableObjectAndVerifyLuceneQueryResult(server3, regionName, expectedRegionSize, 15,
           25, server1, server2);
-      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 20,
+      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName, expectedRegionSize, 20,
           30, server1, server2, server3);
 
 

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeTestBase.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/LuceneSearchWithRollingUpgradeTestBase.java
@@ -69,6 +69,7 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.version.VersionManager;
 
 public abstract class LuceneSearchWithRollingUpgradeTestBase extends JUnit4DistributedTestCase {
+
   protected File[] testingDirs = new File[3];
 
   protected static String INDEX_NAME = "index";
@@ -224,33 +225,12 @@ public abstract class LuceneSearchWithRollingUpgradeTestBase extends JUnit4Distr
 
 
   void putSerializableObjectAndVerifyLuceneQueryResult(VM putter, String regionName,
-      boolean skipVerification,
       int expectedRegionSize, int start, int end, VM... vms) throws Exception {
     // do puts
     putSerializableObject(putter, regionName, start, end);
 
     // verify present in others
-
-    if (!skipVerification) {
-      verifyLuceneQueryResultInEachVM(regionName, expectedRegionSize, vms);
-    }
-  }
-
-  public boolean hasLuceneVersionMismatch(Host host) {
-    for (VM vm : host.getAllVMs()) {
-      int currentVersionOrdinal = 0;
-      for (KnownVersion productVersion : KnownVersion.getAllVersions()) {
-        if (vm.getVersion().equals(productVersion.getName())) {
-          currentVersionOrdinal = productVersion.ordinal();
-        } else if (vm.getVersion().equals(VersionManager.CURRENT_VERSION)) {
-          currentVersionOrdinal = KnownVersion.CURRENT_ORDINAL;
-        }
-      }
-      if (currentVersionOrdinal < KnownVersion.GEODE_1_15_0.ordinal()) {
-        return true;
-      }
-    }
-    return false;
+    verifyLuceneQueryResultInEachVM(regionName, expectedRegionSize, vms);
   }
 
   void putSerializableObject(VM putter, String regionName, int start, int end)
@@ -315,12 +295,22 @@ public abstract class LuceneSearchWithRollingUpgradeTestBase extends JUnit4Distr
   protected Collection executeLuceneQuery(Object luceneQuery)
       throws IllegalAccessException, InvocationTargetException, NoSuchMethodException {
     Collection results = null;
-    await().ignoreExceptions().untilAsserted(() -> {
-      luceneQuery.getClass().getMethod("findKeys").invoke(luceneQuery);
-    });
-    results = (Collection) luceneQuery.getClass().getMethod("findKeys").invoke(luceneQuery);
-
+    int retryCount = 10;
+    while (true) {
+      try {
+        results = (Collection) luceneQuery.getClass().getMethod("findKeys").invoke(luceneQuery);
+        break;
+      } catch (Exception ex) {
+        if (!ex.getCause().getMessage().contains("currently indexing")) {
+          throw ex;
+        }
+        if (--retryCount == 0) {
+          throw ex;
+        }
+      }
+    }
     return results;
+
   }
 
   protected void verifyLuceneQueryResultInEachVM(String regionName, int expectedRegionSize,

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServersAreRolled.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServersAreRolled.java
@@ -75,7 +75,8 @@ public class RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServe
 
       invokeRunnableInVMs(invokeCreateRegion(regionName, shortcut.name()), server1, server2);
       int expectedRegionSize = 10;
-      putSerializableObject(server1, regionName, 0, 10);
+      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName, expectedRegionSize, 0,
+          10, server1, server2);
       locator1 = rollLocatorToCurrent(locator1, hostName, locatorPorts[0], getTestMethodName(),
           locatorString);
 
@@ -85,35 +86,23 @@ public class RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServe
       server1 = rollServerToCurrentCreateLuceneIndexAndCreateRegion(server1, regionType, null,
           shortcut.name(), regionName, locatorPorts, reindex);
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 15,
+      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName, expectedRegionSize, 15,
           25, server2);
-      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 15,
+      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName, expectedRegionSize, 15,
           25, server1);
       expectedRegionSize += 5;
-      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 20,
+      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName, expectedRegionSize, 20,
           30, server2);
-      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 20,
+      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName, expectedRegionSize, 20,
           30, server1);
 
       server2 = rollServerToCurrentCreateLuceneIndexAndCreateRegion(server2, regionType, null,
           shortcut.name(), regionName, locatorPorts, reindex);
       expectedRegionSize += 5;
-      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 25,
+      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName, expectedRegionSize, 25,
           35, server1, server2);
       expectedRegionSize += 5;
-      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 30,
+      putSerializableObjectAndVerifyLuceneQueryResult(server1, regionName, expectedRegionSize, 30,
           40, server1, server2);
 
     } finally {

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOver.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOver.java
@@ -79,14 +79,10 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRol
       invokeRunnableInVMs(invokeCreateRegion(regionName, shortcut.name()), server2, server3);
       invokeRunnableInVMs(invokeCreateClientRegion(regionName, ClientRegionShortcut.PROXY), client);
       int expectedRegionSize = 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(client, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 0, 10,
+      putSerializableObjectAndVerifyLuceneQueryResult(client, regionName, expectedRegionSize, 0, 10,
           server3);
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(server3, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 10,
+      putSerializableObjectAndVerifyLuceneQueryResult(server3, regionName, expectedRegionSize, 10,
           20, server2);
       locator = rollLocatorToCurrent(locator, hostName, locatorPorts[0], getTestMethodName(),
           locatorString);
@@ -95,40 +91,29 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRol
           shortcut.name(), regionName, locatorPorts, reindex);
       invokeRunnableInVMs(invokeStartCacheServer(csPorts[1]), server3);
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(client, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 20,
+      putSerializableObjectAndVerifyLuceneQueryResult(client, regionName, expectedRegionSize, 20,
           30, server3, server2);
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(server3, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 30,
+      putSerializableObjectAndVerifyLuceneQueryResult(server3, regionName, expectedRegionSize, 30,
           40, server2);
+
       server2 = rollServerToCurrentCreateLuceneIndexAndCreateRegion(server2, regionType, null,
           shortcut.name(), regionName, locatorPorts, reindex);
       invokeRunnableInVMs(invokeStartCacheServer(csPorts[0]), server2);
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(client, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 40,
+      putSerializableObjectAndVerifyLuceneQueryResult(client, regionName, expectedRegionSize, 40,
           50, server2, server3);
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 50,
+      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName, expectedRegionSize, 50,
           60, server3);
 
       client = rollClientToCurrentAndCreateRegion(client, ClientRegionShortcut.PROXY, regionName,
           hostNames, locatorPorts, false, singleHopEnabled);
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(client, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 60,
+      putSerializableObjectAndVerifyLuceneQueryResult(client, regionName, expectedRegionSize, 60,
           70, server2, server3);
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 70,
+      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName, expectedRegionSize, 70,
           80, server3);
 
     } finally {

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOverAllBucketsCreated.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOverAllBucketsCreated.java
@@ -16,7 +16,6 @@ package org.apache.geode.cache.lucene;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assume.assumeFalse;
 
 import org.junit.Test;
 
@@ -35,21 +34,24 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRol
   @Test
   public void test()
       throws Exception {
+    // This test verifies the upgrade from lucene 6 to 7 doesn't cause any issues. Without any
+    // changes to accomodate this upgrade, this test will fail with an IndexFormatTooNewException.
+    //
     // The main sequence in this test that causes the failure is:
     //
-    // - start two servers with old version
-    // - roll one server to new version server
+    // - start two servers with old version using Lucene 6
+    // - roll one server to new version server using Lucene 7
     // - do puts into primary buckets in new server which creates entries in the fileAndChunk region
+    // with Lucene 7 format
     // - stop the new version server which causes the old version server to become primary for those
     // buckets
-    // - do a query which should pass
+    // - do a query which causes the IndexFormatTooNewException to be thrown
     final Host host = Host.getHost(0);
     VM locator = host.getVM(oldVersion, 0);
     VM server1 = host.getVM(oldVersion, 1);
     VM server2 = host.getVM(oldVersion, 2);
     VM client = host.getVM(oldVersion, 3);
 
-    assumeFalse(hasLuceneVersionMismatch(host));
     final String regionName = "aRegion";
     String regionType = "partitionedRedundant";
     RegionShortcut shortcut = RegionShortcut.PARTITION_REDUNDANT;

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion.java
@@ -106,9 +106,7 @@ public class RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentV
       ai2.checkException();
 
       expectedRegionSize += 10;
-      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName,
-          hasLuceneVersionMismatch(host),
-          expectedRegionSize, 15,
+      putSerializableObjectAndVerifyLuceneQueryResult(server2, regionName, expectedRegionSize, 15,
           25, server1, server2);
 
     } finally {


### PR DESCRIPTION
The fix for GEODE-7309 causes failures during the rolling upgrade. This commit needs to be reverted while we are investigating the root cause.

This reverts commit 68629356f561a932f5dfbace70b01d9971a42473.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
