### PR TITLE
GEODE-9645: Introduce credential checking in...

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/DataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/DataSerializer.java
@@ -2899,6 +2899,8 @@ public abstract class DataSerializer {
     return InternalDataSerializer.register((Class<? extends DataSerializer>) c, true);
   }
 
+
+
   /**
    * Creates a new <code>DataSerializer</code>. All class that implement <code>DataSerializer</code>
    * must provide a zero-argument constructor.

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -1512,7 +1512,7 @@ public class PoolImpl implements InternalPool {
     return cache.keepDurableSubscriptionsAlive();
   }
 
-  ArrayList<ProxyCache> getProxyCacheList() {
+  public ArrayList<ProxyCache> getProxyCacheList() {
     return proxyCacheList;
   }
 


### PR DESCRIPTION
RegisterDataSerializersOp

This really has an unsatisfactory unit test because the exceptions are eaten before the test can get them. We can get an unsupported op exception if there is no credentials during the register.