### PR TITLE
GEODE-9717: enable self-service jdk8 pr checks via jdk8 pr label

### DIFF
--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -23,7 +23,7 @@ groups:
   jobs:
   - {{ build_test.name }}
 {%- for test in tests %}
-  {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("jdk8") or test.name == "unit" or test.name == "stress-new" or test.name == "distributed" %}
+  {%- for java_test_version in (java_test_versions) if (java_test_version.name.endswith("jdk11") or (java_test_version.name.endswith("jdk8") and test.PLATFORM == "linux")) and ((not test.ONLY_JDK is defined) or test.ONLY_JDK == java_test_version.version) %}
   - {{test.name}}-test-{{java_test_version.name}}
   {%- endfor %}
 {%- endfor %}
@@ -43,6 +43,14 @@ resources:
     disable_ci_skip: false
     skip_ssl_verification: false
     labels: [windows]
+- name: geode-jdk8
+  type: pull-request
+  source:
+    access_token: ((github-apachegeode-ci-read-only-token))
+    repository: {{repository.fork}}/geode
+    disable_ci_skip: false
+    skip_ssl_verification: false
+    labels: [jdk8]
 - name: geode-status
   type: pull-request
   source:
@@ -275,15 +283,18 @@ jobs:
 
 
 {% for test in tests %}
-  {%- for java_test_version in (java_test_versions) if not java_test_version.name.endswith("jdk8") or test.name == "unit" or test.name == "stress-new" or test.name == "distributed" %}
+  {%- for java_test_version in (java_test_versions) if (java_test_version.name.endswith("jdk11") or (java_test_version.name.endswith("jdk8") and test.PLATFORM == "linux")) and ((not test.ONLY_JDK is defined) or test.ONLY_JDK == java_test_version.version) %}
 - name: {{test.name}}-test-{{java_test_version.name}}
   public: true
   plan:
   - do:
     - in_parallel:
       - get: alpine-tools-image
-{%- if test.PLATFORM=="linux" %}
+{%- if test.PLATFORM == "linux" and (java_test_version.name.endswith("jdk11") or test.name == "stress-new" or test.name == "distributed") %}
       - get: geode
+{%- elif test.PLATFORM == "linux" %}
+      - get: geode
+        resource: geode-jdk8
 {%- else %}
       - get: geode
         resource: geode-windows

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -255,7 +255,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 1h
   GRADLE_TASK: geode-assembly:japicmp
   MAX_IN_FLIGHT: 1
-  ONLY_JDK: 8
+  ONLY_JDK: 11
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'false'
   PLATFORM: linux


### PR DESCRIPTION
You can already add the `windows` label to a PR to also run the Windows tests.  With this enhancement, now you can add a `jdk8` label to also run [the rest of] the JDK8 tests (distributed and stress-new always run both 8 and 11)

Note: if you add both the `windows` and `jdk8` labels, the result will be the sum of the two separately, i.e. it will include Linux JDK11, Windows JDK11, and Linux JDK8 (but not Windows JDK8).  Reasoning: that's probably plenty of coverage for a PR (the remaining quadrant will still be tested in the main pipeline once the PR is merged), and anyway the concourse pr resource we use doesn't support logic "and" of multiple tags (only "or") so there would have to be a separate label like windowsjdk8 which might just be more confusing than its worth...