### PR TITLE
GEODE-9674: fix durable client message loss issue in tests.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -1,0 +1,332 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.security;
+
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.createAndExecuteCQ;
+import static org.apache.geode.distributed.ConfigurationProperties.DURABLE_CLIENT_ID;
+import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.cache.EntryEvent;
+import org.apache.geode.cache.InterestResultPolicy;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.query.dunit.SecurityTestUtils.EventsCqListner;
+import org.apache.geode.cache.util.CacheListenerAdapter;
+import org.apache.geode.test.dunit.AsyncInvocation;
+import org.apache.geode.test.dunit.rules.ClientVM;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.junit.categories.SecurityTest;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+@Category({SecurityTest.class})
+public class AuthExpirationDUnitTest {
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @Rule
+  public RestoreSystemProperties restore = new RestoreSystemProperties();
+
+  @Rule
+  public ServerStarterRule server = new ServerStarterRule()
+      .withSecurityManager(ExpirableSecurityManager.class)
+      .withRegion(RegionShortcut.REPLICATE, "region");
+
+
+  private ClientVM clientVM;
+
+  @After
+  public void after() {
+    if (clientVM != null) {
+      clientVM.invoke(UpdatableUserAuthInitialize::reset);
+    }
+    getSecurityManager().close();
+  }
+
+  private static EventsCqListner CQLISTENER0;
+
+  @Test
+  public void cqClientWillReAuthenticateAutomatically() throws Exception {
+    startClientWithCQ();
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    region.put("1", "value1");
+    clientVM.invoke(() -> {
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .asList()
+              .containsExactly("1"));
+    });
+
+    // expire the current user
+    getSecurityManager().addExpiredUser("user1");
+
+    // update the user to be used before we try to send the 2nd event
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user2");
+    });
+
+    // do a second put, the event should be queued until client re-authenticate
+    region.put("2", "value2");
+
+    clientVM.invoke(() -> {
+      // the client will eventually get the 2nd event
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .asList()
+              .containsExactly("1", "2"));
+    });
+
+    Map<String, List<String>> authorizedOps = getSecurityManager().getAuthorizedOps();
+    assertThat(authorizedOps.keySet().size()).isEqualTo(2);
+    assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:READ:region",
+        "DATA:READ:region:1");
+    assertThat(authorizedOps.get("user2")).asList().containsExactly("DATA:READ:region:2");
+
+    Map<String, List<String>> unAuthorizedOps = getSecurityManager().getUnAuthorizedOps();
+    assertThat(unAuthorizedOps.keySet().size()).isEqualTo(1);
+    assertThat(unAuthorizedOps.get("user1")).asList().containsExactly("DATA:READ:region:2");
+  }
+
+  @Test
+  public void registeredInterest_slowReAuth_policyDefault() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+    ClientVM client2 = cluster.startClientVM(1,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      Region<Object, Object> region = ClusterStartupRule.getClientCache()
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+
+      // this test will succeed because when clients re-connects, it will re-register inteest
+      // a new queue will be created with all the data. Old queue is destroyed.
+      region.registerInterestForAllKeys();
+      UpdatableUserAuthInitialize.setUser("user11");
+      // wait for time longer than server's max time to wait to ree-authenticate
+      UpdatableUserAuthInitialize.setWaitTime(6000);
+    });
+
+    AsyncInvocation<Void> invokePut = client2.invokeAsync(() -> {
+      UpdatableUserAuthInitialize.setUser("user2");
+      Region<Object, Object> region = ClusterStartupRule.getClientCache()
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+      IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
+    });
+
+    getSecurityManager().addExpiredUser("user1");
+    invokePut.await();
+
+    // make sure this client recovers and get all the events and will be able to do client operation
+    clientVM.invoke(() -> {
+      Region<Object, Object> region = ClusterStartupRule.getClientCache().getRegion("region");
+      await().untilAsserted(
+          () -> assertThat(region.keySet()).hasSize(100));
+      region.put("key100", "value100");
+    });
+
+    // user1 should not be used to put any keys to the region
+    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region");
+    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region:key0");
+  }
+
+  @Test
+  public void registeredInterest_slowReAuth_policyKeys_durableClient() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withProperty(DURABLE_CLIENT_ID, "123456")
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Object, Object> region = clientCache
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+
+      region.registerInterestForAllKeys(InterestResultPolicy.KEYS, true);
+      clientCache.readyForEvents();
+      UpdatableUserAuthInitialize.setUser("user11");
+      // wait for time longer than server's max time to wait to re-authenticate
+      UpdatableUserAuthInitialize.setWaitTime(6000);
+    });
+
+    getSecurityManager().addExpiredUser("user1");
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
+
+    // make sure this client recovers and get all the events and will be able to do client operation
+    clientVM.invoke(() -> {
+      Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
+      await().untilAsserted(() -> assertThat(clientRegion).hasSize(100));
+      clientRegion.put("key100", "value100");
+    });
+
+    // user1 should not be used to put any keys to the region
+    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region");
+    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region:key0");
+  }
+
+  private static class MyCacheListener extends CacheListenerAdapter<Object, Object> {
+    public List<String> keys = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void afterCreate(EntryEvent event) {
+      keys.add((String) event.getKey());
+    }
+  }
+
+  private static MyCacheListener myListener = new MyCacheListener();
+
+  @Test
+  public void registeredInterest_slowReAuth_policyNone_durableClient() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withProperty(DURABLE_CLIENT_ID, "123456")
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      myListener = new MyCacheListener();
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Object, Object> region = clientCache
+          .createClientRegionFactory(ClientRegionShortcut.PROXY)
+          .addCacheListener(myListener).create("region");
+
+      // use NONE policy to make sure the old messages still sticks around
+      region.registerInterestForAllKeys(InterestResultPolicy.NONE, true);
+      clientCache.readyForEvents();
+      UpdatableUserAuthInitialize.setUser("user11");
+      // wait for time longer than server's max time to wait to re-authenticate
+      UpdatableUserAuthInitialize.setWaitTime(6000);
+    });
+
+    getSecurityManager().addExpiredUser("user1");
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
+
+    // make sure this client recovers and get all the events and will be able to do client operation
+    clientVM.invoke(() -> {
+      Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
+      await().untilAsserted(() -> assertThat(myListener.keys).hasSize(100));
+      clientRegion.put("key100", "value100");
+    });
+
+    // user1 should not be used to put any keys to the region
+    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region");
+    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region:key0");
+  }
+
+
+  @Test
+  public void registeredInterest_slowReAuth_policyNone_nonDurableClient()
+      throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withPoolSubscription(true)
+            .withServerConnection(serverPort));
+
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      ClientCache clientCache = ClusterStartupRule.getClientCache();
+      Region<Object, Object> region = clientCache
+          .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
+
+      // use InterestResultPolicy.NONE to make sure the old queue is still around
+      region.registerInterestForAllKeys(InterestResultPolicy.NONE);
+      UpdatableUserAuthInitialize.setUser("user11");
+      // wait for time longer than server's max time to wait to ree-authenticate
+      UpdatableUserAuthInitialize.setWaitTime(6000);
+    });
+
+    getSecurityManager().addExpiredUser("user1");
+    Region<Object, Object> region = server.getCache().getRegion("/region");
+    IntStream.range(0, 100).forEach(i -> region.put("key" + i, "value" + i));
+
+    // client will recover but there will be message loss
+    clientVM.invoke(() -> {
+      Region<Object, Object> clientRegion = ClusterStartupRule.getClientCache().getRegion("region");
+      await().during(10, TimeUnit.SECONDS).untilAsserted(
+          () -> assertThat(clientRegion.keySet()).hasSizeLessThan(100));
+      clientRegion.put("key100", "value100");
+    });
+
+    // user1 should not be used to put any keys to the region
+    assertThat(getSecurityManager().getAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region");
+    assertThat(getSecurityManager().getAuthorizedOps().get("user11"))
+        .contains("DATA:WRITE:region:key100");
+    assertThat(getSecurityManager().getUnAuthorizedOps().get("user1"))
+        .containsExactly("DATA:READ:region:key0");
+  }
+
+  private void startClientWithCQ() throws Exception {
+    int serverPort = server.getPort();
+    clientVM = cluster.startClientVM(0,
+        c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
+            .withCacheSetup(
+                ccf -> ccf.setPoolSubscriptionRedundancy(2).setPoolSubscriptionEnabled(true))
+            .withServerConnection(serverPort));
+
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user1");
+      CQLISTENER0 = createAndExecuteCQ(ClusterStartupRule.getClientCache().getQueryService(), "CQ1",
+          "select * from /region");
+    });
+  }
+
+  private ExpirableSecurityManager getSecurityManager() {
+    return (ExpirableSecurityManager) server.getCache().getSecurityService().getSecurityManager();
+  }
+
+
+}

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationFunctionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationFunctionDUnitTest.java
@@ -1,4 +1,5 @@
 /*
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
@@ -11,17 +12,18 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 package org.apache.geode.security;
 
 import static org.apache.geode.cache.execute.FunctionService.onRegion;
 import static org.apache.geode.cache.execute.FunctionService.onServer;
 import static org.apache.geode.cache.execute.FunctionService.onServers;
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.collectSecurityManagers;
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.getSecurityManager;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
-import static org.apache.geode.security.ClientAuthenticationTestUtils.collectSecurityManagers;
-import static org.apache.geode.security.ClientAuthenticationTestUtils.getSecurityManager;
 import static org.apache.geode.security.SecurityManager.PASSWORD;
 import static org.apache.geode.security.SecurityManager.USER_NAME;
 import static org.apache.geode.test.version.VersionManager.CURRENT_VERSION;

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationMultiServerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationMultiServerDUnitTest.java
@@ -1,4 +1,5 @@
 /*
+ *
  * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
  * agreements. See the NOTICE file distributed with this work for additional information regarding
  * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
@@ -11,13 +12,14 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
 package org.apache.geode.security;
 
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.collectSecurityManagers;
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.createAndExecuteCQ;
+import static org.apache.geode.cache.query.dunit.SecurityTestUtils.getSecurityManager;
 import static org.apache.geode.distributed.ConfigurationProperties.SECURITY_CLIENT_AUTH_INIT;
-import static org.apache.geode.security.AuthExpirationDUnitTest.createAndExecuteCQ;
-import static org.apache.geode.security.ClientAuthenticationTestUtils.collectSecurityManagers;
-import static org.apache.geode.security.ClientAuthenticationTestUtils.getSecurityManager;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
@@ -37,8 +39,8 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.ServerOperationException;
+import org.apache.geode.cache.query.dunit.SecurityTestUtils.EventsCqListner;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.security.AuthExpirationDUnitTest.EventsCqListner;
 import org.apache.geode.test.concurrent.FileBasedCountDownLatch;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.rules.ClientVM;
@@ -80,6 +82,7 @@ public class AuthExpirationMultiServerDUnitTest {
   @After
   public void after() {
     UpdatableUserAuthInitialize.reset();
+    closeSecurityManager();
   }
 
   @Test
@@ -312,6 +315,12 @@ public class AuthExpirationMultiServerDUnitTest {
   private void expireUserOnAllVms(String user) {
     MemberVM.invokeInEveryMember(() -> {
       getSecurityManager().addExpiredUser(user);
+    }, locator, server1, server2);
+  }
+
+  private void closeSecurityManager() {
+    MemberVM.invokeInEveryMember(() -> {
+      getSecurityManager().close();
     }, locator, server1, server2);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
@@ -148,6 +148,7 @@ public class MessageDispatcherTest {
 
     // since we keep throwing the AuthenticationExpiredException, we will eventually call this
     verify(dispatcher).pauseOrUnregisterProxy(any(AuthenticationExpiredException.class));
+    verify(dispatcher, never()).dispatchResidualMessages();
   }
 
   @Test
@@ -163,5 +164,6 @@ public class MessageDispatcherTest {
     verify(dispatcher, never()).sendMessageDirectly(any());
     // we will eventually pauseOrUnregisterProxy
     verify(dispatcher).pauseOrUnregisterProxy(any(AuthenticationExpiredException.class));
+    verify(dispatcher, never()).dispatchResidualMessages();
   }
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationTestUtils.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationTestUtils.java
@@ -20,15 +20,9 @@ import static org.apache.geode.security.SecurityTestUtils.REGION_NAME;
 import static org.apache.geode.security.SecurityTestUtils.getCache;
 import static org.junit.Assert.assertNotNull;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Properties;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.test.dunit.rules.ClusterStartupRule;
-import org.apache.geode.test.dunit.rules.MemberVM;
 
 /**
  * Extracted from ClientAuthenticationDUnitTest
@@ -119,37 +113,5 @@ public abstract class ClientAuthenticationTestUtils {
     Region region = getCache().getRegion(REGION_NAME);
     assertNotNull(region);
     region.registerInterestRegex(".*");
-  }
-
-
-  protected static ExpirableSecurityManager collectSecurityManagers(MemberVM... vms) {
-    List<ExpirableSecurityManager> results = new ArrayList<>();
-    for (MemberVM vm : vms) {
-      results.add(vm.invoke(() -> getSecurityManager()));
-    }
-
-    ExpirableSecurityManager consolidated = new ExpirableSecurityManager();
-    for (ExpirableSecurityManager result : results) {
-      consolidated.getExpiredUsers().addAll(result.getExpiredUsers());
-      combine(consolidated.getAuthorizedOps(), result.getAuthorizedOps());
-      combine(consolidated.getUnAuthorizedOps(), result.getUnAuthorizedOps());
-    }
-    return consolidated;
-  }
-
-  protected static void combine(Map<String, List<String>> to, Map<String, List<String>> from) {
-    for (String key : from.keySet()) {
-      if (to.containsKey(key)) {
-        to.get(key).addAll(from.get(key));
-      } else {
-        to.put(key, from.get(key));
-      }
-    }
-  }
-
-  protected static ExpirableSecurityManager getSecurityManager() {
-    return (ExpirableSecurityManager) Objects.requireNonNull(ClusterStartupRule.getCache())
-        .getSecurityService()
-        .getSecurityManager();
   }
 }

--- a/geode-dunit/src/main/java/org/apache/geode/cache/query/dunit/SecurityTestUtils.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache/query/dunit/SecurityTestUtils.java
@@ -1,0 +1,96 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.cache.query.dunit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.geode.cache.query.CqAttributesFactory;
+import org.apache.geode.cache.query.CqEvent;
+import org.apache.geode.cache.query.CqException;
+import org.apache.geode.cache.query.CqExistsException;
+import org.apache.geode.cache.query.CqListener;
+import org.apache.geode.cache.query.CqQuery;
+import org.apache.geode.cache.query.QueryService;
+import org.apache.geode.cache.query.RegionNotFoundException;
+import org.apache.geode.security.ExpirableSecurityManager;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+
+public class SecurityTestUtils {
+  public static ExpirableSecurityManager collectSecurityManagers(MemberVM... vms) {
+    List<ExpirableSecurityManager> results = new ArrayList<>();
+    for (MemberVM vm : vms) {
+      results.add(vm.invoke(() -> getSecurityManager()));
+    }
+
+    ExpirableSecurityManager consolidated = new ExpirableSecurityManager();
+    for (ExpirableSecurityManager result : results) {
+      consolidated.getExpiredUsers().addAll(result.getExpiredUsers());
+      combine(consolidated.getAuthorizedOps(), result.getAuthorizedOps());
+      combine(consolidated.getUnAuthorizedOps(), result.getUnAuthorizedOps());
+    }
+    return consolidated;
+  }
+
+  public static void combine(Map<String, List<String>> to, Map<String, List<String>> from) {
+    for (String key : from.keySet()) {
+      if (to.containsKey(key)) {
+        to.get(key).addAll(from.get(key));
+      } else {
+        to.put(key, from.get(key));
+      }
+    }
+  }
+
+  public static ExpirableSecurityManager getSecurityManager() {
+    return (ExpirableSecurityManager) Objects.requireNonNull(ClusterStartupRule.getCache())
+        .getSecurityService()
+        .getSecurityManager();
+  }
+
+  public static class EventsCqListner implements CqListener {
+    private List<String> keys = new ArrayList<>();
+
+    @Override
+    public void onEvent(CqEvent aCqEvent) {
+      keys.add(aCqEvent.getKey().toString());
+    }
+
+    @Override
+    public void onError(CqEvent aCqEvent) {}
+
+    public List<String> getKeys() {
+      return keys;
+    }
+  }
+
+  public static EventsCqListner createAndExecuteCQ(QueryService queryService, String cqName,
+      String query)
+      throws CqExistsException, CqException, RegionNotFoundException {
+    CqAttributesFactory cqaf = new CqAttributesFactory();
+    EventsCqListner listenter = new EventsCqListner();
+    cqaf.addCqListener(listenter);
+
+    CqQuery cq = queryService.newCq(cqName, query, cqaf.create());
+    cq.execute();
+    return listenter;
+  }
+}


### PR DESCRIPTION
* do not try to dispatch residual messages when exception occurred.
* add durable client flag when register interest
* for caching_proxy region, count the events received instread of the region size