### PR TITLE
GEODE-9674: fix durable client message loss issue in tests. 

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -1,0 +1,275 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.security;
+
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.createAndExecuteCQ;
+import static org.apache.geode.distributed.ConfigurationProperties.DURABLE_CLIENT_ID;
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.InterestResultPolicy;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.query.dunit.SecurityTestUtils.EventsCqListner;
+import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+@Category({SecurityTest.class})
+public class AuthExpirationDUnitTest {
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public RestoreSystemProperties restore = new RestoreSystemProperties();
+
+  @Rule
+  public ServerStarterRule server = new ServerStarterRule()
+      .withSecurityManager(ExpirableSecurityManager.class)
+      .withRegion(RegionShortcut.REPLICATE, "region");
+
+
+  private ClientVM clientVM;
+
+  @After
+  public void after() {
+    if (clientVM != null) {
+      clientVM.invoke(UpdatableUserAuthInitialize::reset);
+    }
+    getSecurityManager().close();
+  }
+
+  private static EventsCqListner CQLISTENER0;
+
+  @Test
+  public void cqClientWillReAuthenticateAutomatically() throws Exception {
+    startClientWithCQ();
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    region.put("1", "value1");
+    clientVM.invoke(() -> {
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .asList()
+              .containsExactly("1"));
+    });
+
+    // expire the current user
+    getSecurityManager().addExpiredUser("user1");
+
+    // update the user to be used before we try to send the 2nd event
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user2");
+    });
+
+    // do a second put, the event should be queued until client re-authenticate
+    region.put("2", "value2");
+
+    clientVM.invoke(() -> {
+      // the client will eventually get the 2nd event
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .asList()
+              .containsExactly("1", "2"));
+    });
+
+    Map<String, List<String>> authorizedOps = getSecurityManager().getAuthorizedOps();
+    assertThat(authorizedOps.keySet().size()).isEqualTo(2);
+    assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:READ:region",
+        "DATA:READ:region:1");
+    assertThat(authorizedOps.get("user2")).asList().containsExactly("DATA:READ:region:2");
+
+    Map<String, List<String>> unAuthorizedOps = getSecurityManager().getUnAuthorizedOps();
+    assertThat(unAuthorizedOps.keySet().size()).isEqualTo(1);
+    assertThat(unAuthorizedOps.get("user1")).asList().containsExactly("DATA:READ:region:2");
+  }
+
+  @Test
+  public void registeredInterest_slowReAuth_policyDefault() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+    ClientVM client2 = cluster.startClientVM(1,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      Region<Object, Object> region = ClusterStartupRule.getClientCache()
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+
+      // this test will succeed because when clients re-connects, it will re-register inteest
+      // a new queue will be created with all the data. Old queue is destroyed.
+      region.registerInterestForAllKeys();
+      UpdatableUserAuthInitialize.setUser("user11");
+      // wait for time longer than server's max time to wait to ree-authenticate
+      UpdatableUserAuthInitialize.setWaitTime(6000);
+    });
+
+    AsyncInvocation<Void> invokePut = client2.invokeAsync(() -> {
+      UpdatableUserAuthInitialize.setUser("user2");
+      Region<Object, Object> region = ClusterStartupRule.getClientCache()
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+      IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
+    });
+
+    getSecurityManager().addExpiredUser("user1");
+    invokePut.await();
+
+    // make sure this client recovers and get all the events and will be able to do client operation
+    clientVM.invoke(() -> {
+      Region<Object, Object> region = ClusterStartupRule.getClientCache().getRegion("region");
+      await().untilAsserted(
+          () -> assertThat(region.keySet()).hasSize(100));
+      region.put("key100", "value100");
+    });
+
+    // user1 should not be used to put any keys to the region
+    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region");
+    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region:key0");
+  }
+
+  @Test
+  public void registeredInterest_slowReAuth_policyNone_durableClient() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withProperty(DURABLE_CLIENT_ID, "123456")
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Object, Object> region = clientCache
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+
+      // use InterestResultPolicy.NONE to make sure the old queue is still around
+      region.registerInterestForAllKeys(InterestResultPolicy.NONE, true);
+      clientCache.readyForEvents();
+      UpdatableUserAuthInitialize.setUser("user11");
+      // wait for time longer than server's max time to wait to re-authenticate
+      UpdatableUserAuthInitialize.setWaitTime(6000);
+    });
+
+    getSecurityManager().addExpiredUser("user1");
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
+
+    // make sure this client recovers and get all the events and will be able to do client operation
+    clientVM.invoke(() -> {
+      Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
+      await().untilAsserted(
+          () -> assertThat(clientRegion.keySet()).hasSize(100));
+      clientRegion.put("key100", "value100");
+    });
+
+    // user1 should not be used to put any keys to the region
+    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region");
+    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region:key0");
+  }
+
+  @Test
+  public void registeredInterest_slowReAuth_policyNone_nonDurableClient()
+      throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Object, Object> region = clientCache
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+
+      // use InterestResultPolicy.NONE to make sure the old queue is still around
+      region.registerInterestForAllKeys(InterestResultPolicy.NONE);
+      UpdatableUserAuthInitialize.setUser("user11");
+      // wait for time longer than server's max time to wait to ree-authenticate
+      UpdatableUserAuthInitialize.setWaitTime(6000);
+    });
+
+    getSecurityManager().addExpiredUser("user1");
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
+
+    // client will recover but there will be message loss
+    clientVM.invoke(() -> {
+      Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
+      await().during(10, TimeUnit.SECONDS).untilAsserted(
+          () -> assertThat(clientRegion.keySet()).hasSizeLessThan(100));
+      clientRegion.put("key100", "value100");
+    });
+
+    // user1 should not be used to put any keys to the region
+    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region");
+    assertThat(getSecurityManager().getAuthorizedOps().get("user11"))
+        .contains("DATA:WRITE:region:key100");
+    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region:key0");
+  }
+
+  private void startClientWithCQ() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withCacheSetup(
+                ccf -> ccf.setPoolSubscriptionRedundancy(2).setPoolSubscriptionEnabled(true))
+            .withServerConnection(serverPort));
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      CQLISTENER0 = createAndExecuteCQ(ClusterStartupRule.getClientCache().getQueryService(), "CQ1",
+          "select * from /region");
+    });
+  }
+
+  private ExpirableSecurityManager getSecurityManager() {
+    return (ExpirableSecurityManager) server.getCache().getSecurityService().getSecurityManager();
+  }
+
+
+}

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationFunctionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationFunctionDUnitTest.java
@@ -1,4 +1,5 @@
 /*
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
@@ -11,17 +12,18 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 package org.apache.geode.security;
 
 import static org.apache.geode.cache.execute.FunctionService.onRegion;
 import static org.apache.geode.cache.execute.FunctionService.onServer;
 import static org.apache.geode.cache.execute.FunctionService.onServers;
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.collectSecurityManagers;
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.getSecurityManager;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
-import static org.apache.geode.security.ClientAuthenticationTestUtils.collectSecurityManagers;
-import static org.apache.geode.security.ClientAuthenticationTestUtils.getSecurityManager;
 import static org.apache.geode.security.SecurityManager.PASSWORD;
 import static org.apache.geode.security.SecurityManager.USER_NAME;
 import static org.apache.geode.test.version.VersionManager.CURRENT_VERSION;

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -327,7 +327,7 @@ public class QueueManagerImpl implements QueueManager {
       }
       if (primary.sendClientReady()) {
         try {
-          logger.info("Sending ready for events to primary: {}", primary);
+          logger.info("readyForEvents: Sending ready for events to primary: {}", primary);
           ReadyForEventsOp.execute(pool, primary);
         } catch (Exception e) {
           if (logger.isDebugEnabled()) {
@@ -342,7 +342,7 @@ public class QueueManagerImpl implements QueueManager {
 
   private void readyForEventsAfterFailover(QueueConnectionImpl primary) {
     try {
-      logger.info("Sending ready for events to primary: {}", primary);
+      logger.info("readyForEventsAfterFailover: Sending ready for events to primary: {}", primary);
       ReadyForEventsOp.execute(pool, primary);
     } catch (Exception e) {
       if (logger.isDebugEnabled()) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
@@ -388,6 +388,8 @@ public class MessageDispatcher extends LoggingThread {
           waitForResumption();
         }
 
+        logger.info("available ids = {}, clientMessage = {}", _messageQueue.size(), clientMessage);
+
         // if message is not delivered due to authentication expiation, this clientMessage
         // would not be null.
         if (clientMessage == null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
@@ -422,7 +422,7 @@ public class MessageDispatcher extends LoggingThread {
           wait_for_re_auth_start_time = -1;
         } catch (NotAuthorizedException notAuthorized) {
           // behave as if the message is dispatched, remove from the queue
-          logger.info("skip delivering message: " + clientMessage, notAuthorized);
+          logger.warn("skip delivering message: " + clientMessage, notAuthorized);
           _messageQueue.remove();
           clientMessage = null;
         } catch (AuthenticationExpiredException expired) {
@@ -440,15 +440,17 @@ public class MessageDispatcher extends LoggingThread {
           } else {
             long elapsedTime = System.currentTimeMillis() - wait_for_re_auth_start_time;
             if (elapsedTime > reAuthenticateWaitTime) {
-              logger.warn("Client did not re-authenticate back successfully in " + elapsedTime
-                  + "ms. Unregister this client proxy.");
-              pauseOrUnregisterProxy(expired);
+              synchronized (_stopDispatchingLock) {
+                logger.warn("Client did not re-authenticate back successfully in " + elapsedTime
+                    + "ms. Unregister this client proxy.");
+                pauseOrUnregisterProxy(expired);
+              }
+              exceptionOccurred = true;
             } else {
               Thread.sleep(200);
             }
           }
         }
-
       } catch (MessageTooLargeException e) {
         logger.warn("Message too large to send to client: {}, {}", clientMessage, e.getMessage());
       } catch (IOException e) {
@@ -482,7 +484,6 @@ public class MessageDispatcher extends LoggingThread {
             // Let the CacheClientNotifier discover the proxy is not alive.
             // See isAlive().
             // getProxy().close(false);
-
             pauseOrUnregisterProxy(e);
           } // _isStopped
         } // synchronized
@@ -531,54 +532,59 @@ public class MessageDispatcher extends LoggingThread {
 
     // Processing gets here if isStopped=true. What is this code below doing?
     if (!exceptionOccurred) {
-      List<ClientMessage> list = new ArrayList<>();
-      try {
-        // Clear the interrupt status if any,
-        Thread.interrupted();
-        int size = _messageQueue.size();
-        list.addAll(uncheckedCast(_messageQueue.peek(size)));
-        if (logger.isDebugEnabled()) {
-          logger.debug(
-              "{}: After flagging the dispatcher to stop , the residual List of messages to be dispatched={} size={}",
-              this, list, list.size());
-        }
-        if (list.size() > 0) {
-          long start = getStatistics().startTime();
-          Iterator<ClientMessage> itr = list.iterator();
-          while (itr.hasNext()) {
-            dispatchMessage(itr.next());
-            getStatistics().endMessage(start);
-            itr.remove();
-          }
-          _messageQueue.remove();
-        }
-      } catch (CancelException e) {
-        if (logger.isDebugEnabled()) {
-          logger.debug("CacheClientNotifier stopped due to cancellation");
-        }
-      } catch (Exception e) {
-        String extraMsg = null;
-
-        if ("Broken pipe".equals(e.getMessage())) {
-          extraMsg = "Problem caused by broken pipe on socket.";
-        } else if (e instanceof RegionDestroyedException) {
-          extraMsg = "Problem caused by message queue being closed.";
-        }
-        if (extraMsg == null) {
-          extraMsg = "Problem caused by: " + e.getMessage();
-        }
-        logger.info(String.format(
-            "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
-            (!isStopped()) ? toString() + ": " : "", list.size()));
-        logger.info(extraMsg);
-      }
-
-      if (!list.isEmpty() && logger.isTraceEnabled()) {
-        logger.trace("Messages remaining in the list are: {}", list);
-      }
+      dispatchResidualMessages();
     }
     if (logger.isTraceEnabled()) {
       logger.trace("{}: Dispatcher thread is ending", this);
+    }
+  }
+
+  @VisibleForTesting
+  void dispatchResidualMessages() {
+    List<ClientMessage> list = new ArrayList<>();
+    try {
+      // Clear the interrupt status if any,
+      Thread.interrupted();
+      int size = _messageQueue.size();
+      list.addAll(uncheckedCast(_messageQueue.peek(size)));
+      if (logger.isDebugEnabled()) {
+        logger.debug(
+            "{}: After flagging the dispatcher to stop , the residual List of messages to be dispatched={} size={}",
+            this, list, list.size());
+      }
+      if (list.size() > 0) {
+        long start = getStatistics().startTime();
+        Iterator<ClientMessage> itr = list.iterator();
+        while (itr.hasNext()) {
+          dispatchMessage(itr.next());
+          getStatistics().endMessage(start);
+          itr.remove();
+        }
+        _messageQueue.remove();
+      }
+    } catch (CancelException e) {
+      if (logger.isDebugEnabled()) {
+        logger.debug("CacheClientNotifier stopped due to cancellation");
+      }
+    } catch (Exception e) {
+      String extraMsg = null;
+
+      if ("Broken pipe".equals(e.getMessage())) {
+        extraMsg = "Problem caused by broken pipe on socket.";
+      } else if (e instanceof RegionDestroyedException) {
+        extraMsg = "Problem caused by message queue being closed.";
+      }
+      if (extraMsg == null) {
+        extraMsg = "Problem caused by: " + e.getMessage();
+      }
+      logger.info(String.format(
+          "%s Possibility of not being able to send some or all of the messages to clients. Total messages currently present in the list %s.",
+          (!isStopped()) ? toString() + ": " : "", list.size()));
+      logger.info(extraMsg);
+    }
+
+    if (!list.isEmpty() && logger.isTraceEnabled()) {
+      logger.trace("Messages remaining in the list are: {}", list);
     }
   }
 

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/ConnectionFactoryImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/ConnectionFactoryImplTest.java
@@ -1,0 +1,103 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.cache.client.internal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.distributed.internal.ServerLocation;
+
+public class ConnectionFactoryImplTest {
+  private ConnectionFactoryImpl factory;
+  private ConnectionConnector connector;
+  private ConnectionSource source;
+  private PoolImpl pool;
+  private CancelCriterion cancelCriterion;
+  private Connection connection;
+  private ServerLocation server;
+
+  @Before
+  public void before() throws Exception {
+    server = mock(ServerLocation.class);
+    connection = mock(Connection.class);
+    connector = mock(ConnectionConnector.class);
+    source = mock(ConnectionSource.class);
+    pool = mock(PoolImpl.class);
+    cancelCriterion = mock(CancelCriterion.class);
+    factory = new ConnectionFactoryImpl(connector, source, 5, pool, cancelCriterion);
+  }
+
+  @Test
+  public void authenticateIfRequired_noOp_whenUsedByGateway() throws Exception {
+    when(pool.isUsedByGateway()).thenReturn(true);
+    factory.authenticateIfRequired(connection);
+    verify(connection, never()).getServer();
+  }
+
+  @Test
+  public void authenticateIfRequired_noOp_whenMultiUser() throws Exception {
+    when(pool.isUsedByGateway()).thenReturn(false);
+    when(pool.getMultiuserAuthentication()).thenReturn(true);
+    factory.authenticateIfRequired(connection);
+    verify(connection, never()).getServer();
+  }
+
+  @Test
+  public void authenticateIfRequired_noOp_whenServerNotRequireCredential() throws Exception {
+    when(pool.isUsedByGateway()).thenReturn(false);
+    when(pool.getMultiuserAuthentication()).thenReturn(false);
+    when(connection.getServer()).thenReturn(server);
+    when(server.getRequiresCredentials()).thenReturn(false);
+    factory.authenticateIfRequired(connection);
+    verify(connection).getServer();
+    verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
+  }
+
+  @Test
+  public void authenticateIfRequired_noOp_whenServerHasUserId() throws Exception {
+    when(pool.isUsedByGateway()).thenReturn(false);
+    when(pool.getMultiuserAuthentication()).thenReturn(false);
+    when(connection.getServer()).thenReturn(server);
+    when(server.getRequiresCredentials()).thenReturn(true);
+    when(server.getUserId()).thenReturn(1234L);
+    factory.authenticateIfRequired(connection);
+    verify(connection).getServer();
+    verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
+  }
+
+  @Test
+  public void authenticateIfRequired() throws Exception {
+    when(pool.isUsedByGateway()).thenReturn(false);
+    when(pool.getMultiuserAuthentication()).thenReturn(false);
+    when(connection.getServer()).thenReturn(server);
+    when(server.getRequiresCredentials()).thenReturn(true);
+    when(server.getUserId()).thenReturn(-1L);
+    when(pool.executeOn(any(Connection.class), any(Op.class))).thenReturn(123L);
+    factory.authenticateIfRequired(connection);
+    verify(connection).getServer();
+    verify(pool).executeOn(any(Connection.class), any(Op.class));
+    verify(server).setUserId(123L);
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/OpExecutorImplUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/OpExecutorImplUnitTest.java
@@ -1,0 +1,102 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.cache.client.internal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.apache.geode.CancelCriterion;
+import org.apache.geode.cache.client.internal.pooling.ConnectionManager;
+import org.apache.geode.distributed.internal.ServerLocation;
+
+public class OpExecutorImplUnitTest {
+  private OpExecutorImpl executor;
+  private ConnectionManager connectionManager;
+  private QueueManager queueManager;
+  private EndpointManager endpointManager;
+  private RegisterInterestTracker tracker;
+  private CancelCriterion cancelCriterion;
+  private PoolImpl pool;
+  private ServerLocation server;
+  private Connection connection;
+  private AbstractOp op;
+
+  @Before
+  public void before() throws Exception {
+    connectionManager = mock(ConnectionManager.class);
+    queueManager = mock(QueueManager.class);
+    endpointManager = mock(EndpointManager.class);
+    tracker = mock(RegisterInterestTracker.class);
+    cancelCriterion = mock(CancelCriterion.class);
+    server = mock(ServerLocation.class);
+    connection = mock(Connection.class);
+    pool = mock(PoolImpl.class);
+    op = mock(AbstractOp.class);
+    when(connection.getServer()).thenReturn(server);
+
+    executor = new OpExecutorImpl(connectionManager, queueManager, endpointManager, tracker, 1, 5L,
+        5L, cancelCriterion, pool);
+  }
+
+  @Test
+  public void authenticateIfRequired_noOp_WhenNotRequireCredential() throws Exception {
+    when(server.getRequiresCredentials()).thenReturn(false);
+    executor.authenticateIfRequired(connection, op);
+    verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
+  }
+
+  @Test
+  public void authenticateIfRequired_noOp_WhenOpNeedsNoUserId() throws Exception {
+    when(server.getRequiresCredentials()).thenReturn(true);
+    when(op.needsUserId()).thenReturn(false);
+    executor.authenticateIfRequired(connection, op);
+    verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
+  }
+
+  @Test
+  public void authenticateIfRequired_noOp_singleUser_hasId() throws Exception {
+    when(server.getRequiresCredentials()).thenReturn(true);
+    when(op.needsUserId()).thenReturn(true);
+    when(pool.getMultiuserAuthentication()).thenReturn(false);
+    when(server.getUserId()).thenReturn(123L);
+    executor.authenticateIfRequired(connection, op);
+    verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
+
+  }
+
+  @Test
+  public void authenticateIfRequired_setId_singleUser_hasNoId() throws Exception {
+    when(server.getRequiresCredentials()).thenReturn(true);
+    when(op.needsUserId()).thenReturn(true);
+    when(pool.getMultiuserAuthentication()).thenReturn(false);
+    when(server.getUserId()).thenReturn(-1L);
+    when(pool.executeOn(any(Connection.class), any(Op.class))).thenReturn(123L);
+    when(connection.getWrappedConnection()).thenReturn(connection);
+    executor.authenticateIfRequired(connection, op);
+    verify(pool).executeOn(any(Connection.class), any(Op.class));
+    verify(server).setUserId(eq(123L));
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
@@ -148,6 +148,7 @@ public class MessageDispatcherTest {
 
     // since we keep throwing the AuthenticationExpiredException, we will eventually call this
     verify(dispatcher).pauseOrUnregisterProxy(any(AuthenticationExpiredException.class));
+    verify(dispatcher, never()).dispatchResidualMessages();
   }
 
   @Test
@@ -163,5 +164,6 @@ public class MessageDispatcherTest {
     verify(dispatcher, never()).sendMessageDirectly(any());
     // we will eventually pauseOrUnregisterProxy
     verify(dispatcher).pauseOrUnregisterProxy(any(AuthenticationExpiredException.class));
+    verify(dispatcher, never()).dispatchResidualMessages();
   }
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -14,12 +14,14 @@
  */
 package org.apache.geode.security;
 
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.createAndExecuteCQ;
+import static org.apache.geode.distributed.ConfigurationProperties.DURABLE_CLIENT_ID;
+import static org.apache.geode.distributed.ConfigurationProperties.DURABLE_CLIENT_TIMEOUT;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -43,16 +45,8 @@ import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientRegionFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.ServerOperationException;
-import org.apache.geode.cache.query.CqAttributesFactory;
-import org.apache.geode.cache.query.CqEvent;
-import org.apache.geode.cache.query.CqException;
-import org.apache.geode.cache.query.CqExistsException;
-import org.apache.geode.cache.query.CqListener;
-import org.apache.geode.cache.query.CqQuery;
-import org.apache.geode.cache.query.QueryService;
-import org.apache.geode.cache.query.RegionNotFoundException;
-import org.apache.geode.distributed.ConfigurationProperties;
-import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.cache.query.dunit.SecurityTestUtils.EventsCqListner;
+import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.rules.ClientVM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
@@ -98,6 +92,7 @@ public class AuthExpirationDUnitTest {
     if (clientVM != null) {
       clientVM.invoke(UpdatableUserAuthInitialize::reset);
     }
+    getSecurityManager().close();
   }
 
   @Test
@@ -258,53 +253,6 @@ public class AuthExpirationDUnitTest {
   private static EventsCqListner CQLISTENER0;
   private static EventsCqListner CQLISTENER1;
 
-  @Test
-  public void cqNewerClientWillReAuthenticateAutomatically() throws Exception {
-    // this test should only test the newer client
-    if (TestVersion.compare(clientVersion, test_start_version) <= 0) {
-      return;
-    }
-
-    startClientWithCQ();
-
-    Region<Object, Object> region = server.getCache().getRegion("/region");
-    region.put("1", "value1");
-    clientVM.invoke(() -> {
-      await().untilAsserted(
-          () -> assertThat(CQLISTENER0.getKeys())
-              .asList()
-              .containsExactly("1"));
-    });
-
-    // expire the current user
-    getSecurityManager().addExpiredUser("user1");
-
-    // update the user to be used before we try to send the 2nd event
-    clientVM.invoke(() -> {
-      UpdatableUserAuthInitialize.setUser("user2");
-    });
-
-    // do a second put, the event should be queued until client re-authenticate
-    region.put("2", "value2");
-
-    clientVM.invoke(() -> {
-      // the client will eventually get the 2nd event
-      await().untilAsserted(
-          () -> assertThat(CQLISTENER0.getKeys())
-              .asList()
-              .containsExactly("1", "2"));
-    });
-
-    Map<String, List<String>> authorizedOps = getSecurityManager().getAuthorizedOps();
-    assertThat(authorizedOps.keySet().size()).isEqualTo(2);
-    assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:READ:region",
-        "DATA:READ:region:1");
-    assertThat(authorizedOps.get("user2")).asList().containsExactly("DATA:READ:region:2");
-
-    Map<String, List<String>> unAuthorizedOps = getSecurityManager().getUnAuthorizedOps();
-    assertThat(unAuthorizedOps.keySet().size()).isEqualTo(1);
-    assertThat(unAuthorizedOps.get("user1")).asList().containsExactly("DATA:READ:region:2");
-  }
 
   @Test
   public void cqOlderClientWillNotReAuthenticateAutomatically() throws Exception {
@@ -486,12 +434,11 @@ public class AuthExpirationDUnitTest {
   }
 
   @Test
-  public void registeredInterestForInterestPolicyNone() throws Exception {
+  public void registeredInterest_PolicyNone_non_durableClient() throws Exception {
     int serverPort = server.getPort();
     clientVM = cluster.startClientVM(0, clientVersion,
         c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
-            .withCacheSetup(
-                ccf -> ccf.setPoolSubscriptionEnabled(true).setPoolSubscriptionRedundancy(0))
+            .withPoolSubscription(true)
             .withServerConnection(serverPort));
 
     clientVM.invoke(() -> {
@@ -504,10 +451,14 @@ public class AuthExpirationDUnitTest {
     Region<Object, Object> region = server.getCache().getRegion("/region");
     region.put("1", "value1");
     clientVM.invoke(() -> {
+      Region<Object, Object> clientRegion =
+          ClusterStartupRule.getClientCache().getRegion("region");
+      await().untilAsserted(
+          () -> assertThat(clientRegion.keySet()).containsExactly("1"));
       UpdatableUserAuthInitialize.setUser("user2");
     });
-    getSecurityManager().addExpiredUser("user1");
 
+    getSecurityManager().addExpiredUser("user1");
     region.put("2", "value2");
 
     // for old client, server close the proxy, client have reconnect mechanism which
@@ -518,7 +469,7 @@ public class AuthExpirationDUnitTest {
         Region<Object, Object> clientRegion =
             ClusterStartupRule.getClientCache().getRegion("region");
         await().during(10, TimeUnit.SECONDS).untilAsserted(
-            () -> assertThat(clientRegion.keySet().size()).isLessThan(2));
+            () -> assertThat(clientRegion.keySet()).isEmpty());
         // but client will reconnect successfully using the 2nd user
         clientRegion.put("2", "value2");
       });
@@ -528,7 +479,7 @@ public class AuthExpirationDUnitTest {
         Region<Object, Object> clientRegion =
             ClusterStartupRule.getClientCache().getRegion("region");
         await().untilAsserted(
-            () -> assertThat(clientRegion.keySet()).hasSize(2));
+            () -> assertThat(clientRegion.keySet()).containsExactly("1", "2"));
       });
     }
 
@@ -538,160 +489,63 @@ public class AuthExpirationDUnitTest {
   }
 
   @Test
-  public void newClient_registeredInterest_slowReAuth_policyDefault() throws Exception {
-    // this test only test the newer client
-    if (TestVersion.compare(clientVersion, test_start_version) <= 0) {
-      return;
-    }
-
+  public void registeredInterestForInterestPolicyNone_durableClient() throws Exception {
     int serverPort = server.getPort();
     clientVM = cluster.startClientVM(0, clientVersion,
         c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
             .withPoolSubscription(true)
+            .withProperty(DURABLE_CLIENT_ID, "123456")
             .withServerConnection(serverPort));
-
-    ClientVM client2 = cluster.startClientVM(1, clientVersion,
-        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
-            .withPoolSubscription(true)
-            .withServerConnection(serverPort));
-
-    clientVM.invoke(() -> {
-      UpdatableUserAuthInitialize.setUser("user1");
-      Region<Object, Object> region = ClusterStartupRule.getClientCache()
-          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
-
-      // this test will succeed because when clients re-connects, it will re-register inteest
-      // a new queue will be created with all the data. Old queue is destroyed.
-      region.registerInterestForAllKeys();
-      UpdatableUserAuthInitialize.setUser("user11");
-      // wait for time longer than server's max time to wait to ree-authenticate
-      UpdatableUserAuthInitialize.setWaitTime(6000);
-    });
-
-    AsyncInvocation<Void> invokePut = client2.invokeAsync(() -> {
-      UpdatableUserAuthInitialize.setUser("user2");
-      Region<Object, Object> region = ClusterStartupRule.getClientCache()
-          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
-      IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
-    });
-
-    getSecurityManager().addExpiredUser("user1");
-    invokePut.await();
-
-    // make sure this client recovers and get all the events and will be able to do client operation
-    clientVM.invoke(() -> {
-      Region<Object, Object> region = ClusterStartupRule.getClientCache().getRegion("region");
-      await().untilAsserted(
-          () -> assertThat(region.keySet()).hasSize(100));
-      region.put("key100", "value100");
-    });
-
-    // user1 should not be used to put any keys to the region
-    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
-        .containsExactly("DATA:READ:region");
-    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
-        .containsExactly("DATA:READ:region:key0");
-  }
-
-  @Test
-  public void newClient_registeredInterest_slowReAuth_policyNone_durableClient() throws Exception {
-    // this test only test the newer client
-    if (TestVersion.compare(clientVersion, test_start_version) <= 0) {
-      return;
-    }
-    int serverPort = server.getPort();
-    clientVM = cluster.startClientVM(0, clientVersion,
-        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
-            .withProperty(ConfigurationProperties.DURABLE_CLIENT_ID, "123456")
-            .withPoolSubscription(true)
-            .withServerConnection(serverPort));
-
 
     clientVM.invoke(() -> {
       UpdatableUserAuthInitialize.setUser("user1");
       ClientCache clientCache = ClusterStartupRule.getClientCache();
-      Region<Object, Object> region = clientCache
+      Region<Object, Object> clientRegion = clientCache
           .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
-
-      // use InterestResultPolicy.NONE to make sure the old queue is still around
-      region.registerInterestForAllKeys(InterestResultPolicy.NONE);
+      clientRegion.registerInterestForAllKeys(InterestResultPolicy.NONE, true);
       clientCache.readyForEvents();
-      UpdatableUserAuthInitialize.setUser("user11");
-      // wait for time longer than server's max time to wait to re-authenticate
-      UpdatableUserAuthInitialize.setWaitTime(6000);
     });
 
-    getSecurityManager().addExpiredUser("user1");
     Region<Object, Object> region = server.getCache().getRegion("/region");
-    IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
-
-    // make sure this client recovers and get all the events and will be able to do client operation
+    region.put("1", "value1");
     clientVM.invoke(() -> {
-      Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
+      Region<Object, Object> clientRegion =
+          ClusterStartupRule.getClientCache().getRegion("region");
       await().untilAsserted(
-          () -> assertThat(clientRegion.keySet()).hasSize(100));
-      clientRegion.put("key100", "value100");
-    });
-
-    // user1 should not be used to put any keys to the region
-    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
-        .containsExactly("DATA:READ:region");
-    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
-        .containsExactly("DATA:READ:region:key0");
-  }
-
-  @Test
-  public void newClient_registeredInterest_slowReAuth_policyNone_nonDurableClient()
-      throws Exception {
-    // this test only test the newer client
-    if (TestVersion.compare(clientVersion, test_start_version) <= 0) {
-      return;
-    }
-    int serverPort = server.getPort();
-    clientVM = cluster.startClientVM(0, clientVersion,
-        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
-            .withPoolSubscription(true)
-            .withServerConnection(serverPort));
-
-
-    clientVM.invoke(() -> {
-      UpdatableUserAuthInitialize.setUser("user1");
-      ClientCache clientCache = ClusterStartupRule.getClientCache();
-      Region<Object, Object> region = clientCache
-          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
-
-      // use InterestResultPolicy.NONE to make sure the old queue is still around
-      region.registerInterestForAllKeys(InterestResultPolicy.NONE);
-      UpdatableUserAuthInitialize.setUser("user11");
-      // wait for time longer than server's max time to wait to ree-authenticate
-      UpdatableUserAuthInitialize.setWaitTime(6000);
+          () -> assertThat(clientRegion.keySet()).containsExactly("1"));
+      UpdatableUserAuthInitialize.setUser("user2");
     });
 
     getSecurityManager().addExpiredUser("user1");
-    Region<Object, Object> region = server.getCache().getRegion("/region");
-    IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
+    region.put("2", "value2");
 
-    // client will recover but there will be message loss
-    clientVM.invoke(() -> {
-      Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
-      await().during(10, TimeUnit.SECONDS).untilAsserted(
-          () -> assertThat(clientRegion.keySet()).hasSizeLessThan(100));
-      clientRegion.put("key100", "value100");
-    });
+    // for durable client, the key "2" will eventually be delivered to the clients
+    if (TestVersion.compare(clientVersion, test_start_version) <= 0) {
+      clientVM.invoke(() -> {
+        Region<Object, Object> clientRegion =
+            ClusterStartupRule.getClientCache().getRegion("region");
+        await().untilAsserted(
+            () -> assertThat(clientRegion.keySet()).containsExactly("2"));
+        // but client will reconnect successfully using the 2nd user
+        clientRegion.put("2", "value2");
+      });
+    } else {
+      // new client would have no message loss
+      clientVM.invoke(() -> {
+        Region<Object, Object> clientRegion =
+            ClusterStartupRule.getClientCache().getRegion("region");
+        await().untilAsserted(
+            () -> assertThat(clientRegion.keySet()).containsExactly("1", "2"));
+      });
+    }
 
-    // user1 should not be used to put any keys to the region
+    // user1 should not be used to put key2 to the region in any cases
     assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
-        .containsExactly("DATA:READ:region");
-    assertThat(getSecurityManager().getAuthorizedOps().get("user11"))
-        .contains("DATA:WRITE:region:key100");
-    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
-        .containsExactly("DATA:READ:region:key0");
+        .doesNotContain("DATA:READ:region:2");
   }
 
-
-
   @Test
-  public void registeredInterestWithFailedReAuth() throws Exception {
+  public void registeredInterest_FailedReAuth_non_durableClient() throws Exception {
     int serverPort = server.getPort();
     clientVM = cluster.startClientVM(0, clientVersion,
         c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
@@ -715,10 +569,53 @@ public class AuthExpirationDUnitTest {
     clientVM.invoke(() -> {
       IgnoredException.addIgnoredException(AuthenticationFailedException.class);
       Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
-      await().during(2, TimeUnit.SECONDS).untilAsserted(() -> assertThat(clientRegion).isEmpty());
+      await().during(10, TimeUnit.SECONDS).untilAsserted(() -> assertThat(clientRegion).isEmpty());
       assertThatThrownBy(() -> clientRegion.put("key100", "value100"))
           .hasCauseInstanceOf(AuthenticationFailedException.class);
     });
+
+    // client can't re-authenticate back, no CacheClientProxy exists (old queue destroyed)
+    assertThat(server.getServer().getAllClientSessions()).isEmpty();
+  }
+
+  @Test
+  public void registeredInterest_FailedReAuth_durableClient() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0, clientVersion,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withProperty(DURABLE_CLIENT_ID, "123456")
+            .withProperty(DURABLE_CLIENT_TIMEOUT, "10")
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Object, Object> region = clientCache
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+      region.registerInterestForAllKeys(InterestResultPolicy.NONE, true);
+      UpdatableUserAuthInitialize.setUser("user11");
+      clientCache.readyForEvents();
+      // invalid wait time will cause re-auth to throw exception
+      UpdatableUserAuthInitialize.setWaitTime(-1);
+    });
+
+    getSecurityManager().addExpiredUser("user1");
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    IntStream.range(0, 10).forEach(i -> region.put("key" + i, "value" + i));
+
+    clientVM.invoke(() -> {
+      IgnoredException.addIgnoredException(AuthenticationFailedException.class);
+      Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
+      await().during(10, TimeUnit.SECONDS).untilAsserted(() -> assertThat(clientRegion).isEmpty());
+    });
+
+    // since we set a timeout, queue will be destroyed
+    await().untilAsserted(() -> assertThat(getDurableClientProxy("123456")).isNull());
+  }
+
+  private CacheClientProxy getDurableClientProxy(String durableId) {
+    return (CacheClientProxy) server.getServer().getClientSession(durableId);
   }
 
   private void startClientWithCQ() throws Exception {
@@ -736,31 +633,4 @@ public class AuthExpirationDUnitTest {
     });
   }
 
-  protected static EventsCqListner createAndExecuteCQ(QueryService queryService, String cqName,
-      String query)
-      throws CqExistsException, CqException, RegionNotFoundException {
-    CqAttributesFactory cqaf = new CqAttributesFactory();
-    EventsCqListner listenter = new EventsCqListner();
-    cqaf.addCqListener(listenter);
-
-    CqQuery cq = queryService.newCq(cqName, query, cqaf.create());
-    cq.execute();
-    return listenter;
-  }
-
-  protected static class EventsCqListner implements CqListener {
-    private List<String> keys = new ArrayList<>();
-
-    @Override
-    public void onEvent(CqEvent aCqEvent) {
-      keys.add(aCqEvent.getKey().toString());
-    }
-
-    @Override
-    public void onError(CqEvent aCqEvent) {}
-
-    public List<String> getKeys() {
-      return keys;
-    }
-  }
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationTestUtils.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationTestUtils.java
@@ -20,15 +20,9 @@ import static org.apache.geode.security.SecurityTestUtils.REGION_NAME;
 import static org.apache.geode.security.SecurityTestUtils.getCache;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.test.dunit.rules.ClusterStartupRule;
-import org.apache.geode.test.dunit.rules.MemberVM;
 
 /**
  * Extracted from ClientAuthenticationDUnitTest
@@ -119,37 +113,5 @@ public abstract class ClientAuthenticationTestUtils {
     Region region = getCache().getRegion(REGION_NAME);
     assertNotNull(region);
     region.registerInterestRegex(".*");
-  }
-
-
-  protected static ExpirableSecurityManager collectSecurityManagers(MemberVM... vms) {
-    List<ExpirableSecurityManager> results = new ArrayList<>();
-    for (MemberVM vm : vms) {
-      results.add(vm.invoke(() -> getSecurityManager()));
-    }
-
-    ExpirableSecurityManager consolidated = new ExpirableSecurityManager();
-    for (ExpirableSecurityManager result : results) {
-      consolidated.getExpiredUsers().addAll(result.getExpiredUsers());
-      combine(consolidated.getAuthorizedOps(), result.getAuthorizedOps());
-      combine(consolidated.getUnAuthorizedOps(), result.getUnAuthorizedOps());
-    }
-    return consolidated;
-  }
-
-  protected static void combine(Map<String, List<String>> to, Map<String, List<String>> from) {
-    for (String key : from.keySet()) {
-      if (to.containsKey(key)) {
-        to.get(key).addAll(from.get(key));
-      } else {
-        to.put(key, from.get(key));
-      }
-    }
-  }
-
-  protected static ExpirableSecurityManager getSecurityManager() {
-    return (ExpirableSecurityManager) Objects.requireNonNull(ClusterStartupRule.getCache())
-        .getSecurityService()
-        .getSecurityManager();
   }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/cache/query/dunit/SecurityTestUtils.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache/query/dunit/SecurityTestUtils.java
@@ -1,0 +1,96 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.cache.query.dunit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqException;
+import org.apache.geode.cache.query.CqExistsException;
+import org.apache.geode.cache.query.CqListener;
+import org.apache.geode.cache.query.CqQuery;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.RegionNotFoundException;
+import org.apache.geode.security.ExpirableSecurityManager;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+
+public class SecurityTestUtils {
+  public static ExpirableSecurityManager collectSecurityManagers(MemberVM... vms) {
+    List<ExpirableSecurityManager> results = new ArrayList<>();
+    for (MemberVM vm : vms) {
+      results.add(vm.invoke(() -> getSecurityManager()));
+    }
+
+    ExpirableSecurityManager consolidated = new ExpirableSecurityManager();
+    for (ExpirableSecurityManager result : results) {
+      consolidated.getExpiredUsers().addAll(result.getExpiredUsers());
+      combine(consolidated.getAuthorizedOps(), result.getAuthorizedOps());
+      combine(consolidated.getUnAuthorizedOps(), result.getUnAuthorizedOps());
+    }
+    return consolidated;
+  }
+
+  public static void combine(Map<String, List<String>> to, Map<String, List<String>> from) {
+    for (String key : from.keySet()) {
+      if (to.containsKey(key)) {
+        to.get(key).addAll(from.get(key));
+      } else {
+        to.put(key, from.get(key));
+      }
+    }
+  }
+
+  public static ExpirableSecurityManager getSecurityManager() {
+    return (ExpirableSecurityManager) Objects.requireNonNull(ClusterStartupRule.getCache())
+        .getSecurityService()
+        .getSecurityManager();
+  }
+
+  public static class EventsCqListner implements CqListener {
+    private List<String> keys = new ArrayList<>();
+
+    @Override
+    public void onEvent(CqEvent aCqEvent) {
+      keys.add(aCqEvent.getKey().toString());
+    }
+
+    @Override
+    public void onError(CqEvent aCqEvent) {}
+
+    public List<String> getKeys() {
+      return keys;
+    }
+  }
+
+  public static EventsCqListner createAndExecuteCQ(QueryService queryService, String cqName,
+      String query)
+      throws CqExistsException, CqException, RegionNotFoundException {
+    CqAttributesFactory cqaf = new CqAttributesFactory();
+    EventsCqListner listenter = new EventsCqListner();
+    cqaf.addCqListener(listenter);
+
+    CqQuery cq = queryService.newCq(cqName, query, cqaf.create());
+    cq.execute();
+    return listenter;
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
@@ -91,6 +91,7 @@ public class ExpirableSecurityManager extends SimpleSecurityManager implements S
     maps.put(user.toString(), list);
   }
 
+  @Override
   public void close() {
     expired_users.clear();
     authorizedOps.clear();

--- a/geode-junit/src/main/java/org/apache/geode/security/UpdatableUserAuthInitialize.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/UpdatableUserAuthInitialize.java
@@ -17,8 +17,11 @@ package org.apache.geode.security;
 
 import java.util.Properties;
 
+import org.apache.logging.log4j.Logger;
+
 import org.apache.geode.LogWriter;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * this is used in conjunction with ExpirableSecurityManager. It will create a new set of
@@ -28,6 +31,7 @@ import org.apache.geode.distributed.DistributedMember;
  * make sure reset is called after each test to clean things up.
  */
 public class UpdatableUserAuthInitialize implements AuthInitialize {
+  private static Logger logger = LogService.getLogger();
   private static final String TEST_UPDATABLE_USER = "test.updatable.user";
   private static final String TEST_UPDATABLE_WAIT_TIME = "test.updatable.waitTime";
   // use static field for ease of testing since there is only one instance of this in each VM
@@ -46,8 +50,8 @@ public class UpdatableUserAuthInitialize implements AuthInitialize {
   public Properties getCredentials(Properties securityProps, DistributedMember server,
       boolean isPeer) throws AuthenticationFailedException {
     Properties credentials = new Properties();
-    credentials.put("security-username", user);
-    credentials.put("security-password", user);
+    credentials.setProperty("security-username", user);
+    credentials.setProperty("security-password", user);
 
     if (waitTime < 0) {
       throw new AuthenticationFailedException("Something wrong happened.");


### PR DESCRIPTION
* do not try to dispatch residual messages when exception occurred.
* add more tests to verify peer connection, bulk operations and durable clients behavior
* add durable client flag when register interest
* move tests out of upgrade module if does not need older versions to test to avoid conflict in stress tests