### PR TITLE
GEODE-9701: Support lower VM counts in ClusterStartupRule

### DIFF
--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleDistributedTest.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.rules.tests;
+
+import static org.apache.geode.test.dunit.VM.DEFAULT_VM_COUNT;
+import static org.apache.geode.test.dunit.VM.getVMCount;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+
+public class ClusterStartupRuleDistributedTest {
+
+  @Rule
+  public ClusterStartupRule clusterStartupRule = new ClusterStartupRule();
+
+  @Test
+  public void hasFourVMsByDefault() {
+    assertThat(getVMCount()).isEqualTo(DEFAULT_VM_COUNT);
+  }
+
+}

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleLimitedVmCountTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/ClusterStartupRuleLimitedVmCountTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.rules.tests;
+
+import static org.apache.geode.test.dunit.VM.getVMCount;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+
+public class ClusterStartupRuleLimitedVmCountTest {
+
+  @Rule
+  public ClusterStartupRule clusterStartupRule = new ClusterStartupRule(2);
+
+  @Test
+  public void limitsVmCount() {
+    assertThat(getVMCount()).isEqualTo(2);
+  }
+}

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedRuleLimitedVmCountTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedRuleLimitedVmCountTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.test.dunit.rules.tests;
+
+import static org.apache.geode.test.dunit.VM.getVMCount;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.dunit.rules.DistributedRule;
+
+public class DistributedRuleLimitedVmCountTest {
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule(2);
+
+  @Test
+  public void limitsVmCount() {
+    assertThat(getVMCount()).isEqualTo(2);
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
@@ -178,6 +178,17 @@ public class DUnitLauncher {
   }
 
   /**
+   * Launch DUnit if not already launched.
+   *
+   * @param vmCount specified number of VMs
+   * @param launchLocator determines if default dunit locator should be launched
+   */
+  public static void launchIfNeeded(int vmCount, boolean launchLocator) {
+    NUM_VMS = vmCount;
+    launchIfNeeded(launchLocator);
+  }
+
+  /**
    * Test it see if the eclise dunit environment is launched.
    */
   public static boolean isLaunched() {

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/ClusterStartupRule.java
@@ -40,7 +40,6 @@ import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.cache.InternalCache;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.SerializableConsumerIF;
 import org.apache.geode.test.dunit.VM;
@@ -149,10 +148,7 @@ public class ClusterStartupRule implements SerializableTestRule {
       // GEODE-6247: JDK 11 has an issue where native code is reporting committed is 2MB > max.
       IgnoredException.addIgnoredException("committed = 538968064 should be < max = 536870912");
     }
-    DUnitLauncher.launchIfNeeded(false);
-    for (int i = 0; i < vmCount; i++) {
-      Host.getHost(0).getVM(i);
-    }
+    DUnitLauncher.launchIfNeeded(vmCount, false);
     restoreSystemProperties.beforeDistributedTest(description);
     occupiedVMs = new HashMap<>();
   }


### PR DESCRIPTION
PROBLEM

ClusterStartupRule currently always creates at least 4 DUnit VMs.

Some usages would benefit from the option of specifying a vmCount
limit which would create only the number VMs specified including
values less than the current default of 4.

SOLUTION

Add the ability to launch DUnit with a vmCount along with a boolean
option for starting the default DUnit locator. Use this new 
combination of options within ClusterStartupRule.

NOTE

ClusterStartupRule always starts DUnit without the default DUnit 
locator. 

This is for use in tests only.