### PR TITLE
GEODE-9623: Radish COMMAND command should return simple strings

### DIFF
--- a/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/ClusterNodesResponseProcessor.java
+++ b/geode-apis-compatible-with-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/ClusterNodesResponseProcessor.java
@@ -54,7 +54,7 @@ public class ClusterNodesResponseProcessor implements RedisResponseProcessor {
 
     ByteBuf response;
     try {
-      response = Coder.getBulkStringResponse(channel.alloc().buffer(), input);
+      response = Coder.getStringResponse(channel.alloc().buffer(), input, true);
     } catch (CoderException e) {
       throw new RuntimeException(e);
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/AbstractExecutor.java
@@ -31,7 +31,7 @@ public abstract class AbstractExecutor implements Executor {
 
   protected RedisResponse respondBulkStrings(Object message) {
     if (message instanceof Collection) {
-      return RedisResponse.array((Collection<?>) message);
+      return RedisResponse.array((Collection<?>) message, true);
     } else {
       return RedisResponse.bulkString(message);
     }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/RedisResponse.java
@@ -78,7 +78,7 @@ public class RedisResponse {
   public static RedisResponse bulkString(Object value) {
     return new RedisResponse((buffer) -> {
       try {
-        return Coder.getBulkStringResponse(buffer, value);
+        return Coder.getStringResponse(buffer, value, true);
       } catch (CoderException e) {
         return Coder.getErrorResponse(buffer, "Internal server error: " + e.getMessage());
       }
@@ -103,10 +103,10 @@ public class RedisResponse {
     });
   }
 
-  public static RedisResponse array(Collection<?> collection) {
+  public static RedisResponse array(Collection<?> collection, boolean useBulkStrings) {
     return new RedisResponse((buffer) -> {
       try {
-        return Coder.getArrayResponse(buffer, collection);
+        return Coder.getArrayResponse(buffer, collection, useBulkStrings);
       } catch (CoderException e) {
         return Coder.getErrorResponse(buffer, "Internal server error: " + e.getMessage());
       }
@@ -114,7 +114,7 @@ public class RedisResponse {
   }
 
   public static RedisResponse array(Object... items) {
-    return array(Arrays.asList(items));
+    return array(Arrays.asList(items), true);
   }
 
   public static RedisResponse emptyArray() {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
@@ -97,7 +97,7 @@ public class ClusterExecutor extends AbstractExecutor {
       slots.add(entry);
     }
 
-    return RedisResponse.array(slots);
+    return RedisResponse.array(slots, true);
   }
 
   /**

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -50,7 +50,7 @@ public class PingExecutor extends AbstractExecutor {
       } else {
         result = stringToBytes("");
       }
-      redisResponse = RedisResponse.array(Arrays.asList(bPING_RESPONSE_LOWERCASE, result));
+      redisResponse = RedisResponse.array(Arrays.asList(bPING_RESPONSE_LOWERCASE, result), true);
     }
 
     return redisResponse;

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HGetAllExecutor.java
@@ -50,7 +50,7 @@ public class HGetAllExecutor extends AbstractExecutor {
     RedisHashCommands redisHashCommands = context.getHashCommands();
     Collection<byte[]> fieldsAndValues = redisHashCommands.hgetall(key);
 
-    return RedisResponse.array(fieldsAndValues);
+    return RedisResponse.array(fieldsAndValues, true);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HKeysExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HKeysExecutor.java
@@ -53,6 +53,6 @@ public class HKeysExecutor extends AbstractExecutor {
       return RedisResponse.emptyArray();
     }
 
-    return RedisResponse.array(keys);
+    return RedisResponse.array(keys, true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMGetExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HMGetExecutor.java
@@ -55,6 +55,6 @@ public class HMGetExecutor extends AbstractExecutor {
 
     List<byte[]> values = redisHashCommands.hmget(key, fields);
 
-    return RedisResponse.array(values);
+    return RedisResponse.array(values, true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HValsExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/hash/HValsExecutor.java
@@ -61,7 +61,7 @@ public class HValsExecutor extends AbstractExecutor {
       return RedisResponse.emptyArray();
     }
 
-    return RedisResponse.array(values);
+    return RedisResponse.array(values, true);
   }
 
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PubSubExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PubSubExecutor.java
@@ -44,11 +44,11 @@ public class PubSubExecutor implements Executor {
             .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, new String(subCommand)));
       }
       List<byte[]> channelsResponse = doChannels(args, context);
-      return RedisResponse.array(channelsResponse);
+      return RedisResponse.array(channelsResponse, true);
     } else if (equalsIgnoreCaseBytes(subCommand, bNUMSUB)) {
       List<Object> numSubresponse = context.getPubSub()
           .findNumberOfSubscribersPerChannel(args.subList(1, args.size()));
-      return RedisResponse.array(numSubresponse);
+      return RedisResponse.array(numSubresponse, true);
     } else if (equalsIgnoreCaseBytes(subCommand, bNUMPAT)) {
       if (args.size() > 1) {
         return RedisResponse

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/CommandExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/server/CommandExecutor.java
@@ -51,6 +51,6 @@ public class CommandExecutor extends AbstractExecutor {
       response.add(oneCommand);
     }
 
-    return RedisResponse.array(response);
+    return RedisResponse.array(response, false);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SMembersExecutor.java
@@ -30,6 +30,6 @@ public class SMembersExecutor extends AbstractExecutor {
     RedisSetCommands redisSetCommands = context.getSetCommands();
     Set<byte[]> members = redisSetCommands.smembers(key);
 
-    return RedisResponse.array(members);
+    return RedisResponse.array(members, true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SPopExecutor.java
@@ -57,6 +57,6 @@ public class SPopExecutor extends AbstractExecutor {
       return RedisResponse.bulkString(popped.iterator().next());
     }
 
-    return RedisResponse.array(popped);
+    return RedisResponse.array(popped, true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SRandMemberExecutor.java
@@ -56,7 +56,7 @@ public class SRandMemberExecutor extends AbstractExecutor {
     Collection<byte[]> results = redisSetCommands.srandmember(key, count);
 
     if (countSpecified) {
-      return RedisResponse.array(results);
+      return RedisResponse.array(results, true);
     } else if (results.isEmpty()) {
       return RedisResponse.nil();
     } else {

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZPopExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractZPopExecutor.java
@@ -47,6 +47,6 @@ public abstract class AbstractZPopExecutor extends AbstractExecutor {
       return RedisResponse.emptyArray();
     }
 
-    return RedisResponse.array(zpop(context.getSortedSetCommands(), command.getKey(), count));
+    return RedisResponse.array(zpop(context.getSortedSetCommands(), command.getKey(), count), true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByLexExecutor.java
@@ -40,6 +40,6 @@ public class ZRangeByLexExecutor extends AbstractSortedSetRangeExecutor<SortedSe
   @Override
   public RedisResponse executeRangeCommand(RedisSortedSetCommands commands, RedisKey key,
       SortedSetLexRangeOptions options) {
-    return RedisResponse.array(commands.zrangebylex(key, options));
+    return RedisResponse.array(commands.zrangebylex(key, options), true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByScoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeByScoreExecutor.java
@@ -40,6 +40,6 @@ public class ZRangeByScoreExecutor
   @Override
   public RedisResponse executeRangeCommand(RedisSortedSetCommands commands, RedisKey key,
       SortedSetScoreRangeOptions options) {
-    return RedisResponse.array(commands.zrangebyscore(key, options));
+    return RedisResponse.array(commands.zrangebyscore(key, options), true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRangeExecutor.java
@@ -39,6 +39,6 @@ public class ZRangeExecutor extends AbstractSortedSetRangeExecutor<SortedSetRank
   @Override
   public RedisResponse executeRangeCommand(RedisSortedSetCommands commands, RedisKey key,
       SortedSetRankRangeOptions options) {
-    return RedisResponse.array(commands.zrange(key, options));
+    return RedisResponse.array(commands.zrange(key, options), true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeByLexExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeByLexExecutor.java
@@ -26,6 +26,6 @@ public class ZRevRangeByLexExecutor extends ZRangeByLexExecutor {
   @Override
   public RedisResponse executeRangeCommand(RedisSortedSetCommands commands, RedisKey key,
       SortedSetLexRangeOptions options) {
-    return RedisResponse.array(commands.zrevrangebylex(key, options));
+    return RedisResponse.array(commands.zrevrangebylex(key, options), true);
   }
 }

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeByScoreExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeByScoreExecutor.java
@@ -22,7 +22,7 @@ public class ZRevRangeByScoreExecutor extends ZRangeByScoreExecutor {
   @Override
   public RedisResponse executeRangeCommand(RedisSortedSetCommands commands, RedisKey key,
       SortedSetScoreRangeOptions options) {
-    return RedisResponse.array(commands.zrevrangebyscore(key, options));
+    return RedisResponse.array(commands.zrevrangebyscore(key, options), true);
   }
 
   @Override

--- a/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeExecutor.java
+++ b/geode-apis-compatible-with-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZRevRangeExecutor.java
@@ -27,6 +27,6 @@ public class ZRevRangeExecutor extends ZRangeExecutor {
   @Override
   public RedisResponse executeRangeCommand(RedisSortedSetCommands commands, RedisKey key,
       SortedSetRankRangeOptions options) {
-    return RedisResponse.array(commands.zrevrange(key, options));
+    return RedisResponse.array(commands.zrevrange(key, options), true);
   }
 }


### PR DESCRIPTION
- Since native redis returns simple strings (and not bulk strings) for
  this command.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
