### PR TITLE
GEODE-9536: Disable jar deploy tests on Windows

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/DeploymentSemanticVersionJarDUnitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/DeploymentSemanticVersionJarDUnitTest.java
@@ -41,9 +41,15 @@ import org.apache.geode.test.compiler.JarBuilder;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.assertions.ClusterManagementListResultAssert;
+import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
 public class DeploymentSemanticVersionJarDUnitTest {
-  @ClassRule
+  // Classloaders hold onto the deployed jars. On Windows, this prevents Geode and tests from
+  // deleting the files, causing this test to fail.
+  @ClassRule(order = 0)
+  public static IgnoreOnWindowsRule ignoreOnWindows = new IgnoreOnWindowsRule();
+
+  @ClassRule(order = 1)
   public static TemporaryFolder stagingTempDir = new TemporaryFolder();
 
   @Rule

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DeploySemanticVersionJarDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/DeploySemanticVersionJarDUnitTest.java
@@ -34,9 +34,15 @@ import org.apache.geode.test.compiler.JarBuilder;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
 public class DeploySemanticVersionJarDUnitTest {
-  @ClassRule
+  // Classloaders hold onto the deployed jars. On Windows, this prevents Geode and tests from
+  // deleting the files, causing this test to fail.
+  @ClassRule(order = 0)
+  public static IgnoreOnWindowsRule ignoreOnWindows = new IgnoreOnWindowsRule();
+
+  @ClassRule(order = 1)
   public static TemporaryFolder stagingTempDir = new TemporaryFolder();
 
   @Rule


### PR DESCRIPTION
PROBLEM

Classloaders keep deployed jar files open. On Windows, this prevents
Geode and tests from deleting the files, causing tests in these classes
to fail:
- DeploySemanticVersionJarDUnitTest (geode-gfsh)
- DeploymentSemanticVersionJarDUnitTest (geode-assembly)

SOLUTION

Ignore these tests on Windows.

NOTE

This prepares for an upcoming PR to run all distributed tests (except
explicitly ignored ones like these) on Windows.
