### PR TITLE
GEODE-9642: skip RedundancyRecovery for colocated regions, if colocat…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRColocationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRColocationDUnitTest.java
@@ -2612,10 +2612,12 @@ public class PRColocationDUnitTest extends JUnit4CacheTestCase {
     public void waitForRegion(Region region, long timeout) throws InterruptedException {
       long start = System.currentTimeMillis();
       synchronized (this) {
-        long waitStart = (timeout / 10) - (System.currentTimeMillis() - start);
-        this.wait(waitStart);
-        if (!recoveryStartedOnRegions.contains(region)) {
-          return;
+        while (!recoveryStartedOnRegions.contains(region)) {
+          long waitStart = (timeout / 10) - (System.currentTimeMillis() - start);
+          if (waitStart <= 0) {
+            return;
+          }
+          this.wait(waitStart);
         }
         while (!recoveredRegions.contains(region)) {
           long remaining = timeout - (System.currentTimeMillis() - start);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PRHARedundancyProvider.java
@@ -1371,6 +1371,10 @@ public class PRHARedundancyProvider {
    * redundancy of existing buckets
    */
   void startRedundancyRecovery() {
+    if (partitionedRegion.getColocatedWith() != null
+        && !ColocationHelper.isColocationComplete(partitionedRegion)) {
+      return;
+    }
     partitionedRegion.getRegionAdvisor().addMembershipListener(new PRMembershipListener());
     scheduleRedundancyRecovery(null);
   }


### PR DESCRIPTION
…ion is not completed

Co-authored-by: albertogpz alberto.gomez@est.tech

In this solution, for each server, if colocation is not completed (due to any possible reason), we are skipping RedundancyRecovery. So, when last server is registering partitioned region, he will set colocation completed and notify all other servers, and he will trigger creation of buckets on all other servers.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [*] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [*] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [*] Is your initial contribution a single, squashed commit?

- [*] Does `gradlew build` run cleanly?

- [*] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
