### PR TITLE
GEODE-9703: roll redis benchmark baseline past the module rename

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -37,7 +37,7 @@ benchmarks:
     timeout: 12h
   - title: 'radish'
     # The current radish baseline version is taken from the commit:
-    #   GEODE-9169: remove netty context switch (#6725)
+    #   GEODE-9567: Restore accidentally-removed patch file.
     baseline_branch: '311ba9853ee32742690374b9e57b1ffa2c750843'
     baseline_version: ''
     flag: '-PtestJVM=/usr/lib/jvm/bellsoft-java11-amd64 -Pbenchmark.withRedisCluster=geode -Pbenchmark.withServerCount=2'


### PR DESCRIPTION
otherwise benchmarks cannot run