### PR TITLE
GEODE-9536: Disable client version test on Windows

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/BackwardCompatibilityHigherVersionClientDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/BackwardCompatibilityHigherVersionClientDUnitTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -48,12 +49,17 @@ import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
 /**
  * Test to verify that server responds to a higher versioned client.
  */
 @Category({ClientServerTest.class})
 public class BackwardCompatibilityHigherVersionClientDUnitTest extends JUnit4DistributedTestCase {
+  // On Windows, when the server closes the socket, the client can't read the server's reply. The
+  // client quietly ignores the server's reply rather than throwing the required exception.
+  @ClassRule
+  public static IgnoreOnWindowsRule ignoreOnWindowsRule = new IgnoreOnWindowsRule();
 
   /** the cache */
   private static Cache cache = null;


### PR DESCRIPTION
PROBLEM

When a server receives a connection request with an unrecognized client
version, it sends an informative reply and immediately closes the
socket.

In this situation, the client wants to throw a
`ServerRefusedConnectionException` with a message that includes the
server's informative reply.

On Windows, when the client attempts to read the server's reply, the
socket throws a `SocketException` with the message "Connection reset".
As a result, the caller never receives the informative
`ServerRefusedConnectionException`.

SOLUTION

Disable this test on Windows until the underlying issue is fixed.  See
https://issues.apache.org/jira/browse/GEODE-9698

NOTE

This prepares for an upcoming PR to run all distributed tests (except
explicitly ignored ones like these) on Windows.
