### PR TITLE
GEODE-9756: add  "geode-for-redis-redundant-copies" gemfire property

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1929,8 +1929,9 @@ public interface ConfigurationProperties {
    * all local addresses.
    * </p>
    * <U>Default</U>: ""
+   * </p>
+   * <U>Since</U>: Geode 1.15
    */
-
   String GEODE_FOR_REDIS_BIND_ADDRESS = "geode-for-redis-bind-address";
   /**
    * The static String definition of the <i>"geode-for-redis-enabled"</i> property <a
@@ -1944,6 +1945,7 @@ public interface ConfigurationProperties {
    * When the default value of false, Geode for Redis is not available.
    * Set to true to enable Geode for Redis.
    * </p>
+   * <U>Since</U>: Geode 1.15
    */
   String GEODE_FOR_REDIS_ENABLED = "geode-for-redis-enabled";
   /**
@@ -1954,20 +1956,47 @@ public interface ConfigurationProperties {
    * to authenticate using only a password. This requires a SecurityManager to be configured.
    * </p>
    * <U>Default</U>: default
+   * </p>
+   * <U>Since</U>: Geode 1.15
    */
   String GEODE_FOR_REDIS_USERNAME = "geode-for-redis-username";
   /**
    * The static String definition of the <i>"geode-for-redis-port"</i> property <a
    * name="geode-for-redis-port"/a>
    * </p>
-   * <U>Description</U>: Specifies the port on which the server listens for connections from Geode
-   * Geode for Redis. A value of 0 selects a random port.</td>
+   * <U>Description</U>: Specifies the port on which the Geode for Redis server listens for clients.
+   * A value of 0 selects a random port.</td>
    * </p>
    * <U>Default</U>: 6379
    * </p>
    * <U>Allowed values</U>: 0..65535
+   * </p>
+   * <U>Since</U>: Geode 1.15
    */
   String GEODE_FOR_REDIS_PORT = "geode-for-redis-port";
+  /**
+   * The static String definition of the <i>"geode-for-redis-replica-count"</i> property <a
+   * name="geode-for-redis-replica-count"/a>
+   * </p>
+   * <U>Description</U>: Specifies the number of replicas Geode for Redis will attempt to keep
+   * in the cluster. A value of 0 means no replicas; no extra copies of data will be stored in
+   * the cluster. Note that extra servers need to be running for replicas to be made. For
+   * example if the cluster only has one server then no replicas will exist no matter what the
+   * value of this property is. Also note that Geode for Redis uses a Geode partitioned region
+   * to implement replicas and this property corresponds to the partitioned region's
+   * "redundantCopies"
+   * attribute. Because of this, geode-for-redis-replica-count can also be customized by setting
+   * {@link #ENFORCE_UNIQUE_HOST} or {@link #REDUNDANCY_ZONE}.
+   * This property must be set the same on every server in the cluster that is running a
+   * Geode for Redis server.</td>
+   * </p>
+   * <U>Default</U>: 1
+   * </p>
+   * <U>Allowed values</U>: 0..3
+   * </p>
+   * <U>Since</U>: Geode 1.15
+   */
+  String GEODE_FOR_REDIS_REPLICA_COUNT = "geode-for-redis-replica-count";
   /**
    * The static String definition of the <i>"lock-memory"</i> property <a name="lock-memory"/a>
    * </p>

--- a/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/ConfigurationProperties.java
@@ -1975,17 +1975,17 @@ public interface ConfigurationProperties {
    */
   String GEODE_FOR_REDIS_PORT = "geode-for-redis-port";
   /**
-   * The static String definition of the <i>"geode-for-redis-replica-count"</i> property <a
-   * name="geode-for-redis-replica-count"/a>
+   * The static String definition of the <i>"geode-for-redis-redundant-copies"</i> property <a
+   * name="geode-for-redis-redundant-copies"/a>
    * </p>
-   * <U>Description</U>: Specifies the number of replicas Geode for Redis will attempt to keep
-   * in the cluster. A value of 0 means no replicas; no extra copies of data will be stored in
-   * the cluster. Note that extra servers need to be running for replicas to be made. For
-   * example if the cluster only has one server then no replicas will exist no matter what the
-   * value of this property is. Also note that Geode for Redis uses a Geode partitioned region
-   * to implement replicas and this property corresponds to the partitioned region's
-   * "redundantCopies"
-   * attribute. Because of this, geode-for-redis-replica-count can also be customized by setting
+   * <U>Description</U>: Specifies the number of redundant copies Geode for Redis will attempt to
+   * keep in the cluster. A value of 0 means no extra copies of data will be stored in
+   * the cluster. Note that extra servers need to be running for redundant copies to be made. For
+   * example if the cluster only has one server then no redundant copies will exist no matter what
+   * the value of this property is. Also note that Geode for Redis uses a Geode partitioned region
+   * to implement redundant copies and this property corresponds to the partitioned region's
+   * "redundant-copies" attribute.
+   * Because of this, geode-for-redis-redundant-copies can also be customized by setting
    * {@link #ENFORCE_UNIQUE_HOST} or {@link #REDUNDANCY_ZONE}.
    * This property must be set the same on every server in the cluster that is running a
    * Geode for Redis server.</td>
@@ -1996,7 +1996,7 @@ public interface ConfigurationProperties {
    * </p>
    * <U>Since</U>: Geode 1.15
    */
-  String GEODE_FOR_REDIS_REPLICA_COUNT = "geode-for-redis-replica-count";
+  String GEODE_FOR_REDIS_REDUNDANT_COPIES = "geode-for-redis-redundant-copies";
   /**
    * The static String definition of the <i>"lock-memory"</i> property <a name="lock-memory"/a>
    * </p>

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
@@ -61,6 +61,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.GATEWAY_SSL_T
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REPLICA_COUNT;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_USERNAME;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
@@ -1314,13 +1315,15 @@ public abstract class AbstractDistributionConfig extends AbstractConfig
     m.put(MEMCACHED_BIND_ADDRESS,
         "The address the GemFireMemcachedServer will listen on for remote connections. Default is \"\" which causes the GemFireMemcachedServer to listen on the host's default address. This property is ignored if memcached-port is \"0\".");
     m.put(GEODE_FOR_REDIS_BIND_ADDRESS,
-        "Specifies the address on which the Redis API for Geode is listening. If set to the empty string or this property is not specified, localhost is requested from the operating system.");
+        "Specifies the address on which the Geode for Redis server is listening. If set to the empty string or this property is not specified, then all local addresses are listened to.  Default is an empty string.");
     m.put(GEODE_FOR_REDIS_ENABLED,
-        "When the default value of false, the Redis API for Geode is not available.  Set to true to enable the Redis API for Geode.");
+        "When false Geode for Redis is not available. Set to true to enable Geode for Redis.  Default is false.");
     m.put(GEODE_FOR_REDIS_USERNAME,
-        "Specifies the username that the server uses when a client attempts to authenticate using only a password. The default is 'default'.");
+        "Specifies the username that the Geode for Redis server uses when a client attempts to authenticate using only a password. The default is 'default'.");
     m.put(GEODE_FOR_REDIS_PORT,
-        "Specifies the port on which the server listens for Redis API for Geode connections. A value of 0 selects a random port.  Default is 6379.");
+        "Specifies the port on which the Geode for Redis server listens for client connections. A value of 0 selects a random port.  Default is 6379.");
+    m.put(GEODE_FOR_REDIS_REPLICA_COUNT,
+        "Specifies how many extra copies of data will be stored in the cluster by Geode for Redis.  Default is 1.");
     m.put(ENABLE_CLUSTER_CONFIGURATION,
         "Enables cluster configuration support in dedicated locators.  This allows the locator to share configuration information amongst members and save configuration changes made using GFSH.");
     m.put(ENABLE_MANAGEMENT_REST_SERVICE,

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/AbstractDistributionConfig.java
@@ -61,7 +61,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.GATEWAY_SSL_T
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_PORT;
-import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REPLICA_COUNT;
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REDUNDANT_COPIES;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_USERNAME;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
@@ -1322,7 +1322,7 @@ public abstract class AbstractDistributionConfig extends AbstractConfig
         "Specifies the username that the Geode for Redis server uses when a client attempts to authenticate using only a password. The default is 'default'.");
     m.put(GEODE_FOR_REDIS_PORT,
         "Specifies the port on which the Geode for Redis server listens for client connections. A value of 0 selects a random port.  Default is 6379.");
-    m.put(GEODE_FOR_REDIS_REPLICA_COUNT,
+    m.put(GEODE_FOR_REDIS_REDUNDANT_COPIES,
         "Specifies how many extra copies of data will be stored in the cluster by Geode for Redis.  Default is 1.");
     m.put(ENABLE_CLUSTER_CONFIGURATION,
         "Enables cluster configuration support in dedicated locators.  This allows the locator to share configuration information amongst members and save configuration changes made using GFSH.");

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -61,7 +61,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.GATEWAY_SSL_T
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_PORT;
-import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REPLICA_COUNT;
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REDUNDANT_COPIES;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_USERNAME;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
@@ -3547,20 +3547,21 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   int DEFAULT_REDIS_PORT = 6379;
 
   /**
-   * Returns the value of the {@link ConfigurationProperties#GEODE_FOR_REDIS_REPLICA_COUNT} property
+   * Returns the value of the {@link ConfigurationProperties#GEODE_FOR_REDIS_REDUNDANT_COPIES}
+   * property
    *
-   * @return the Geode for Redis replica count
+   * @return the Geode for Redis redundant copies
    *
    */
-  @ConfigAttributeGetter(name = GEODE_FOR_REDIS_REPLICA_COUNT)
-  int getRedisReplicaCount();
+  @ConfigAttributeGetter(name = GEODE_FOR_REDIS_REDUNDANT_COPIES)
+  int getRedisRedundantCopies();
 
-  @ConfigAttributeSetter(name = GEODE_FOR_REDIS_REPLICA_COUNT)
-  void setRedisReplicaCount(int value);
+  @ConfigAttributeSetter(name = GEODE_FOR_REDIS_REDUNDANT_COPIES)
+  void setRedisRedundantCopies(int value);
 
   @ConfigAttribute(type = Integer.class, min = 0, max = 3)
-  String REDIS_REPLICA_COUNT_NAME = GEODE_FOR_REDIS_REPLICA_COUNT;
-  int DEFAULT_REDIS_REPLICA_COUNT = 1;
+  String REDIS_REDUNDANT_COPIES_NAME = GEODE_FOR_REDIS_REDUNDANT_COPIES;
+  int DEFAULT_REDIS_REDUNDANT_COPIES = 1;
 
   // Added for the HTTP service
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -61,6 +61,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.GATEWAY_SSL_T
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REPLICA_COUNT;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_USERNAME;
 import static org.apache.geode.distributed.ConfigurationProperties.GROUPS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
@@ -3500,8 +3501,6 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * {@link ConfigurationProperties#GEODE_FOR_REDIS_ENABLED} property
    *
    * @return boolean value indicating whether or not a Redis API for Geode Server should be started
-   *
-   * @since GemFire 14.0
    */
   @ConfigAttributeGetter(name = GEODE_FOR_REDIS_ENABLED)
   boolean getRedisEnabled();
@@ -3521,8 +3520,6 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * {@link ConfigurationProperties#GEODE_FOR_REDIS_USERNAME} property
    *
    * @return the authentication username for GeodeRedisServer
-   *
-   * @since GemFire 8.0
    */
   @ConfigAttributeGetter(name = GEODE_FOR_REDIS_USERNAME)
   String getRedisUsername();
@@ -3538,8 +3535,6 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
    * Returns the value of the {@link ConfigurationProperties#GEODE_FOR_REDIS_PORT} property
    *
    * @return the port on which GeodeRedisServer should be started
-   *
-   * @since GemFire 8.0
    */
   @ConfigAttributeGetter(name = GEODE_FOR_REDIS_PORT)
   int getRedisPort();
@@ -3550,6 +3545,22 @@ public interface DistributionConfig extends Config, LogConfig, StatisticsConfig 
   @ConfigAttribute(type = Integer.class, min = 0, max = 65535)
   String REDIS_PORT_NAME = GEODE_FOR_REDIS_PORT;
   int DEFAULT_REDIS_PORT = 6379;
+
+  /**
+   * Returns the value of the {@link ConfigurationProperties#GEODE_FOR_REDIS_REPLICA_COUNT} property
+   *
+   * @return the Geode for Redis replica count
+   *
+   */
+  @ConfigAttributeGetter(name = GEODE_FOR_REDIS_REPLICA_COUNT)
+  int getRedisReplicaCount();
+
+  @ConfigAttributeSetter(name = GEODE_FOR_REDIS_REPLICA_COUNT)
+  void setRedisReplicaCount(int value);
+
+  @ConfigAttribute(type = Integer.class, min = 0, max = 3)
+  String REDIS_REPLICA_COUNT_NAME = GEODE_FOR_REDIS_REPLICA_COUNT;
+  int DEFAULT_REDIS_REPLICA_COUNT = 1;
 
   // Added for the HTTP service
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -503,6 +503,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * port on which GeodeRedisServer is started
    */
   private int redisPort = DEFAULT_REDIS_PORT;
+  private int redisReplicaCount = DEFAULT_REDIS_REPLICA_COUNT;
 
 
   private boolean jmxManager =
@@ -796,6 +797,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     redisBindAddress = other.getRedisBindAddress();
     redisUsername = other.getRedisUsername();
     redisEnabled = other.getRedisEnabled();
+    redisReplicaCount = other.getRedisReplicaCount();
     userCommandPackages = other.getUserCommandPackages();
 
     // following added for 8.0
@@ -3307,6 +3309,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(redisBindAddress, that.redisBindAddress)
         .append(redisUsername, that.redisUsername)
         .append(redisPort, that.redisPort)
+        .append(redisReplicaCount, that.redisReplicaCount)
         .append(redisEnabled, that.redisEnabled)
         .append(jmxManagerBindAddress, that.jmxManagerBindAddress)
         .append(jmxManagerHostnameForClients, that.jmxManagerHostnameForClients)
@@ -3402,7 +3405,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(loadSharedConfigurationFromDir).append(clusterConfigDir).append(httpServicePort)
         .append(httpServiceBindAddress).append(startDevRestApi).append(memcachedPort)
         .append(memcachedProtocol).append(memcachedBindAddress).append(distributedTransactions)
-        .append(redisPort).append(redisBindAddress).append(redisUsername)
+        .append(redisPort).append(redisBindAddress).append(redisUsername).append(redisReplicaCount)
         .append(redisEnabled).append(jmxManager)
         .append(jmxManagerStart).append(jmxManagerPort).append(jmxManagerBindAddress)
         .append(jmxManagerHostnameForClients).append(jmxManagerPasswordFile)
@@ -3511,6 +3514,16 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   @Override
   public void setRedisPort(int value) {
     redisPort = value;
+  }
+
+  @Override
+  public int getRedisReplicaCount() {
+    return redisReplicaCount;
+  }
+
+  @Override
+  public void setRedisReplicaCount(int value) {
+    redisReplicaCount = value;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfigImpl.java
@@ -503,7 +503,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
    * port on which GeodeRedisServer is started
    */
   private int redisPort = DEFAULT_REDIS_PORT;
-  private int redisReplicaCount = DEFAULT_REDIS_REPLICA_COUNT;
+  private int redisRedundantCopies = DEFAULT_REDIS_REDUNDANT_COPIES;
 
 
   private boolean jmxManager =
@@ -797,7 +797,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
     redisBindAddress = other.getRedisBindAddress();
     redisUsername = other.getRedisUsername();
     redisEnabled = other.getRedisEnabled();
-    redisReplicaCount = other.getRedisReplicaCount();
+    redisRedundantCopies = other.getRedisRedundantCopies();
     userCommandPackages = other.getUserCommandPackages();
 
     // following added for 8.0
@@ -3309,7 +3309,7 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(redisBindAddress, that.redisBindAddress)
         .append(redisUsername, that.redisUsername)
         .append(redisPort, that.redisPort)
-        .append(redisReplicaCount, that.redisReplicaCount)
+        .append(redisRedundantCopies, that.redisRedundantCopies)
         .append(redisEnabled, that.redisEnabled)
         .append(jmxManagerBindAddress, that.jmxManagerBindAddress)
         .append(jmxManagerHostnameForClients, that.jmxManagerHostnameForClients)
@@ -3405,7 +3405,8 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
         .append(loadSharedConfigurationFromDir).append(clusterConfigDir).append(httpServicePort)
         .append(httpServiceBindAddress).append(startDevRestApi).append(memcachedPort)
         .append(memcachedProtocol).append(memcachedBindAddress).append(distributedTransactions)
-        .append(redisPort).append(redisBindAddress).append(redisUsername).append(redisReplicaCount)
+        .append(redisPort).append(redisBindAddress).append(redisUsername).append(
+            redisRedundantCopies)
         .append(redisEnabled).append(jmxManager)
         .append(jmxManagerStart).append(jmxManagerPort).append(jmxManagerBindAddress)
         .append(jmxManagerHostnameForClients).append(jmxManagerPasswordFile)
@@ -3517,13 +3518,13 @@ public class DistributionConfigImpl extends AbstractDistributionConfig implement
   }
 
   @Override
-  public int getRedisReplicaCount() {
-    return redisReplicaCount;
+  public int getRedisRedundantCopies() {
+    return redisRedundantCopies;
   }
 
   @Override
-  public void setRedisReplicaCount(int value) {
-    redisReplicaCount = value;
+  public void setRedisRedundantCopies(int value) {
+    redisRedundantCopies = value;
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/LonerDistributionManager.java
@@ -1194,7 +1194,8 @@ public class LonerDistributionManager implements DistributionManager {
   @Override
   public boolean enforceUniqueZone() {
     return system.getConfig().getEnforceUniqueHost()
-        || system.getConfig().getRedundancyZone() != null;
+        || (system.getConfig().getRedundancyZone() != null
+            && !system.getConfig().getRedundancyZone().isEmpty());
   }
 
   @Override

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -101,7 +101,7 @@ public class DistributionConfigJUnitTest {
   @Test
   public void testGetAttributeNames() {
     String[] attNames = AbstractDistributionConfig._getAttNames();
-    assertThat(attNames).hasSize(169);
+    assertThat(attNames).hasSize(170);
 
     List boolList = new ArrayList();
     List intList = new ArrayList();
@@ -136,7 +136,7 @@ public class DistributionConfigJUnitTest {
     // TODO - This makes no sense. One has no idea what the correct expected number of attributes
     // are.
     assertThat(boolList).hasSize(36);
-    assertThat(intList).hasSize(35);
+    assertThat(intList).hasSize(36);
     assertThat(stringList).hasSize(88);
     assertThat(fileList).hasSize(5);
     assertThat(otherList).hasSize(5);

--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -19,7 +19,7 @@ package org.apache.geode.redis;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_PORT;
-import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REPLICA_COUNT;
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REDUNDANT_COPIES;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -135,7 +135,7 @@ public class GeodeRedisServerStartupDUnitTest {
   }
 
   @Test
-  public void startupFailsGivenInvalidReplicaCount() {
+  public void startupFailsGivenInvalidRedundantCopies() {
     int port = AvailablePortHelper.getRandomAvailableTCPPort();
 
     addIgnoredException("Could not start server compatible with Redis");
@@ -143,17 +143,17 @@ public class GeodeRedisServerStartupDUnitTest {
         .withProperty(GEODE_FOR_REDIS_PORT, "" + port)
         .withProperty(GEODE_FOR_REDIS_BIND_ADDRESS, "localhost")
         .withProperty(GEODE_FOR_REDIS_ENABLED, "true")
-        .withProperty(GEODE_FOR_REDIS_REPLICA_COUNT, "4")))
+        .withProperty(GEODE_FOR_REDIS_REDUNDANT_COPIES, "4")))
             .hasStackTraceContaining(
-                "Could not set \"" + GEODE_FOR_REDIS_REPLICA_COUNT
+                "Could not set \"" + GEODE_FOR_REDIS_REDUNDANT_COPIES
                     + "\" to \"4\" because its value can not be greater than \"3\".");
     assertThatThrownBy(() -> cluster.startServerVM(0, s -> s
         .withProperty(GEODE_FOR_REDIS_PORT, "" + port)
         .withProperty(GEODE_FOR_REDIS_BIND_ADDRESS, "localhost")
         .withProperty(GEODE_FOR_REDIS_ENABLED, "true")
-        .withProperty(GEODE_FOR_REDIS_REPLICA_COUNT, "-1")))
+        .withProperty(GEODE_FOR_REDIS_REDUNDANT_COPIES, "-1")))
             .hasStackTraceContaining(
-                "Could not set \"" + GEODE_FOR_REDIS_REPLICA_COUNT
+                "Could not set \"" + GEODE_FOR_REDIS_REDUNDANT_COPIES
                     + "\" to \"-1\" because its value can not be less than \"0\".");
   }
 
@@ -190,32 +190,32 @@ public class GeodeRedisServerStartupDUnitTest {
   }
 
   @Test
-  public void startupWorksGivenReplicaCountOfZero() {
+  public void startupWorksGivenRedundantCopiesOfZero() {
     MemberVM server = cluster.startServerVM(0, s -> s
-        .withProperty(GEODE_FOR_REDIS_REPLICA_COUNT, "0")
+        .withProperty(GEODE_FOR_REDIS_REDUNDANT_COPIES, "0")
         .withProperty(GEODE_FOR_REDIS_PORT, "0")
         .withProperty(GEODE_FOR_REDIS_ENABLED, "true"));
 
-    int replicaCount = cluster.getMember(0).invoke("getReplicaCount", () -> {
+    int RedundantCopies = cluster.getMember(0).invoke("getRedundantCopies", () -> {
       PartitionedRegion pr = (PartitionedRegion) RedisClusterStartupRule.getCache()
           .getRegion(RegionProvider.DEFAULT_REDIS_REGION_NAME);
       return pr.getPartitionAttributes().getRedundantCopies();
     });
-    assertThat(replicaCount).isEqualTo(0);
+    assertThat(RedundantCopies).isEqualTo(0);
   }
 
   @Test
-  public void startupWorksGivenReplicaCountOfThree() {
+  public void startupWorksGivenRedundantCopiesOfThree() {
     MemberVM server = cluster.startServerVM(0, s -> s
-        .withProperty(GEODE_FOR_REDIS_REPLICA_COUNT, "3")
+        .withProperty(GEODE_FOR_REDIS_REDUNDANT_COPIES, "3")
         .withProperty(GEODE_FOR_REDIS_PORT, "0")
         .withProperty(GEODE_FOR_REDIS_ENABLED, "true"));
 
-    int replicaCount = cluster.getMember(0).invoke("getReplicaCount", () -> {
+    int RedundantCopies = cluster.getMember(0).invoke("getRedundantCopies", () -> {
       PartitionedRegion pr = (PartitionedRegion) RedisClusterStartupRule.getCache()
           .getRegion(RegionProvider.DEFAULT_REDIS_REGION_NAME);
       return pr.getPartitionAttributes().getRedundantCopies();
     });
-    assertThat(replicaCount).isEqualTo(3);
+    assertThat(RedundantCopies).isEqualTo(3);
   }
 }

--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/GeodeRedisServerStartupDUnitTest.java
@@ -19,6 +19,7 @@ package org.apache.geode.redis;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_ENABLED;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REPLICA_COUNT;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,9 +34,11 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.redis.internal.GeodeRedisServer;
 import org.apache.geode.redis.internal.GeodeRedisService;
+import org.apache.geode.redis.internal.RegionProvider;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
@@ -132,6 +135,29 @@ public class GeodeRedisServerStartupDUnitTest {
   }
 
   @Test
+  public void startupFailsGivenInvalidReplicaCount() {
+    int port = AvailablePortHelper.getRandomAvailableTCPPort();
+
+    addIgnoredException("Could not start server compatible with Redis");
+    assertThatThrownBy(() -> cluster.startServerVM(0, s -> s
+        .withProperty(GEODE_FOR_REDIS_PORT, "" + port)
+        .withProperty(GEODE_FOR_REDIS_BIND_ADDRESS, "localhost")
+        .withProperty(GEODE_FOR_REDIS_ENABLED, "true")
+        .withProperty(GEODE_FOR_REDIS_REPLICA_COUNT, "4")))
+            .hasStackTraceContaining(
+                "Could not set \"" + GEODE_FOR_REDIS_REPLICA_COUNT
+                    + "\" to \"4\" because its value can not be greater than \"3\".");
+    assertThatThrownBy(() -> cluster.startServerVM(0, s -> s
+        .withProperty(GEODE_FOR_REDIS_PORT, "" + port)
+        .withProperty(GEODE_FOR_REDIS_BIND_ADDRESS, "localhost")
+        .withProperty(GEODE_FOR_REDIS_ENABLED, "true")
+        .withProperty(GEODE_FOR_REDIS_REPLICA_COUNT, "-1")))
+            .hasStackTraceContaining(
+                "Could not set \"" + GEODE_FOR_REDIS_REPLICA_COUNT
+                    + "\" to \"-1\" because its value can not be less than \"0\".");
+  }
+
+  @Test
   public void startupOnSpecifiedPort() {
     MemberVM server = cluster.startServerVM(0, s -> s
         .withProperty(GEODE_FOR_REDIS_PORT, "4242")
@@ -161,5 +187,35 @@ public class GeodeRedisServerStartupDUnitTest {
 
     assertThat(cluster.getRedisPort(server))
         .isNotEqualTo(GeodeRedisServer.DEFAULT_REDIS_SERVER_PORT);
+  }
+
+  @Test
+  public void startupWorksGivenReplicaCountOfZero() {
+    MemberVM server = cluster.startServerVM(0, s -> s
+        .withProperty(GEODE_FOR_REDIS_REPLICA_COUNT, "0")
+        .withProperty(GEODE_FOR_REDIS_PORT, "0")
+        .withProperty(GEODE_FOR_REDIS_ENABLED, "true"));
+
+    int replicaCount = cluster.getMember(0).invoke("getReplicaCount", () -> {
+      PartitionedRegion pr = (PartitionedRegion) RedisClusterStartupRule.getCache()
+          .getRegion(RegionProvider.DEFAULT_REDIS_REGION_NAME);
+      return pr.getPartitionAttributes().getRedundantCopies();
+    });
+    assertThat(replicaCount).isEqualTo(0);
+  }
+
+  @Test
+  public void startupWorksGivenReplicaCountOfThree() {
+    MemberVM server = cluster.startServerVM(0, s -> s
+        .withProperty(GEODE_FOR_REDIS_REPLICA_COUNT, "3")
+        .withProperty(GEODE_FOR_REDIS_PORT, "0")
+        .withProperty(GEODE_FOR_REDIS_ENABLED, "true"));
+
+    int replicaCount = cluster.getMember(0).invoke("getReplicaCount", () -> {
+      PartitionedRegion pr = (PartitionedRegion) RedisClusterStartupRule.getCache()
+          .getRegion(RegionProvider.DEFAULT_REDIS_REGION_NAME);
+      return pr.getPartitionAttributes().getRedundantCopies();
+    });
+    assertThat(replicaCount).isEqualTo(3);
   }
 }

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REPLICA_COUNT;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_USERNAME;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
@@ -38,6 +39,7 @@ public class GeodeRedisServerRule extends SerializableExternalResource {
     cacheFactory.set(LOG_LEVEL, "warn");
     cacheFactory.set(MCAST_PORT, "0");
     cacheFactory.set(LOCATORS, "");
+    cacheFactory.set(GEODE_FOR_REDIS_REPLICA_COUNT, "0");
   }
 
   public void setEnableUnsupportedCommands(boolean allow) {

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/GeodeRedisServerRule.java
@@ -16,7 +16,7 @@
 
 package org.apache.geode.redis;
 
-import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REPLICA_COUNT;
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_REDUNDANT_COPIES;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_USERNAME;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
@@ -39,7 +39,7 @@ public class GeodeRedisServerRule extends SerializableExternalResource {
     cacheFactory.set(LOG_LEVEL, "warn");
     cacheFactory.set(MCAST_PORT, "0");
     cacheFactory.set(LOCATORS, "");
-    cacheFactory.set(GEODE_FOR_REDIS_REPLICA_COUNT, "0");
+    cacheFactory.set(GEODE_FOR_REDIS_REDUNDANT_COPIES, "0");
   }
 
   public void setEnableUnsupportedCommands(boolean allow) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -90,7 +90,7 @@ public class RegionProvider {
     PartitionAttributesFactory<RedisKey, RedisData> attributesFactory =
         new PartitionAttributesFactory<>();
     DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
-    attributesFactory.setRedundantCopies(config.getRedisReplicaCount());
+    attributesFactory.setRedundantCopies(config.getRedisRedundantCopies());
     attributesFactory.setPartitionResolver(new RedisPartitionResolver());
     attributesFactory.setTotalNumBuckets(REDIS_REGION_BUCKETS);
     redisDataRegionFactory.setPartitionAttributes(attributesFactory.create());

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RegionProvider.java
@@ -32,6 +32,7 @@ import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.distributed.DistributedMember;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalRegionFactory;
 import org.apache.geode.internal.cache.PartitionedRegion;
@@ -88,6 +89,8 @@ public class RegionProvider {
 
     PartitionAttributesFactory<RedisKey, RedisData> attributesFactory =
         new PartitionAttributesFactory<>();
+    DistributionConfig config = cache.getInternalDistributedSystem().getConfig();
+    attributesFactory.setRedundantCopies(config.getRedisReplicaCount());
     attributesFactory.setPartitionResolver(new RedisPartitionResolver());
     attributesFactory.setTotalNumBuckets(REDIS_REGION_BUCKETS);
     redisDataRegionFactory.setPartitionAttributes(attributesFactory.create());


### PR DESCRIPTION
This is the same as the previous pull request for GEODE-9756 except that the name of the property is now "geode-for-redis-redundant-copies".

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
