### PR TITLE
GEODE-9746: do not logout old subjects immediately when we get a new subject for the same uniqueId

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -94,6 +94,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientProxyFactory.InternalCacheClientProxyFactory;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
+import org.apache.geode.internal.cache.tier.sockets.ClientUserAuths;
 import org.apache.geode.internal.cache.tier.sockets.MessageDispatcher;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.serialization.KnownVersion;
@@ -1612,7 +1613,8 @@ public class DeltaPropagationDUnitTest implements Serializable {
           clientVersion, acceptorId, notifyBySubscription, securityService, subject,
           statisticsClock,
           notifier.getCache().getInternalDistributedSystem().getStatisticsManager(),
-          DEFAULT_CACHECLIENTPROXYSTATSFACTORY, CustomMessageDispatcher::new);
+          DEFAULT_CACHECLIENTPROXYSTATSFACTORY, CustomMessageDispatcher::new,
+          new ClientUserAuths(proxyId.hashCode()));
     }
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerConnectDisconnectDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerConnectDisconnectDistributedTest.java
@@ -151,7 +151,7 @@ public class ClientServerConnectDisconnectDistributedTest implements Serializabl
     authorizations = new ArrayList<>();
     for (ServerConnection sc : acceptor.getAllServerConnections()) {
       ClientUserAuths auth = sc.getClientUserAuths();
-      assertThat(auth.getAllSubjects().size()).isNotEqualTo(0);
+      assertThat(auth.getAllSubjects()).isNotEmpty();
       authorizations.add(auth);
       for (Subject subject : auth.getAllSubjects()) {
         assertThat(subject.getPrincipal()).isNotNull();
@@ -204,7 +204,7 @@ public class ClientServerConnectDisconnectDistributedTest implements Serializabl
     }
 
     for (ClientUserAuths auth : authorizations) {
-      assertThat(auth.getAllSubjects().size()).isEqualTo(0);
+      assertThat(auth.getAllSubjects()).isEmpty();
     }
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerConnectDisconnectDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientServerConnectDisconnectDistributedTest.java
@@ -151,9 +151,9 @@ public class ClientServerConnectDisconnectDistributedTest implements Serializabl
     authorizations = new ArrayList<>();
     for (ServerConnection sc : acceptor.getAllServerConnections()) {
       ClientUserAuths auth = sc.getClientUserAuths();
-      assertThat(auth.getSubjects().size()).isNotEqualTo(0);
+      assertThat(auth.getAllSubjects().size()).isNotEqualTo(0);
       authorizations.add(auth);
-      for (Subject subject : auth.getSubjects()) {
+      for (Subject subject : auth.getAllSubjects()) {
         assertThat(subject.getPrincipal()).isNotNull();
         assertThat(subject.getPrincipals()).isNotNull();
         assertThat(subject.isAuthenticated()).isTrue();
@@ -204,7 +204,7 @@ public class ClientServerConnectDisconnectDistributedTest implements Serializabl
     }
 
     for (ClientUserAuths auth : authorizations) {
-      assertThat(auth.getSubjects().size()).isEqualTo(0);
+      assertThat(auth.getAllSubjects().size()).isEqualTo(0);
     }
   }
 

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/SecurityWithExpirationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/SecurityWithExpirationIntegrationTest.java
@@ -19,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
 
+import org.apache.shiro.subject.Subject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -55,6 +56,14 @@ public class SecurityWithExpirationIntegrationTest {
     getSecurityManager().addExpiredUser("data");
     assertThatThrownBy(() -> this.securityService.authorize(ResourcePermissions.DATA_READ))
         .isInstanceOf(AuthenticationExpiredException.class);
+  }
+
+  @Test
+  public void logoutMultipleTimeOnTheSameSubjectShouldNotThrowExcpetion() {
+    this.securityService.login(loginCredentials("data", "data"));
+    Subject subject = securityService.getSubject();
+    subject.logout();
+    subject.logout();
   }
 
   private Properties loginCredentials(String username, String password) {

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/SecurityWithExpirationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/security/SecurityWithExpirationIntegrationTest.java
@@ -59,7 +59,7 @@ public class SecurityWithExpirationIntegrationTest {
   }
 
   @Test
-  public void logoutMultipleTimeOnTheSameSubjectShouldNotThrowExcpetion() {
+  public void logoutMultipleTimeOnTheSameSubjectShouldNotThrowException() {
     this.securityService.login(loginCredentials("data", "data"));
     Subject subject = securityService.getSubject();
     subject.logout();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -223,7 +223,7 @@ public class CacheClientProxy implements ClientSession {
   private Subject subject;
 
   /**
-   * used for cq name to subject/auth mapping, always initialized in single/multi user casees
+   * used for cq name to subject/auth mapping, always initialized in single/multi user cases
    */
   private ClientUserAuths clientUserAuths;
 
@@ -783,9 +783,10 @@ public class CacheClientProxy implements ClientSession {
         else if (subject != null) {
           logger.debug("CacheClientProxy.close, logging out: " + subject.getPrincipal());
           subject.logout();
+          subject = null;
         }
         // for multiUser case, in non-durable case, we are closing the connection
-        else {
+        else if (clientUserAuths != null) {
           clientUserAuths.cleanup(true);
           clientUserAuths = null;
         }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
+import static org.apache.geode.logging.internal.spi.LoggingProvider.SECURITY_LOGGER_NAME;
+
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketException;
@@ -94,6 +96,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
 @SuppressWarnings("synthetic-access")
 public class CacheClientProxy implements ClientSession {
   private static final Logger logger = LogService.getLogger();
+  private static final Logger secureLogger = LogService.getLogger(SECURITY_LOGGER_NAME);
 
   @Immutable
   @VisibleForTesting
@@ -781,12 +784,13 @@ public class CacheClientProxy implements ClientSession {
         // single user case -- integrated security
         // connection is closed, so we can log out this subject
         else if (subject != null) {
-          logger.debug("CacheClientProxy.close, logging out: " + subject.getPrincipal());
+          secureLogger.debug("CacheClientProxy.close, logging out {}. ", subject.getPrincipal());
           subject.logout();
           subject = null;
         }
         // for multiUser case, in non-durable case, we are closing the connection
         else if (clientUserAuths != null) {
+          secureLogger.debug("CacheClientProxy.close, cleanup all client subjects. ");
           clientUserAuths.cleanup(true);
           clientUserAuths = null;
         }
@@ -979,8 +983,8 @@ public class CacheClientProxy implements ClientSession {
 
     // Logout the subject
     if (subject != null) {
-      logger.info(
-          "CacheClientProxy.closeOtherTransientFields, logging out: " + subject.getPrincipal());
+      secureLogger.debug(
+          "CacheClientProxy.closeOtherTransientFields, logging out {}. ", subject.getPrincipal());
       subject.logout();
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
@@ -18,13 +18,18 @@ import static org.apache.geode.cache.client.internal.AuthenticateUserOp.NOT_A_US
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.shiro.subject.Subject;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.TestOnly;
 
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.security.AuthorizeRequest;
@@ -38,7 +43,12 @@ public class ClientUserAuths {
       new ConcurrentHashMap<>();
   private final ConcurrentMap<String, UserAuthAttributes> cqNameVsUserAuth =
       new ConcurrentHashMap<>();
-  private final ConcurrentMap<Long, Subject> uniqueIdVsSubject = new ConcurrentHashMap<>();
+  // use a list to store all the subjects that's created for this user id
+  // it's observed that even in the non-expirable credential case, the will be multiple
+  // subjects created associated with one userId. We always save the current subject to the top of
+  // the list. The rest are "to-be-retired".
+  private final ConcurrentMap<Long, CopyOnWriteArrayList<Subject>> uniqueIdVsSubject =
+      new ConcurrentHashMap<>();
   private final ConcurrentMap<String, Long> cqNameVsUniqueId = new ConcurrentHashMap<>();
 
   private final int m_seed;
@@ -52,17 +62,32 @@ public class ClientUserAuths {
     return newId;
   }
 
-  public Long putSubject(Subject subject, long existingUniqueId) {
-    final Long newId;
+
+  public long putSubject(@NotNull Subject subject, long existingUniqueId) {
+    final long newId;
     if (existingUniqueId == 0 || existingUniqueId == NOT_A_USER_ID) {
       newId = getNextID();
     } else {
       newId = existingUniqueId;
     }
 
-    Subject oldSubject = uniqueIdVsSubject.put(newId, subject);
-    removeSubject(oldSubject);
-    logger.debug("Subject of {} added.", newId);
+    // we are saving all the subjects that's related to this uniqueId
+    // we cannot immediately log out the old subject of this userId because
+    // it might already be bound to another thread and doing operations. If
+    // we log out that subject immediately, that thread "authorize" would get null principal.
+    synchronized (this) {
+      CopyOnWriteArrayList<Subject> subjects;
+      if (!uniqueIdVsSubject.containsKey(newId)) {
+        logger.debug("Subject of {} added.", newId);
+        subjects = new CopyOnWriteArrayList<>();
+        uniqueIdVsSubject.put(newId, subjects);
+      } else {
+        logger.debug("Subject of {} replaced.", newId);
+        subjects = uniqueIdVsSubject.get(newId);
+      }
+      // always add the latest subject to the top of the list;
+      subjects.add(0, subject);
+    }
     return newId;
   }
 
@@ -90,28 +115,29 @@ public class ClientUserAuths {
   }
 
   @VisibleForTesting
+  @TestOnly
   protected Collection<Subject> getSubjects() {
-    return Collections.unmodifiableCollection(uniqueIdVsSubject.values());
+    List<Subject> all = uniqueIdVsSubject.values().stream()
+        .flatMap(List::stream)
+        .collect(Collectors.toList());
+    return Collections.unmodifiableCollection(all);
   }
 
-  public Subject getSubject(final Long userId) {
-    return uniqueIdVsSubject.get(userId);
+  public synchronized Subject getSubject(final Long userId) {
+    CopyOnWriteArrayList<Subject> subjects = uniqueIdVsSubject.get(userId);
+    if (subjects == null || subjects.isEmpty()) {
+      return null;
+    }
+    return subjects.get(0);
   }
 
-  public void removeSubject(final Long userId) {
+  public synchronized void removeSubject(final Long userId) {
     logger.debug("Subject of {} removed.", userId);
-    removeSubject(uniqueIdVsSubject.remove(userId));
-  }
-
-  @VisibleForTesting
-  void removeSubject(Subject subject) {
-    if (subject == null) {
+    CopyOnWriteArrayList<Subject> subjects = uniqueIdVsSubject.remove(userId);
+    if (subjects == null) {
       return;
     }
-    if (subject.getPrincipal() == null) {
-      return;
-    }
-    subject.logout();
+    subjects.forEach(Subject::logout);
   }
 
   public UserAuthAttributes getUserAuthAttributes(final String cqName) {
@@ -121,7 +147,7 @@ public class ClientUserAuths {
   public Subject getSubject(final String cqName) {
     Long uniqueId = cqNameVsUniqueId.get(cqName);
     if (uniqueId != null) {
-      return uniqueIdVsSubject.get(uniqueId);
+      return uniqueIdVsSubject.get(uniqueId).get(0);
     }
     return null;
   }
@@ -188,6 +214,7 @@ public class ClientUserAuths {
   }
 
   public void cleanup(boolean fromCacheClientProxy) {
+    // for old security model
     for (UserAuthAttributes userAuth : uniqueIdVsUserAuth.values()) {
       // isDurable is checked for multiuser in CQ
       if (!fromCacheClientProxy && !userAuth.isDurable()) {
@@ -199,7 +226,8 @@ public class ClientUserAuths {
       }
     }
 
-    // Logout the subjects
+    // for integrated security, doesn't matter if this is called from proxy
+    // or from the connection, we are closing the client connection
     for (final Long subjectId : uniqueIdVsSubject.keySet()) {
       removeSubject(subjectId);
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
@@ -121,7 +121,7 @@ public class ClientUserAuths {
 
   @VisibleForTesting
   @TestOnly
-  protected Collection<Subject> getSubjects() {
+  protected synchronized Collection<Subject> getSubjects() {
     List<Subject> all = uniqueIdVsSubject.values().stream()
         .flatMap(List::stream)
         .collect(Collectors.toList());

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuths.java
@@ -15,6 +15,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.cache.client.internal.AuthenticateUserOp.NOT_A_USER_ID;
+import static org.apache.geode.logging.internal.spi.LoggingProvider.SECURITY_LOGGER_NAME;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -31,7 +32,6 @@ import org.apache.shiro.subject.Subject;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.TestOnly;
 
-import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.security.AuthorizeRequest;
 import org.apache.geode.internal.security.AuthorizeRequestPP;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -43,6 +43,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  */
 public class ClientUserAuths {
   private static final Logger logger = LogService.getLogger();
+  private static final Logger secureLogger = LogService.getLogger(SECURITY_LOGGER_NAME);
 
   private final ConcurrentMap<Long, UserAuthAttributes> uniqueIdVsUserAuth =
       new ConcurrentHashMap<>();
@@ -83,11 +84,11 @@ public class ClientUserAuths {
     synchronized (this) {
       List<Subject> subjects;
       if (!uniqueIdVsSubjects.containsKey(newId)) {
-        logger.debug("Subject of {} added.", newId);
+        secureLogger.debug("Subject of {} added.", newId);
         subjects = new ArrayList<>();
         uniqueIdVsSubjects.put(newId, subjects);
       } else {
-        logger.debug("Subject of {} replaced.", newId);
+        secureLogger.debug("Subject of {} replaced.", newId);
         subjects = uniqueIdVsSubjects.get(newId);
       }
       // always add the latest subject to the top of the list;
@@ -119,7 +120,6 @@ public class ClientUserAuths {
     return uniqueIdVsUserAuth.get(userId);
   }
 
-  @VisibleForTesting
   @TestOnly
   protected synchronized Collection<Subject> getAllSubjects() {
     List<Subject> all = uniqueIdVsSubjects.values().stream()
@@ -141,7 +141,7 @@ public class ClientUserAuths {
     if (subjects == null) {
       return;
     }
-    logger.debug("{} Subjects of {} removed.", subjects.size(), userId);
+    secureLogger.debug("{} Subjects of {} removed.", subjects.size(), userId);
     subjects.forEach(Subject::logout);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
@@ -80,6 +80,8 @@ public class CacheClientProxyTest {
     proxyStatsFactory = mock(CacheClientProxyStatsFactory.class);
     dispatcherFactory = mock(MessageDispatcherFactory.class);
     clientUserAuths = mock(ClientUserAuths.class);
+    when(proxyStatsFactory.create(any(), any(), any()))
+        .thenReturn(mock(CacheClientProxyStats.class));
 
     proxyWithSingleUser =
         new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
@@ -104,8 +106,6 @@ public class CacheClientProxyTest {
 
   @Test
   public void deliverMessageWhenSubjectIsNotNull() {
-    when(proxyStatsFactory.create(any(), any(), any()))
-        .thenReturn(mock(CacheClientProxyStats.class));
     proxyWithSingleUser =
         new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
             securityService, subject, clock, statsFactory, proxyStatsFactory, dispatcherFactory,
@@ -120,8 +120,6 @@ public class CacheClientProxyTest {
 
   @Test
   public void deliverMessageWhenSubjectIsNull() {
-    when(proxyStatsFactory.create(any(), any(), any()))
-        .thenReturn(mock(CacheClientProxyStats.class));
     proxyWithMultiUser =
         new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
             securityService, null, clock, statsFactory, proxyStatsFactory, dispatcherFactory,
@@ -157,18 +155,18 @@ public class CacheClientProxyTest {
   }
 
   @Test
-  public void close_singleUser() {
+  public void close_singleUser_logout_subject() {
     when(id.isDurable()).thenReturn(false);
     CacheClientProxy spy = spy(proxyWithSingleUser);
     doNothing().when(spy).closeTransientFields();
     boolean keepProxy = spy.close(true, false);
     assertThat(keepProxy).isFalse();
-    verify(subject, times(1)).logout();
+    verify(subject).logout();
     verify(clientUserAuths, never()).cleanup(anyBoolean());
   }
 
   @Test
-  public void close_multiUser() {
+  public void close_multiUser_calls_ClientUserAuthsCleanUp() {
     when(id.isDurable()).thenReturn(false);
     CacheClientProxy spy = spy(proxyWithMultiUser);
     doNothing().when(spy).closeTransientFields();

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
@@ -20,9 +20,11 @@ package org.apache.geode.internal.cache.tier.sockets;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -43,7 +45,8 @@ import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.statistics.StatisticsClock;
 
 public class CacheClientProxyTest {
-  private CacheClientProxy proxy;
+  private CacheClientProxy proxyWithSingleUser;
+  private CacheClientProxy proxyWithMultiUser;
   private CacheClientNotifier notifier;
   private Socket socket;
   private ClientProxyMembershipID id;
@@ -57,6 +60,7 @@ public class CacheClientProxyTest {
   private MessageDispatcherFactory dispatcherFactory;
   private InetAddress inetAddress;
   private CacheServerStats stats;
+  private ClientUserAuths clientUserAuths;
 
   @Before
   public void before() throws Exception {
@@ -75,32 +79,41 @@ public class CacheClientProxyTest {
     statsFactory = mock(StatisticsFactory.class);
     proxyStatsFactory = mock(CacheClientProxyStatsFactory.class);
     dispatcherFactory = mock(MessageDispatcherFactory.class);
+    clientUserAuths = mock(ClientUserAuths.class);
+
+    proxyWithSingleUser =
+        new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
+            securityService, subject, clock, statsFactory, proxyStatsFactory, dispatcherFactory,
+            clientUserAuths);
+
+    proxyWithMultiUser =
+        new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
+            securityService, null, clock, statsFactory, proxyStatsFactory, dispatcherFactory,
+            clientUserAuths);
   }
 
   @Test
   public void noExceptionWhenGettingSubjectForCQWhenSubjectIsNotNull() {
-    proxy = spy(new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
-        securityService, subject, clock, statsFactory, proxyStatsFactory, dispatcherFactory));
-    proxy.getSubject("cq");
+    proxyWithSingleUser.getSubject("cq");
   }
 
   @Test
   public void noExceptionWhenGettingSubjectForCQWhenSubjectIsNull() {
-    proxy = spy(new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
-        securityService, null, clock, statsFactory, proxyStatsFactory, dispatcherFactory));
-    proxy.getSubject("cq");
+    proxyWithMultiUser.getSubject("cq");
   }
 
   @Test
   public void deliverMessageWhenSubjectIsNotNull() {
     when(proxyStatsFactory.create(any(), any(), any()))
         .thenReturn(mock(CacheClientProxyStats.class));
-    proxy = spy(new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
-        securityService, subject, clock, statsFactory, proxyStatsFactory, dispatcherFactory));
-    assertThat(proxy.getSubject()).isNotNull();
+    proxyWithSingleUser =
+        new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
+            securityService, subject, clock, statsFactory, proxyStatsFactory, dispatcherFactory,
+            clientUserAuths);
+    assertThat(proxyWithSingleUser.getSubject()).isNotNull();
     Conflatable message = mock(ClientUpdateMessage.class);
     when(securityService.needPostProcess()).thenReturn(true);
-    proxy.deliverMessage(message);
+    proxyWithSingleUser.deliverMessage(message);
     verify(securityService).bindSubject(subject);
     verify(securityService).postProcess(any(), any(), any(), anyBoolean());
   }
@@ -109,23 +122,59 @@ public class CacheClientProxyTest {
   public void deliverMessageWhenSubjectIsNull() {
     when(proxyStatsFactory.create(any(), any(), any()))
         .thenReturn(mock(CacheClientProxyStats.class));
-    proxy = spy(new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
-        securityService, null, clock, statsFactory, proxyStatsFactory, dispatcherFactory));
-    assertThat(proxy.getSubject()).isNull();
+    proxyWithMultiUser =
+        new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
+            securityService, null, clock, statsFactory, proxyStatsFactory, dispatcherFactory,
+            clientUserAuths);
+    assertThat(proxyWithMultiUser.getSubject()).isNull();
     Conflatable message = mock(ClientUpdateMessage.class);
     when(securityService.needPostProcess()).thenReturn(true);
     when(proxyStatsFactory.create(any(), any(), any()))
         .thenReturn(mock(CacheClientProxyStats.class));
-    proxy.deliverMessage(message);
+    proxyWithMultiUser.deliverMessage(message);
     verify(securityService, never()).bindSubject(subject);
     verify(securityService, never()).postProcess(any(), any(), any(), anyBoolean());
   }
 
   @Test
   public void replacingSubjectShouldNotLogout() {
-    proxy = new CacheClientProxy(cache, notifier, socket, id, true, (byte) 1, version, 1L, true,
-        securityService, subject, clock, statsFactory, proxyStatsFactory, dispatcherFactory);
-    proxy.setSubject(mock(Subject.class));
+    proxyWithSingleUser.setSubject(mock(Subject.class));
     verify(subject, never()).logout();
+  }
+
+  @Test
+  public void close_keepProxy_ShouldNotLogoutUser() {
+    when(id.isDurable()).thenReturn(true);
+    boolean keepProxy = proxyWithSingleUser.close(true, false);
+    assertThat(keepProxy).isTrue();
+    verify(subject, never()).logout();
+    verify(clientUserAuths, never()).cleanup(anyBoolean());
+
+    keepProxy = proxyWithMultiUser.close(true, false);
+    assertThat(keepProxy).isTrue();
+    verify(subject, never()).logout();
+    verify(clientUserAuths, never()).cleanup(anyBoolean());
+  }
+
+  @Test
+  public void close_singleUser() {
+    when(id.isDurable()).thenReturn(false);
+    CacheClientProxy spy = spy(proxyWithSingleUser);
+    doNothing().when(spy).closeTransientFields();
+    boolean keepProxy = spy.close(true, false);
+    assertThat(keepProxy).isFalse();
+    verify(subject, times(1)).logout();
+    verify(clientUserAuths, never()).cleanup(anyBoolean());
+  }
+
+  @Test
+  public void close_multiUser() {
+    when(id.isDurable()).thenReturn(false);
+    CacheClientProxy spy = spy(proxyWithMultiUser);
+    doNothing().when(spy).closeTransientFields();
+    boolean keepProxy = spy.close(true, false);
+    assertThat(keepProxy).isFalse();
+    verify(subject, never()).logout();
+    verify(clientUserAuths, times(1)).cleanup(anyBoolean());
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuthsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuthsTest.java
@@ -18,9 +18,11 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -45,37 +47,68 @@ public class ClientUserAuthsTest {
   }
 
   @Test
-  public void putSubjectWithNegativeOneWillProduceNewId() throws Exception {
+  public void putSubjectWithNegativeOneWillProduceNewId() {
     Long uniqueId = auth.putSubject(subject1, -1);
-    verify(auth).removeSubject((Subject) null);
+    verify(auth, never()).removeSubject(anyLong());
     assertThat(uniqueId).isEqualTo(123L);
   }
 
   @Test
-  public void putSubjectWithZeroWillProduceNewId() throws Exception {
+  public void putSubjectWithZeroWillProduceNewId() {
     Long uniqueId = auth.putSubject(subject1, 0);
-    verify(auth).removeSubject((Subject) null);
+    verify(auth, never()).removeSubject(anyLong());
     assertThat(uniqueId).isEqualTo(123L);
+    verify(subject1, never()).logout();
   }
 
   @Test
-  public void putSubjectWithExistingId() throws Exception {
+  public void putSubjectWithExistingId() {
     Long uniqueId = auth.putSubject(subject1, 456L);
-    verify(auth).removeSubject((Subject) null);
+    verify(auth, never()).removeSubject(anyLong());
     assertThat(uniqueId).isEqualTo(456L);
+    verify(subject1, never()).logout();
   }
 
   @Test
-  public void replacedSubjectShouldLogout() throws Exception {
+  public void replacedSubjectShouldNotLogout() {
     Long id1 = auth.putSubject(subject1, -1);
     Long id2 = auth.putSubject(subject2, id1);
     assertThat(id1).isEqualTo(id2);
-    verify(auth).removeSubject(eq(subject1));
-    verify(subject1).logout();
+    verify(auth, never()).removeSubject(anyLong());
+    verify(subject1, never()).logout();
+
   }
 
   @Test
-  public void cqSubjectIsTracked() throws Exception {
+  public void getSubjectReturnsTheLatestOne() {
+    Long id1 = auth.putSubject(subject1, -1);
+    assertThat(auth.getSubject(id1)).isSameAs(subject1);
+    auth.putSubject(subject2, id1);
+    assertThat(auth.getSubject(id1)).isSameAs(subject2);
+  }
+
+  @Test
+  public void getSubjectOfNonExistentId() {
+    assertThat(auth.getSubject(5678L)).isNull();
+  }
+
+  @Test
+  public void removeSubjectOfNonExistentId() {
+    assertThatNoException().isThrownBy(() -> auth.removeSubject(5678L));
+  }
+
+  @Test
+  public void removeSubject() {
+    Long id1 = auth.putSubject(subject1, -1);
+    auth.putSubject(subject2, id1);
+    auth.removeSubject(id1);
+    assertThat(auth.getSubject(id1)).isNull();
+    verify(subject1).logout();
+    verify(subject2).logout();
+  }
+
+  @Test
+  public void cqSubjectIsTracked() {
     Long id1 = auth.putSubject(subject1, -1);
     auth.setUserAuthAttributesForCq("cq1", id1, true);
     Subject subject = auth.getSubject("cq1");

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuthsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ClientUserAuthsTest.java
@@ -98,6 +98,16 @@ public class ClientUserAuthsTest {
   }
 
   @Test
+  public void getSubjectWithCq() {
+    long id = auth.putSubject(subject1, -1);
+    auth.setUserAuthAttributesForCq("cq", id, true);
+    assertThat(auth.getSubject("cq")).isSameAs(subject1);
+
+    auth.removeSubject(id);
+    assertThat(auth.getSubject("cq")).isNull();
+  }
+
+  @Test
   public void removeSubject() {
     Long id1 = auth.putSubject(subject1, -1);
     auth.putSubject(subject2, id1);

--- a/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
@@ -29,13 +29,11 @@ import org.apache.geode.examples.SimpleSecurityManager;
  * this is a test security manager that will authenticate credentials when username matches the
  * password. It will authorize all operations. It keeps a list of expired users, and will throw
  * AuthenticationExpiredException if the user is in that list. This security manager is usually used
- * with NewCredentialAuthInitialize.
+ * with UpdatableUserAuthInitialize.
  *
  * make sure to call reset after each test to clean things up.
  */
 public class ExpirableSecurityManager extends SimpleSecurityManager implements Serializable {
-  // use static field for ease of testing since there is only one instance of this in each VM
-  // we only need ConcurrentHashSet here, but map is only construct available in the library
   private final Set<String> expired_users = ConcurrentHashMap.newKeySet();
   private final Map<String, List<String>> authorizedOps =
       new ConcurrentHashMap<>();


### PR DESCRIPTION
In some cases, client will send in Authentication request with existing uniqueId (in both re-auth or non-re-auth cases), we used to just replace the old subject with the new subject and log out the old subject immediately, but this old subject might already be bound with a running thread, hence causing "FailedToFindSubject" exception on that thread. We can't immediately log out the old subject, so we have to keep reference of them and log out them all at connection closing time.

This PR also includes a minor fix in CacheClientProxy for completeness of the logic