### PR TITLE
GEODE-9629: previous fix missed removing this other public getter

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
@@ -430,14 +430,6 @@ public interface GatewaySender {
   boolean mustGroupTransactionEvents();
 
   /**
-   * Returns retriesToGetTransactionEventsFromQueue int property for this GatewaySender.
-   *
-   * @return retriesToGetTransactionEventsFromQueue int property for this GatewaySender
-   *
-   */
-  int getRetriesToGetTransactionEventsFromQueue();
-
-  /**
    * Returns the number of dispatcher threads working for this <code>GatewaySender</code>. Default
    * number of dispatcher threads is 5.
    *

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/wan/AbstractGatewaySender.java
@@ -568,7 +568,12 @@ public abstract class AbstractGatewaySender implements InternalGatewaySender, Di
     return groupTransactionEvents;
   }
 
-  @Override
+  /**
+   * Returns retriesToGetTransactionEventsFromQueue int property for this GatewaySender.
+   *
+   * @return retriesToGetTransactionEventsFromQueue int property for this GatewaySender
+   *
+   */
   public int getRetriesToGetTransactionEventsFromQueue() {
     return retriesToGetTransactionEventsFromQueue;
   }


### PR DESCRIPTION
first fix #6915 removed the errant setter.  this fix removes the getter. (both were introduced in 1.15, so removing it now before we ship 1.15.0 does not break compatibility with any released version of Geode)

adding new methods to a public interface like GatewaySender is a breaking change for other implementations of this interface, such as in Spring Data Geode project.  We can consider bringing these only when a new major is proposed (e.g. Geode 2.0)

All of the Geode code that uses this getter already uses AbstractGatewaySender anyway, so the easiest fix is just to push this down for now.