### PR TITLE
GEODE-6588: Use System.lineSeparator()

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.wan;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.DISTRIBUTED_SYSTEM_ID;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
@@ -223,7 +224,7 @@ public class SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest {
   }
 
   private Vector<String> parseSendersConnectedFromGfshOutput(String gfshOutput) {
-    String lines[] = gfshOutput.split(System.getProperty("line.separator"));
+    String lines[] = gfshOutput.split(lineSeparator());
     final String sendersConnectedColumnHeader = "Senders Connected";
     String receiverInfo = null;
     for (int i = 0; i < lines.length; i++) {

--- a/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestInterfaceIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/rest/internal/web/RestInterfaceIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.rest.internal.web;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
@@ -281,7 +282,7 @@ public class RestInterfaceIntegrationTest {
           String line;
 
           while ((line = responseBodyReader.readLine()) != null) {
-            buffer.append(line).append(System.getProperty("line.separator"));
+            buffer.append(line).append(lineSeparator());
           }
 
           return buffer.toString().trim();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexUsingXMLDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexUsingXMLDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.cache.query.dunit;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.CACHE_XML_FILE;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -722,9 +723,9 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
             }
 
             // compare.
-            getLogWriter().info("Execute query : " + System.getProperty("line.separator")
+            getLogWriter().info("Execute query : " + lineSeparator()
                 + " QUERY_STR with index: " + queryStrings[0] + " "
-                + System.getProperty("line.separator") + " QUERY_STR without index: "
+                + lineSeparator() + " QUERY_STR without index: "
                 + queryStrings[1]);
             resultsSet.CompareQueryResultsWithoutAndWithIndexes(selectResults, 1, queryStrings);
           }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/EventIdOptimizationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/EventIdOptimizationDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.ha;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
@@ -530,7 +531,7 @@ public class EventIdOptimizationDUnitTest extends JUnit4DistributedTestCase {
       if (!containsEventId) {
         validationFailed = true;
         failureMsg.append("key = ").append(key).append(" ; eventID = ").append(eventIdAtClient2)
-            .append(System.getProperty("line.separator"));
+            .append(lineSeparator());
       }
     }
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/unsafe/ReadOpFileAccessControllerJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/unsafe/ReadOpFileAccessControllerJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.unsafe;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.junit.Assert.assertNotNull;
@@ -71,7 +72,6 @@ public class ReadOpFileAccessControllerJUnitTest {
   private Registry registry = null;
 
   public static final String SERVICE_URLPREFIX = "service:jmx:rmi:///jndi/rmi:";
-  private static final String NEW_LINE = System.getProperty("line.separator");
 
   @Rule
   public TemporaryFolder tempFolder = new TemporaryFolder();
@@ -169,9 +169,9 @@ public class ReadOpFileAccessControllerJUnitTest {
     File file = tempFolder.newFile("jmxremote.access");
     BufferedWriter writer = new BufferedWriter(new FileWriter(file));
     writer.append("admin readwrite");
-    writer.append(NEW_LINE);
+    writer.append(lineSeparator());
     writer.append("user readonly");
-    writer.append(NEW_LINE);
+    writer.append(lineSeparator());
     writer.flush();
     writer.close();
     return file.getAbsolutePath();
@@ -181,9 +181,9 @@ public class ReadOpFileAccessControllerJUnitTest {
     File file = tempFolder.newFile("jmxremote.password");
     BufferedWriter writer = new BufferedWriter(new FileWriter(file));
     writer.append("admin admin");
-    writer.append(NEW_LINE);
+    writer.append(lineSeparator());
     writer.append("user user");
-    writer.append(NEW_LINE);
+    writer.append(lineSeparator());
     writer.flush();
     writer.close();
     return file.getAbsolutePath();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemConfigImpl.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.admin.internal;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.admin.internal.InetAddressUtils.toHostString;
 import static org.apache.geode.admin.internal.InetAddressUtilsWithLogging.validateHost;
 import static org.apache.geode.distributed.ConfigurationProperties.BIND_ADDRESS;
@@ -1189,7 +1190,7 @@ public class DistributedSystemConfigImpl implements DistributedSystemConfig {
   @Override
   public String toString() {
     StringBuffer buf = new StringBuffer(1000);
-    String lf = System.getProperty("line.separator");
+    String lf = lineSeparator();
     if (lf == null) {
       lf = ",";
     }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.cache.query.internal.CompiledValue.indexThresholdSize;
-import static org.apache.geode.internal.lang.SystemUtils.getLineSeparator;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -813,18 +813,18 @@ public class HashIndex extends AbstractIndex {
   }
 
   public String dump() {
-    StringBuilder sb = new StringBuilder(toString()).append(" {").append(getLineSeparator());
-    sb.append(" -----------------------------------------------").append(getLineSeparator());
+    StringBuilder sb = new StringBuilder(toString()).append(" {").append(lineSeparator());
+    sb.append(" -----------------------------------------------").append(lineSeparator());
     for (Object anEntriesSet : this.entriesSet) {
       Entry indexEntry = (Entry) anEntriesSet;
-      sb.append(" Key = ").append(indexEntry.getKey()).append(getLineSeparator());
+      sb.append(" Key = ").append(indexEntry.getKey()).append(lineSeparator());
       sb.append(" Value Type = ").append(' ').append(indexEntry.getValue().getClass().getName())
-          .append(getLineSeparator());
+          .append(lineSeparator());
       if (indexEntry.getValue() instanceof Collection) {
         sb.append(" Value Size = ").append(' ').append(((Collection) indexEntry.getValue()).size())
-            .append(getLineSeparator());
+            .append(lineSeparator());
       } else if (indexEntry.getValue() instanceof RegionEntry) {
-        sb.append(" Value Size = ").append(" " + 1).append(getLineSeparator());
+        sb.append(" Value Size = ").append(" " + 1).append(lineSeparator());
       } else {
         throw new AssertionError("value instance of " + indexEntry.getValue().getClass().getName());
       }
@@ -837,9 +837,9 @@ public class HashIndex extends AbstractIndex {
         if (value instanceof Collection) {
           sb.append("  Value.size = ").append(((Collection) value).size());
         }
-        sb.append(getLineSeparator());
+        sb.append(lineSeparator());
       }
-      sb.append(" -----------------------------------------------").append(getLineSeparator());
+      sb.append(" -----------------------------------------------").append(lineSeparator());
     }
     sb.append("}// Index ").append(getName()).append(" end");
     return sb.toString();
@@ -983,11 +983,11 @@ public class HashIndex extends AbstractIndex {
 
     public String toString() {
       StringBuilder sb = new StringBuilder();
-      sb.append("No Keys = ").append(getNumberOfKeys()).append(getLineSeparator());
-      sb.append("No Values = ").append(getNumberOfValues()).append(getLineSeparator());
-      sb.append("No Uses = ").append(getTotalUses()).append(getLineSeparator());
-      sb.append("No Updates = ").append(getNumUpdates()).append(getLineSeparator());
-      sb.append("Total Update time = ").append(getTotalUpdateTime()).append(getLineSeparator());
+      sb.append("No Keys = ").append(getNumberOfKeys()).append(lineSeparator());
+      sb.append("No Values = ").append(getNumberOfValues()).append(lineSeparator());
+      sb.append("No Uses = ").append(getTotalUses()).append(lineSeparator());
+      sb.append("No Updates = ").append(getNumUpdates()).append(lineSeparator());
+      sb.append("Total Update time = ").append(getTotalUpdateTime()).append(lineSeparator());
       return sb.toString();
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexManager.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexManager.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
-import static org.apache.geode.internal.lang.SystemUtils.getLineSeparator;
+import static java.lang.System.lineSeparator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1347,7 +1347,7 @@ public class IndexManager {
       if (ind instanceof FutureTask) {
         continue;
       }
-      sb.append(ind).append(getLineSeparator());
+      sb.append(ind).append(lineSeparator());
     }
     return sb.toString();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractDiskRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractDiskRegion.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.lang.System.lineSeparator;
+
 import java.io.PrintStream;
 import java.util.EnumSet;
 import java.util.Map;
@@ -914,7 +916,7 @@ public abstract class AbstractDiskRegion implements DiskRegionView {
   }
 
   public String dump2() {
-    final String lineSeparator = System.getProperty("line.separator");
+    final String lineSeparator = lineSeparator();
     StringBuffer sb = new StringBuffer();
     String name = getName();
     if (isBucket() && logger.isTraceEnabled(LogMarker.PERSIST_RECOVERY_VERBOSE)) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskInitFile.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskInitFile.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.lang.System.lineSeparator;
+
 import java.io.BufferedInputStream;
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -2555,7 +2557,7 @@ public class DiskInitFile implements DiskInitFileInterpreter {
     boolean statisticsEnabled = drv.getStatisticsEnabled();
     boolean offHeap = drv.getOffHeap();
     StringBuilder sb = new StringBuilder();
-    final String lineSeparator = System.getProperty("line.separator");
+    final String lineSeparator = lineSeparator();
 
     if (lruOption != null) {
       EvictionAlgorithm ea = EvictionAlgorithm.parseAction(lruOption);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/LocalRegion.java
@@ -14,10 +14,10 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.AFTER_INITIAL_IMAGE;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.ANY_INIT;
 import static org.apache.geode.internal.cache.LocalRegion.InitializationLevel.BEFORE_INITIAL_IMAGE;
-import static org.apache.geode.internal.lang.SystemUtils.getLineSeparator;
 import static org.apache.geode.internal.offheap.annotations.OffHeapIdentifier.ENTRY_EVENT_NEW_VALUE;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 
@@ -4354,17 +4354,17 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
           if (key instanceof VersionedObjectList) {
             Set keys = ((VersionedObjectList) key).keySet();
             for (Object k : keys) {
-              buffer.append("  ").append(k).append(getLineSeparator());
+              buffer.append("  ").append(k).append(lineSeparator());
             }
           } else {
-            buffer.append("  ").append(key).append(getLineSeparator());
+            buffer.append("  ").append(key).append(lineSeparator());
           }
         }
       }
     } // for
     if (logger.isDebugEnabled()) {
       logger.debug("{} refreshEntriesFromServerKeys count={} policy={}{}{}", this, totalKeys, pol,
-          getLineSeparator(), buffer);
+          lineSeparator(), buffer);
     }
   }
 
@@ -8465,8 +8465,8 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
     if (rvv != null && getDataPolicy().withStorage()) {
       if (isRvvDebugEnabled) {
         logger.trace(LogMarker.RVV_VERBOSE,
-            "waiting for my version vector to dominate{}mine={}{} other={}", getLineSeparator(),
-            getLineSeparator(), versionVector.fullToString(), rvv);
+            "waiting for my version vector to dominate{}mine={}{} other={}", lineSeparator(),
+            lineSeparator(), versionVector.fullToString(), rvv);
       }
       boolean result = versionVector.waitToDominate(rvv, this);
       if (!result) {
@@ -8988,7 +8988,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         if (isDebugEnabled) {
           logger.debug(
               "putAll in client encountered a PutAllPartialResultException:{}{}. Adjusted keys are: {}",
-              e.getMessage(), getLineSeparator(), proxyResult.getKeys());
+              e.getMessage(), lineSeparator(), proxyResult.getKeys());
         }
         Throwable txException = e.getFailure();
         while (txException != null) {
@@ -9205,7 +9205,7 @@ public class LocalRegion extends AbstractRegion implements LoaderHelperFactory,
         if (isDebugEnabled) {
           logger.debug(
               "removeAll in client encountered a BulkOpPartialResultException: {}{}. Adjusted keys are: {}",
-              e.getMessage(), getLineSeparator(), proxyResult.getKeys());
+              e.getMessage(), lineSeparator(), proxyResult.getKeys());
         }
         Throwable txException = e.getFailure();
         while (txException != null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -14,9 +14,9 @@
  */
 package org.apache.geode.internal.cache;
 
+import static java.lang.System.lineSeparator;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toSet;
-import static org.apache.geode.internal.lang.SystemUtils.getLineSeparator;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -717,13 +717,13 @@ public class PartitionedRegion extends LocalRegion
 
     public synchronized String dump() {
       StringBuilder sb = new StringBuilder("prIdToPR Map@");
-      sb.append(System.identityHashCode(prIdToPR)).append(':').append(getLineSeparator());
+      sb.append(System.identityHashCode(prIdToPR)).append(':').append(lineSeparator());
       Map.Entry mapEntry;
       for (Iterator iterator = prIdToPR.entrySet().iterator(); iterator.hasNext();) {
         mapEntry = (Map.Entry) iterator.next();
         sb.append(mapEntry.getKey()).append("=>").append(mapEntry.getValue());
         if (iterator.hasNext()) {
-          sb.append(getLineSeparator());
+          sb.append(lineSeparator());
         }
       }
       return sb.toString();

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/StringUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/StringUtils.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.lang;
 
+import static java.lang.System.lineSeparator;
+
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -33,9 +35,9 @@ import org.apache.geode.internal.cache.Token;
 @Deprecated
 public class StringUtils extends org.apache.commons.lang3.StringUtils {
 
-  public static final String COMMA_DELIMITER = ",";
-  public static final String LINE_SEPARATOR = System.getProperty("line.separator");
-  public static final String SPACE = " ";
+  static final String COMMA_DELIMITER = ",";
+  static final String LINE_SEPARATOR = lineSeparator();
+  static final String SPACE = " ";
 
   private static final int MAX_ARRAY_ELEMENTS_TO_CONVERT =
       Integer.getInteger("StringUtils.MAX_ARRAY_ELEMENTS_TO_CONVERT", 16);

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/SystemUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/SystemUtils.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.lang;
 
+
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -47,8 +48,6 @@ public class SystemUtils {
   public static final String MAC_OSX_NAME = "Mac";
   public static final String WINDOWS_OS_NAME = "Windows";
   public static final String SOLARIS_OS_NAME = "SunOS";
-
-  private static final String LINE_SEPARATOR = System.getProperty("line.separator");
 
   /**
    * Utility method to determine whether the Java application process is executing on the Apple JVM.
@@ -253,13 +252,6 @@ public class SystemUtils {
   private static boolean isOS(final String expectedOsName) {
     String osName = getOsName();
     return osName != null && osName.contains(expectedOsName);
-  }
-
-  /**
-   * Returns the value of {@code System.getProperty("line.separator")}.
-   */
-  public static String getLineSeparator() {
-    return LINE_SEPARATOR;
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/shared/StringPrintWriter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/shared/StringPrintWriter.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.internal.shared;
 
+import static java.lang.System.lineSeparator;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.io.Writer;
@@ -56,8 +58,8 @@ public class StringPrintWriter extends PrintWriter {
    * Create a new string writer using the specified string-builder and line separator.
    *
    * @param sb the {@link StringBuilder} to use as the internal buffer
-   * @param lineSep the line separator to use, or null to use the default from system
-   *        "line.separator" property
+   * @param lineSep the line separator to use, or null to use the default from
+   *        {@link System#lineSeparator()}.
    */
   public StringPrintWriter(StringBuilder sb, String lineSep) {
     super(dummyLock, false);
@@ -66,7 +68,7 @@ public class StringPrintWriter extends PrintWriter {
         : java.security.AccessController.doPrivileged(new PrivilegedAction<String>() {
           @Override
           public String run() {
-            return System.getProperty("line.separator");
+            return lineSeparator();
           }
         });
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/BeanUtilFuncs.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/BeanUtilFuncs.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.management.internal.beans;
 
+import static java.lang.System.lineSeparator;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -56,7 +58,7 @@ public class BeanUtilFuncs {
     long seekPosition = fileLength - readSize;
     StringBuilder returnStr = new StringBuilder();
     StringBuilder workingString = new StringBuilder();
-    String separator = System.getProperty("line.separator");
+    String separator = lineSeparator();
 
     while (linesRead < numLines) {
 

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/MemberMBeanBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/MemberMBeanBridge.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.management.internal.beans;
 
-import static org.apache.geode.internal.lang.SystemUtils.getLineSeparator;
+import static java.lang.System.lineSeparator;
 
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -767,9 +767,9 @@ public class MemberMBeanBridge {
     StringBuilder result = new StringBuilder();
     result.append(mainTail);
     if (childTail != null) {
-      result.append(getLineSeparator())
+      result.append(lineSeparator())
           .append("-------------------- tail of child log --------------------")
-          .append(getLineSeparator());
+          .append(lineSeparator());
       result.append(childTail);
     }
     return result.toString();

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/ShowLogCommandDistributedTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/ShowLogCommandDistributedTestBase.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
@@ -130,7 +131,7 @@ public class ShowLogCommandDistributedTestBase implements Serializable {
     assertThat(gfsh.getGfshOutput()).doesNotContain(MESSAGE_ON_MANAGER);
     assertThat(gfsh.getGfshOutput()).doesNotContain(MESSAGE_ON_SERVER2);
 
-    assertThat(output.split(System.getProperty("line.separator"))).hasSize(51);
+    assertThat(output.split(lineSeparator())).hasSize(51);
   }
 
   @Test

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/CliUtils.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/CliUtils.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.io.File;
@@ -185,7 +186,7 @@ public class CliUtils {
 
   public static void runLessCommandAsExternalViewer(Result commandResult) {
     StringBuilder sb = new StringBuilder();
-    String NEW_LINE = System.getProperty("line.separator");
+    String NEW_LINE = lineSeparator();
 
     while (commandResult.hasNextLine()) {
       sb.append(commandResult.nextLine()).append(NEW_LINE);

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/AlterRuntimeConfigCommand.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLING_ENABLED;
 
 import java.util.HashMap;
@@ -199,7 +200,7 @@ public class AlterRuntimeConfigCommand extends GfshCommand {
         successfulMembers.add(result.getMemberIdOrName());
       }
     }
-    final String lineSeparator = System.getProperty("line.separator");
+    final String lineSeparator = lineSeparator();
 
 
     if (!successfulMembers.isEmpty()) {

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.cache.Region.SEPARATOR;
 
 import java.util.ArrayList;
@@ -129,7 +130,7 @@ public class RebalanceCommand extends GfshCommand {
     }
 
     TabularResultModel table1 = result.addTable("Table" + index);
-    String newLine = System.getProperty("line.separator");
+    String newLine = lineSeparator();
     StringBuilder resultStr = new StringBuilder();
     resultStr.append(newLine);
     table1.accumulate("Rebalanced Stats", CliStrings.REBALANCE__MSG__TOTALBUCKETCREATEBYTES);

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.management.internal.cli.commands.StartMemberUtils.resolveWorkingDirectory;
 
 import java.io.File;
@@ -233,7 +234,7 @@ public class StartLocatorCommand extends OfflineGfshCommand {
     ProcessStreamReader.InputListener inputListener = line -> {
       message.append(line);
       if (readingMode == ProcessStreamReader.ReadingMode.BLOCKING) {
-        message.append(SystemUtils.getLineSeparator());
+        message.append(lineSeparator());
       }
     };
 

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.lang.System.lineSeparator;
 import static org.apache.geode.management.cli.GfshCommand.EXPERIMENTAL;
 import static org.apache.geode.management.internal.cli.commands.StartMemberUtils.resolveWorkingDirectory;
 
@@ -370,7 +371,7 @@ public class StartServerCommand extends OfflineGfshCommand {
     ProcessStreamReader.InputListener inputListener = line -> {
       message.append(line);
       if (readingMode == ProcessStreamReader.ReadingMode.BLOCKING) {
-        message.append(SystemUtils.getLineSeparator());
+        message.append(lineSeparator());
       }
     };
 

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/domain/DataCommandRequest.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/domain/DataCommandRequest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.management.internal.cli.domain;
 
+import static java.lang.System.lineSeparator;
+
 import java.io.Serializable;
 
 import org.apache.geode.management.internal.i18n.CliStrings;
@@ -40,7 +42,7 @@ public class DataCommandRequest implements Serializable {
   private String valueClass;
   private Object principal;
 
-  public static final String NEW_LINE = System.getProperty("line.separator");
+  public static final String NEW_LINE = lineSeparator();
 
   @Override
   public String toString() {

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/functions/ExportConfigFunction.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/functions/ExportConfigFunction.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.management.internal.cli.functions;
 
+import static java.lang.System.lineSeparator;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Map;
@@ -73,7 +75,7 @@ public class ExportConfigFunction implements InternalFunction<Object> {
           (DistributionConfigImpl) ((InternalDistributedSystem) cache.getDistributedSystem())
               .getConfig();
       StringBuilder propStringBuf = new StringBuilder();
-      String lineSeparator = System.getProperty("line.separator");
+      String lineSeparator = lineSeparator();
       for (Map.Entry entry : config.getConfigPropsFromSource(ConfigSource.runtime()).entrySet()) {
         if (entry.getValue() != null && !entry.getValue().equals("")) {
           propStringBuf.append(entry.getKey()).append("=").append(entry.getValue())

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
@@ -107,7 +107,7 @@ public class Gfsh extends JLineShell {
   public static final String GFSH_APP_NAME = "gfsh";
 
   public static final String LINE_INDENT = "    ";
-  public static final String LINE_SEPARATOR = System.getProperty("line.separator");
+  public static final String LINE_SEPARATOR = lineSeparator();
   // Default Window dimensions
   public static final int DEFAULT_WIDTH = 100;
   public static final String ENV_APP_NAME = "APP_NAME";
@@ -456,7 +456,7 @@ public class Gfsh extends JLineShell {
     env.put(ENV_SYS_CLASSPATH, System.getProperty("java.class.path"));
     env.put(ENV_SYS_JAVA_VERSION, System.getProperty("java.version"));
     env.put(ENV_SYS_OS, System.getProperty("os.name"));
-    env.put(ENV_SYS_OS_LINE_SEPARATOR, System.getProperty("line.separator"));
+    env.put(ENV_SYS_OS_LINE_SEPARATOR, lineSeparator());
     env.put(ENV_SYS_GEODE_HOME_DIR, System.getenv("GEODE_HOME"));
 
     env.put(ENV_APP_NAME, Gfsh.GFSH_APP_NAME);

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -219,7 +219,7 @@ gradle.taskGraph.whenReady({ graph ->
         systemProperty 'java.io.tmpdir', System.getProperty('java.io.tmpdir')
       }
 
-      def eol = System.getProperty('line.separator')
+      def eol = System.lineSeparator()
       def progress = new File(resultsDir, "$test.name-progress.txt")
       beforeTest { desc ->
         def now = new Date().format('yyyy-MM-dd HH:mm:ss.SSS Z')


### PR DESCRIPTION
* Replace synchronized System.getProperty("line.separator") calls with
System.lineSeparator().

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
