### PR TITLE
GEODE-9792: synchronize multi-user authentication on different threads

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/OpExecutorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/OpExecutorImpl.java
@@ -146,7 +146,8 @@ public class OpExecutorImpl implements ExecutablePool {
           absOp.getMessage().setIsRetry();
         }
         try {
-          authenticateIfRequired(conn, op);
+          // if single user, the connection is already authenticated and has userId already
+          authenticateIfMultiUser(conn, op);
           return executeWithPossibleReAuthentication(conn, op);
         } catch (MessageTooLargeException e) {
           throw new GemFireIOException("unable to transmit message to server", e);
@@ -695,7 +696,7 @@ public class OpExecutorImpl implements ExecutablePool {
   }
 
   @VisibleForTesting
-  void authenticateIfRequired(final Connection connection, final Op op) {
+  void authenticateIfMultiUser(final Connection connection, final Op op) {
     if (!connection.getServer().getRequiresCredentials()) {
       return;
     }
@@ -704,24 +705,20 @@ public class OpExecutorImpl implements ExecutablePool {
       return;
     }
 
-    if (pool.getMultiuserAuthentication()) {
-      final UserAttributes ua = UserAttributes.userAttributes.get();
-      if (ua == null || ua.getServerToId().containsKey(connection.getServer())) {
-        return;
-      }
-      authenticateMultiuser(pool, connection, ua);
+    if (!pool.getMultiuserAuthentication()) {
       return;
     }
 
-    if (connection.getServer().getUserId() == -1) {
-      // This should not be reached, but keeping this code here in case it is reached.
-      final Connection wrappedConnection = connection.getWrappedConnection();
-      connection.getServer().setUserId(AuthenticateUserOp.executeOn(wrappedConnection, pool));
-      if (logger.isDebugEnabled()) {
-        logger.debug(
-            "OpExecutorImpl.execute() - single user mode - authenticated this user on {}",
-            connection);
+    final UserAttributes ua = UserAttributes.userAttributes.get();
+    if (ua == null) {
+      return;
+    }
+
+    synchronized (ua) {
+      if (ua.getServerToId().containsKey(connection.getServer())) {
+        return;
       }
+      authenticateMultiuser(pool, connection, ua);
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/PoolImpl.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -794,14 +793,7 @@ public class PoolImpl implements InternalPool {
    */
   @Override
   public Object execute(Op op) {
-    // if(multiuser)
-    // get a server from threadlocal cache else throw cacheWriterException
-    // executeOn(ServerLocation server, Op op, boolean accessed,boolean onlyUseExistingCnx)
-
-    // Retries are ignored here. FIX IT - FIXED.
-    // But this may lead to a user getting authenticated on all servers, even if
-    // a single server could have serviced all its requests.
-    authenticateIfRequired(null, op);
+    checkMultiUserHasUserAttributes(op);
     return executor.execute(op);
   }
 
@@ -816,7 +808,7 @@ public class PoolImpl implements InternalPool {
    */
   @Override
   public Object execute(Op op, int retries) {
-    authenticateIfRequired(null, op);
+    checkMultiUserHasUserAttributes(op);
     return executor.execute(op, retries);
   }
 
@@ -829,7 +821,7 @@ public class PoolImpl implements InternalPool {
    */
   @Override
   public Object executeOn(ServerLocation server, Op op) {
-    authenticateIfRequired(server, op);
+    checkMultiUserHasUserAttributes(op);
     return executor.executeOn(server, op);
   }
 
@@ -844,7 +836,7 @@ public class PoolImpl implements InternalPool {
   @Override
   public Object executeOn(ServerLocation server, Op op, boolean accessed,
       boolean onlyUseExistingCnx) {
-    authenticateIfRequired(server, op);
+    checkMultiUserHasUserAttributes(op);
     return executor.executeOn(server, op, accessed, onlyUseExistingCnx);
   }
 
@@ -857,7 +849,7 @@ public class PoolImpl implements InternalPool {
    */
   @Override
   public Object executeOn(Connection con, Op op) {
-    authenticateIfRequired(con.getServer(), op);
+    checkMultiUserHasUserAttributes(op);
     return executor.executeOn(con, op);
   }
 
@@ -875,14 +867,14 @@ public class PoolImpl implements InternalPool {
    */
   @Override
   public Object executeOnQueuesAndReturnPrimaryResult(Op op) {
-    authenticateOnAllServers(op);
+    checkMultiUserHasUserAttributes(op);
     return executor.executeOnQueuesAndReturnPrimaryResult(op);
   }
 
   @Override
   public void executeOnAllQueueServers(Op op)
       throws NoSubscriptionServersAvailableException, SubscriptionNotEnabledException {
-    authenticateOnAllServers(op);
+    checkMultiUserHasUserAttributes(op);
     executor.executeOnAllQueueServers(op);
   }
 
@@ -1522,14 +1514,9 @@ public class PoolImpl implements InternalPool {
 
   /**
    * This is only for multi-user case
-   *
-   * Assert thread-local var is not null.
-   *
-   * If serverLocation is non-null, check if the the user is authenticated on that server. If not,
-   * authenticate it and return.
-   *
+   * make sure thread-local var is not null.
    */
-  private void authenticateIfRequired(ServerLocation serverLocation, Op op) {
+  private void checkMultiUserHasUserAttributes(Op op) {
     if (!multiuserSecureModeEnabled) {
       return;
     }
@@ -1542,51 +1529,6 @@ public class PoolImpl implements InternalPool {
     if (userAttributes == null) {
       throw new UnsupportedOperationException(
           "Use Pool APIs for doing operations when multiuser-secure-mode-enabled is set to true.");
-    }
-
-    if (serverLocation != null) {
-      if (!userAttributes.getServerToId().containsKey(serverLocation)) {
-        Long userId = (Long) AuthenticateUserOp.executeOn(serverLocation, this,
-            userAttributes.getCredentials());
-        if (userId != null) {
-          userAttributes.setServerToId(serverLocation, userId);
-        }
-      }
-    }
-  }
-
-  private void authenticateOnAllServers(Op op) {
-    if (multiuserSecureModeEnabled && ((AbstractOp) op).needsUserId()) {
-      UserAttributes userAttributes = UserAttributes.userAttributes.get();
-      if (userAttributes != null) {
-        ConcurrentHashMap<ServerLocation, Long> map = userAttributes.getServerToId();
-
-        if (queueManager == null) {
-          throw new SubscriptionNotEnabledException();
-        }
-        Connection primary = queueManager.getAllConnectionsNoWait().getPrimary();
-        if (primary != null && !map.containsKey(primary.getServer())) {
-          Long userId = (Long) AuthenticateUserOp.executeOn(primary.getServer(), this,
-              userAttributes.getCredentials());
-          if (userId != null) {
-            map.put(primary.getServer(), userId);
-          }
-        }
-
-        List<Connection> backups = queueManager.getAllConnectionsNoWait().getBackups();
-        for (Connection conn : backups) {
-          if (!map.containsKey(conn.getServer())) {
-            Long userId = (Long) AuthenticateUserOp.executeOn(conn.getServer(), this,
-                userAttributes.getCredentials());
-            if (userId != null) {
-              map.put(conn.getServer(), userId);
-            }
-          }
-        }
-      } else {
-        throw new UnsupportedOperationException(
-            "Use Pool APIs for doing operations when multiuser-secure-mode-enabled is set to true.");
-      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/UserAttributes.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/UserAttributes.java
@@ -23,6 +23,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.distributed.internal.ServerLocation;
 
+/**
+ * An instance of the class is created per ProxyCache/RegionService
+ */
 public class UserAttributes {
 
   private Properties credentials;

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/OpExecutorImplUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/OpExecutorImplUnitTest.java
@@ -18,7 +18,6 @@
 package org.apache.geode.cache.client.internal;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -63,7 +62,7 @@ public class OpExecutorImplUnitTest {
   @Test
   public void authenticateIfRequired_noOp_WhenNotRequireCredential() {
     when(server.getRequiresCredentials()).thenReturn(false);
-    executor.authenticateIfRequired(connection, op);
+    executor.authenticateIfMultiUser(connection, op);
     verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
   }
 
@@ -71,7 +70,7 @@ public class OpExecutorImplUnitTest {
   public void authenticateIfRequired_noOp_WhenOpNeedsNoUserId() {
     when(server.getRequiresCredentials()).thenReturn(true);
     when(op.needsUserId()).thenReturn(false);
-    executor.authenticateIfRequired(connection, op);
+    executor.authenticateIfMultiUser(connection, op);
     verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
   }
 
@@ -81,7 +80,7 @@ public class OpExecutorImplUnitTest {
     when(op.needsUserId()).thenReturn(true);
     when(pool.getMultiuserAuthentication()).thenReturn(false);
     when(server.getUserId()).thenReturn(123L);
-    executor.authenticateIfRequired(connection, op);
+    executor.authenticateIfMultiUser(connection, op);
     verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
 
   }
@@ -94,9 +93,8 @@ public class OpExecutorImplUnitTest {
     when(server.getUserId()).thenReturn(-1L);
     when(pool.executeOn(any(Connection.class), any(Op.class))).thenReturn(123L);
     when(connection.getWrappedConnection()).thenReturn(connection);
-    executor.authenticateIfRequired(connection, op);
-    verify(pool).executeOn(any(Connection.class), any(Op.class));
-    verify(server).setUserId(eq(123L));
+    executor.authenticateIfMultiUser(connection, op);
+    verify(pool, never()).executeOn(any(Connection.class), any(Op.class));
   }
 
 }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/security/MultiUserAPIDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/security/MultiUserAPIDUnitTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
+import java.util.concurrent.Future;
 
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -31,6 +32,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionService;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.query.CqAttributesFactory;
@@ -39,11 +41,12 @@ import org.apache.geode.cache.query.Query;
 import org.apache.geode.examples.SimpleSecurityManager;
 import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
-import org.apache.geode.security.templates.TrackableUserPasswordAuthInit;
+import org.apache.geode.security.templates.CountableUserPasswordAuthInit;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.ClientCacheRule;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
 public class MultiUserAPIDUnitTest {
   @ClassRule
@@ -213,7 +216,7 @@ public class MultiUserAPIDUnitTest {
 
   @Test
   public void jsonFormatterOnTheClientWithSingleUser() throws Exception {
-    client.withProperty(SECURITY_CLIENT_AUTH_INIT, TrackableUserPasswordAuthInit.class.getName())
+    client.withProperty(SECURITY_CLIENT_AUTH_INIT, CountableUserPasswordAuthInit.class.getName())
         .withProperty(UserPasswordAuthInit.USER_NAME, "data")
         .withProperty(UserPasswordAuthInit.PASSWORD, "data")
         .withMultiUser(false)
@@ -226,12 +229,38 @@ public class MultiUserAPIDUnitTest {
     region.put("key", value);
 
     // make sure the client only needs to authenticate once
-    assertThat(TrackableUserPasswordAuthInit.timeInitialized.get()).isEqualTo(1);
+    assertThat(CountableUserPasswordAuthInit.count.get()).isEqualTo(1);
   }
+
+  @Rule
+  public ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  @Test
+  public void multiUser_OneUserShouldOnlyAuthenticateOnceByDifferentThread() throws Exception {
+    ClientCache cache = client.withServerConnection(server.getPort())
+        .withProperty(SECURITY_CLIENT_AUTH_INIT, CountableUserPasswordAuthInit.class.getName())
+        .withMultiUser(true)
+        .createCache();
+    Properties properties = new Properties();
+    properties.setProperty(UserPasswordAuthInit.USER_NAME, "data");
+    properties.setProperty(UserPasswordAuthInit.PASSWORD, "data");
+    RegionService regionService = cache.createAuthenticatedView(properties);
+
+    cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
+    Region region = regionService.getRegion(SEPARATOR + "region");
+
+    Future<Object> put1 = executor.submit(() -> region.put("key", "value"));
+    Future<Object> put2 = executor.submit(() -> region.put("key", "value"));
+
+    put1.get();
+    put2.get();
+    assertThat(CountableUserPasswordAuthInit.count.get()).isEqualTo(1);
+  }
+
 
   @After
   public void after() throws Exception {
-    TrackableUserPasswordAuthInit.reset();
+    CountableUserPasswordAuthInit.reset();
   }
 
   @Test

--- a/geode-junit/src/main/java/org/apache/geode/security/templates/CountableUserPasswordAuthInit.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/templates/CountableUserPasswordAuthInit.java
@@ -22,17 +22,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.geode.LogWriter;
 import org.apache.geode.security.AuthenticationFailedException;
 
-public class TrackableUserPasswordAuthInit extends UserPasswordAuthInit {
-  public static AtomicInteger timeInitialized = new AtomicInteger(0);
+public class CountableUserPasswordAuthInit extends UserPasswordAuthInit {
+  public static AtomicInteger count = new AtomicInteger(0);
 
   public static void reset() {
-    timeInitialized.set(0);
+    count.set(0);
   }
 
   @Override
   public void init(final LogWriter systemLogWriter, final LogWriter securityLogWriter)
       throws AuthenticationFailedException {
     super.init(systemLogWriter, securityLogWriter);
-    timeInitialized.incrementAndGet();
+    count.incrementAndGet();
   }
 }


### PR DESCRIPTION
In multi-user case, different threads sometimes will send in multiple authentication requests for the same user. 
Also renamed and removed some unnecessary AuthenticateUserOp calls.