### PR TITLE
GEODE-9792: avoid sending in multiple authentication request on the same connection by different threads

### DIFF
--- a/geode-junit/src/main/java/org/apache/geode/security/templates/TrackableUserPasswordAuthInit.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/templates/TrackableUserPasswordAuthInit.java
@@ -1,0 +1,38 @@
+/*
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.security.templates;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.geode.LogWriter;
+import org.apache.geode.security.AuthenticationFailedException;
+
+public class TrackableUserPasswordAuthInit extends UserPasswordAuthInit {
+  public static AtomicInteger timeInitialized = new AtomicInteger(0);
+
+  public static void reset() {
+    timeInitialized.set(0);
+  }
+
+  @Override
+  public void init(final LogWriter systemLogWriter, final LogWriter securityLogWriter)
+      throws AuthenticationFailedException {
+    super.init(systemLogWriter, securityLogWriter);
+    timeInitialized.incrementAndGet();
+  }
+}


### PR DESCRIPTION
It's observed that AuthenticationRequest will come in multiple times in the same connection by different threads. This PR would fix that.