### PR TITLE
GEODE-9675: remove useless but flaky test

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/ClusterDistributionManagerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/ClusterDistributionManagerDUnitTest.java
@@ -155,27 +155,6 @@ public class ClusterDistributionManagerDUnitTest extends CacheTestCase {
   }
 
   /**
-   * Demonstrate that a new UDP port is used when an attempt is made to reconnect using a shunned
-   * port
-   */
-  @Test
-  public void testConnectAfterBeingShunned() {
-    InternalDistributedSystem system = getSystem();
-    Distribution membership = MembershipManagerHelper.getDistribution(system);
-    InternalDistributedMember memberBefore = membership.getLocalMember();
-
-    // TODO GMS needs to have a system property allowing the bind-port to be set
-    System.setProperty(GEMFIRE_PREFIX + "jg-bind-port", "" + memberBefore.getMembershipPort());
-    system.disconnect();
-    system = getSystem();
-    membership = MembershipManagerHelper.getDistribution(system);
-    system.disconnect();
-    InternalDistributedMember memberAfter = membership.getLocalMember();
-
-    assertThat(memberAfter.getMembershipPort()).isEqualTo(memberBefore.getMembershipPort());
-  }
-
-  /**
    * Test the handling of "surprise members" in the membership manager. Create a DistributedSystem
    * in this VM and then add a fake member to its surpriseMember set. Then ensure that it stays in
    * the set when a new membership view arrives that doesn't contain it. Then wait until the member


### PR DESCRIPTION
This test has a number of problems, in addition to the flakiness described in the bug report, to wit:

- The comment “Demonstrate that a new UDP port is used…” is at odds with the assertion at the end of the method (which asserts that the same port is used).
- Contrary to the comment, GMSMembership doesn’t “shun” members when they are shutting down, rather it keeps them in a shutdownMembers set so as to attenuate failure detection signals from them. Perhaps in the dim past these members were actually “shunned”?
- I have no idea why the test disconnect()s, then re-acquires system and membership and then disconnect()s again before calling getLocalMember() on the membership acquired before the second disconnect!
- The TODO at line 167 seems superfluous since we proceed to set just such a system property on the very next line
- Whether the property is set or not, on line 168, the test passes! (at least in manual runs)—implying that setting that system property is superfluous.

Which leads me to believe this test is worthless and the best fix for GEODE-9675 is to delete this test.

This PR deletes the test.

- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
