### PR TITLE
GEODE-9650: LOLWUT command

### DIFF
--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/LolWutIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/LolWutIntegrationTest.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.server;
+
+import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.commands.ProtocolCommand;
+import redis.clients.jedis.util.SafeEncoder;
+
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.redis.GeodeRedisServerRule;
+import org.apache.geode.redis.RedisIntegrationTest;
+import org.apache.geode.redis.internal.netty.Coder;
+import org.apache.geode.test.awaitility.GeodeAwaitility;
+
+public class LolWutIntegrationTest implements RedisIntegrationTest {
+  private static final int REDIS_CLIENT_TIMEOUT =
+      Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
+  private static final String GEODE_VERSION_STRING = KnownVersion.getCurrentVersion().toString();
+  private static final int DEFAULT_MAZE_HEIGHT = 10 + 2; // Top & bottom walls, version string
+  private static final int MAX_MAZE_HEIGHT = (1024 * 1024) + 2;
+  private Jedis jedis;
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule()
+      .withProperty(LOG_LEVEL, "info");
+
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
+
+  @Before
+  public void setUp() {
+    jedis = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    jedis.flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void shouldReturnGeodeVersion() {
+    String actualResult = Coder.bytesToString((byte[]) jedis.sendCommand(new ProtocolCommand() {
+      @Override
+      public byte[] getRaw() {
+        return SafeEncoder.encode("lolwut");
+      }
+    }));
+
+    assertThat(actualResult).contains(GEODE_VERSION_STRING);
+  }
+
+  @Test
+  public void shouldReturnDefaultMazeSize_givenNoArgs() {
+    String actualResult = Coder.bytesToString((byte[]) jedis.sendCommand(new ProtocolCommand() {
+      @Override
+      public byte[] getRaw() {
+        return SafeEncoder.encode("lolwut");
+      }
+    }));
+
+    String[] lines = actualResult.split("\\n");
+    assertThat(lines.length).isEqualTo(DEFAULT_MAZE_HEIGHT);
+  }
+
+
+  @Test
+  public void shouldReturnSpecifiedMazeWidth_givenNumericArg() {
+    String actualResult = Coder.bytesToString((byte[]) jedis.sendCommand(new ProtocolCommand() {
+      @Override
+      public byte[] getRaw() {
+        return SafeEncoder.encode("lolwut");
+      }
+    }, SafeEncoder.encode("20")));
+
+    String[] lines = actualResult.split("\\n");
+    assertThat(lines[0].length()).isEqualTo((20 - 1) * 2);
+  }
+
+  @Test
+  public void shouldReturnSpecifiedMazeHeight_givenNumericArgs() {
+    String actualResult = Coder.bytesToString((byte[]) jedis.sendCommand(new ProtocolCommand() {
+      @Override
+      public byte[] getRaw() {
+        return SafeEncoder.encode("lolwut");
+      }
+    }, SafeEncoder.encode("10"),
+        SafeEncoder.encode("20")));
+
+    String[] lines = actualResult.split("\\n");
+    assertThat(lines.length).isEqualTo(20 + 2);
+  }
+
+  @Test
+  public void shouldLimitMazeWidth() {
+    String actualResult = Coder.bytesToString((byte[]) jedis.sendCommand(new ProtocolCommand() {
+      @Override
+      public byte[] getRaw() {
+        return SafeEncoder.encode("lolwut");
+      }
+    }, SafeEncoder.encode("2048")));
+
+    String[] lines = actualResult.split("\\n");
+    assertThat(lines[0].length()).isEqualTo((1024 - 1) * 2);
+  }
+
+  @Test
+  public void shouldLimitMazeHeight() {
+    String actualResult = Coder.bytesToString((byte[]) jedis.sendCommand(new ProtocolCommand() {
+      @Override
+      public byte[] getRaw() {
+        return SafeEncoder.encode("lolwut");
+      }
+    }, SafeEncoder.encode("10"),
+        SafeEncoder.encode(Integer.toString(MAX_MAZE_HEIGHT * 2))));
+
+    String[] lines = actualResult.split("\\n");
+    assertThat(lines.length).isEqualTo(MAX_MAZE_HEIGHT);
+  }
+
+  @Test
+  public void shouldNotError_givenVersionArg() {
+    String actualResult = Coder.bytesToString((byte[]) jedis.sendCommand(new ProtocolCommand() {
+      @Override
+      public byte[] getRaw() {
+        return SafeEncoder.encode("lolwut");
+      }
+    },
+        SafeEncoder.encode("version"),
+        SafeEncoder.encode("ignored")));
+
+    assertThat(actualResult).contains(GEODE_VERSION_STRING);
+  }
+
+  @Test
+  public void shouldError_givenNonNumericArg() {
+    assertThatThrownBy(() -> jedis.sendCommand(new ProtocolCommand() {
+      @Override
+      public byte[] getRaw() {
+        return SafeEncoder.encode("lolwut");
+      }
+    },
+        SafeEncoder.encode("notEvenCloseToANumber")))
+            .hasMessage("ERR value is not an integer or out of range");
+  }
+
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/RedisCommandType.java
@@ -84,6 +84,7 @@ import org.apache.geode.redis.internal.executor.server.CommandExecutor;
 import org.apache.geode.redis.internal.executor.server.DBSizeExecutor;
 import org.apache.geode.redis.internal.executor.server.FlushAllExecutor;
 import org.apache.geode.redis.internal.executor.server.InfoExecutor;
+import org.apache.geode.redis.internal.executor.server.LolWutExecutor;
 import org.apache.geode.redis.internal.executor.server.ShutDownExecutor;
 import org.apache.geode.redis.internal.executor.server.SlowlogExecutor;
 import org.apache.geode.redis.internal.executor.server.TimeExecutor;
@@ -280,6 +281,8 @@ public enum RedisCommandType {
       .flags(ADMIN, RANDOM, LOADING, STALE)),
   INFO(new InfoExecutor(), SUPPORTED, new Parameter().min(1).max(2, ERROR_SYNTAX).firstKey(0)
       .flags(RANDOM, LOADING, STALE)),
+  LOLWUT(new LolWutExecutor(), SUPPORTED, new Parameter().min(1).firstKey(0).flags(READONLY, FAST)),
+
 
   /********** Publish Subscribe **********/
   SUBSCRIBE(new SubscribeExecutor(), SUPPORTED, new Parameter().min(2).firstKey(0).flags(

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
@@ -29,11 +29,11 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 public class LolWutExecutor extends AbstractExecutor {
   @Override
   public RedisResponse executeCommand(Command command,
-                                      ExecutionHandlerContext context) {
+      ExecutionHandlerContext context) {
     long height = 10;
     List<byte[]> commands = command.getProcessedCommand();
     if (commands.size() > 1) {
-      for(int i=1; i< commands.size(); i++) {
+      for (int i = 1; i < commands.size(); i++) {
         if (Coder.bytesToString(commands.get(i)).equalsIgnoreCase("version")) {
           i += 1; // skip next arg, we only have one version for now
         } else {
@@ -67,24 +67,24 @@ public class LolWutExecutor extends AbstractExecutor {
   }
 
   private static void mazeTopAndEntrance(StringBuilder mazeString, int width, int[] leftLinks,
-                                         int[] rightLinks) {
+      int[] rightLinks) {
     int tempIndex;
-    for (tempIndex = width; --tempIndex > 0;
-         leftLinks[tempIndex] = rightLinks[tempIndex] = tempIndex) {
+    for (tempIndex = width; --tempIndex > 0; leftLinks[tempIndex] =
+        rightLinks[tempIndex] = tempIndex) {
       mazeString.append("._"); // top walls
     }
     mazeString.append("\n "); // Open wall for entrance at top left
   }
 
   private static void mazeRows(StringBuilder mazeString, long height,
-                               int width, int[] leftLinks,
-                               int[] rightLinks, Random rand) {
+      int width, int[] leftLinks,
+      int[] rightLinks, Random rand) {
     int currentCell;
     String first;
     String second;
     int tempIndex;
     while (--height > 0) {
-      for (currentCell = width; --currentCell > 0; ) {
+      for (currentCell = width; --currentCell > 0;) {
         if (currentCell != (tempIndex = leftLinks[currentCell - 1])
             && rand.nextBoolean()) { // connect cell to cell on right?
           rightLinks[tempIndex] = rightLinks[currentCell];
@@ -96,7 +96,7 @@ public class LolWutExecutor extends AbstractExecutor {
           second = "|"; // wall to the right
         }
         if (currentCell != (tempIndex = leftLinks[currentCell])
-            && rand.nextBoolean())  { // omit down-connection?
+            && rand.nextBoolean()) { // omit down-connection?
           rightLinks[tempIndex] = rightLinks[currentCell];
           leftLinks[rightLinks[currentCell]] = tempIndex;
           leftLinks[currentCell] = currentCell;
@@ -113,12 +113,12 @@ public class LolWutExecutor extends AbstractExecutor {
   }
 
   private static void mazeBottomRow(StringBuilder mazeString, int width, int[] leftLinks,
-                                    int[] rightLinks, Random rand) {
+      int[] rightLinks, Random rand) {
     int currentCell;
     int tempIndex;
-    for (currentCell = width; --currentCell > 0; ) {
-      if (currentCell != (tempIndex = leftLinks[currentCell - 1]) && (
-          currentCell == rightLinks[currentCell] || rand.nextBoolean())) {
+    for (currentCell = width; --currentCell > 0;) {
+      if (currentCell != (tempIndex = leftLinks[currentCell - 1])
+          && (currentCell == rightLinks[currentCell] || rand.nextBoolean())) {
         leftLinks[rightLinks[tempIndex] = rightLinks[currentCell]] = tempIndex;
         leftLinks[rightLinks[currentCell] = currentCell - 1] = currentCell;
         mazeString.append("_.");

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
@@ -16,6 +16,8 @@
 package org.apache.geode.redis.internal.executor.server;
 
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+
 import java.util.List;
 import java.util.Random;
 
@@ -27,46 +29,70 @@ import org.apache.geode.redis.internal.netty.Command;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class LolWutExecutor extends AbstractExecutor {
+
+  public static final int DEFAULT_WIDTH = 40;
+  public static final int DEFAULT_HEIGHT = 10;
+  private static int width = DEFAULT_WIDTH;
+  private static int height = DEFAULT_HEIGHT;
+
   @Override
   public RedisResponse executeCommand(Command command,
       ExecutionHandlerContext context) {
-    long height = 10;
+
+    long inputWidth = -1;
+    long inputHeight = -1;
+
     List<byte[]> commands = command.getProcessedCommand();
     if (commands.size() > 1) {
       for (int i = 1; i < commands.size(); i++) {
         if (Coder.bytesToString(commands.get(i)).equalsIgnoreCase("version")) {
           i += 1; // skip next arg, we only have one version for now
         } else {
-          height = Coder.bytesToLong(commands.get(i));
+          try {
+            if (inputWidth < 0) {
+              inputWidth = Coder.bytesToLong(commands.get(i));
+            } else if (inputHeight < 0) {
+              inputHeight = Coder.bytesToLong(commands.get(i));
+            } else {
+              break; // all required args filled
+            }
+          } catch (NumberFormatException ignored) {
+            return RedisResponse.error(ERROR_NOT_INTEGER);
+          }
         }
       }
     }
+    if (inputHeight >= 0) {
+      height = (int) inputHeight;
+    }
+    if (inputWidth >= 0) {
+      width = (int) inputWidth;
+    }
 
-    return RedisResponse.bulkString(makeArbitraryHeightMaze(height));
+    return RedisResponse.bulkString(makeArbitraryHeightMaze());
   }
 
   // Adapted from code here: https://tromp.github.io/maze.html
-  public static String makeArbitraryHeightMaze(long height) {
+  public static String makeArbitraryHeightMaze() {
     StringBuilder mazeString = new StringBuilder();
-    final int width = 40;
     int[] leftLinks = new int[width];
     int[] rightLinks = new int[width];
 
     Random rand = new Random();
     leftLinks[0] = 1;
 
-    mazeTopAndEntrance(mazeString, width, leftLinks, rightLinks);
+    mazeTopAndEntrance(mazeString, leftLinks, rightLinks);
 
-    mazeRows(mazeString, height, width, leftLinks, rightLinks, rand);
+    mazeRows(mazeString, leftLinks, rightLinks, rand);
 
-    mazeBottomRow(mazeString, width, leftLinks, rightLinks, rand);
+    mazeBottomRow(mazeString, leftLinks, rightLinks, rand);
 
     mazeString.append("\n " + KnownVersion.getCurrentVersion().toString() + "\n");
 
     return mazeString.toString();
   }
 
-  private static void mazeTopAndEntrance(StringBuilder mazeString, int width, int[] leftLinks,
+  private static void mazeTopAndEntrance(StringBuilder mazeString, int[] leftLinks,
       int[] rightLinks) {
     int tempIndex;
     for (tempIndex = width; --tempIndex > 0; leftLinks[tempIndex] =
@@ -76,13 +102,14 @@ public class LolWutExecutor extends AbstractExecutor {
     mazeString.append("\n "); // Open wall for entrance at top left
   }
 
-  private static void mazeRows(StringBuilder mazeString, long height,
-      int width, int[] leftLinks,
+  private static void mazeRows(StringBuilder mazeString,
+      int[] leftLinks,
       int[] rightLinks, Random rand) {
     int currentCell;
+    int tempIndex;
     String first;
     String second;
-    int tempIndex;
+
     while (--height > 0) {
       for (currentCell = width; --currentCell > 0;) {
         if (currentCell != (tempIndex = leftLinks[currentCell - 1])
@@ -91,7 +118,7 @@ public class LolWutExecutor extends AbstractExecutor {
           leftLinks[rightLinks[currentCell]] = tempIndex;
           rightLinks[currentCell] = currentCell - 1;
           leftLinks[currentCell - 1] = currentCell;
-          second = ".";
+          second = "."; // no wall to right
         } else {
           second = "|"; // wall to the right
         }
@@ -112,10 +139,11 @@ public class LolWutExecutor extends AbstractExecutor {
     }
   }
 
-  private static void mazeBottomRow(StringBuilder mazeString, int width, int[] leftLinks,
+  private static void mazeBottomRow(StringBuilder mazeString, int[] leftLinks,
       int[] rightLinks, Random rand) {
     int currentCell;
     int tempIndex;
+
     for (currentCell = width; --currentCell > 0;) {
       if (currentCell != (tempIndex = leftLinks[currentCell - 1])
           && (currentCell == rightLinks[currentCell] || rand.nextBoolean())) {
@@ -124,7 +152,7 @@ public class LolWutExecutor extends AbstractExecutor {
         mazeString.append("_.");
       } else {
         if (currentCell == 1) {
-          mazeString.append("_ "); // maze exit
+          mazeString.append("_."); // maze exit
         } else {
           mazeString.append("_|"); // regular wall
         }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
@@ -86,7 +86,7 @@ public class LolWutExecutor extends AbstractExecutor {
   }
 
   // Adapted from code here: https://tromp.github.io/maze.html
-  private static String makeArbitrarySizeMaze() {
+  private String makeArbitrarySizeMaze() {
     StringBuilder mazeString = new StringBuilder();
     int[] leftLinks = new int[width];
     int[] rightLinks = new int[width];
@@ -105,7 +105,7 @@ public class LolWutExecutor extends AbstractExecutor {
     return mazeString.toString();
   }
 
-  private static void mazeTopAndEntrance(StringBuilder mazeString, int[] leftLinks,
+  private void mazeTopAndEntrance(StringBuilder mazeString, int[] leftLinks,
       int[] rightLinks) {
     int tempIndex;
     for (tempIndex = width; --tempIndex > 0; leftLinks[tempIndex] =
@@ -115,7 +115,7 @@ public class LolWutExecutor extends AbstractExecutor {
     mazeString.append("\n "); // Open wall for entrance at top left
   }
 
-  private static void mazeRows(StringBuilder mazeString,
+  private void mazeRows(StringBuilder mazeString,
       int[] leftLinks,
       int[] rightLinks, Random rand) {
     int currentCell;
@@ -152,7 +152,7 @@ public class LolWutExecutor extends AbstractExecutor {
     }
   }
 
-  private static void mazeBottomRowAndExit(StringBuilder mazeString, int[] leftLinks,
+  private void mazeBottomRowAndExit(StringBuilder mazeString, int[] leftLinks,
       int[] rightLinks, Random rand) {
     int currentCell;
     int tempIndex;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+package org.apache.geode.redis.internal.executor.server;
+
+
+import java.util.List;
+import java.util.Random;
+
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.redis.internal.executor.AbstractExecutor;
+import org.apache.geode.redis.internal.executor.RedisResponse;
+import org.apache.geode.redis.internal.netty.Command;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+
+public class LolWutExecutor extends AbstractExecutor {
+  @Override
+  public RedisResponse executeCommand(Command command,
+                                      ExecutionHandlerContext context) {
+    StringBuilder mazeString = new StringBuilder();
+    final int width = 40;
+    int height = 10;
+    List<byte[]> commands = command.getProcessedCommand();
+    if (commands.size() > 1) {
+      // get and validate height argument
+    }
+
+    int[] left = new int[width];
+    left[0] = 1;
+    int[] right = new int[width];
+
+    // Top of maze
+    for (int i = width; --i > 0; left[i] = right[i] = i) {
+      mazeString.append("._");
+    }
+
+    // Entrance
+    mazeString.append("\n ");
+
+    // Do a row of the maze
+    int temp;
+    Random rand = new Random();
+    while (--height > 0) {
+      String first;
+      String second;
+      for (int i = width; --i > 0; /* */) {
+        if ((i != (temp = left[i - 1])) && rand.nextBoolean()) {
+          // connect to cell to right
+          right[temp] = right[i];
+          left[right[i]] = temp;
+          right[i] = i - 1;
+          left[i - 1] = i;
+          second = ".";
+        } else {
+          // block cell to right
+          second = "|";
+        }
+        if ((i != (temp = left[i])) && rand.nextBoolean()) {
+          // block off cell below
+          right[temp] = right[i];
+          left[right[i]] = temp;
+          left[i] = i;
+          right[i] = i;
+          first = "_";
+        } else {
+          // leave open lower wall
+          first = " ";
+        }
+        mazeString.append(first);
+        mazeString.append(second);
+      }
+      mazeString.append("\n|");
+    }
+
+    // Handle last row
+    for (int i = width; --i > 0; ) {
+      if ((i != (temp = left[i - 1])) && (i == right[i] || rand.nextBoolean())) {
+        left[right[temp]] = right[i] = temp;
+        left[(right[i] = i - 1)] = i;
+        mazeString.append("_.");
+      } else {
+        mazeString.append('_');
+        if (i==1) {
+          mazeString.append(" "); // Exit
+        } else {
+          mazeString.append('|');
+        }
+      }
+
+      temp = left[i];
+      right[temp] = right[i];
+      left[right[i]] = temp;
+      left[i] = i;
+      right[i] = i;
+    }
+    mazeString.append("\n " + KnownVersion.getCurrentVersion().toString() + "\n");
+
+    return RedisResponse.bulkString(mazeString.toString());
+  }
+}

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -192,6 +192,10 @@ public class StringBytesGlossary {
   @MakeImmutable
   public static final byte[] bLIMIT = stringToBytes("LIMIT");
 
+  // LolWutExecutor
+  @MakeImmutable
+  public static final byte[] bVERSION = stringToBytes("VERSION");
+
   // ********** Constants for Double Infinity comparisons **********
   public static final String P_INF = "+inf";
   public static final String INF = "inf";


### PR DESCRIPTION
This implements a version of the Redis LOLWUT command, which is supposed to (a) algorithmically generate computer art, and (b) output the program version. Optionally, the LOLWUT command can take arguments to affect the output.

This implementation generates arbitrary-size mazes. By default, it generates a 40-cell-wide maze of height 10, but given arguments it can generate a valid maze of any width and height, while consuming a small and fixed amount of memory. After the maze, it outputs the Geode version.