### PR TITLE
GEODE-9749: ignore the test case that shows GEODE-9704.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -167,6 +168,7 @@ public class AuthExpirationDUnitTest {
   }
 
   @Test
+  @Ignore("unnecessary test case for re-auth, but it manifests GEODE-9704")
   public void registeredInterest_slowReAuth_policyKeys_durableClient() throws Exception {
     int serverPort = server.getPort();
     clientVM = cluster.startClientVM(0,


### PR DESCRIPTION
ignore an extra test case that manifests an existing race condition.