### PR TITLE
GEODE-9792: synchronize multi-user authentication on different threads

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/UserAttributes.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/UserAttributes.java
@@ -23,6 +23,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.distributed.internal.ServerLocation;
 
+/**
+ * An instance of the class is created per ProxyCache/RegionService
+ */
 public class UserAttributes {
 
   private Properties credentials;

--- a/geode-cq/src/distributedTest/java/org/apache/geode/security/MultiUserAPIDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/security/MultiUserAPIDUnitTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Properties;
+import java.util.concurrent.Future;
 
 import org.junit.After;
 import org.junit.BeforeClass;
@@ -27,10 +28,13 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.apache.geode.cache.CacheTransactionManager;
+import org.apache.geode.cache.CommitConflictException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionService;
 import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.client.ClientCache;
+import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.cache.client.Pool;
 import org.apache.geode.cache.execute.FunctionService;
 import org.apache.geode.cache.query.CqAttributesFactory;
@@ -39,11 +43,12 @@ import org.apache.geode.cache.query.Query;
 import org.apache.geode.examples.SimpleSecurityManager;
 import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
-import org.apache.geode.security.templates.TrackableUserPasswordAuthInit;
+import org.apache.geode.security.templates.CountableUserPasswordAuthInit;
 import org.apache.geode.security.templates.UserPasswordAuthInit;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.rules.ClientCacheRule;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
 public class MultiUserAPIDUnitTest {
   @ClassRule
@@ -213,7 +218,7 @@ public class MultiUserAPIDUnitTest {
 
   @Test
   public void jsonFormatterOnTheClientWithSingleUser() throws Exception {
-    client.withProperty(SECURITY_CLIENT_AUTH_INIT, TrackableUserPasswordAuthInit.class.getName())
+    client.withProperty(SECURITY_CLIENT_AUTH_INIT, CountableUserPasswordAuthInit.class.getName())
         .withProperty(UserPasswordAuthInit.USER_NAME, "data")
         .withProperty(UserPasswordAuthInit.PASSWORD, "data")
         .withMultiUser(false)
@@ -226,12 +231,38 @@ public class MultiUserAPIDUnitTest {
     region.put("key", value);
 
     // make sure the client only needs to authenticate once
-    assertThat(TrackableUserPasswordAuthInit.timeInitialized.get()).isEqualTo(1);
+    assertThat(CountableUserPasswordAuthInit.count.get()).isEqualTo(1);
   }
+
+  @Rule
+  public ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  @Test
+  public void multiUser_OneUserShouldOnlyAuthenticateOnceByDifferentThread() throws Exception {
+    ClientCache cache = client.withServerConnection(server.getPort())
+        .withProperty(SECURITY_CLIENT_AUTH_INIT, CountableUserPasswordAuthInit.class.getName())
+        .withMultiUser(true)
+        .createCache();
+    Properties properties = new Properties();
+    properties.setProperty(UserPasswordAuthInit.USER_NAME, "data");
+    properties.setProperty(UserPasswordAuthInit.PASSWORD, "data");
+    RegionService regionService = cache.createAuthenticatedView(properties);
+
+    cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
+    Region region = regionService.getRegion(SEPARATOR + "region");
+
+    Future<Object> put1 = executor.submit(() -> region.put("key", "value"));
+    Future<Object> put2 = executor.submit(() -> region.put("key", "value"));
+
+    put1.get();
+    put2.get();
+    assertThat(CountableUserPasswordAuthInit.count.get()).isEqualTo(1);
+  }
+
 
   @After
   public void after() throws Exception {
-    TrackableUserPasswordAuthInit.reset();
+    CountableUserPasswordAuthInit.reset();
   }
 
   @Test
@@ -251,5 +282,51 @@ public class MultiUserAPIDUnitTest {
     // need to get the jsonFormatter from the proxy cache
     PdxInstance value = regionService.getJsonFormatter().toPdxInstance(json);
     regionView.put("key", value);
+  }
+
+  @Test
+  public void transactionTest() throws Exception {
+    ClientCache cache = client.withServerConnection(server.getPort())
+        .withCredential("data", "data")
+        .createCache();
+    Region<Object, Object> region = client.createProxyRegion("region");
+    CacheTransactionManager txManager =
+        cache.getCacheTransactionManager();
+
+    try {
+      txManager.begin();
+      region.put("key1", "value1");
+      region.put("key2", "value2");
+      txManager.commit();
+    } catch (CommitConflictException conflict) {
+      // ... do necessary work for a transaction that failed on commit
+    } finally {
+      if (txManager.exists()) {
+        txManager.rollback();
+      }
+    }
+  }
+
+  @Test
+  public void multiUserWithClientSubscription() throws Exception {
+    ClientCache cache = client.withServerConnection(server.getPort())
+        .withPoolSubscription(true)
+        .withProperty(SECURITY_CLIENT_AUTH_INIT, CountableUserPasswordAuthInit.class.getName())
+        .withMultiUser(true)
+        .createCache();
+    Properties properties = new Properties();
+    properties.setProperty(UserPasswordAuthInit.USER_NAME, "data");
+    properties.setProperty(UserPasswordAuthInit.PASSWORD, "wrongPassword");
+    RegionService regionService = cache.createAuthenticatedView(properties);
+
+    cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
+    Region region = regionService.getRegion(SEPARATOR + "region");
+    assertThatThrownBy(() -> region.registerInterestForAllKeys())
+        .isInstanceOf(UnsupportedOperationException.class);
+    CqQuery cqQuery =
+        regionService.getQueryService()
+            .newCq("select * from /region", new CqAttributesFactory().create());
+    assertThatThrownBy(() -> cqQuery.execute())
+        .hasCauseInstanceOf(AuthenticationFailedException.class);
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/security/templates/CountableUserPasswordAuthInit.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/templates/CountableUserPasswordAuthInit.java
@@ -22,17 +22,17 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.geode.LogWriter;
 import org.apache.geode.security.AuthenticationFailedException;
 
-public class TrackableUserPasswordAuthInit extends UserPasswordAuthInit {
-  public static AtomicInteger timeInitialized = new AtomicInteger(0);
+public class CountableUserPasswordAuthInit extends UserPasswordAuthInit {
+  public static AtomicInteger count = new AtomicInteger(0);
 
   public static void reset() {
-    timeInitialized.set(0);
+    count.set(0);
   }
 
   @Override
   public void init(final LogWriter systemLogWriter, final LogWriter securityLogWriter)
       throws AuthenticationFailedException {
     super.init(systemLogWriter, securityLogWriter);
-    timeInitialized.incrementAndGet();
+    count.incrementAndGet();
   }
 }


### PR DESCRIPTION
Avoid making multiple authentication requests in multi-user case.

Also remove some unnecessary code and small refactoring.