### PR TITLE
GEODE-9672: Disable native redis multibulk test

### DIFF
--- a/geode-apis-compatible-with-redis/src/acceptanceTest/resources/0001-configure-redis-tests.patch
+++ b/geode-apis-compatible-with-redis/src/acceptanceTest/resources/0001-configure-redis-tests.patch
@@ -74,7 +74,7 @@ index 8978631e0..33c10eb15 100644
      } elseif {$opt eq {--port}} {
          set ::port $arg
 diff --git a/tests/unit/auth.tcl b/tests/unit/auth.tcl
-index 633cda95c..5cb6dbab8 100644
+index f5da728e8..6ae96f295 100644
 --- a/tests/unit/auth.tcl
 +++ b/tests/unit/auth.tcl
 @@ -1,15 +1,16 @@
@@ -110,6 +110,41 @@ index 633cda95c..5cb6dbab8 100644
      } {OK}
  
      test {Once AUTH succeeded we can actually send commands to the server} {
+@@ -25,19 +26,19 @@ start_server {tags {"auth"} overrides {requirepass foobar}} {
+         r incr foo
+     } {101}
+ 
+-    test {For unauthenticated clients multibulk and bulk length are limited} {
+-        set rr [redis [srv "host"] [srv "port"] 0]
+-        $rr write "*100\r\n"
+-        $rr flush
+-        catch {[$rr read]} e
+-        assert_match {*unauthenticated multibulk length*} $e
+-        $rr close
+-
+-        set rr [redis [srv "host"] [srv "port"] 0]
+-        $rr write "*1\r\n\$100000000\r\n"
+-        $rr flush
+-        catch {[$rr read]} e
+-        assert_match {*unauthenticated bulk length*} $e
+-        $rr close
+-    }
++#    test {For unauthenticated clients multibulk and bulk length are limited} {
++#        set rr [redis [srv "host"] [srv "port"] 0]
++#        $rr write "*100\r\n"
++#        $rr flush
++#        catch {[$rr read]} e
++#        assert_match {*unauthenticated multibulk length*} $e
++#        $rr close
++#
++#        set rr [redis [srv "host"] [srv "port"] 0]
++#        $rr write "*1\r\n\$100000000\r\n"
++#        $rr flush
++#        catch {[$rr read]} e
++#        assert_match {*unauthenticated bulk length*} $e
++#        $rr close
++#    }
+ }
 diff --git a/tests/unit/dump.tcl b/tests/unit/dump.tcl
 index 4c4e5d075..18bb694f2 100644
 --- a/tests/unit/dump.tcl


### PR DESCRIPTION
- Until we can evaluate whether it is feasible to re-enable this test
  (and provide an underlying fix).

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
