### PR TITLE
GEODE-9645 and GEODE-9647: Fix behavior of registering data serializers when Multi User Auth is involved

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiUserAuthenticationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiUserAuthenticationDUnitTest.java
@@ -18,8 +18,12 @@ package org.apache.geode.management.internal.security;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -30,6 +34,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import org.apache.geode.DataSerializable;
+import org.apache.geode.DataSerializer;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionService;
 import org.apache.geode.cache.client.ClientCache;
@@ -43,6 +49,7 @@ import org.apache.geode.cache.query.CqListener;
 import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.RegionNotFoundException;
+import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.examples.SimpleSecurityManager;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -77,12 +84,82 @@ public class MultiUserAuthenticationDUnitTest {
     Properties serverProps = new Properties();
     serverProps.setProperty("security-username", "cluster");
     serverProps.setProperty("security-password", "cluster");
+    serverProps.setProperty(ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER, "*");
     lsRule.startServerVM(1, serverProps, locator.getPort());
     lsRule.startServerVM(2, serverProps, locator.getPort());
 
     // create region and put in some values
     gfsh.connectAndVerify(locator);
     gfsh.executeAndAssertThat("create region --name=region --type=PARTITION").statusIsSuccess();
+  }
+
+
+  private static class TestObject implements DataSerializable {
+
+    private String id;
+
+    @Override
+    public void toData(DataOutput out) throws IOException {
+      DataSerializer.writeString(id, out);
+    }
+
+    @Override
+    public void fromData(DataInput in) throws IOException {
+      id = DataSerializer.readString(in);
+    }
+  }
+
+  private static class TestObjectDataSerializer extends DataSerializer implements Serializable {
+
+    @Override
+    public Class<?>[] getSupportedClasses() {
+      return new Class<?>[] {TestObject.class};
+    }
+
+    @Override
+    public boolean toData(Object o, DataOutput out) {
+      return o instanceof TestObject;
+    }
+
+    @Override
+    public Object fromData(DataInput in) {
+      return new TestObject();
+    }
+
+    @Override
+    public int getId() {
+      return 99;
+    }
+  }
+
+
+  @Test
+  public void validatePropogationOfDataSerializersInMultUserAuthMode() throws Exception {
+    int locatorPort = locator.getPort();
+    for (int i = 0; i < SESSION_COUNT; i++) {
+      ClientCache cache = client.withCacheSetup(f -> f.setPoolSubscriptionEnabled(true)
+              .setPoolMultiuserAuthentication(true)
+              .addPoolLocator("localhost", locatorPort))
+          .createCache();
+
+      RegionService regionService1 = client.createAuthenticatedView("data", "data");
+      RegionService regionService2 = client.createAuthenticatedView("cluster", "cluster");
+
+      cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
+
+      Region region = regionService1.getRegion(SEPARATOR + "region");
+
+      DataSerializer.register(TestObjectDataSerializer.class, regionService1);
+
+      for (int j = 0; j < KEY_COUNT; j++) {
+        String key = i + "" + j;
+        region.put(key, new TestObject());
+      }
+
+      regionService1.close();
+      regionService2.close();
+      cache.close();
+    }
   }
 
   @Test

--- a/geode-core/src/main/java/org/apache/geode/DataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/DataSerializer.java
@@ -51,6 +51,7 @@ import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionService;
 import org.apache.geode.internal.HeapDataOutputStream;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.ObjToByteArraySerializer;
@@ -2896,7 +2897,17 @@ public abstract class DataSerializer {
    */
   @SuppressWarnings("unchecked")
   public static DataSerializer register(Class<?> c) {
-    return InternalDataSerializer.register((Class<? extends DataSerializer>) c, true);
+    return InternalDataSerializer.register((Class<? extends DataSerializer>) c, null, true);
+  }
+
+  public static DataSerializer register(Class<?> c, boolean distribute) {
+    return InternalDataSerializer.register((Class<? extends DataSerializer>) c, null,
+        distribute);
+  }
+
+  public static DataSerializer register(Class<?> c, RegionService regionService) {
+    return InternalDataSerializer.register((Class<? extends DataSerializer>) c, regionService,
+        true);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/DataSerializerRecoveryListener.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/DataSerializerRecoveryListener.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.cache.client.internal;
 
+import java.util.Properties;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -28,6 +29,7 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.internal.InternalDataSerializer.SerializerAttributesHolder;
 import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.management.internal.security.ResourceConstants;
 
 public class DataSerializerRecoveryListener extends EndpointManager.EndpointListenerAdapter {
   private static final Logger logger = LogService.getLogger();
@@ -114,6 +116,12 @@ public class DataSerializerRecoveryListener extends EndpointManager.EndpointList
         }
       } else {
         try {
+
+          Properties properties = new Properties();
+          properties.setProperty(ResourceConstants.USER_NAME, System.getProperties().getProperty(ResourceConstants.USER_NAME));
+          properties.setProperty(ResourceConstants.PASSWORD, System.getProperties().getProperty(ResourceConstants.PASSWORD));
+          UserAttributes.userAttributes.set(new UserAttributes(properties, pool));
+
           RegisterDataSerializersOp.execute(pool, holders, eventId);
         } catch (CancelException ignored) {
         } catch (RejectedExecutionException e) {


### PR DESCRIPTION
Basically we have two problems that are being dealt with here both in the context of MultiUserAuth.

1) When we register a new DataSerializer, we should be supplying credentials to enable the registration process to talk to the server.

2) When we get notified of a new endpoint being up, DataSerializerRecoveryTask is called. In this class we don't have a copy of the auth information which causes a warning and crash.

Part 1 was fixed by plumbing the credentials down to the point of the registration with the server.

Part 2 has the problem the there are really two levels of authentication going on. Cluster level and user level.
The addition of DataSerializers is a cluster level operations. Adding new data is user level.

As a first cut, I have the DataSerializerRecoveryTask reach into the system settings and grab the credentials it needs. I am not sure if this is satisfactory. Hence this is not a pull request per se. Just a draft...
