### PR TITLE
GEODE-9666: Avoid caching InetSocketAddress

### DIFF
--- a/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/InetSocketWrapper.java
+++ b/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/InetSocketWrapper.java
@@ -23,7 +23,6 @@ import org.apache.commons.validator.routines.InetAddressValidator;
 class InetSocketWrapper {
   String hostName;
   protected InetSocketAddress inetSocketAddress;
-  private InetSocketAddress attemptedToResolve;
 
   protected InetSocketWrapper() {}
 
@@ -77,13 +76,6 @@ class InetSocketWrapper {
    * value will not hold an InetAddress, so calling getAddress() on it will return null.
    */
   public InetSocketAddress getSocketInetAddress() {
-    if (attemptedToResolve == null) {
-      attemptedToResolve = basicGetInetSocketAddress();
-    }
-    return attemptedToResolve;
-  }
-
-  private InetSocketAddress basicGetInetSocketAddress() {
     if (inetSocketAddress.isUnresolved()) {
       // note that this leaves the InetAddress null if the hostname isn't resolvable
       return new InetSocketAddress(inetSocketAddress.getHostString(), inetSocketAddress.getPort());

--- a/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/HostAndPortTest.java
+++ b/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/HostAndPortTest.java
@@ -49,7 +49,7 @@ public class HostAndPortTest {
    * Test that getSocketInentAddress returns unresolved InetSocketAddress
    */
   @Test
-  public void getSocketInentAddress_returns_unresolved_SocketAddress() {
+  public void getSocketInetAddress_returns_unresolved_SocketAddress() {
     HostAndPort locator1 = new HostAndPort("fakelocalhost", 8090);
 
     InetSocketAddress actual = locator1.getSocketInetAddress();
@@ -57,6 +57,18 @@ public class HostAndPortTest {
     assertThat(actual.isUnresolved())
         .as("Hostname resolved unexpectedly. Check for DNS hijacking in addition to code errors.")
         .isTrue();
+  }
+
+  @Test
+  public void cachesSocketAddressForIP() {
+    HostAndPort hostAndPort = new HostAndPort("127.0.0.1", 8080);
+    assertThat(hostAndPort.getSocketInetAddress()).isSameAs(hostAndPort.getSocketInetAddress());
+  }
+
+  @Test
+  public void doesNotCacheSocketAddressForHostname() {
+    HostAndPort hostAndPort = new HostAndPort("localhost", 8080);
+    assertThat(hostAndPort.getSocketInetAddress()).isNotSameAs(hostAndPort.getSocketInetAddress());
   }
 
   /**


### PR DESCRIPTION
The changes for GEODE-9139 changed the behavior of
`org.apache.geode.distributed.internal.tcpserver.HostAndPort` to
permanently cache the internal `InetSocketAddress` once it has tried one
time to resolve the address. This undoes part of the fix introduced by
GEODE-7808, in which `HostAndPort` was created as a way to hold an
unresolved hostname.

The issue is that the cached `InetSocketAddress` may contain a stale or
unresolved address which will be returned by `getSocketInetAddress` for
the lifetime of the `HostAndPort`/`InetSocketWrapper` object. This prevents
the address from being resolved correctly after changes in DNS records.
(Such changes are common in cloud environments.)

This commit removes the cached internal `InetSocketAddress` from
`InetSocketWrapper` so that `getSocketInetAddress` will try to resolve the
address each time it is called with an unresolved address.