### PR TITLE
GEODE-9623: Unsupported commands should not be returned by COMMAND when not enabled

### DIFF
--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/CommandIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/CommandIntegrationTest.java
@@ -84,19 +84,15 @@ public class CommandIntegrationTest {
   @Test
   public void commandDoesNotReturnUnsupported_whenUnsupportedCommandsAreDisabled() {
     radishServer.setEnableUnsupportedCommands(false);
-    try {
-      Map<String, CommandStructure> results = processRawCommands(radishClient.command());
+    Map<String, CommandStructure> results = processRawCommands(radishClient.command());
 
-      // Find an unsupported command
-      RedisCommandType someUnsupported = Arrays.stream(RedisCommandType.values())
-          .filter(RedisCommandType::isUnsupported).findFirst()
-          .orElseThrow(() -> new AssertionError("Could not find any UNSUPPORTED commands"));
+    // Find an unsupported command
+    RedisCommandType someUnsupported = Arrays.stream(RedisCommandType.values())
+        .filter(RedisCommandType::isUnsupported).findFirst()
+        .orElseThrow(() -> new AssertionError("Could not find any UNSUPPORTED commands"));
 
-      for (CommandStructure meta : results.values()) {
-        assertThat(meta.name).isNotEqualToIgnoringCase(someUnsupported.name());
-      }
-    } finally {
-      radishServer.setEnableUnsupportedCommands(true);
+    for (CommandStructure meta : results.values()) {
+      assertThat(meta.name).isNotEqualToIgnoringCase(someUnsupported.name());
     }
   }
 

--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/CommandIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/server/CommandIntegrationTest.java
@@ -27,8 +27,8 @@ import java.util.Map;
 
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.sync.RedisCommands;
-import junit.framework.AssertionFailedError;
 import org.assertj.core.api.SoftAssertions;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -59,6 +59,11 @@ public class CommandIntegrationTest {
             .connect().sync();
   }
 
+  @After
+  public void teardown() {
+    radishServer.setEnableUnsupportedCommands(true);
+  }
+
   @Test
   public void commandReturnsResultsMatchingNativeRedis() {
     Map<String, CommandStructure> goldenResults = processRawCommands(redisClient.command());
@@ -85,7 +90,7 @@ public class CommandIntegrationTest {
       // Find an unsupported command
       RedisCommandType someUnsupported = Arrays.stream(RedisCommandType.values())
           .filter(RedisCommandType::isUnsupported).findFirst()
-          .orElseThrow(() -> new AssertionFailedError("Could not find any UNSUPPORTED commands"));
+          .orElseThrow(() -> new AssertionError("Could not find any UNSUPPORTED commands"));
 
       for (CommandStructure meta : results.values()) {
         assertThat(meta.name).isNotEqualToIgnoringCase(someUnsupported.name());

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/CommandExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/CommandExecutor.java
@@ -32,7 +32,10 @@ public class CommandExecutor extends AbstractExecutor {
     List<Object> response = new ArrayList<>();
 
     for (RedisCommandType type : RedisCommandType.values()) {
-      if (type.isInternal() || type.isUnknown() || type == RedisCommandType.QUIT) {
+      if (type.isInternal()
+          || type.isUnknown()
+          || (type.isUnsupported() && !context.allowUnsupportedCommands())
+          || type == RedisCommandType.QUIT) {
         continue;
       }
 


### PR DESCRIPTION


- If the `enable-unsupported-commands` system property is not enabled
  then the COMMAND command should not return information about
  unsupported commands in its response.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
