### PR TITLE
geode 4181/junit 5

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -583,6 +583,26 @@
         <version>2.2</version>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-api</artifactId>
+        <version>5.7.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>5.7.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-engine</artifactId>
+        <version>5.7.2</version>
+      </dependency>
+      <dependency>
+        <groupId>org.junit.vintage</groupId>
+        <artifactId>junit-vintage-engine</artifactId>
+        <version>5.7.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.seleniumhq.selenium</groupId>
         <artifactId>selenium-api</artifactId>
         <version>3.141.59</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -65,6 +65,7 @@ class DependencyConstraints implements Plugin<Project> {
 
     // These versions are referenced in test.gradle, which is aggressively injected into all projects.
     deps.put("junit.version", "4.13.2")
+    deps.put("junit-jupiter.version", "5.7.2")
     deps.put("cglib.version", "3.3.0")
     return deps
   }
@@ -219,6 +220,16 @@ class DependencyConstraints implements Plugin<Project> {
 
     dependencySet(group: 'org.hamcrest', version: '2.2') {
       entry('hamcrest')
+    }
+
+    dependencySet(group: 'org.junit.jupiter', version: get('junit-jupiter.version')) {
+      entry('junit-jupiter-api')
+      entry('junit-jupiter-params')
+      entry('junit-jupiter-engine')
+    }
+
+    dependencySet(group: 'org.junit.vintage', version: get('junit-jupiter.version')) {
+      entry('junit-vintage-engine')
     }
 
     dependencySet(group: 'org.seleniumhq.selenium', version: '3.141.59') {

--- a/extensions/geode-modules/build.gradle
+++ b/extensions/geode-modules/build.gradle
@@ -41,6 +41,7 @@ dependencies {
   // test
   testImplementation('org.apache.bcel:bcel')
   testImplementation('junit:junit')
+  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
   testImplementation('org.apache.tomcat:catalina-ha:' + DependencyConstraints.get('tomcat6.version'))

--- a/geode-apis-compatible-with-redis/build.gradle
+++ b/geode-apis-compatible-with-redis/build.gradle
@@ -28,6 +28,9 @@ facets {
     includeInCheckLifecycle = false
   }
 }
+commonTest {
+  useJUnitPlatform()
+}
 
 dependencies {
   api(platform(project(':boms:geode-all-bom')))

--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -28,11 +28,13 @@ dependencies {
 
   // test
   testImplementation('junit:junit')
+  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 
 
   // jmhTest
   jmhTestImplementation('junit:junit')
+  jmhTestRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   jmhTestImplementation('org.assertj:assertj-core')
 }

--- a/geode-concurrency-test/build.gradle
+++ b/geode-concurrency-test/build.gradle
@@ -25,6 +25,7 @@ dependencies {
   implementation('junit:junit')
   implementation('org.apache.logging.log4j:log4j-api')
   integrationTestImplementation('org.assertj:assertj-core')
+  integrationTestRuntimeOnly('org.junit.vintage:junit-vintage-engine')
 }
 
 integrationTest {

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
@@ -338,6 +338,7 @@ class ProcessManager implements ChildVMLauncher {
     List<String> originalClassPathEntries = Arrays.asList(classPath.split(File.pathSeparator));
     String classPathAttributeValue = originalClassPathEntries.stream()
         .map(Paths::get)
+        .filter(Files::exists)
         .map(currentWorkingDir::relativize) // Entries must be relative to pathing jar's dir
         .map(p -> Files.isDirectory(p) ? p + "/" : p.toString()) // Dir entries must end with /
         .map(s -> s.replaceAll("\\\\", "/")) // Separator must be /

--- a/geode-jmh/build.gradle
+++ b/geode-jmh/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   api('org.openjdk.jmh:jmh-core')
 
   testImplementation('junit:junit')
+  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 }

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -38,6 +38,8 @@ dependencies {
   api('junit:junit') {
     exclude module: 'hamcrest'
   }
+  api('org.junit.jupiter:junit-jupiter-api')
+  api('org.junit.jupiter:junit-jupiter-params')
   api('org.assertj:assertj-core')
   api('org.mockito:mockito-core')
 
@@ -59,6 +61,9 @@ dependencies {
   api('io.micrometer:micrometer-core')
 
   api('org.skyscreamer:jsonassert')
+
+  implementation('org.junit.jupiter:junit-jupiter-engine')
+  implementation('org.junit.vintage:junit-vintage-engine')
 
   implementation('pl.pragmatists:JUnitParams')
 

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/runners/GeodeParamsRunner.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/runners/GeodeParamsRunner.java
@@ -14,11 +14,154 @@
  */
 package org.apache.geode.test.junit.runners;
 
+import static java.util.Objects.isNull;
+import static org.junit.runner.Description.createTestDescription;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
 import junitparams.JUnitParamsRunner;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.Description;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 
+/**
+ * Extends and adapts {@link JUnitParamsRunner} to be compatible with the way JUnit Vintage filters
+ * tests by {@link Category}. The differences from {@code JUnitParamsRunner} are:
+ * <ul>
+ * <li>When {@code GeodeParamsRunner} describes a test class, each parameterized test description
+ * includes the {@code Category} annotation (if any) from the corresponding test method.</li>
+ * <li>When Junit Vintage applies a filter, if the filter would exclude a test with parameters,
+ * {@code GeodeParamsRunner} excludes <em>every</em> parameterization of the test method.
+ * </li>
+ * </ul>
+ * <p>
+ * <strong>Problem:</strong> {@code GeodeParamsRunner}'s filtering behavior makes it impossible
+ * to execute a subset of the parameterizations of a single test method. But because all
+ * parameterizations of a method share the same {@code Category} annotation, this behavior allows
+ * JUnit Vintage to filter tests by category. A more nuanced fix would require a significant
+ * rewrite of {@code JUnitParamsRunner}.
+ */
 public class GeodeParamsRunner extends JUnitParamsRunner {
+  private static final String EXCLUDE_FILTER_PREFIX = "exclude ";
+  private final Map<String, FrameworkMethod> testNameToFrameworkMethod = new HashMap<>();
+
   public GeodeParamsRunner(Class<?> testClass) throws InitializationError {
     super(testClass);
+  }
+
+  /**
+   * Overrides {@link JUnitParamsRunner#describeMethod(FrameworkMethod)} to include a parameterized
+   * test method's {@code Category} annotation (if any) in the descriptions of the method's tests.
+   */
+  @Override
+  public Description describeMethod(FrameworkMethod method) {
+    Description description = super.describeMethod(method);
+    if (description.isTest()) {
+      return description;
+    }
+    recordTestNamesToFrameworkMethod(description.getChildren(), method);
+    return vintageCompatibleSuiteDescription(description, method.getMethod());
+  }
+
+  /**
+   * Overrides {@link JUnitParamsRunner#filter(Filter)} to exclude all of a parameterized
+   * method's tests if the filter would exclude any of the method's tests.
+   */
+  @Override
+  public void filter(Filter filter) throws NoTestsRemainException {
+    System.out.printf("DHE: filter(%s)%n", filter.describe());
+    super.filter(vintageCompatibleFilter(filter, testNameToFrameworkMethod));
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "(" + getTestClass().getJavaClass().getSimpleName() + ")";
+  }
+
+  private void recordTestNamesToFrameworkMethod(Collection<Description> testDescriptions,
+      FrameworkMethod method) {
+    testDescriptions.stream()
+        .map(Description::getDisplayName)
+        .forEach(testName -> testNameToFrameworkMethod.put(testName, method));
+  }
+
+  private String displayNameOf(FrameworkMethod method) {
+    return createTestDescription(getTestClass().getJavaClass(), method.getName()).getDisplayName();
+  }
+
+  /**
+   * Adapts a filter to exclude all of a parameterized test method's tests if the filter would
+   * exclude any of the method's tests.
+   */
+  public Filter vintageCompatibleFilter(
+      Filter originalFilter, Map<String, FrameworkMethod> parameterizedTestMap) {
+    String filterDescription = originalFilter.describe();
+    if (!filterDescription.startsWith(EXCLUDE_FILTER_PREFIX)) {
+      // The filter is not an exclude filter. JUnitParamsRunner applies it correctly.
+      return originalFilter;
+    }
+    String excludedTestName = filterDescription.substring(EXCLUDE_FILTER_PREFIX.length());
+    FrameworkMethod parameterizedMethod = parameterizedTestMap.get(excludedTestName);
+    if (isNull(parameterizedMethod)) {
+      // The filter excludes a non-parameterized test. JUnitParamsRunner applies it correctly.
+      return originalFilter;
+    }
+    return new ExcludeByDisplayName(displayNameOf(parameterizedMethod));
+  }
+
+  /**
+   * Adapts a suite description to add the given method's {@code Category} annotation (if any) to
+   * the descriptions of the suite's tests.
+   */
+  private static Description vintageCompatibleSuiteDescription(
+      Description originalDescription, Method method) {
+    Category categories = method.getAnnotation(Category.class);
+    if (isNull(categories)) {
+      return originalDescription;
+    }
+    Description compatibleDescription = originalDescription.childlessCopy();
+    originalDescription.getChildren().stream()
+        .map(testDescription -> vintageCompatibleTestDescription(testDescription, categories))
+        .forEach(compatibleDescription::addChild);
+    return compatibleDescription;
+  }
+
+  /**
+   * Adapts a test description to add the given {@link Category} annotation.
+   */
+  private static Description vintageCompatibleTestDescription(
+      Description originalDescription, Category categories) {
+    Class<?> testClass = originalDescription.getTestClass();
+    String displayName = originalDescription.getMethodName();
+    return createTestDescription(testClass, displayName, categories);
+  }
+
+  /**
+   * Filter descriptions by display name.
+   */
+  private static class ExcludeByDisplayName extends Filter {
+    private final String displayNameToExclude;
+
+    public ExcludeByDisplayName(String displayNameToExclude) {
+      this.displayNameToExclude = displayNameToExclude;
+    }
+
+    @Override
+    public boolean shouldRun(Description description) {
+      boolean shouldRun = !description.getDisplayName().equals(displayNameToExclude);
+      System.out.printf("DHE: %s shouldRun(%s): %s%n", describe(), description, shouldRun);
+      return shouldRun;
+    }
+
+    @Override
+    public String describe() {
+      return "exclude display name " + displayNameToExclude;
+    }
   }
 }

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/rules/ConcurrencyRuleTest.java
@@ -32,11 +32,11 @@ import java.util.function.Consumer;
 
 import junitparams.Parameters;
 import org.junit.Before;
-import org.junit.ComparisonFailure;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.MultipleFailureException;
+import org.opentest4j.AssertionFailedError;
 
 import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
@@ -399,7 +399,7 @@ public class ConcurrencyRuleTest {
         .repeatForDuration(Duration.ofSeconds(2));
 
     assertThatThrownBy(() -> execution.execute(concurrencyRule))
-        .isInstanceOf(ComparisonFailure.class);
+        .isInstanceOf(AssertionFailedError.class);
     assertThat(invoked.get()).isTrue();
   }
 
@@ -519,8 +519,8 @@ public class ConcurrencyRuleTest {
     assertThat(errors.get(0)).isInstanceOf(AssertionError.class)
         .hasMessageContaining(IOException.class.getName());
     assertThat(errors.get(1)).isInstanceOf(AssertionError.class)
-        .hasMessageContaining("[successful] value")
-        .hasMessageContaining("[wrong] value");
+        .hasMessageContaining("successful value")
+        .hasMessageContaining("wrong value");
     assertThat(errors.get(2)).hasMessageContaining("foo")
         .isInstanceOf(IOException.class);
   }

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/runners/ComparableDescription.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/runners/ComparableDescription.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.runners;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.runner.Description;
+
+/**
+ * Converts a {@link Description} into a form that compares all informative fields.
+ */
+class ComparableDescription {
+  private final Class<?> testClass;
+  private final String displayName;
+  private final Collection<Annotation> annotations = new HashSet<>();
+  private final List<ComparableDescription> children = new ArrayList<>();
+
+  /**
+   * Returns a comparable version of the description, retaining annotations on all descriptions.
+   */
+  public static ComparableDescription comparingAllDetails(Description description) {
+    return new ComparableDescription(description, true);
+  }
+
+  /**
+   * Returns a comparable version of the description, discarding annotations on test descriptions.
+   */
+  public static ComparableDescription ignoringTestAnnotations(Description description) {
+    return new ComparableDescription(description, false);
+  }
+
+  private ComparableDescription(Description description, boolean includeTestAnnotations) {
+    testClass = description.getTestClass();
+    displayName = description.getDisplayName();
+    if (description.isTest() && includeTestAnnotations) {
+      annotations.addAll(description.getAnnotations());
+    }
+    description.getChildren().stream()
+        .map(child -> new ComparableDescription(child, includeTestAnnotations))
+        .forEach(children::add);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ComparableDescription that = (ComparableDescription) o;
+    return Objects.equals(testClass, that.testClass)
+        && Objects.equals(displayName, that.displayName)
+        && Objects.equals(annotations, that.annotations)
+        && Objects.equals(children, that.children);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(testClass, displayName, annotations, children);
+  }
+
+  @Override
+  public String toString() {
+    return getClass().getSimpleName() + "{" +
+        "testClass=" + testClass +
+        ", displayName='" + displayName + '\'' +
+        ", annotations=" + annotations +
+        ", children=" + children +
+        '}';
+  }
+}

--- a/geode-junit/src/test/java/org/apache/geode/test/junit/runners/GeodeParamsRunnerTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/junit/runners/GeodeParamsRunnerTest.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.junit.runners;
+
+import static java.util.Arrays.stream;
+import static java.util.Objects.isNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+import org.junit.runner.manipulation.Filter;
+import org.junit.runner.manipulation.NoTestsRemainException;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.model.InitializationError;
+
+class GeodeParamsRunnerTest {
+  @Nested
+  class GetDescription {
+    @ParameterizedTest(name = "{displayName}({arguments})")
+    @ValueSource(classes = {ATestClass.class, ATestSubclass.class})
+    public void describesTheSameNonParameterizedTestsAsJUnitParamsRunner(Class<?> testClass)
+        throws InitializationError {
+      Description geodeParamsRunnerClassDescription = new GeodeParamsRunner(testClass)
+          .getDescription();
+
+      Collection<ComparableDescription> geodeParamsRunnerNonParameterizedTestDescriptions =
+          geodeParamsRunnerClassDescription.getChildren().stream()
+              // Each test child describes a non-parameterized test method.
+              .filter(Description::isTest)
+              .map(ComparableDescription::comparingAllDetails)
+              .collect(toList());
+
+      Description jUnitParamsRunnerClassDescription = new JUnitParamsRunner(testClass)
+          .getDescription();
+      Collection<ComparableDescription> jUnitParamsRunnerNonParameterizedTestDescriptions =
+          jUnitParamsRunnerClassDescription.getChildren().stream()
+              .filter(Description::isTest)
+              .map(ComparableDescription::comparingAllDetails)
+              .collect(toList());
+
+      assertThat(geodeParamsRunnerNonParameterizedTestDescriptions)
+          .isEqualTo(jUnitParamsRunnerNonParameterizedTestDescriptions);
+    }
+
+    /**
+     * Compares the parameterized test suites produced by {@code GeodeParamsRunner} to those
+     * produced by {@code JUnitParamsRunner}, comparing every detail except the annotations on
+     * the parameterized test descriptions. A separate test verifies those annotations.
+     */
+    @ParameterizedTest(name = "{displayName}({arguments})")
+    @ValueSource(classes = {ATestClass.class, ATestSubclass.class})
+    public void describesTheSameParameterizedSuitesAsJUnitParamsRunnerIgnoringTestAnnotations(
+        Class<?> testClass)
+        throws InitializationError {
+      Description geodeParamsRunnerClassDescription = new GeodeParamsRunner(testClass)
+          .getDescription();
+
+      Collection<ComparableDescription> geodeParamsRunnerSuiteDescriptions =
+          geodeParamsRunnerClassDescription.getChildren().stream()
+              // Each suite child describes a parameterized test method.
+              .filter(Description::isSuite)
+              // Ignore annotations on the test descriptions in the suite. Another test verifies
+              // those.
+              .map(ComparableDescription::ignoringTestAnnotations)
+              .collect(toList());
+
+      Description jUnitParamsRunnerClassDescription = new JUnitParamsRunner(testClass)
+          .getDescription();
+      Collection<ComparableDescription> jUnitParamsRunnerSuiteDescriptions =
+          jUnitParamsRunnerClassDescription.getChildren().stream()
+              .filter(Description::isSuite)
+              .map(ComparableDescription::ignoringTestAnnotations)
+              .collect(toList());
+
+      assertThat(geodeParamsRunnerSuiteDescriptions)
+          .isEqualTo(jUnitParamsRunnerSuiteDescriptions);
+    }
+
+    @ParameterizedTest(name = "{displayName}({arguments})")
+    @ValueSource(classes = {ATestClass.class, ATestSubclass.class})
+    public void describesEachParameterizedTestWithCategoryAnnotationFromMethod(Class<?> testClass)
+        throws InitializationError {
+      List<Description> childDescriptions = new GeodeParamsRunner(testClass)
+          .getDescription()
+          .getChildren();
+
+      List<Method> parameterizedTestMethods = parameterizedTestMethodsOf(testClass);
+      SoftAssertions softly = new SoftAssertions();
+      parameterizedTestMethods.forEach(method -> {
+        String methodName = method.getName();
+        Description suiteDescription = findByDisplayName(childDescriptions, methodName);
+        softly.assertThat(suiteDescription)
+            .as("suite description for parameterized method " + methodName)
+            .isNotNull();
+        if (isNull(suiteDescription)) {
+          return;
+        }
+
+        // The suite description contains one test description for each parameterization. Each test
+        // description must have the same Category annotation as the method.
+        suiteDescription.getChildren().forEach(
+            testDescription -> softly.assertThat(testDescription.getAnnotation(Category.class))
+                .as("Category annotation on test description " + testDescription)
+                .isEqualTo(method.getAnnotation(Category.class)));
+      });
+      softly.assertAll();
+    }
+  }
+
+  @Nested
+  class Filtering {
+    private final Class<?> testClass = ATestSubclass.class;
+    private final RunNotifier notifier = new RunNotifier();
+    private final List<String> executions = new ArrayList<>();
+
+    @BeforeEach
+    void recordTestExecutions() {
+      RunListener listener = new RunListener() {
+        @Override
+        public void testStarted(Description description) {
+          executions.add(description.getDisplayName());
+        }
+      };
+      notifier.addListener(listener);
+    }
+
+    @ParameterizedTest(name = "{displayName}({arguments})")
+    @ValueSource(classes = {ATestClass.class, ATestSubclass.class})
+    void executesEveryTest_ifNoFilterApplied(Class<?> testClass) throws InitializationError {
+      GeodeParamsRunner runner = new GeodeParamsRunner(testClass);
+      Description classDescription = runner.getDescription();
+
+      // The runner must execute every test.
+      Collection<String> requiredExecutions =
+          testDescriptionDescendantsOf(classDescription).stream()
+              .map(Description::getDisplayName)
+              .collect(toSet());
+
+      // No filter applied
+
+      runner.run(notifier);
+
+      assertThat(executions)
+          .as(() -> "tests executed by " + runner)
+          .hasSameElementsAs(requiredExecutions);
+    }
+
+    @ParameterizedTest(name = "{displayName}({arguments})")
+    @ValueSource(classes = {ATestClass.class, ATestSubclass.class})
+    void skipsNonParameterizedTest_ifExcludedByFilter(Class<?> testClass)
+        throws InitializationError, NoTestsRemainException {
+      GeodeParamsRunner runner = new GeodeParamsRunner(testClass);
+      Description classDescription = runner.getDescription();
+
+      // Each test description child describes a non-parameterized test. Pick one to exclude.
+      Description testToExclude = testDescriptionChildrenOf(classDescription)
+          .get(0);
+
+      // The runner must execute every test except the excluded one.
+      Collection<String> requiredExecutions = testDescriptionDescendantsOf(classDescription)
+          .stream()
+          .filter(d -> !d.equals(testToExclude))
+          .map(Description::getDisplayName)
+          .collect(toList());
+
+      runner.filter(new ExcludeDescriptionFilter(testToExclude));
+
+      runner.run(notifier);
+
+      assertThat(executions)
+          .as(() -> "tests executed by " + runner + " after excluding " + testToExclude)
+          .hasSameElementsAs(requiredExecutions);
+    }
+
+    @ParameterizedTest(name = "{displayName}({arguments})")
+    @ValueSource(classes = {ATestClass.class, ATestSubclass.class})
+    void skipsEveryTestInParameterizedTestSuite_ifFilterExcludesAnyTestInSuite(Class<?> testClass)
+        throws InitializationError, NoTestsRemainException {
+      GeodeParamsRunner runner = new GeodeParamsRunner(testClass);
+      Description classDescription = runner.getDescription();
+
+      // Each suite child of classDescription describes a parameterized method. Pick a suite.
+      Description suite = suiteDescriptionChildrenOf(classDescription).get(0);
+
+      // Each child of the suite describes a test with parameters. Pick a test to exclude.
+      List<Description> testsInSuite = suite.getChildren();
+      Description testToExclude = testsInSuite.get(0);
+
+      // The runner must execute every test except the ones in the same suite as the excluded test.
+      Collection<String> requiredExecutions =
+          testDescriptionDescendantsOf(classDescription).stream()
+              .filter(d -> !testsInSuite.contains(d))
+              .map(Description::getDisplayName)
+              .collect(toSet());
+
+      runner.filter(new ExcludeDescriptionFilter(testToExclude));
+
+      runner.run(notifier);
+
+      assertThat(executions)
+          .as(() -> "tests executed by " + runner + " after excluding " + testToExclude)
+          .hasSameElementsAs(requiredExecutions);
+    }
+  }
+
+  // A category to test GeodeParamsRunner
+  public static class ATestCategory {
+  }
+
+  /**
+   * Cases for {@code GeodeParamsRunner} to handle: Every combination of parameterized (or not)
+   * and categorized (or not).
+   */
+  @RunWith(GeodeParamsRunner.class)
+  public static class ATestClass {
+    @org.junit.Test
+    @Parameters({"A", "B"})
+    @Category(ATestCategory.class)
+    public void parameterizedTestInCategory(String ignored) {}
+
+    @org.junit.Test
+    @Parameters({"A", "B"})
+    public void parameterizedTestNotInCategory(String ignored) {}
+
+    @org.junit.Test
+    @Category(ATestCategory.class)
+    public void nonParameterizedTestInCategory() {}
+
+    @Test
+    public void nonParameterizedTestNotInCategory() {}
+  }
+
+  /**
+   * A special case for {@code GeodeParamsRunner} to handle: {@code JUnitParamsRunner} describes
+   * the same methods for this subclass as for {@code ATestClass}, but the display names mention
+   * the subclass and not the class where the method was declared.
+   */
+  public static class ATestSubclass extends ATestClass {
+  }
+
+  private static class ExcludeDescriptionFilter extends Filter {
+    private final Description description;
+
+    ExcludeDescriptionFilter(Description description) {
+      this.description = description;
+    }
+
+    @Override
+    public boolean shouldRun(Description description) {
+      return !this.description.equals(description);
+    }
+
+    @Override
+    public String describe() {
+      return "exclude " + description;
+    }
+  }
+
+  /**
+   * Returns a consumer that accepts a Description and adds the description and its descendants to
+   * the given collection.
+   */
+  private static Consumer<Description> addSelfAndDescendantsTo(
+      Collection<Description> descriptions) {
+    return parent -> {
+      descriptions.add(parent);
+      parent.getChildren().forEach(addSelfAndDescendantsTo(descriptions));
+    };
+  }
+
+  /**
+   * Returns a collection of root's descendants. The collection does not contain root.
+   */
+  private static Collection<Description> descendantsOf(Description root) {
+    List<Description> descendants = new ArrayList<>();
+    root.getChildren().forEach(addSelfAndDescendantsTo(descendants));
+    return descendants;
+  }
+
+  /**
+   * Returns the description with the given name in descriptions, or null if there is no such
+   * description.
+   */
+  private static Description findByDisplayName(List<Description> descriptions, String displayName) {
+    return descriptions.stream()
+        .filter(d -> d.getDisplayName().equals(displayName))
+        .findAny()
+        .orElse(null);
+  }
+
+  private static List<Method> parameterizedTestMethodsOf(Class<?> testClass) {
+    return testMethodsOf(testClass)
+        .filter(m -> m.isAnnotationPresent(Parameters.class))
+        .collect(toList());
+  }
+
+  /**
+   * Returns a list of the suite description children of root.
+   */
+  private static List<Description> suiteDescriptionChildrenOf(Description root) {
+    return root.getChildren().stream()
+        .filter(Description::isSuite)
+        .collect(toList());
+  }
+
+  /**
+   * Returns a list of the test description children of root.
+   */
+  private static List<Description> testDescriptionChildrenOf(Description root) {
+    return root.getChildren().stream()
+        .filter(Description::isTest)
+        .collect(toList());
+  }
+
+  /**
+   * Returns a list of the test description descendants of root.
+   */
+  private static List<Description> testDescriptionDescendantsOf(Description root) {
+    return descendantsOf(root).stream()
+        .filter(Description::isTest)
+        .collect(toList());
+  }
+
+  private static Stream<Method> testMethodsOf(Class<?> testClass) {
+    return stream(testClass.getMethods())
+        .filter(m -> m.isAnnotationPresent(org.junit.Test.class));
+  }
+}

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -58,6 +58,16 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>compile</scope>
@@ -137,6 +147,16 @@
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>pl.pragmatists</groupId>

--- a/geode-rebalancer/build.gradle
+++ b/geode-rebalancer/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   }
 
   testImplementation('junit:junit')
+  testImplementation('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
 

--- a/geode-web-management/build.gradle
+++ b/geode-web-management/build.gradle
@@ -30,6 +30,10 @@ facets {
   }
 }
 
+commonTest {
+  useJUnitPlatform()
+}
+
 sourceSets {
   integrationTest {
     resources {

--- a/gradle/jmh.gradle
+++ b/gradle/jmh.gradle
@@ -60,6 +60,10 @@ facets {
   }
 }
 
+jmhTest {
+  useJUnitPlatform()
+}
+
 configurations {
   jmhTestRuntimeOnly.extendsFrom(jmhRuntimeOnly)
 }

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -90,14 +90,6 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
   outputs.upToDateWhen { false }
 }
 
-configure([integrationTest, distributedTest, performanceTest]) {
-  useJUnit {
-    if (project.hasProperty("testCategory")) {
-      includeCategories += project.testCategory
-    }
-  }
-}
-
 if (project.hasProperty("forceTest")) {
   // All test facets already force rerun.  Only :test can be upToDate.
   test {
@@ -134,6 +126,11 @@ task repeatUnitTest(type: RepeatTest) {
   // default classpath works for this one.
 }
 
+configure([test, integrationTest, distributedTest, performanceTest, acceptanceTest, uiTest, upgradeTest,
+           repeatDistributedTest, repeatIntegrationTest, repeatUpgradeTest, repeatUnitTest, repeatAcceptanceTest]) {
+  useJUnitPlatform()
+}
+
 configure([integrationTest, distributedTest, performanceTest, acceptanceTest, uiTest, upgradeTest]) {
   if (project.hasProperty('excludeTest')) {
     exclude project.getProperty('excludeTest').split(',')
@@ -143,13 +140,21 @@ configure([integrationTest, distributedTest, performanceTest, acceptanceTest, ui
 configure([repeatDistributedTest, repeatIntegrationTest, repeatUpgradeTest, repeatUnitTest, repeatAcceptanceTest]) {
   times = Integer.parseInt(repeat)
   forkEvery 1
-  useJUnit {}
+
+  testFramework.options.excludeTags += "org.apache.geode.test.junit.categories.IgnoreInRepeatTestTasks"
+
   outputs.upToDateWhen { false }
 
   if (project.hasProperty("failOnNoMatchingTests")) {
     filter {
       setFailOnNoMatchingTests(Boolean.valueOf(project.failOnNoMatchingTests))
     }
+  }
+}
+
+configure([integrationTest, distributedTest, performanceTest]) {
+  if (project.hasProperty("testCategory")) {
+    testFramework.options.includeTags += project.testCategory
   }
 }
 

--- a/static-analysis/pmd-rules/build.gradle
+++ b/static-analysis/pmd-rules/build.gradle
@@ -20,6 +20,7 @@ apply from: "${rootDir}/${scriptDir}/warnings.gradle"
 
 dependencies {
   implementation(platform(project(':boms:geode-all-bom')))
+  testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   implementation('net.sourceforge.pmd:pmd-java')
   testImplementation('net.sourceforge.pmd:pmd-test')
 }


### PR DESCRIPTION
- GEODE-4181: Add JUnit 5 Support
- GPR describes category-less methods same as JUP
- GPR restores discareded category
- GPR executes all tests if no filter
- GPR excludes suite if parm test excluded
