### PR TITLE
GEODE-9629: Remove from the GatewaySender API one setter method.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
@@ -516,12 +516,4 @@ public interface GatewaySender {
    */
   void setGatewayEventFilters(List<GatewayEventFilter> filters);
 
-  /**
-   * Set the number of retries to get transaction events
-   * for this GatewaySender when GroupTransactionEvents
-   * is set.
-   *
-   */
-  void setRetriesToGetTransactionEventsFromQueue(int retries);
-
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySenderFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySenderFactory.java
@@ -57,7 +57,6 @@ public interface GatewaySenderFactory {
    */
   GatewaySenderFactory setRetriesToGetTransactionEventsFromQueue(int retries);
 
-
   /**
    * Adds a <code>GatewayEventFilter</code>
    *

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
@@ -720,11 +720,6 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     }
   }
 
-  @Override
-  public void setRetriesToGetTransactionEventsFromQueue(int retries) {
-    retriesToGetTransactionEventsFromQueue = retries;
-  }
-
   public boolean beforeEnqueue(GatewayQueueEvent gatewayEvent) {
     boolean enqueue = true;
     for (GatewayEventFilter filter : getGatewayEventFilters()) {


### PR DESCRIPTION
The following setter has been removed from the GatewaySender
interface: setRetriesToGetTransactionEventsFromQueue()

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
