### PR TITLE
GEODE-9641: Remove unnecessary allocation of HeapDataOutputStream

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/ReplyMessage.java
@@ -274,10 +274,11 @@ public class ReplyMessage extends HighPriorityDistributionMessage {
       SerializationContext context) throws IOException {
     super.toData(out, context);
 
-    final HeapDataOutputStream hdos =
-        new HeapDataOutputStream(context.getSerializationVersion());
+    HeapDataOutputStream hdos = null;
     boolean failedSerialization = false;
-    if (this.returnValueIsException || this.returnValue != null) {
+    final boolean hasReturnValue = this.returnValueIsException || this.returnValue != null;
+    if (hasReturnValue) {
+      hdos = new HeapDataOutputStream(context.getSerializationVersion());
       try {
         context.getSerializer().writeObject(this.returnValue, hdos);
       } catch (NotSerializableException e) {
@@ -309,14 +310,16 @@ public class ReplyMessage extends HighPriorityDistributionMessage {
     if (this.processorId != 0) {
       out.writeInt(processorId);
     }
-    if (this.returnValueIsException || this.returnValue != null) {
+    if (hasReturnValue) {
       if (failedSerialization) {
         context.getSerializer().writeObject(this.returnValue, out);
       } else {
         hdos.sendTo(out);
       }
     }
-    hdos.close();
+    if (hdos != null) {
+      hdos.close();
+    }
   }
 
   @Override


### PR DESCRIPTION
GEODE-9641 was introduced by the fix for GEODE-9204.
This change removes the unnecessary allocation of `HeapDataOutputStream` in `ReplyMessage.toData()`.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
