### PR TITLE
GEODE-9812: Add Radish tests that kills multiple servers

### DIFF
--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsKillMultipleServersDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsKillMultipleServersDUnitTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.executor.string;
 
+import static org.apache.geode.distributed.ConfigurationProperties.REDUNDANCY_ZONE;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 
@@ -49,10 +50,19 @@ public class StringsKillMultipleServersDUnitTest {
   @BeforeClass
   public static void classSetup() {
     MemberVM locator = cluster.startLocatorVM(0);
-    cluster.startRedisVM(1, locator.getPort());
-    cluster.startRedisVM(2, locator.getPort());
-    cluster.startRedisVM(3, locator.getPort());
-    cluster.startRedisVM(4, locator.getPort());
+    int locatorPort = locator.getPort();
+    cluster.startRedisVM(1, x -> x
+        .withConnectionToLocator(locatorPort)
+        .withProperty(REDUNDANCY_ZONE, "A"));
+    cluster.startRedisVM(2, x -> x
+        .withConnectionToLocator(locatorPort)
+        .withProperty(REDUNDANCY_ZONE, "B"));
+    cluster.startRedisVM(3, x -> x
+        .withConnectionToLocator(locatorPort)
+        .withProperty(REDUNDANCY_ZONE, "A"));
+    cluster.startRedisVM(4, x -> x
+        .withConnectionToLocator(locatorPort)
+        .withProperty(REDUNDANCY_ZONE, "B"));
 
     int redisServerPort1 = cluster.getRedisPort(1);
     jedisCluster =
@@ -76,7 +86,7 @@ public class StringsKillMultipleServersDUnitTest {
 
     Future<Void> future1 = executor.submit(() -> doSetOps(running, counter));
     Future<Void> future2 = executor.submit(() -> doGetOps(running, counter));
-    await().until(() -> counter.get() > 100);
+    await().until(() -> counter.get() > 1000);
 
     cluster.crashVM(3);
     cluster.crashVM(4);

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsKillMultipleServersDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsKillMultipleServersDUnitTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.executor.string;
+
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+
+import java.util.Random;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+public class StringsKillMultipleServersDUnitTest {
+
+  @ClassRule
+  public static RedisClusterStartupRule cluster = new RedisClusterStartupRule(5);
+
+  @Rule
+  public ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  private static JedisCluster jedisCluster;
+
+  @BeforeClass
+  public static void classSetup() {
+    MemberVM locator = cluster.startLocatorVM(0);
+    cluster.startRedisVM(1, locator.getPort());
+    cluster.startRedisVM(2, locator.getPort());
+    cluster.startRedisVM(3, locator.getPort());
+    cluster.startRedisVM(4, locator.getPort());
+
+    cluster.enableDebugLogging(1);
+
+    int redisServerPort1 = cluster.getRedisPort(1);
+    jedisCluster =
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), 10_000);
+  }
+
+  @After
+  public void after() {
+    cluster.flushAll();
+  }
+
+  @AfterClass
+  public static void tearDown() {
+    jedisCluster.close();
+  }
+
+  @Test
+  public void operationsShouldContinueAfterMultipleServerFailures() throws Exception {
+    AtomicBoolean running = new AtomicBoolean(true);
+    AtomicInteger counter = new AtomicInteger(0);
+
+    Future<Void> future = executor.submit(() -> doOps(running, counter));
+    await().until(() -> counter.get() > 100);
+
+    cluster.crashVM(3);
+    cluster.crashVM(4);
+    int afterCrashCount = counter.get();
+
+    long start = System.currentTimeMillis();
+    await().alias("ensure that operations are continuing after multiple server failures")
+        .until(() -> counter.get() > afterCrashCount + 10_000);
+
+    long runTime = System.currentTimeMillis() - start;
+
+    running.set(false);
+
+    // Any exception here would fail the test.
+    future.get();
+
+    System.err.println("await runtime = " + runTime);
+  }
+
+  private Void doOps(AtomicBoolean running, AtomicInteger counter) {
+    Random random = new Random();
+    while (running.get()) {
+      int i = counter.getAndIncrement();
+      jedisCluster.set("key-" + i, "value-" + i);
+      jedisCluster.get("key-" + random.nextInt(i + 1));
+    }
+    return null;
+  }
+
+}


### PR DESCRIPTION
- Despite data loss, the test ensures that operations continue without
  errors related to MOVED responses or missing slots.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
