### PR TITLE
GEODE-9692: enable HashesAndCrashesDUnitTest

### DIFF
--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
@@ -31,8 +31,8 @@ import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.sync.RedisAdvancedClusterCommands;
 import org.apache.logging.log4j.Logger;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -64,8 +64,8 @@ public class HashesAndCrashesDUnitTest {
 
   private static final int MAX_RETRIES = 10;
 
-  @BeforeClass
-  public static void setup() {
+  @Before
+  public void setup() {
     locator = clusterStartUp.startLocatorVM(0);
 
     server1 = clusterStartUp.startRedisVM(1, locator.getPort());
@@ -89,8 +89,8 @@ public class HashesAndCrashesDUnitTest {
     commands = clusterClient.connect().sync();
   }
 
-  @AfterClass
-  public static void cleanup() {
+  @After
+  public void cleanup() {
     try {
       clusterClient.shutdown();
       clusterStartUp.stop(0);

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/hash/HashesAndCrashesDUnitTest.java
@@ -65,7 +65,7 @@ public class HashesAndCrashesDUnitTest {
   private static final int MAX_RETRIES = 10;
 
   @BeforeClass
-  public void setup() {
+  public static void setup() {
     locator = clusterStartUp.startLocatorVM(0);
 
     server1 = clusterStartUp.startRedisVM(1, locator.getPort());


### PR DESCRIPTION
When I previously checked which Ignored tests pass, I found that this one did not. Since then someone must have fixed whatever issue was causing the failures because now they all pass. I simply removed the @Ignore.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
