### PR TITLE
GEODE-9745: use geode-for-redis in stats

### DIFF
--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/statistics/GeodeRedisStats.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/statistics/GeodeRedisStats.java
@@ -53,10 +53,9 @@ public class GeodeRedisStats {
   private final Statistics stats;
   private final StatisticsClock clock;
 
-  public GeodeRedisStats(StatisticsFactory factory, String textId,
-      StatisticsClock clock) {
+  public GeodeRedisStats(StatisticsFactory factory, String name, StatisticsClock clock) {
     this.clock = clock;
-    stats = factory == null ? null : factory.createAtomicStatistics(type, textId);
+    stats = factory == null ? null : factory.createAtomicStatistics(type, name);
   }
 
   static {
@@ -68,15 +67,15 @@ public class GeodeRedisStats {
     fillListWithCommandDescriptors(statisticsTypeFactory, descriptorList);
 
     StatisticDescriptor[] descriptorArray =
-        descriptorList.toArray(new StatisticDescriptor[descriptorList.size()]);
+        descriptorList.toArray(new StatisticDescriptor[0]);
 
     type = statisticsTypeFactory
-        .createType("statsForServergeodeForRedis",
-            "Statistics for a Geode server compatible with Redis",
+        .createType("GeodeForRedisStats",
+            "Statistics for a geode-for-redis server",
             descriptorArray);
 
-    fillCompletedIdMap(type);
-    fillTimeIdMap(type);
+    fillCompletedIdMap();
+    fillTimeIdMap();
 
     currentlyConnectedClients = type.nameToId("connectedClients");
     passiveExpirationChecksId = type.nameToId("passiveExpirationChecks");
@@ -182,7 +181,7 @@ public class GeodeRedisStats {
     }
   }
 
-  private static void fillCompletedIdMap(StatisticsType type) {
+  private static void fillCompletedIdMap() {
     for (RedisCommandType command : RedisCommandType.values()) {
       String name = command.name().toLowerCase();
       String statName = name + "Completed";
@@ -242,7 +241,7 @@ public class GeodeRedisStats {
         "nanoseconds"));
   }
 
-  private static void fillTimeIdMap(StatisticsType type) {
+  private static void fillTimeIdMap() {
     for (RedisCommandType command : RedisCommandType.values()) {
       String name = command.name().toLowerCase();
       String statName = name + "Time";


### PR DESCRIPTION
- The stat type, instance name, and description are now based on "geode for redis".
- The instance name now also includes the server's address and port.
- Cleaned up some warnings in GeodeRedisStats.java.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
