### PR TITLE
GEODE-9707: capture hprof files even on OOM

### DIFF
--- a/ci/scripts/rsync_code_down.sh
+++ b/ci/scripts/rsync_code_down.sh
@@ -48,7 +48,7 @@ case $ARTIFACT_SLUG in
     ;;
   *)
     JAVA_BUILD_PATH=/usr/lib/jvm/bellsoft-java${JAVA_BUILD_VERSION}-amd64
-    del="&&"
+    del=";"
     ;;
 esac
 


### PR DESCRIPTION
example of what fails without this change: https://concourse.apachegeode-ci.info/builds/86869