### PR TITLE
GEODE-9736: empty PatternSubscription lists are no longer added to the cache

### DIFF
--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscriptionManager.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/pubsub/AbstractSubscriptionManager.java
@@ -15,10 +15,11 @@
  */
 package org.apache.geode.redis.internal.pubsub;
 
+import static java.util.Collections.emptyList;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,12 +33,18 @@ abstract class AbstractSubscriptionManager implements SubscriptionManager {
       new ConcurrentHashMap<>();
 
   protected ClientSubscriptionManager getClientManager(byte[] channelOrPattern) {
+    if (isEmpty()) {
+      return emptyClientManager();
+    }
     SubscriptionId subscriptionId = new SubscriptionId(channelOrPattern);
     return clientManagers.getOrDefault(subscriptionId, emptyClientManager());
   }
 
   @Override
   public List<byte[]> getIds() {
+    if (isEmpty()) {
+      return emptyList();
+    }
     final ArrayList<byte[]> result = new ArrayList<>(clientManagers.size());
     for (SubscriptionId key : clientManagers.keySet()) {
       result.add(key.getSubscriptionIdBytes());
@@ -47,6 +54,9 @@ abstract class AbstractSubscriptionManager implements SubscriptionManager {
 
   @Override
   public List<byte[]> getIds(byte[] pattern) {
+    if (isEmpty()) {
+      return emptyList();
+    }
     final GlobPattern globPattern = new GlobPattern(pattern);
     final ArrayList<byte[]> result = new ArrayList<>();
     for (SubscriptionId key : clientManagers.keySet()) {
@@ -56,6 +66,10 @@ abstract class AbstractSubscriptionManager implements SubscriptionManager {
       }
     }
     return result;
+  }
+
+  protected boolean isEmpty() {
+    return clientManagers.isEmpty();
   }
 
   @Override
@@ -105,6 +119,9 @@ abstract class AbstractSubscriptionManager implements SubscriptionManager {
 
   @Override
   public void remove(byte[] channelOrPattern, Client client) {
+    if (isEmpty()) {
+      return;
+    }
     SubscriptionId subscriptionId = new SubscriptionId(channelOrPattern);
     ClientSubscriptionManager manager = clientManagers.get(subscriptionId);
     if (manager == null) {
@@ -136,7 +153,7 @@ abstract class AbstractSubscriptionManager implements SubscriptionManager {
 
         @Override
         public Collection<Subscription> getSubscriptions() {
-          return Collections.emptyList();
+          return emptyList();
         }
       };
 

--- a/geode-for-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PatternSubscriptionManagerTest.java
+++ b/geode-for-redis/src/test/java/org/apache/geode/redis/internal/pubsub/PatternSubscriptionManagerTest.java
@@ -69,6 +69,17 @@ public class PatternSubscriptionManagerTest extends SubscriptionManagerTestBase 
   }
 
   @Test
+  public void emptyManagerDoesNotCachePatternSubscriptions() {
+    PatternSubscriptionManager manager = new PatternSubscriptionManager();
+    byte[] channel = stringToBytes("channel");
+
+    List<PatternSubscriptions> subscriptions = manager.getPatternSubscriptions(channel);
+
+    assertThat(subscriptions).isEmpty();
+    assertThat(manager.cacheSize()).isZero();
+  }
+
+  @Test
   public void managerWithOneSubscriptionReturnsIt() {
     PatternSubscriptionManager manager = new PatternSubscriptionManager();
     byte[] pattern = stringToBytes("ch*");
@@ -86,6 +97,20 @@ public class PatternSubscriptionManagerTest extends SubscriptionManagerTestBase 
     assertThat(cachedSubscriptions).isSameAs(subscriptions);
     assertThat(subscriptions).containsExactly(expected);
     assertThat(manager.getPatternSubscriptions(otherChannel)).isEmpty();
+    assertThat(manager.cacheSize()).isOne();
+  }
+
+  @Test
+  public void managerWithOneSubscriptionThatDoesNotMatchChannelDoesNotCache() {
+    PatternSubscriptionManager manager = new PatternSubscriptionManager();
+    byte[] pattern = stringToBytes("ch*");
+    byte[] otherChannel = stringToBytes("otherChannel");
+    Client client = mock(Client.class);
+    when(client.addPatternSubscription(eq(pattern))).thenReturn(true);
+    manager.add(pattern, client);
+
+    assertThat(manager.getPatternSubscriptions(otherChannel)).isEmpty();
+    assertThat(manager.cacheSize()).isZero();
   }
 
   @Test


### PR DESCRIPTION
also did some earlier checks for empty manager map to prevent
object allocations when no managers exist.
Added unit tests to confirm new behavior.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
