### PR TITLE
GEODE-9717: fix to ensure all required PR check jobs are present

### DIFF
--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -290,7 +290,7 @@ jobs:
   - do:
     - in_parallel:
       - get: alpine-tools-image
-{%- if test.PLATFORM == "linux" and (java_test_version.name.endswith("jdk11") or test.name == "stress-new" or test.name == "distributed") %}
+{%- if test.PLATFORM == "linux" and (java_test_version.name.endswith("jdk11") or test.name == "unit" or test.name == "stress-new" or test.name == "distributed") %}
       - get: geode
 {%- elif test.PLATFORM == "linux" %}
       - get: geode

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -105,7 +105,6 @@ tests:
   EXECUTE_TEST_TIMEOUT: 30m
   GRADLE_TASK: test
   MAX_IN_FLIGHT: 1
-  ONLY_JDK: 8
   PARALLEL_DUNIT: 'false'
   PARALLEL_GRADLE: 'true'
   PLATFORM: linux
@@ -243,6 +242,7 @@ tests:
   EXECUTE_TEST_TIMEOUT: 6h
   GRADLE_TASK: test
   MAX_IN_FLIGHT: 1
+  ONLY_JDK: 11
   PARALLEL_DUNIT: 'false'
   PLATFORM: windows
   RAM: '10'


### PR DESCRIPTION
turns out PR expects both Unit test 8 and 11, so put back unit-jdk8