### PR TITLE
GEODE-9774: Clear networkHop variable at function execution exit

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutor.java
@@ -215,21 +215,27 @@ public class PartitionedRegionFunctionExecutor extends AbstractExecution {
 
   @Override
   public ResultCollector executeFunction(final Function function, long timeout, TimeUnit unit) {
-    if (!function.hasResult()) /* NO RESULT:fire-n-forget */ {
-      this.pr.executeFunction(function, this, null, this.executeOnBucketSet);
-      return NO_RESULT;
-    }
-    ResultCollector inRc = (rc == null) ? new DefaultResultCollector() : rc;
-    ResultCollector rcToReturn =
-        this.pr.executeFunction(function, this, inRc, this.executeOnBucketSet);
-    if (timeout > 0) {
-      try {
-        rcToReturn.getResult(timeout, unit);
-      } catch (Exception exception) {
-        throw new FunctionException(exception);
+    try {
+      if (!function.hasResult()) /* NO RESULT:fire-n-forget */ {
+        this.pr.executeFunction(function, this, null, this.executeOnBucketSet);
+        return NO_RESULT;
+      }
+      ResultCollector inRc = (rc == null) ? new DefaultResultCollector() : rc;
+      ResultCollector rcToReturn =
+          this.pr.executeFunction(function, this, inRc, this.executeOnBucketSet);
+      if (timeout > 0) {
+        try {
+          rcToReturn.getResult(timeout, unit);
+        } catch (Exception exception) {
+          throw new FunctionException(exception);
+        }
+      }
+      return rcToReturn;
+    } finally {
+      if (pr.getNetworkHopType() != PartitionedRegion.NETWORK_HOP_NONE) {
+        pr.clearNetworkHopData();
       }
     }
-    return rcToReturn;
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/execute/PartitionedRegionFunctionExecutorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.internal.cache.execute;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.internal.cache.PartitionedRegion;
+
+public class PartitionedRegionFunctionExecutorTest {
+
+  @Test
+  public void executeThatSetsNetworkHopClearsItAtExit() {
+    PartitionedRegion region = mock(PartitionedRegion.class);
+    when(region.getNetworkHopType()).thenReturn((byte) 1);
+    PartitionedRegionFunctionExecutor executor = new PartitionedRegionFunctionExecutor(region);
+    executor.execute(new TestFunction());
+    verify(region, times(1)).clearNetworkHopData();
+  }
+
+  @Test
+  public void executeThatDoesNotSetNetworkHopDoesNotClearItAtExit() {
+    PartitionedRegion region = mock(PartitionedRegion.class);
+    when(region.getNetworkHopType()).thenReturn((byte) 0);
+    PartitionedRegionFunctionExecutor executor = new PartitionedRegionFunctionExecutor(region);
+    executor.execute(new TestFunction());
+    verify(region, never()).clearNetworkHopData();
+  }
+
+  private static class TestFunction implements Function {
+    @Override
+    public void execute(FunctionContext context) {}
+  }
+}

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/functions/TestFunction.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/functions/TestFunction.java
@@ -96,6 +96,9 @@ public class TestFunction<T> implements Function<T>, Declarable2, DataSerializab
       "executeFunctionRunningForLongTime";
   public static final String TEST_FUNCTION_BUCKET_FILTER = "TestFunctionBucketFilter";
   public static final String TEST_FUNCTION_NONHA_NOP = "executeFunctionNoHANop";
+  public static final String TEST_FUNCTION_SINGLE_HOP_FORCE_NETWORK_HOP =
+      "executeFunctionSingleHopForceNetworkHop";
+  public static final String TEST_FUNCTION_GET_NETWORK_HOP = "executeFunctionGetNetworkHop";
   private static final String ID = "id";
   private static final String HAVE_RESULTS = "haveResults";
   private final Properties props;
@@ -190,6 +193,10 @@ public class TestFunction<T> implements Function<T>, Declarable2, DataSerializab
       executeFunctionBucketFilter(context);
     } else if (id.equals(TEST_FUNCTION_NONHA_NOP)) {
       execute1(context);
+    } else if (id.equals(TEST_FUNCTION_SINGLE_HOP_FORCE_NETWORK_HOP)) {
+      executeSingleHopForceNetworkHop(context);
+    } else if (id.equals(TEST_FUNCTION_GET_NETWORK_HOP)) {
+      executeGetNetworkHop(context);
     } else if (noAckTest.equals("true")) {
       execute1(context);
     }
@@ -1013,6 +1020,25 @@ public class TestFunction<T> implements Function<T>, Declarable2, DataSerializab
       e.printStackTrace();
     }
     context.getResultSender().lastResult(context.getArguments());
+  }
+
+  private void executeSingleHopForceNetworkHop(FunctionContext context) {
+    RegionFunctionContext rfContext = (RegionFunctionContext) context;
+    final PartitionedRegion pr = (PartitionedRegion) rfContext.getDataSet();
+    Set keySet = (Set) rfContext.getArguments();
+    // Read entries from the region to provoke hops to another server
+    for (Object key : keySet) {
+      pr.get(key);
+    }
+    int networkHopType = pr.getNetworkHopType();
+    context.getResultSender().lastResult(networkHopType);
+  }
+
+  private void executeGetNetworkHop(FunctionContext context) {
+    RegionFunctionContext rfContext = (RegionFunctionContext) context;
+    final PartitionedRegion pr = (PartitionedRegion) rfContext.getDataSet();
+    int networkHopType = pr.getNetworkHopType();
+    context.getResultSender().lastResult(networkHopType);
   }
 
   /**


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
