### PR TITLE
GEODE-9802: Do not use ephemeral port in test

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/logging/internal/LoggingWithReconnectDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/logging/internal/LoggingWithReconnectDistributedTest.java
@@ -50,6 +50,7 @@ import org.apache.geode.distributed.internal.Distribution;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.membership.api.MemberDisconnectedException;
 import org.apache.geode.distributed.internal.membership.gms.GMSMembership;
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.assertj.LogFileAssert;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
@@ -197,17 +198,16 @@ public class LoggingWithReconnectDistributedTest implements Serializable {
   }
 
   private void createServer(String serverName, File serverDir, int locatorPort) {
-    ServerLauncher.Builder builder = new ServerLauncher.Builder();
-    builder.setMemberName(serverName);
-    builder.setWorkingDirectory(serverDir.getAbsolutePath());
-    builder.setServerPort(0);
-    builder.set(LOCATORS, "localHost[" + locatorPort + "]");
-    builder.set(DISABLE_AUTO_RECONNECT, "false");
-    builder.set(ENABLE_CLUSTER_CONFIGURATION, "false");
-    builder.set(MAX_WAIT_TIME_RECONNECT, "1000");
-    builder.set(MEMBER_TIMEOUT, "2000");
+    serverLauncher = new ServerLauncher.Builder().setMemberName(serverName)
+        .setWorkingDirectory(serverDir.getAbsolutePath())
+        .setServerPort(AvailablePortHelper.getRandomAvailableTCPPort())
+        .set(LOCATORS, "localHost[" + locatorPort + "]")
+        .set(DISABLE_AUTO_RECONNECT, "false")
+        .set(ENABLE_CLUSTER_CONFIGURATION, "false")
+        .set(MAX_WAIT_TIME_RECONNECT, "1000")
+        .set(MEMBER_TIMEOUT, "2000")
+        .build();
 
-    serverLauncher = builder.build();
     serverLauncher.start();
 
     system = (InternalDistributedSystem) serverLauncher.getCache().getDistributedSystem();


### PR DESCRIPTION
 - Change LoggingWithReconnectDistributedTest.createServer() to use
 AvailablePortHelper

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [N/A] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
