### PR TITLE
GEODE-9725: Remove membership port range feature from AvailablePort

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/DistributedSystemDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/DistributedSystemDUnitTest.java
@@ -101,7 +101,7 @@ public class DistributedSystemDUnitTest extends JUnit4DistributedTestCase {
     this.locatorPort = getRandomAvailableTCPPort();
     this.tcpPort = getRandomAvailableTCPPort();
 
-    int[] portRange = getRandomAvailableTCPPortRange(3, true);
+    int[] portRange = getRandomAvailableTCPPortRange(3);
     this.lowerBoundOfPortRange = portRange[0];
     this.upperBoundOfPortRange = portRange[portRange.length - 1];
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.internal;
 
 import static java.util.Arrays.stream;
 import static java.util.Comparator.naturalOrder;
-import static org.apache.geode.distributed.internal.DistributionConfig.DEFAULT_MEMBERSHIP_PORT_RANGE;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPortRange;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableUDPPort;
@@ -38,20 +37,15 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import junitparams.Parameters;
-import junitparams.naming.TestCaseName;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ErrorCollector;
-import org.junit.runner.RunWith;
 
 import org.apache.geode.internal.lang.SystemUtils;
 import org.apache.geode.internal.membership.utils.AvailablePort;
-import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
-@RunWith(GeodeParamsRunner.class)
 public class AvailablePortHelperIntegrationTest {
 
   private Set<ServerSocket> serverSockets;
@@ -78,63 +72,47 @@ public class AvailablePortHelperIntegrationTest {
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRange_returnsUsablePorts(boolean useMembershipPortRange) {
-    int[] results = getRandomAvailableTCPPortRange(10, useMembershipPortRange);
+  public void getRandomAvailableTCPPortRange_returnsUsablePorts() {
+    int[] results = getRandomAvailableTCPPortRange(10);
 
     stream(results).forEach(port -> assertThatPort(port)
         .isUsable());
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRange_returnsUniquePorts(boolean useMembershipPortRange) {
-    int[] results = getRandomAvailableTCPPortRange(10, useMembershipPortRange);
+  public void getRandomAvailableTCPPortRange_returnsUniquePorts() {
+    int[] results = getRandomAvailableTCPPortRange(10);
 
     assertThat(results)
         .doesNotHaveDuplicates();
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRange_returnsNaturallyOrderedPorts(
-      boolean useMembershipPortRange) {
-    int[] results = getRandomAvailableTCPPortRange(10, useMembershipPortRange);
+  public void getRandomAvailableTCPPortRange_returnsNaturallyOrderedPorts() {
+    int[] results = getRandomAvailableTCPPortRange(10);
 
     assertThat(results)
         .isSortedAccordingTo(naturalOrder());
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRange_returnsConsecutivePorts(
-      boolean useMembershipPortRange) {
-    int[] results = getRandomAvailableTCPPortRange(10, useMembershipPortRange);
+  public void getRandomAvailableTCPPortRange_returnsConsecutivePorts() {
+    int[] results = getRandomAvailableTCPPortRange(10);
 
     assertThatSequence(results)
         .isConsecutive();
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRange_returnsPortsInRange(boolean useMembershipPortRange) {
-    int lower =
-        useMembershipPortRange ? DEFAULT_MEMBERSHIP_PORT_RANGE[0] : AVAILABLE_PORTS_LOWER_BOUND;
-    int upper =
-        useMembershipPortRange ? DEFAULT_MEMBERSHIP_PORT_RANGE[1] : AVAILABLE_PORTS_UPPER_BOUND;
+  public void getRandomAvailableTCPPortRange_returnsPortsInRange() {
 
-    int[] results = getRandomAvailableTCPPortRange(10, useMembershipPortRange);
+    int[] results = getRandomAvailableTCPPortRange(10);
 
     stream(results).forEach(port ->
 
     assertThat(port)
-        .isGreaterThanOrEqualTo(lower)
-        .isLessThanOrEqualTo(upper));
+        .isGreaterThanOrEqualTo(AVAILABLE_PORTS_LOWER_BOUND)
+        .isLessThanOrEqualTo(AVAILABLE_PORTS_UPPER_BOUND));
   }
 
   @Test
@@ -154,13 +132,11 @@ public class AvailablePortHelperIntegrationTest {
   }
 
   @Test
-  @Parameters({"true", "false"})
-  @TestCaseName("{method}(useMembershipPortRange={0})")
-  public void getRandomAvailableTCPPortRange_returnsUniqueRanges(boolean useMembershipPortRange) {
+  public void getRandomAvailableTCPPortRange_returnsUniqueRanges() {
     Collection<Integer> previousPorts = new HashSet<>();
     for (int i = 0; i < 3; ++i) {
 
-      int[] results = getRandomAvailableTCPPortRange(5, useMembershipPortRange);
+      int[] results = getRandomAvailableTCPPortRange(5);
 
       Collection<Integer> ports = toSet(results);
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
@@ -280,9 +280,12 @@ class ProcessManager implements ChildVMLauncher {
     cmds.add("-D" + DUnitLauncher.WORKSPACE_DIR_PARAM + "=" + new File(".").getAbsolutePath());
     cmds.add("-DAvailablePort.lowerBound=" + AvailablePort.AVAILABLE_PORTS_LOWER_BOUND);
     cmds.add("-DAvailablePort.upperBound=" + AvailablePort.AVAILABLE_PORTS_UPPER_BOUND);
-    cmds.add(String.format("-D%s=%d-%d", GEMFIRE_PREFIX + MEMBERSHIP_PORT_RANGE_NAME,
-        AvailablePort.MEMBERSHIP_PORTS_LOWER_BOUND,
-        AvailablePort.MEMBERSHIP_PORTS_UPPER_BOUND));
+    String membershipPortRange = System.getProperty(GEMFIRE_PREFIX + MEMBERSHIP_PORT_RANGE_NAME);
+    if (membershipPortRange != null) {
+      cmds.add(
+          String.format("-D%s=%s", GEMFIRE_PREFIX + MEMBERSHIP_PORT_RANGE_NAME,
+              membershipPortRange));
+    }
     if (vmNum >= 0) { // let the locator print a banner
       if (version.equals(VersionManager.CURRENT_VERSION)) { // enable the banner for older versions
         cmds.add("-D" + InternalLocator.INHIBIT_DM_BANNER + "=true");

--- a/geode-junit/src/main/java/org/apache/geode/internal/AvailablePortHelper.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/AvailablePortHelper.java
@@ -17,8 +17,6 @@ package org.apache.geode.internal;
 import static java.util.stream.Collectors.toList;
 import static org.apache.geode.internal.membership.utils.AvailablePort.AVAILABLE_PORTS_LOWER_BOUND;
 import static org.apache.geode.internal.membership.utils.AvailablePort.AVAILABLE_PORTS_UPPER_BOUND;
-import static org.apache.geode.internal.membership.utils.AvailablePort.MEMBERSHIP_PORTS_LOWER_BOUND;
-import static org.apache.geode.internal.membership.utils.AvailablePort.MEMBERSHIP_PORTS_UPPER_BOUND;
 import static org.apache.geode.internal.membership.utils.AvailablePort.MULTICAST;
 import static org.apache.geode.internal.membership.utils.AvailablePort.SOCKET;
 import static org.apache.geode.internal.membership.utils.AvailablePort.getAddress;
@@ -38,7 +36,6 @@ import org.apache.geode.internal.membership.utils.AvailablePort.Keeper;
  * allocate ports in a round-robin fashion.
  */
 public class AvailablePortHelper {
-  private final AtomicInteger nextMembershipPort;
   private final AtomicInteger nextAvailablePort;
 
   // Singleton object is only used to track the current ports
@@ -46,10 +43,9 @@ public class AvailablePortHelper {
 
   private AvailablePortHelper() {
     Random rand = rand();
-    nextAvailablePort =
-        randomInRange(rand, AVAILABLE_PORTS_LOWER_BOUND, AVAILABLE_PORTS_UPPER_BOUND);
-    nextMembershipPort =
-        randomInRange(rand, MEMBERSHIP_PORTS_LOWER_BOUND, MEMBERSHIP_PORTS_UPPER_BOUND);
+    int initialValue = rand.nextInt(AVAILABLE_PORTS_UPPER_BOUND - AVAILABLE_PORTS_LOWER_BOUND)
+        + AVAILABLE_PORTS_LOWER_BOUND;
+    nextAvailablePort = new AtomicInteger(initialValue);
   }
 
   /**
@@ -78,22 +74,16 @@ public class AvailablePortHelper {
   /**
    * Returns the requested number of consecutive available tcp ports from the specified range.
    */
-  public static int[] getRandomAvailableTCPPortRange(final int count,
-      final boolean useMembershipPortRange) {
-    AtomicInteger targetRange =
-        useMembershipPortRange ? singleton.nextMembershipPort : singleton.nextAvailablePort;
-    int targetLowerBound =
-        useMembershipPortRange ? MEMBERSHIP_PORTS_LOWER_BOUND : AVAILABLE_PORTS_LOWER_BOUND;
-    int targetUpperBound =
-        useMembershipPortRange ? MEMBERSHIP_PORTS_UPPER_BOUND : AVAILABLE_PORTS_UPPER_BOUND;
+  public static int[] getRandomAvailableTCPPortRange(final int count) {
+    AtomicInteger targetRange = singleton.nextAvailablePort;
 
     int[] ports = new int[count];
     boolean needMorePorts = true;
 
     while (needMorePorts) {
       int base = targetRange.getAndAdd(count);
-      if (base + count > targetUpperBound) {
-        targetRange.set(targetLowerBound);
+      if (base + count > AVAILABLE_PORTS_UPPER_BOUND) {
+        targetRange.set(AVAILABLE_PORTS_LOWER_BOUND);
         continue;
       }
 
@@ -140,18 +130,15 @@ public class AvailablePortHelper {
     // range, JVM 1 starts halfway through, JVM 2 starts 1/4 of the way through, then further
     // ranges are 3/4, 1/8, 3/8, 5/8, 7/8, 1/16, etc.
 
-    singleton.nextMembershipPort.set(MEMBERSHIP_PORTS_LOWER_BOUND);
     singleton.nextAvailablePort.set(AVAILABLE_PORTS_LOWER_BOUND);
     if (jvmIndex == 0) {
       return;
     }
 
-    int membershipRange = MEMBERSHIP_PORTS_UPPER_BOUND - MEMBERSHIP_PORTS_LOWER_BOUND;
     int availableRange = AVAILABLE_PORTS_UPPER_BOUND - AVAILABLE_PORTS_LOWER_BOUND;
     int numChunks = Integer.highestOneBit(jvmIndex) << 1;
     int chunkNumber = 2 * (jvmIndex - Integer.highestOneBit(jvmIndex)) + 1;
 
-    singleton.nextMembershipPort.addAndGet(chunkNumber * membershipRange / numChunks);
     singleton.nextAvailablePort.addAndGet(chunkNumber * availableRange / numChunks);
   }
 
@@ -186,10 +173,6 @@ public class AvailablePortHelper {
         return keeper;
       }
     }
-  }
-
-  private static AtomicInteger randomInRange(Random rand, int lowerBound, int upperBound) {
-    return new AtomicInteger(rand.nextInt(upperBound - lowerBound) + lowerBound);
   }
 
   private static Random rand() {


### PR DESCRIPTION
`AvailablePort` and `AvailablePortHelper` have methods to retrieve an
"available" port from the membership port range. This feature is both
unnecessary and inherently unreliable.

INHERENTLY UNRELIABLE

The default membership port range overlaps each OS's ephemeral port
range. An ephemeral port deemed to be "available" by one of these
methods can be put into use by another process even before the method
returns. It is not safe to rely on such a port to remain available after
it is checked.

UNNECESSARY

Currently the only callers that request ports from the membership port
range are two tests in `DistributedSystemDUnitTest`. In each case, the
test uses the returned ports to *set* the membership port range for a
member. There is no need for the ports to come from any particular
range.

There are no other uses of this feature, either in the product or in
tests.

SOLUTION

Remove the "membership port range" feature from `AvailablePort` and
`AvailablePortHelper`.

Change `DistributedSystemDUnitTest` to get available ports from the
"available port range." This range is safe to use (assuming all other
concurrently-running tests are well-behaved).
