### PR TITLE
GEODE-9621: Change spotlessGradle behavior for delcaring dependency v…

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -67,6 +67,7 @@ class DependencyConstraints implements Plugin<Project> {
     deps.put("junit.version", "4.13.2")
     deps.put("junit-jupiter.version", "5.7.2")
     deps.put("cglib.version", "3.3.0")
+    deps.put("gradle-tooling-api.version", "5.1.1")
     return deps
   }
 

--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -261,9 +261,7 @@ dependencies {
 
   // This is used by 'gradle within gradle' tests. No need to bump this version; but if you do,
   // don't have it be the same version as the outer gradle version.
-  //spotless:off
-  acceptanceTestImplementation('org.gradle:gradle-tooling-api:5.1.1')
-  //spotless:on
+  acceptanceTestImplementation('org.gradle:gradle-tooling-api:' + DependencyConstraints.get('gradle-tooling-api.version'))
 
   acceptanceTestImplementation('org.testcontainers:testcontainers')
 

--- a/gradle/spotless.gradle
+++ b/gradle/spotless.gradle
@@ -143,14 +143,15 @@ spotless {
       })
     }
 
-    custom 'Do not pad spaces before parenthesis in gradle dependency declaration.', {
-      it.replaceAll(/\n(\s*\S*(?:[cC]ompile|[rR]untime|[iI]mplementation|[tT]est)(?:Only)?) +\(/, '\n$1(')
-    }
+    replaceRegex('Do not pad spaces before parenthesis in gradle dependency declaration.',
+      /\n(\s*\S*(?:[cC]ompile|[rR]untime|[iI]mplementation|[tT]est)(?:Only)?) +\(/,
+      '\n$1(')
 
     custom 'Drop version portion of dependency', {
-      it.replaceAll(/(\s*\S*(?:api|[cC]ompileOnly|[rR]untimeOnly|[iI]mplementation|[tT]est))\('([\w.-]+):([\w.-]+):([\w.-]+)'\)/, { original, declaration, group, name, version ->
-        "${declaration}('${group}:${name}')"
-      })
+      def match
+      if ((match = it =~ /(\s*\S*(?:api|[cC]ompileOnly|[rR]untimeOnly|[iI]mplementation|[tT]est))\('([\w.-]+):([\w.-]+):([\w.-]+)'\)/)) {
+        throw new AssertionError("Error in: ${target} ${match.group(0)}.\nDo not declare raw dependency versions in project Gradle files. 'spotlessApply' cannot resolve this issue.\n")
+      }
     }
 
     indentWithSpaces(2)


### PR DESCRIPTION
…ersions

Instead of dropping the version string automatically, we throw and force
the user to add the version to the dependency constraint plugin.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
