### PR TITLE
GEODE-9536: Make PingOp test more patient

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/PingOpDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/PingOpDistributedTest.java
@@ -136,8 +136,12 @@ public class PingOpDistributedTest implements Serializable {
     GeodeAwaitility.await().untilAsserted(() -> {
       client.invoke(() -> executePing(poolName, server1Port, distributedMember1));
       Long subsequentHeartbeat = server1.invoke(this::getSingleHeartBeat);
-
-      assertThat(subsequentHeartbeat).isGreaterThan(firstHeartbeat);
+      if (subsequentHeartbeat < firstHeartbeat) {
+        throw new Error("Heartbeat decreased from initial " + firstHeartbeat
+            + " to " + subsequentHeartbeat);
+      }
+      assertThat(subsequentHeartbeat)
+          .isGreaterThan(firstHeartbeat);
     });
   }
 


### PR DESCRIPTION
PROBLEM

On some versions of Windows (such as the version we use in CI), the
granularity of `System.currentTimeMillis()` is ~15ms.

`PingOpDistributedTest.regularPingFlow()` executes two pings and
asserts that the resulting heartbeat timestamp to has increased from one
ping to the next.

The test's two pings often occur so rapidly that the heartbeat
timestamps appear to be the same, causing the assertion to fail.

SOLUTION

Change the test to use `await()` to repeat the pings until the heartbeat
timestamp increases.

NOTE

This prepares for an upcoming PR to run all distributed tests on
Windows.
