### PR TITLE
GEODE-9449: Remove 'b' prefix from constants

### DIFF
--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/DumpRestoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/executor/key/DumpRestoreIntegrationTest.java
@@ -15,7 +15,7 @@
 
 package org.apache.geode.redis.internal.executor.key;
 
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bRADISH_DUMP_HEADER;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.RADISH_DUMP_HEADER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayOutputStream;
@@ -54,9 +54,9 @@ public class DumpRestoreIntegrationTest extends AbstractDumpRestoreIntegrationTe
 
   @Test
   public void restoreWithUnknownVersion_isNotSupported() throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream(bRADISH_DUMP_HEADER.length + 2);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream(RADISH_DUMP_HEADER.length + 2);
     DataOutputStream output = new DataOutputStream(baos);
-    output.write(bRADISH_DUMP_HEADER);
+    output.write(RADISH_DUMP_HEADER);
     output.writeShort(0);
 
     assertThatThrownBy(

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -17,7 +17,7 @@
 package org.apache.geode.redis.internal.data;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_KEY_EXISTS;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bRADISH_DUMP_HEADER;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.RADISH_DUMP_HEADER;
 
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
@@ -228,7 +228,7 @@ public abstract class AbstractRedisData implements RedisData {
   @Override
   public byte[] dump() throws IOException {
     ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    baos.write(bRADISH_DUMP_HEADER);
+    baos.write(RADISH_DUMP_HEADER);
     DataOutputStream outputStream = new DataOutputStream(baos);
     outputStream.writeShort(KnownVersion.CURRENT.ordinal());
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
@@ -18,7 +18,7 @@ package org.apache.geode.redis.internal.data;
 
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_RESTORE_INVALID_PAYLOAD;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bRADISH_DUMP_HEADER;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.RADISH_DUMP_HEADER;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -82,14 +82,14 @@ public interface RedisData extends Delta, DataSerializableFixedID, Sizeable {
 
   default RedisData restore(byte[] data) throws Exception {
     Object obj;
-    byte[] header = new byte[bRADISH_DUMP_HEADER.length];
+    byte[] header = new byte[RADISH_DUMP_HEADER.length];
 
     try {
       ByteArrayInputStream bais = new ByteArrayInputStream(data);
       bais.read(header);
 
       // Don't handle Redis dump formats yet
-      if (!Arrays.equals(header, bRADISH_DUMP_HEADER)) {
+      if (!Arrays.equals(header, RADISH_DUMP_HEADER)) {
         throw new RedisException(ERROR_RESTORE_INVALID_PAYLOAD);
       }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSortedSet.java
@@ -21,8 +21,8 @@ import static org.apache.geode.internal.JvmSizeUtils.memoryOverhead;
 import static org.apache.geode.redis.internal.data.NullRedisDataStructures.NULL_REDIS_SORTED_SET;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_SORTED_SET;
 import static org.apache.geode.redis.internal.netty.Coder.doubleToBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGREATEST_MEMBER_NAME;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEAST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.GREATEST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.LEAST_MEMBER_NAME;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -703,22 +703,22 @@ public class RedisSortedSet extends AbstractRedisData {
     return null;
   }
 
-  // Comparison to allow the use of bLEAST_MEMBER_NAME and bGREATEST_MEMBER_NAME to always be less
+  // Comparison to allow the use of LEAST_MEMBER_NAME and GREATEST_MEMBER_NAME to always be less
   // than or greater than respectively any other byte array representing a member name. The use of
   // "==" is important as it allows us to differentiate between the constant byte arrays defined
   // in StringBytesGlossary and user-supplied member names which may be equal in content but have
   // a different memory address.
   public static int checkDummyMemberNames(byte[] array1, byte[] array2) {
-    if (array2 == bLEAST_MEMBER_NAME || array1 == bGREATEST_MEMBER_NAME) {
-      if (array1 == bLEAST_MEMBER_NAME || array2 == bGREATEST_MEMBER_NAME) {
+    if (array2 == LEAST_MEMBER_NAME || array1 == GREATEST_MEMBER_NAME) {
+      if (array1 == LEAST_MEMBER_NAME || array2 == GREATEST_MEMBER_NAME) {
         throw new IllegalStateException(
             "Arrays cannot both be least member name or greatest member name");
       }
       return 1; // array2 < array1
-    } else if (array1 == bLEAST_MEMBER_NAME || array2 == bGREATEST_MEMBER_NAME) {
+    } else if (array1 == LEAST_MEMBER_NAME || array2 == GREATEST_MEMBER_NAME) {
       return -1; // array1 < array2
     } else {
-      // Neither of the input arrays are using bLEAST_MEMBER_NAME or bGREATEST_MEMBER_NAME, so real
+      // Neither of the input arrays are using LEAST_MEMBER_NAME or GREATEST_MEMBER_NAME, so real
       // lexicographical comparison is needed
       return 0;
     }
@@ -813,7 +813,7 @@ public class RedisSortedSet extends AbstractRedisData {
     public ScoreDummyOrderedSetEntry(double score, boolean isExclusive, boolean isMinimum) {
       // If we are using an exclusive minimum comparison, or an inclusive maximum comparison then
       // this entry should act as if it is greater than the entry it's being compared to
-      this.member = isExclusive ^ isMinimum ? bLEAST_MEMBER_NAME : bGREATEST_MEMBER_NAME;
+      this.member = isExclusive ^ isMinimum ? LEAST_MEMBER_NAME : GREATEST_MEMBER_NAME;
       this.score = score;
     }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/cluster/ClusterExecutor.java
@@ -20,10 +20,10 @@ import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS;
 import static org.apache.geode.redis.internal.RegionProvider.REDIS_SLOTS_PER_BUCKET;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINFO;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bKEYSLOT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNODES;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSLOTS;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INFO;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.KEYSLOT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NODES;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.SLOTS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,16 +55,16 @@ public class ClusterExecutor implements CommandExecutor {
     List<byte[]> args = command.getProcessedCommand();
     byte[] subcommand = args.get(1);
 
-    if (equalsIgnoreCaseBytes(subcommand, bINFO)) {
+    if (equalsIgnoreCaseBytes(subcommand, INFO)) {
       checkNumArgs(command, subcommand, 2);
       return getInfo(context);
-    } else if (equalsIgnoreCaseBytes(subcommand, bNODES)) {
+    } else if (equalsIgnoreCaseBytes(subcommand, NODES)) {
       checkNumArgs(command, subcommand, 2);
       return getNodes(context);
-    } else if (equalsIgnoreCaseBytes(subcommand, bSLOTS)) {
+    } else if (equalsIgnoreCaseBytes(subcommand, SLOTS)) {
       checkNumArgs(command, subcommand, 2);
       return getSlots(context);
-    } else if (equalsIgnoreCaseBytes(subcommand, bKEYSLOT)) {
+    } else if (equalsIgnoreCaseBytes(subcommand, KEYSLOT)) {
       checkNumArgs(command, subcommand, 3);
       return RedisResponse.integer(KeyHashUtil.slotForKey(args.get(2)));
     } else {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/connection/PingExecutor.java
@@ -16,8 +16,8 @@
 package org.apache.geode.redis.internal.executor.connection;
 
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPING_RESPONSE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPING_RESPONSE_LOWERCASE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PING_RESPONSE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PING_RESPONSE_LOWERCASE;
 
 import java.util.Arrays;
 import java.util.List;
@@ -39,7 +39,7 @@ public class PingExecutor implements CommandExecutor {
       if (commandElems.size() > 1) {
         result = commandElems.get(1);
       } else {
-        result = bPING_RESPONSE;
+        result = PING_RESPONSE;
       }
       redisResponse = RedisResponse.string(result);
     } else {
@@ -50,7 +50,7 @@ public class PingExecutor implements CommandExecutor {
       } else {
         result = stringToBytes("");
       }
-      redisResponse = RedisResponse.array(Arrays.asList(bPING_RESPONSE_LOWERCASE, result), true);
+      redisResponse = RedisResponse.array(Arrays.asList(PING_RESPONSE_LOWERCASE, result), true);
     }
 
     return redisResponse;

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/key/AbstractScanExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/key/AbstractScanExecutor.java
@@ -22,8 +22,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.COUNT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.MATCH;
 
 import java.util.List;
 
@@ -79,11 +79,11 @@ public abstract class AbstractScanExecutor implements CommandExecutor {
 
       for (int i = 3; i < commandElems.size(); i = i + 2) {
         byte[] commandElemBytes = commandElems.get(i);
-        if (equalsIgnoreCaseBytes(commandElemBytes, bMATCH)) {
+        if (equalsIgnoreCaseBytes(commandElemBytes, MATCH)) {
           commandElemBytes = commandElems.get(i + 1);
           globPattern = commandElemBytes;
 
-        } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
+        } else if (equalsIgnoreCaseBytes(commandElemBytes, COUNT)) {
           commandElemBytes = commandElems.get(i + 1);
           try {
             count = narrowLongToInt(bytesToLong(commandElemBytes));

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/key/RestoreExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/key/RestoreExecutor.java
@@ -19,8 +19,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_TTL;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_KEY_EXISTS;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bABSTTL;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bREPLACE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ABSTTL;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.REPLACE;
 
 import java.util.List;
 
@@ -75,9 +75,9 @@ public class RestoreExecutor implements CommandExecutor {
   private RestoreOptions parseOptions(List<byte[]> options) {
     RestoreOptions restoreOptions = new RestoreOptions();
     for (byte[] optionBytes : options) {
-      if (Coder.equalsIgnoreCaseBytes(optionBytes, bREPLACE)) {
+      if (Coder.equalsIgnoreCaseBytes(optionBytes, REPLACE)) {
         restoreOptions.setReplace(true);
-      } else if (Coder.equalsIgnoreCaseBytes(optionBytes, bABSTTL)) {
+      } else if (Coder.equalsIgnoreCaseBytes(optionBytes, ABSTTL)) {
         restoreOptions.setAbsttl(true);
       } else {
         throw new RedisException(ERROR_SYNTAX);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/key/ScanExecutor.java
@@ -21,8 +21,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.COUNT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.MATCH;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -67,11 +67,11 @@ public class ScanExecutor extends AbstractScanExecutor {
 
     for (int i = 2; i < commandElems.size(); i = i + 2) {
       byte[] commandElemBytes = commandElems.get(i);
-      if (equalsIgnoreCaseBytes(commandElemBytes, bMATCH)) {
+      if (equalsIgnoreCaseBytes(commandElemBytes, MATCH)) {
         commandElemBytes = commandElems.get(i + 1);
         globPattern = commandElemBytes;
 
-      } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
+      } else if (equalsIgnoreCaseBytes(commandElemBytes, COUNT)) {
         commandElemBytes = commandElems.get(i + 1);
         try {
           count = narrowLongToInt(bytesToLong(commandElemBytes));

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PsubscribeExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PsubscribeExecutor.java
@@ -17,7 +17,7 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import static org.apache.geode.redis.internal.executor.pubsub.SubscribeExecutor.createSubscribeResponse;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPSUBSCRIBE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PSUBSCRIBE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -40,6 +40,6 @@ public class PsubscribeExecutor implements CommandExecutor {
       results.add(result);
     }
 
-    return createSubscribeResponse(results, bPSUBSCRIBE);
+    return createSubscribeResponse(results, PSUBSCRIBE);
   }
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PubSubExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/PubSubExecutor.java
@@ -20,9 +20,9 @@ package org.apache.geode.redis.internal.executor.pubsub;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_PUBSUB_SUBCOMMAND;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCHANNELS;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNUMPAT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNUMSUB;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CHANNELS;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NUMPAT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NUMSUB;
 
 import java.util.List;
 
@@ -38,18 +38,18 @@ public class PubSubExecutor implements CommandExecutor {
     List<byte[]> args = command.getCommandArguments();
     byte[] subCommand = args.get(0);
 
-    if (equalsIgnoreCaseBytes(subCommand, bCHANNELS)) {
+    if (equalsIgnoreCaseBytes(subCommand, CHANNELS)) {
       if (args.size() > 2) {
         return RedisResponse
             .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, new String(subCommand)));
       }
       List<byte[]> channelsResponse = doChannels(args, context);
       return RedisResponse.array(channelsResponse, true);
-    } else if (equalsIgnoreCaseBytes(subCommand, bNUMSUB)) {
+    } else if (equalsIgnoreCaseBytes(subCommand, NUMSUB)) {
       List<Object> numSubresponse = context.getPubSub()
           .findNumberOfSubscribersPerChannel(args.subList(1, args.size()));
       return RedisResponse.array(numSubresponse, true);
-    } else if (equalsIgnoreCaseBytes(subCommand, bNUMPAT)) {
+    } else if (equalsIgnoreCaseBytes(subCommand, NUMPAT)) {
       if (args.size() > 1) {
         return RedisResponse
             .error(String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, new String(subCommand)));

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/pubsub/SubscribeExecutor.java
@@ -16,7 +16,7 @@
 package org.apache.geode.redis.internal.executor.pubsub;
 
 import static java.util.Arrays.asList;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSUBSCRIBE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.SUBSCRIBE;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -42,7 +42,7 @@ public class SubscribeExecutor implements CommandExecutor {
       results.add(result);
     }
 
-    return createSubscribeResponse(results, bSUBSCRIBE);
+    return createSubscribeResponse(results, SUBSCRIBE);
   }
 
   static RedisResponse createSubscribeResponse(Collection<SubscribeResult> results,

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/server/InfoExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/server/InfoExecutor.java
@@ -16,16 +16,16 @@
 package org.apache.geode.redis.internal.executor.server;
 
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bALL;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCLIENTS;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCLUSTER;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bDEFAULT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bKEYSPACE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMEMORY;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPERSISTENCE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bREPLICATION;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSERVER;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bSTATS;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ALL;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CLIENTS;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CLUSTER;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.DEFAULT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.KEYSPACE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.MEMORY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PERSISTENCE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.REPLICATION;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.SERVER;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.STATS;
 
 import java.text.DecimalFormat;
 import java.util.Arrays;
@@ -64,23 +64,23 @@ public class InfoExecutor implements CommandExecutor {
 
   private String getSpecifiedSection(ExecutionHandlerContext context, List<byte[]> commands) {
     byte[] bytes = toUpperCaseBytes(commands.get(1));
-    if (Arrays.equals(bytes, bSERVER)) {
+    if (Arrays.equals(bytes, SERVER)) {
       return getServerSection(context);
-    } else if (Arrays.equals(bytes, bCLUSTER)) {
+    } else if (Arrays.equals(bytes, CLUSTER)) {
       return getClusterSection();
-    } else if (Arrays.equals(bytes, bPERSISTENCE)) {
+    } else if (Arrays.equals(bytes, PERSISTENCE)) {
       return getPersistenceSection();
-    } else if (Arrays.equals(bytes, bREPLICATION)) {
+    } else if (Arrays.equals(bytes, REPLICATION)) {
       return getReplicationSection();
-    } else if (Arrays.equals(bytes, bSTATS)) {
+    } else if (Arrays.equals(bytes, STATS)) {
       return getStatsSection(context);
-    } else if (Arrays.equals(bytes, bCLIENTS)) {
+    } else if (Arrays.equals(bytes, CLIENTS)) {
       return getClientsSection(context);
-    } else if (Arrays.equals(bytes, bMEMORY)) {
+    } else if (Arrays.equals(bytes, MEMORY)) {
       return getMemorySection(context);
-    } else if (Arrays.equals(bytes, bKEYSPACE)) {
+    } else if (Arrays.equals(bytes, KEYSPACE)) {
       return getKeyspaceSection(context);
-    } else if (Arrays.equals(bytes, bDEFAULT) || Arrays.equals(bytes, bALL)) {
+    } else if (Arrays.equals(bytes, DEFAULT) || Arrays.equals(bytes, ALL)) {
       return getAllSections(context);
     } else {
       return "";

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/server/LolWutExecutor.java
@@ -18,7 +18,7 @@ package org.apache.geode.redis.internal.executor.server;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bVERSION;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.VERSION;
 
 import java.util.List;
 import java.util.Random;
@@ -52,7 +52,7 @@ public class LolWutExecutor implements CommandExecutor {
     List<byte[]> commands = command.getProcessedCommand();
     if (commands.size() > 1) {
       for (int i = 1; i < commands.size(); i++) {
-        if (equalsIgnoreCaseBytes(commands.get(i), bVERSION)) {
+        if (equalsIgnoreCaseBytes(commands.get(i), VERSION)) {
           i += 1; // skip next arg, we only have one version for now
         } else {
           try {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/server/SlowlogExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/server/SlowlogExecutor.java
@@ -16,9 +16,9 @@
 package org.apache.geode.redis.internal.executor.server;
 
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGET;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEN;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bRESET;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.GET;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.LEN;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.RESET;
 
 import java.util.Arrays;
 
@@ -33,11 +33,11 @@ public class SlowlogExecutor implements CommandExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     byte[] subCommand = toUpperCaseBytes(command.getBytesKey());
-    if (Arrays.equals(subCommand, bGET)) {
+    if (Arrays.equals(subCommand, GET)) {
       return RedisResponse.emptyArray();
-    } else if (Arrays.equals(subCommand, bLEN)) {
+    } else if (Arrays.equals(subCommand, LEN)) {
       return RedisResponse.integer(0);
-    } else if (Arrays.equals(subCommand, bRESET)) {
+    } else if (Arrays.equals(subCommand, RESET)) {
       return RedisResponse.ok();
     } else {
       return null;

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/set/SScanExecutor.java
@@ -24,8 +24,8 @@ import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCOUNT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMATCH;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.COUNT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.MATCH;
 
 import java.math.BigInteger;
 import java.util.List;
@@ -84,11 +84,11 @@ public class SScanExecutor extends AbstractScanExecutor {
 
     for (int i = 3; i < commandElems.size(); i = i + 2) {
       byte[] commandElemBytes = commandElems.get(i);
-      if (equalsIgnoreCaseBytes(commandElemBytes, bMATCH)) {
+      if (equalsIgnoreCaseBytes(commandElemBytes, MATCH)) {
         commandElemBytes = commandElems.get(i + 1);
         globPattern = commandElemBytes;
 
-      } else if (equalsIgnoreCaseBytes(commandElemBytes, bCOUNT)) {
+      } else if (equalsIgnoreCaseBytes(commandElemBytes, COUNT)) {
         commandElemBytes = commandElems.get(i + 1);
         try {
           count = narrowLongToInt(bytesToLong(commandElemBytes));

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractSortedSetRangeOptions.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/AbstractSortedSetRangeOptions.java
@@ -19,9 +19,9 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLIMIT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNEGATIVE_ZERO;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWITHSCORES;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.LIMIT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NEGATIVE_ZERO;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.WITHSCORES;
 
 import java.util.Arrays;
 import java.util.List;
@@ -54,10 +54,10 @@ public abstract class AbstractSortedSetRangeOptions<T> {
     // start or end of the range
     for (int index = 4; index < commandElements.size(); ++index) {
       byte[] option = commandElements.get(index);
-      if (equalsIgnoreCaseBytes(option, bLIMIT)) {
+      if (equalsIgnoreCaseBytes(option, LIMIT)) {
         handleLimitArguments(commandElements, index);
         index += 2;
-      } else if (equalsIgnoreCaseBytes(option, bWITHSCORES)) {
+      } else if (equalsIgnoreCaseBytes(option, WITHSCORES)) {
         handleWithScoresArgument();
       } else {
         throw new RedisException(ERROR_SYNTAX);
@@ -66,7 +66,7 @@ public abstract class AbstractSortedSetRangeOptions<T> {
   }
 
   void handleLimitArguments(List<byte[]> commandElements, int commandIndex) {
-    if (!equalsIgnoreCaseBytes(commandElements.get(commandIndex), bLIMIT)) {
+    if (!equalsIgnoreCaseBytes(commandElements.get(commandIndex), LIMIT)) {
       throw new RedisException(ERROR_SYNTAX);
     }
 
@@ -76,7 +76,7 @@ public abstract class AbstractSortedSetRangeOptions<T> {
     }
 
     byte[] offsetBytes = commandElements.get(commandIndex + 1);
-    if (Arrays.equals(offsetBytes, bNEGATIVE_ZERO)) {
+    if (Arrays.equals(offsetBytes, NEGATIVE_ZERO)) {
       throw new RedisException(ERROR_NOT_INTEGER);
     }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetLexRangeOptions.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/SortedSetLexRangeOptions.java
@@ -18,8 +18,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_MIN_MAX_NOT_A
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.data.RedisSortedSet.checkDummyMemberNames;
 import static org.apache.geode.redis.internal.data.RedisSortedSet.javaImplementationOfAnsiCMemCmp;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGREATEST_MEMBER_NAME;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEAST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.GREATEST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.LEAST_MEMBER_NAME;
 
 import java.util.Arrays;
 import java.util.List;
@@ -48,10 +48,10 @@ public class SortedSetLexRangeOptions extends AbstractSortedSetRangeOptions<byte
     if (bytes.length == 1) {
       if (bytes[0] == '+') {
         isExclusive = false;
-        value = bGREATEST_MEMBER_NAME;
+        value = GREATEST_MEMBER_NAME;
       } else if (bytes[0] == '-') {
         isExclusive = false;
-        value = bLEAST_MEMBER_NAME;
+        value = LEAST_MEMBER_NAME;
       } else if (bytes[0] == '(') {
         isExclusive = true;
         value = new byte[0];

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZAddExecutor.java
@@ -20,10 +20,10 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR;
 import static org.apache.geode.redis.internal.netty.Coder.isInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCH;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINCR;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNX;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bXX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CH;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INCR;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.XX;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -94,16 +94,16 @@ public class ZAddExecutor implements CommandExecutor {
 
     while (commandIterator.hasNext() && !scoreFound) {
       byte[] subCommand = toUpperCaseBytes(commandIterator.next());
-      if (Arrays.equals(subCommand, bNX)) {
+      if (Arrays.equals(subCommand, NX)) {
         executorState.nxFound = true;
         optionsFoundCount++;
-      } else if (Arrays.equals(subCommand, bXX)) {
+      } else if (Arrays.equals(subCommand, XX)) {
         executorState.xxFound = true;
         optionsFoundCount++;
-      } else if (Arrays.equals(subCommand, bCH)) {
+      } else if (Arrays.equals(subCommand, CH)) {
         executorState.chFound = true;
         optionsFoundCount++;
-      } else if (Arrays.equals(subCommand, bINCR)) {
+      } else if (Arrays.equals(subCommand, INCR)) {
         executorState.incrFound = true;
         optionsFoundCount++;
       } else if (isInfinity(subCommand)) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/sortedset/ZStoreExecutor.java
@@ -20,8 +20,8 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_WEIGHT_NOT_A_
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bAGGREGATE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWEIGHTS;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.AGGREGATE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.WEIGHTS;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -77,7 +77,7 @@ public abstract class ZStoreExecutor implements CommandExecutor {
     while (argIterator.hasNext()) {
       argument = argIterator.next();
       // found AGGREGATE keyword; parse aggregate
-      if (Arrays.equals(toUpperCaseBytes(argument), bAGGREGATE)) {
+      if (Arrays.equals(toUpperCaseBytes(argument), AGGREGATE)) {
         if (!argIterator.hasNext()) {
           return syntaxErrorResponse;
         }
@@ -88,7 +88,7 @@ public abstract class ZStoreExecutor implements CommandExecutor {
           return syntaxErrorResponse;
         }
         // found WEIGHTS keyword; parse weights
-      } else if (Arrays.equals(toUpperCaseBytes(argument), bWEIGHTS)) {
+      } else if (Arrays.equals(toUpperCaseBytes(argument), WEIGHTS)) {
         for (int i = 0; i < numKeys; i++) {
           if (!argIterator.hasNext()) {
             return syntaxErrorResponse;

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/executor/string/SetExecutor.java
@@ -21,10 +21,10 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.data.RedisDataType.REDIS_STRING;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bEX;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNX;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPX;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bXX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.EX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PX;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.XX;
 
 import java.util.List;
 
@@ -67,9 +67,9 @@ public class SetExecutor implements CommandExecutor {
 
     // Iterate the list in reverse order to allow similar error reporting behaviour to native redis
     for (int index = optionalParameters.size() - 1; index >= 0; --index) {
-      if (equalsIgnoreCaseBytes(optionalParameters.get(index), bXX)) {
+      if (equalsIgnoreCaseBytes(optionalParameters.get(index), XX)) {
         handleXX(executorState);
-      } else if (equalsIgnoreCaseBytes(optionalParameters.get(index), bNX)) {
+      } else if (equalsIgnoreCaseBytes(optionalParameters.get(index), NX)) {
         handleNX(executorState);
       } else {
         // Yhe only valid possibility now is that the parameter is a number preceded by either EX or
@@ -119,7 +119,7 @@ public class SetExecutor implements CommandExecutor {
       throw new IllegalArgumentException(ERROR_NOT_INTEGER);
     }
 
-    if (equalsIgnoreCaseBytes(previousParameter, bEX)) {
+    if (equalsIgnoreCaseBytes(previousParameter, EX)) {
       handleEX(executorState, expiration);
     } else {
       handlePX(executorState, expiration);
@@ -140,8 +140,8 @@ public class SetExecutor implements CommandExecutor {
 
   private void throwIfNotExpirationParameter(byte[] previousParameter) {
     // Numbers must be preceded by either EX or PX
-    if (!equalsIgnoreCaseBytes(previousParameter, bEX)
-        && !equalsIgnoreCaseBytes(previousParameter, bPX)) {
+    if (!equalsIgnoreCaseBytes(previousParameter, EX)
+        && !equalsIgnoreCaseBytes(previousParameter, PX)) {
       throw new IllegalArgumentException(ERROR_SYNTAX);
     }
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/ByteToCommandDecoder.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/ByteToCommandDecoder.java
@@ -20,7 +20,7 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNAUTHENTICAT
 import static org.apache.geode.redis.internal.RedisProperties.getIntegerSystemProperty;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ARRAY_ID;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.BULK_STRING_ID;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCRLF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CRLF;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -219,9 +219,9 @@ public class ByteToCommandDecoder extends ByteToMessageDecoder {
       return false;
     }
     byte[] bytes = {buffer.readByte(), buffer.readByte()};
-    if (!Arrays.equals(bytes, bCRLF)) {
+    if (!Arrays.equals(bytes, CRLF)) {
       throw new RedisCommandParserException(
-          "expected \'\\r\\n\' as byte[] of " + Arrays.toString(bCRLF) + ", got byte[] of "
+          "expected \'\\r\\n\' as byte[] of " + Arrays.toString(CRLF) + ", got byte[] of "
               + Arrays.toString(bytes));
     }
     return true;

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -20,33 +20,33 @@ import static java.lang.Double.POSITIVE_INFINITY;
 import static org.apache.geode.redis.internal.RedisConstants.INTERNAL_SERVER_ERROR;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ARRAY_ID;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.BULK_STRING_ID;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.BUSYKEY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CRLF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CROSSSLOT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.EMPTY_ARRAY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.EMPTY_STRING;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ERR;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ERROR_ID;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INFINITY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INTEGER_ID;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.MOVED;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NIL;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NOAUTH;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.N_INF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.N_INFINITY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.N_INF_STRING;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NaN;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.OK;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ONE_INT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.OOM;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.P_INF;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.P_INFINITY;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.P_INF_STRING;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.SIMPLE_STRING_ID;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bBUSYKEY;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCRLF;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bCROSSSLOT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bEMPTY_ARRAY;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bEMPTY_STRING;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bERR;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINF;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bINFINITY;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMOVED;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNIL;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNOAUTH;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INF;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bN_INFINITY;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNaN;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bOK;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bONE_INT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bOOM;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bP_INF;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bP_INFINITY;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWRONGPASS;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bWRONGTYPE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bZERO_INT;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.WRONGPASS;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.WRONGTYPE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ZERO_INT;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
@@ -86,7 +86,7 @@ public class Coder {
     byte[] toWrite;
 
     if (v == null) {
-      buffer.writeBytes(bNIL);
+      buffer.writeBytes(NIL);
     } else if (v instanceof byte[]) {
       toWrite = (byte[]) v;
       writeStringResponse(buffer, toWrite, useBulkStrings);
@@ -115,12 +115,12 @@ public class Coder {
     if (useBulkStrings) {
       buffer.writeByte(BULK_STRING_ID);
       appendAsciiDigitsToByteBuf(toWrite.length, buffer);
-      buffer.writeBytes(bCRLF);
+      buffer.writeBytes(CRLF);
     } else {
       buffer.writeByte(SIMPLE_STRING_ID);
     }
     buffer.writeBytes(toWrite);
-    buffer.writeBytes(bCRLF);
+    buffer.writeBytes(CRLF);
   }
 
   public static ByteBuf getFlattenedArrayResponse(ByteBuf buffer, Collection<Collection<?>> items)
@@ -136,7 +136,7 @@ public class Coder {
       boolean useBulkStrings) throws CoderException {
     buffer.writeByte(ARRAY_ID);
     appendAsciiDigitsToByteBuf(items.size(), buffer);
-    buffer.writeBytes(bCRLF);
+    buffer.writeBytes(CRLF);
     for (Object next : items) {
       writeCollectionOrString(buffer, next, useBulkStrings);
     }
@@ -157,12 +157,12 @@ public class Coder {
   public static ByteBuf getScanResponse(ByteBuf buffer, int cursor, List<?> scanResult) {
     buffer.writeByte(ARRAY_ID);
     buffer.writeByte(digitToAscii(2));
-    buffer.writeBytes(bCRLF);
+    buffer.writeBytes(CRLF);
     byte[] cursorBytes = intToBytes(cursor);
     writeStringResponse(buffer, cursorBytes, true);
     buffer.writeByte(ARRAY_ID);
     appendAsciiDigitsToByteBuf(scanResult.size(), buffer);
-    buffer.writeBytes(bCRLF);
+    buffer.writeBytes(CRLF);
 
     for (Object nextObject : scanResult) {
       if (nextObject instanceof String) {
@@ -178,22 +178,22 @@ public class Coder {
   }
 
   public static ByteBuf getZeroIntResponse(ByteBuf buffer) {
-    buffer.writeBytes(bZERO_INT);
+    buffer.writeBytes(ZERO_INT);
     return buffer;
   }
 
   public static ByteBuf getOneIntResponse(ByteBuf buffer) {
-    buffer.writeBytes(bONE_INT);
+    buffer.writeBytes(ONE_INT);
     return buffer;
   }
 
   public static ByteBuf getEmptyArrayResponse(ByteBuf buffer) {
-    buffer.writeBytes(bEMPTY_ARRAY);
+    buffer.writeBytes(EMPTY_ARRAY);
     return buffer;
   }
 
   public static ByteBuf getEmptyStringResponse(ByteBuf buffer) {
-    buffer.writeBytes(bEMPTY_STRING);
+    buffer.writeBytes(EMPTY_STRING);
     return buffer;
   }
 
@@ -205,7 +205,7 @@ public class Coder {
   public static ByteBuf getSimpleStringResponse(ByteBuf buffer, byte[] byteArray) {
     buffer.writeByte(SIMPLE_STRING_ID);
     buffer.writeBytes(byteArray);
-    buffer.writeBytes(bCRLF);
+    buffer.writeBytes(CRLF);
     return buffer;
   }
 
@@ -214,7 +214,7 @@ public class Coder {
     buffer.writeByte(ERROR_ID);
     buffer.writeBytes(type);
     buffer.writeBytes(errorAr);
-    buffer.writeBytes(bCRLF);
+    buffer.writeBytes(CRLF);
     return buffer;
   }
 
@@ -223,35 +223,35 @@ public class Coder {
   }
 
   public static ByteBuf getErrorResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, bERR, error);
+    return getErrorResponse0(buffer, ERR, error);
   }
 
   public static ByteBuf getMovedResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, bMOVED, error);
+    return getErrorResponse0(buffer, MOVED, error);
   }
 
   public static ByteBuf getOOMResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, bOOM, error);
+    return getErrorResponse0(buffer, OOM, error);
   }
 
   public static ByteBuf getWrongTypeResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, bWRONGTYPE, error);
+    return getErrorResponse0(buffer, WRONGTYPE, error);
   }
 
   public static ByteBuf getCrossSlotResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, bCROSSSLOT, error);
+    return getErrorResponse0(buffer, CROSSSLOT, error);
   }
 
   public static ByteBuf getWrongpassResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, bWRONGPASS, error);
+    return getErrorResponse0(buffer, WRONGPASS, error);
   }
 
   public static ByteBuf getBusyKeyResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, bBUSYKEY, error);
+    return getErrorResponse0(buffer, BUSYKEY, error);
   }
 
   public static ByteBuf getNoAuthResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, bNOAUTH, error);
+    return getErrorResponse0(buffer, NOAUTH, error);
   }
 
   public static ByteBuf getIntegerResponse(ByteBuf buffer, int integer) {
@@ -265,7 +265,7 @@ public class Coder {
   public static ByteBuf getIntegerResponse(ByteBuf buffer, byte[] integer) {
     buffer.writeByte(INTEGER_ID);
     buffer.writeBytes(integer);
-    buffer.writeBytes(bCRLF);
+    buffer.writeBytes(CRLF);
     return buffer;
   }
 
@@ -275,12 +275,12 @@ public class Coder {
   }
 
   public static ByteBuf getOKResponse(ByteBuf buffer) {
-    buffer.writeBytes(bOK);
+    buffer.writeBytes(OK);
     return buffer;
   }
 
   public static ByteBuf getNilResponse(ByteBuf buffer) {
-    buffer.writeBytes(bNIL);
+    buffer.writeBytes(NIL);
     return buffer;
   }
 
@@ -333,13 +333,13 @@ public class Coder {
 
   public static byte[] doubleToBytes(double d) {
     if (d == Double.POSITIVE_INFINITY) {
-      return bINF;
+      return INF;
     }
     if (d == Double.NEGATIVE_INFINITY) {
-      return bN_INF;
+      return N_INF;
     }
     if (Double.isNaN(d)) {
-      return bNaN;
+      return NaN;
     }
 
     String stringValue = String.valueOf(d);
@@ -432,9 +432,9 @@ public class Coder {
 
     try {
       String d = bytesToString(bytes);
-      if (d.equalsIgnoreCase(P_INF)) {
+      if (d.equalsIgnoreCase(P_INF_STRING)) {
         return Double.POSITIVE_INFINITY;
-      } else if (d.equalsIgnoreCase(N_INF)) {
+      } else if (d.equalsIgnoreCase(N_INF_STRING)) {
         return Double.NEGATIVE_INFINITY;
       } else {
         return Double.parseDouble(d);
@@ -504,23 +504,23 @@ public class Coder {
 
   // Checks if the given byte array is equivalent to the String "NaN", ignoring case.
   public static boolean isNaN(byte[] bytes) {
-    return equalsIgnoreCaseBytes(bytes, bNaN);
+    return equalsIgnoreCaseBytes(bytes, NaN);
   }
 
   // Checks if the given byte array is equivalent to the Strings "INF", "INFINITY", "+INF" or
   // "+INFINITY", ignoring case.
   public static boolean isPositiveInfinity(byte[] bytes) {
-    return equalsIgnoreCaseBytes(bytes, bINF)
-        || equalsIgnoreCaseBytes(bytes, bP_INF)
-        || equalsIgnoreCaseBytes(bytes, bINFINITY)
-        || equalsIgnoreCaseBytes(bytes, bP_INFINITY);
+    return equalsIgnoreCaseBytes(bytes, INF)
+        || equalsIgnoreCaseBytes(bytes, P_INF)
+        || equalsIgnoreCaseBytes(bytes, INFINITY)
+        || equalsIgnoreCaseBytes(bytes, P_INFINITY);
   }
 
   // Checks if the given byte array is equivalent to the Strings "-INF" or "-INFINITY", ignoring
   // case.
   public static boolean isNegativeInfinity(byte[] bytes) {
-    return equalsIgnoreCaseBytes(bytes, bN_INF)
-        || equalsIgnoreCaseBytes(bytes, bN_INFINITY);
+    return equalsIgnoreCaseBytes(bytes, N_INF)
+        || equalsIgnoreCaseBytes(bytes, N_INFINITY);
   }
 
   // Takes a long value and converts it to an int. Values outside the range Integer.MIN_VALUE and

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -53,197 +53,198 @@ public class StringBytesGlossary {
    * byte array of an OK response
    */
   @MakeImmutable
-  public static final byte[] bOK = stringToBytes("+OK\r\n");
+  public static final byte[] OK = stringToBytes("+OK\r\n");
 
   /**
    * byte array of a nil response
    */
   @MakeImmutable
-  public static final byte[] bNIL = stringToBytes("$-1\r\n");
+  public static final byte[] NIL = stringToBytes("$-1\r\n");
 
   /**
    * byte array of an empty array
    */
   @MakeImmutable
-  public static final byte[] bEMPTY_ARRAY = stringToBytes("*0\r\n");
+  public static final byte[] EMPTY_ARRAY = stringToBytes("*0\r\n");
 
   /**
    * byte array of an empty string
    */
   @MakeImmutable
-  public static final byte[] bEMPTY_STRING = stringToBytes("$0\r\n\r\n");
+  public static final byte[] EMPTY_STRING = stringToBytes("$0\r\n\r\n");
 
   @MakeImmutable
-  public static final byte[] bCRLF = stringToBytes("\r\n");
+  public static final byte[] CRLF = stringToBytes("\r\n");
 
   @Immutable
-  public static final byte[] bZERO_INT = stringToBytes(":0\r\n");
+  public static final byte[] ZERO_INT = stringToBytes(":0\r\n");
 
   @Immutable
-  public static final byte[] bONE_INT = stringToBytes(":1\r\n");
+  public static final byte[] ONE_INT = stringToBytes(":1\r\n");
 
   @MakeImmutable
-  public static final byte[] bERR = stringToBytes("ERR ");
+  public static final byte[] ERR = stringToBytes("ERR ");
 
   @MakeImmutable
-  public static final byte[] bOOM = stringToBytes("OOM ");
+  public static final byte[] OOM = stringToBytes("OOM ");
 
   @MakeImmutable
-  public static final byte[] bWRONGTYPE = stringToBytes("WRONGTYPE ");
+  public static final byte[] WRONGTYPE = stringToBytes("WRONGTYPE ");
 
   @MakeImmutable
-  public static final byte[] bMOVED = stringToBytes("MOVED ");
+  public static final byte[] MOVED = stringToBytes("MOVED ");
 
   @MakeImmutable
-  public static final byte[] bBUSYKEY = stringToBytes("BUSYKEY ");
+  public static final byte[] BUSYKEY = stringToBytes("BUSYKEY ");
 
   @MakeImmutable
-  public static final byte[] bCROSSSLOT = stringToBytes("CROSSSLOT ");
+  public static final byte[] CROSSSLOT = stringToBytes("CROSSSLOT ");
 
   @MakeImmutable
-  public static final byte[] bWRONGPASS = stringToBytes("WRONGPASS ");
+  public static final byte[] WRONGPASS = stringToBytes("WRONGPASS ");
 
   @MakeImmutable
-  public static final byte[] bNOAUTH = stringToBytes("NOAUTH ");
+  public static final byte[] NOAUTH = stringToBytes("NOAUTH ");
 
   // ********** Redis Command constants **********
 
   // ClusterExecutor
   @MakeImmutable
-  public static final byte[] bINFO = stringToBytes("INFO");
+  public static final byte[] INFO = stringToBytes("INFO");
   @MakeImmutable
-  public static final byte[] bSLOTS = stringToBytes("SLOTS");
+  public static final byte[] SLOTS = stringToBytes("SLOTS");
   @MakeImmutable
-  public static final byte[] bNODES = stringToBytes("NODES");
+  public static final byte[] NODES = stringToBytes("NODES");
   @MakeImmutable
-  public static final byte[] bKEYSLOT = stringToBytes("KEYSLOT");
+  public static final byte[] KEYSLOT = stringToBytes("KEYSLOT");
 
   // ScanExecutor, HScanExecutor and SScanExecutor
   @MakeImmutable
-  public static final byte[] bMATCH = stringToBytes("MATCH");
+  public static final byte[] MATCH = stringToBytes("MATCH");
   @MakeImmutable
-  public static final byte[] bCOUNT = stringToBytes("COUNT");
+  public static final byte[] COUNT = stringToBytes("COUNT");
 
   // PubSubExecutor
   @MakeImmutable
-  public static final byte[] bCHANNELS = stringToBytes("CHANNELS");
+  public static final byte[] CHANNELS = stringToBytes("CHANNELS");
   @MakeImmutable
-  public static final byte[] bNUMSUB = stringToBytes("NUMSUB");
+  public static final byte[] NUMSUB = stringToBytes("NUMSUB");
   @MakeImmutable
-  public static final byte[] bNUMPAT = stringToBytes("NUMPAT");
+  public static final byte[] NUMPAT = stringToBytes("NUMPAT");
 
   // InfoExecutor
   @MakeImmutable
-  public static final byte[] bSERVER = stringToBytes("SERVER");
+  public static final byte[] SERVER = stringToBytes("SERVER");
   @MakeImmutable
-  public static final byte[] bCLUSTER = stringToBytes("CLUSTER");
+  public static final byte[] CLUSTER = stringToBytes("CLUSTER");
   @MakeImmutable
-  public static final byte[] bPERSISTENCE = stringToBytes("PERSISTENCE");
+  public static final byte[] PERSISTENCE = stringToBytes("PERSISTENCE");
   @MakeImmutable
-  public static final byte[] bREPLICATION = stringToBytes("REPLICATION");
+  public static final byte[] REPLICATION = stringToBytes("REPLICATION");
   @MakeImmutable
-  public static final byte[] bSTATS = stringToBytes("STATS");
+  public static final byte[] STATS = stringToBytes("STATS");
   @MakeImmutable
-  public static final byte[] bCLIENTS = stringToBytes("CLIENTS");
+  public static final byte[] CLIENTS = stringToBytes("CLIENTS");
   @MakeImmutable
-  public static final byte[] bMEMORY = stringToBytes("MEMORY");
+  public static final byte[] MEMORY = stringToBytes("MEMORY");
   @MakeImmutable
-  public static final byte[] bKEYSPACE = stringToBytes("KEYSPACE");
+  public static final byte[] KEYSPACE = stringToBytes("KEYSPACE");
   @MakeImmutable
-  public static final byte[] bDEFAULT = stringToBytes("DEFAULT");
+  public static final byte[] DEFAULT = stringToBytes("DEFAULT");
   @MakeImmutable
-  public static final byte[] bALL = stringToBytes("ALL");
+  public static final byte[] ALL = stringToBytes("ALL");
 
   // SlowlogExecutor and SlowlogParameterRequirements
   @MakeImmutable
-  public static final byte[] bGET = stringToBytes("GET");
+  public static final byte[] GET = stringToBytes("GET");
   @MakeImmutable
-  public static final byte[] bLEN = stringToBytes("LEN");
+  public static final byte[] LEN = stringToBytes("LEN");
   @MakeImmutable
-  public static final byte[] bRESET = stringToBytes("RESET");
+  public static final byte[] RESET = stringToBytes("RESET");
 
   // ZAddExecutor and SetExecutor
   @MakeImmutable
-  public static final byte[] bNX = stringToBytes("NX");
+  public static final byte[] NX = stringToBytes("NX");
   @MakeImmutable
-  public static final byte[] bXX = stringToBytes("XX");
+  public static final byte[] XX = stringToBytes("XX");
 
   // ZAddExecutor
   @MakeImmutable
-  public static final byte[] bCH = stringToBytes("CH");
+  public static final byte[] CH = stringToBytes("CH");
   @MakeImmutable
-  public static final byte[] bINCR = stringToBytes("INCR");
+  public static final byte[] INCR = stringToBytes("INCR");
 
   // ZUnionStoreExecutor
   @MakeImmutable
-  public static final byte[] bWEIGHTS = stringToBytes("WEIGHTS");
+  public static final byte[] WEIGHTS = stringToBytes("WEIGHTS");
   @MakeImmutable
-  public static final byte[] bAGGREGATE = stringToBytes("AGGREGATE");
+  public static final byte[] AGGREGATE = stringToBytes("AGGREGATE");
 
   // SetExecutor
   @MakeImmutable
-  public static final byte[] bEX = stringToBytes("EX");
+  public static final byte[] EX = stringToBytes("EX");
   @MakeImmutable
-  public static final byte[] bPX = stringToBytes("PX");
+  public static final byte[] PX = stringToBytes("PX");
 
   // RestoreExecutor
   @MakeImmutable
-  public static final byte[] bREPLACE = stringToBytes("REPLACE");
+  public static final byte[] REPLACE = stringToBytes("REPLACE");
   @MakeImmutable
-  public static final byte[] bABSTTL = stringToBytes("ABSTTL");
+  public static final byte[] ABSTTL = stringToBytes("ABSTTL");
 
   // Various ZRangeExecutors
   @MakeImmutable
-  public static final byte[] bWITHSCORES = stringToBytes("WITHSCORES");
+  public static final byte[] WITHSCORES = stringToBytes("WITHSCORES");
   @MakeImmutable
-  public static final byte[] bLIMIT = stringToBytes("LIMIT");
+  public static final byte[] LIMIT = stringToBytes("LIMIT");
 
   // LolWutExecutor
   @MakeImmutable
-  public static final byte[] bVERSION = stringToBytes("VERSION");
+  public static final byte[] VERSION = stringToBytes("VERSION");
 
   // ********** Constants for Double Infinity comparisons **********
-  public static final String P_INF = "+inf";
-  public static final String INF = "inf";
-  public static final String P_INFINITY = "+Infinity";
-  public static final String INFINITY = "Infinity";
-  public static final String N_INF = "-inf";
-  public static final String N_INFINITY = "-Infinity";
-  public static final String NaN = "NaN";
+  public static final String P_INF_STRING = "+inf";
+  public static final String INF_STRING = "inf";
+  public static final String P_INFINITY_STRING = "+Infinity";
+  public static final String INFINITY_STRING = "Infinity";
+  public static final String N_INF_STRING = "-inf";
+  public static final String N_INFINITY_STRING = "-Infinity";
+  public static final String NaN_STRING = "NaN";
 
   @MakeImmutable
-  public static final byte[] bP_INF = stringToBytes(P_INF);
+  public static final byte[] P_INF = stringToBytes(P_INF_STRING);
 
   @MakeImmutable
-  public static final byte[] bINF = stringToBytes(INF);
+  public static final byte[] INF = stringToBytes(INF_STRING);
 
   @MakeImmutable
-  public static final byte[] bP_INFINITY = stringToBytes(P_INFINITY);
+  public static final byte[] P_INFINITY = stringToBytes(P_INFINITY_STRING);
 
   @MakeImmutable
-  public static final byte[] bINFINITY = stringToBytes(INFINITY);
+  public static final byte[] INFINITY = stringToBytes(INFINITY_STRING);
 
   @MakeImmutable
-  public static final byte[] bN_INF = stringToBytes(N_INF);
+  public static final byte[] N_INF = stringToBytes(N_INF_STRING);
 
   @MakeImmutable
-  public static final byte[] bN_INFINITY = stringToBytes(N_INFINITY);
+  public static final byte[] N_INFINITY = stringToBytes(N_INFINITY_STRING);
 
   @MakeImmutable
-  public static final byte[] bNaN = stringToBytes(NaN);
+  public static final byte[] NaN = stringToBytes(NaN_STRING);
 
   // ********** Miscellaneous constants for convenience **********
 
-  public static final String PING_RESPONSE = "PONG";
+  public static final String PING_RESPONSE_STRING = "PONG";
 
   @MakeImmutable
-  public static final byte[] bPING_RESPONSE = stringToBytes(PING_RESPONSE);
+  public static final byte[] PING_RESPONSE = stringToBytes(PING_RESPONSE_STRING);
 
   @MakeImmutable
-  public static final byte[] bPING_RESPONSE_LOWERCASE = stringToBytes(PING_RESPONSE.toLowerCase());
+  public static final byte[] PING_RESPONSE_LOWERCASE =
+      stringToBytes(PING_RESPONSE_STRING.toLowerCase());
 
   @MakeImmutable
-  public static final byte[] bRADISH_DUMP_HEADER = stringToBytes("RADISH");
+  public static final byte[] RADISH_DUMP_HEADER = stringToBytes("RADISH");
 
   /**
    * These member names will always be evaluated to be "greater than" or "less than" any other when
@@ -254,30 +255,30 @@ public class StringBytesGlossary {
    * that we can differentiate between the use of these constants and a value potentially entered by
    * the user, which while equal in content, will not share the same memory address.
    */
-  public static final byte[] bGREATEST_MEMBER_NAME = new byte[] {-1};
+  public static final byte[] GREATEST_MEMBER_NAME = new byte[] {-1};
 
-  public static final byte[] bLEAST_MEMBER_NAME = new byte[] {-2};
+  public static final byte[] LEAST_MEMBER_NAME = new byte[] {-2};
 
-  public static final byte[] bNEGATIVE_ZERO = stringToBytes("-0");
+  public static final byte[] NEGATIVE_ZERO = stringToBytes("-0");
 
   ///////////////////// Response Message Types /////////////////////////
 
   @Immutable
-  public static final byte[] bSUBSCRIBE = Coder.stringToBytes("subscribe");
+  public static final byte[] SUBSCRIBE = Coder.stringToBytes("subscribe");
 
   @Immutable
-  public static final byte[] bPSUBSCRIBE = Coder.stringToBytes("psubscribe");
+  public static final byte[] PSUBSCRIBE = Coder.stringToBytes("psubscribe");
 
   @Immutable
-  public static final byte[] bMESSAGE = Coder.stringToBytes("message");
+  public static final byte[] MESSAGE = Coder.stringToBytes("message");
 
   @Immutable
-  public static final byte[] bPMESSAGE = Coder.stringToBytes("pmessage");
+  public static final byte[] PMESSAGE = Coder.stringToBytes("pmessage");
 
   @Immutable
-  public static final byte[] bUNSUBSCRIBE = Coder.stringToBytes("unsubscribe");
+  public static final byte[] UNSUBSCRIBE = Coder.stringToBytes("unsubscribe");
 
   @Immutable
-  public static final byte[] bPUNSUBSCRIBE = Coder.stringToBytes("punsubscribe");
+  public static final byte[] PUNSUBSCRIBE = Coder.stringToBytes("punsubscribe");
 
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/parameters/SlowlogParameterRequirements.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/parameters/SlowlogParameterRequirements.java
@@ -20,9 +20,9 @@ import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_SLOWL
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGET;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEN;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bRESET;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.GET;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.LEN;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.RESET;
 
 import java.util.function.Consumer;
 
@@ -49,9 +49,9 @@ public class SlowlogParameterRequirements {
 
   private static void confirmKnownSubcommands(Command command) {
     byte[] bytes = command.getBytesKey();
-    if (!equalsIgnoreCaseBytes(bytes, bRESET) &&
-        !equalsIgnoreCaseBytes(bytes, bLEN) &&
-        !equalsIgnoreCaseBytes(bytes, bGET)) {
+    if (!equalsIgnoreCaseBytes(bytes, RESET) &&
+        !equalsIgnoreCaseBytes(bytes, LEN) &&
+        !equalsIgnoreCaseBytes(bytes, GET)) {
       throw new RedisParametersMismatchException(
           String.format(ERROR_UNKNOWN_SLOWLOG_SUBCOMMAND, bytesToString(bytes)));
     }
@@ -59,7 +59,7 @@ public class SlowlogParameterRequirements {
 
   private static void confirmArgumentsToGetSubcommand(Command command) {
     byte[] bytes = command.getBytesKey();
-    if (!equalsIgnoreCaseBytes(bytes, bGET)) {
+    if (!equalsIgnoreCaseBytes(bytes, GET)) {
       throw new RedisParametersMismatchException(
           String.format(ERROR_UNKNOWN_SLOWLOG_SUBCOMMAND, bytesToString(bytes)));
     }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Publisher.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Publisher.java
@@ -20,8 +20,8 @@ import static org.apache.geode.internal.lang.utils.JavaWorkarounds.computeIfAbse
 import static org.apache.geode.logging.internal.executors.LoggingExecutors.newCachedThreadPool;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 import static org.apache.geode.redis.internal.netty.Coder.getInternalErrorResponse;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bMESSAGE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPMESSAGE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.MESSAGE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PMESSAGE;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -206,7 +206,7 @@ public class Publisher {
     }
     ByteBuf writeBuf = channelSubscriptions.iterator().next().getChannelWriteBuffer();
     for (byte[] message : request.getMessages()) {
-      writeArrayResponse(writeBuf, bMESSAGE, request.getChannel(), message);
+      writeArrayResponse(writeBuf, MESSAGE, request.getChannel(), message);
     }
     if (channelSubscriptions.size() == 1) {
       Subscription singleSubscription = channelSubscriptions.iterator().next();
@@ -233,7 +233,7 @@ public class Publisher {
       PatternSubscriptions patternSubscriptions) {
     ByteBuf writeBuf = patternSubscriptions.getFirst().getChannelWriteBuffer();
     for (byte[] message : request.getMessages()) {
-      writeArrayResponse(writeBuf, bPMESSAGE, patternSubscriptions.getPattern(),
+      writeArrayResponse(writeBuf, PMESSAGE, patternSubscriptions.getPattern(),
           request.getChannel(), message);
     }
     if (patternSubscriptions.size() == 1) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Subscriptions.java
@@ -17,8 +17,8 @@
 package org.apache.geode.redis.internal.pubsub;
 
 import static java.util.Collections.singletonList;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPUNSUBSCRIBE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bUNSUBSCRIBE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PUNSUBSCRIBE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.UNSUBSCRIBE;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -258,7 +258,7 @@ public class Subscriptions {
 
   private static List<Object> createUnsubscribeItem(boolean channel, byte[] channelOrPattern,
       long subscriptionCount) {
-    return Arrays.asList(channel ? bUNSUBSCRIBE : bPUNSUBSCRIBE, channelOrPattern,
+    return Arrays.asList(channel ? UNSUBSCRIBE : PUNSUBSCRIBE, channelOrPattern,
         subscriptionCount);
   }
 

--- a/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
+++ b/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSortedSetTest.java
@@ -20,8 +20,8 @@ import static java.util.Collections.singletonList;
 import static org.apache.geode.redis.internal.data.RedisSortedSet.OrderedSetEntry.ORDERED_SET_ENTRY_OVERHEAD;
 import static org.apache.geode.redis.internal.data.RedisSortedSet.REDIS_SORTED_SET_OVERHEAD;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bGREATEST_MEMBER_NAME;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bLEAST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.GREATEST_MEMBER_NAME;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.LEAST_MEMBER_NAME;
 import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -463,17 +463,17 @@ public class RedisSortedSetTest {
     RedisSortedSet.AbstractOrderedSetEntry greatest =
         new RedisSortedSet.ScoreDummyOrderedSetEntry(score, true, true);
     RedisSortedSet.AbstractOrderedSetEntry greatestEquivalent =
-        new RedisSortedSet.OrderedSetEntry(bGREATEST_MEMBER_NAME.clone(), score);
+        new RedisSortedSet.OrderedSetEntry(GREATEST_MEMBER_NAME.clone(), score);
 
     RedisSortedSet.AbstractOrderedSetEntry least =
         new RedisSortedSet.ScoreDummyOrderedSetEntry(score, true, false);
     RedisSortedSet.AbstractOrderedSetEntry leastEquivalent =
-        new RedisSortedSet.OrderedSetEntry(bLEAST_MEMBER_NAME.clone(), score);
+        new RedisSortedSet.OrderedSetEntry(LEAST_MEMBER_NAME.clone(), score);
 
-    // bGREATEST_MEMBER_NAME > an array with contents equal to bGREATEST_MEMBER_NAME
+    // GREATEST_MEMBER_NAME > an array with contents equal to GREATEST_MEMBER_NAME
     assertThat(greatest.compareTo(greatestEquivalent)).isEqualTo(1);
 
-    // bLEAST_MEMBER_NAME < an array with contents equal to bLEAST_MEMBER_NAME
+    // LEAST_MEMBER_NAME < an array with contents equal to LEAST_MEMBER_NAME
     assertThat(least.compareTo(leastEquivalent)).isEqualTo(-1);
   }
 
@@ -481,24 +481,24 @@ public class RedisSortedSetTest {
   public void scoreDummyOrderedSetEntryConstructor_setsAppropriateMemberName() {
     RedisSortedSet.AbstractOrderedSetEntry entry =
         new RedisSortedSet.ScoreDummyOrderedSetEntry(1, false, false);
-    assertThat(entry.getMember()).isSameAs(bGREATEST_MEMBER_NAME);
+    assertThat(entry.getMember()).isSameAs(GREATEST_MEMBER_NAME);
 
     entry = new RedisSortedSet.ScoreDummyOrderedSetEntry(1, true, false);
-    assertThat(entry.getMember()).isSameAs(bLEAST_MEMBER_NAME);
+    assertThat(entry.getMember()).isSameAs(LEAST_MEMBER_NAME);
 
     entry = new RedisSortedSet.ScoreDummyOrderedSetEntry(1, false, true);
-    assertThat(entry.getMember()).isSameAs(bLEAST_MEMBER_NAME);
+    assertThat(entry.getMember()).isSameAs(LEAST_MEMBER_NAME);
 
     entry = new RedisSortedSet.ScoreDummyOrderedSetEntry(1, true, true);
-    assertThat(entry.getMember()).isSameAs(bGREATEST_MEMBER_NAME);
+    assertThat(entry.getMember()).isSameAs(GREATEST_MEMBER_NAME);
   }
 
   @Test
   public void memberDummyOrderedSetEntryCompareTo_handlesDummyMemberNames() {
     RedisSortedSet.AbstractOrderedSetEntry greatest =
-        new RedisSortedSet.MemberDummyOrderedSetEntry(bGREATEST_MEMBER_NAME, false, false);
+        new RedisSortedSet.MemberDummyOrderedSetEntry(GREATEST_MEMBER_NAME, false, false);
     RedisSortedSet.AbstractOrderedSetEntry least =
-        new RedisSortedSet.MemberDummyOrderedSetEntry(bLEAST_MEMBER_NAME, false, false);
+        new RedisSortedSet.MemberDummyOrderedSetEntry(LEAST_MEMBER_NAME, false, false);
     RedisSortedSet.AbstractOrderedSetEntry middle =
         new RedisSortedSet.MemberDummyOrderedSetEntry(stringToBytes("middle"), false, false);
 

--- a/geode-for-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
+++ b/geode-for-redis/src/test/java/org/apache/geode/redis/internal/netty/CoderTest.java
@@ -25,7 +25,7 @@ import static org.apache.geode.redis.internal.netty.Coder.isPositiveInfinity;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
 import static org.apache.geode.redis.internal.netty.Coder.toUpperCaseBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bNaN;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NaN;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertArrayEquals;
@@ -86,7 +86,7 @@ public class CoderTest {
 
   @Test
   public void bytesToDouble_errorsWhenGivenNaNAsBytes() {
-    assertThatThrownBy(() -> Coder.bytesToDouble(bNaN)).isInstanceOf(NumberFormatException.class);
+    assertThatThrownBy(() -> Coder.bytesToDouble(NaN)).isInstanceOf(NumberFormatException.class);
   }
 
   @Test

--- a/geode-for-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
+++ b/geode-for-redis/src/test/java/org/apache/geode/redis/internal/pubsub/SubscriptionsJUnitTest.java
@@ -20,8 +20,8 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.geode.redis.internal.netty.Coder.stringToBytes;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bPUNSUBSCRIBE;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.bUNSUBSCRIBE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PUNSUBSCRIBE;
+import static org.apache.geode.redis.internal.netty.StringBytesGlossary.UNSUBSCRIBE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -204,7 +204,7 @@ public class SubscriptionsJUnitTest {
 
     Collection<Collection<?>> result = subscriptions.punsubscribe(singletonList(pattern), client);
 
-    assertThat(result).containsExactly(asList(bPUNSUBSCRIBE, pattern, 2L));
+    assertThat(result).containsExactly(asList(PUNSUBSCRIBE, pattern, 2L));
     assertThat(subscriptions.getPatternSubscriptionCount()).isZero();
   }
 
@@ -218,7 +218,7 @@ public class SubscriptionsJUnitTest {
 
     Collection<Collection<?>> result = subscriptions.punsubscribe(singletonList(pattern), client);
 
-    assertThat(result).containsExactly(asList(bPUNSUBSCRIBE, pattern, 2L));
+    assertThat(result).containsExactly(asList(PUNSUBSCRIBE, pattern, 2L));
     assertThat(subscriptions.getPatternSubscriptionCount()).isZero();
   }
 
@@ -234,8 +234,8 @@ public class SubscriptionsJUnitTest {
     Collection<Collection<?>> result =
         subscriptions.punsubscribe(asList(pattern1, pattern2), client);
 
-    assertThat(result).containsExactly(asList(bPUNSUBSCRIBE, pattern1, 2L),
-        asList(bPUNSUBSCRIBE, pattern2, 1L));
+    assertThat(result).containsExactly(asList(PUNSUBSCRIBE, pattern1, 2L),
+        asList(PUNSUBSCRIBE, pattern2, 1L));
     assertThat(subscriptions.getPatternSubscriptionCount()).isZero();
   }
 
@@ -251,7 +251,7 @@ public class SubscriptionsJUnitTest {
     assertThat(result).hasSize(1);
     @SuppressWarnings("unchecked")
     Collection<Object> firstItem = (Collection<Object>) result.iterator().next();
-    assertThat(firstItem).containsExactly(bPUNSUBSCRIBE, pattern, 1L);
+    assertThat(firstItem).containsExactly(PUNSUBSCRIBE, pattern, 1L);
     assertThat(subscriptions.getPatternSubscriptionCount()).isZero();
   }
 
@@ -264,7 +264,7 @@ public class SubscriptionsJUnitTest {
     assertThat(result).hasSize(1);
     @SuppressWarnings("unchecked")
     Collection<Object> firstItem = (Collection<Object>) result.iterator().next();
-    assertThat(firstItem).containsExactly(bUNSUBSCRIBE, null, 0L);
+    assertThat(firstItem).containsExactly(UNSUBSCRIBE, null, 0L);
   }
 
   @Test
@@ -276,7 +276,7 @@ public class SubscriptionsJUnitTest {
     assertThat(result).hasSize(1);
     @SuppressWarnings("unchecked")
     Collection<Object> firstItem = (Collection<Object>) result.iterator().next();
-    assertThat(firstItem).containsExactly(bPUNSUBSCRIBE, null, 0L);
+    assertThat(firstItem).containsExactly(PUNSUBSCRIBE, null, 0L);
   }
 
   @Test
@@ -289,7 +289,7 @@ public class SubscriptionsJUnitTest {
 
     Collection<Collection<?>> result = subscriptions.unsubscribe(singletonList(channel), client);
 
-    assertThat(result).containsExactly(asList(bUNSUBSCRIBE, channel, 2L));
+    assertThat(result).containsExactly(asList(UNSUBSCRIBE, channel, 2L));
     assertThat(subscriptions.findChannelNames())
         .containsExactlyInAnyOrder(
             stringToBytes("subscriptions"));
@@ -307,8 +307,8 @@ public class SubscriptionsJUnitTest {
     Collection<Collection<?>> result =
         subscriptions.unsubscribe(asList(channel1, channel2), client);
 
-    assertThat(result).containsExactly(asList(bUNSUBSCRIBE, channel1, 2L),
-        asList(bUNSUBSCRIBE, channel2, 1L));
+    assertThat(result).containsExactly(asList(UNSUBSCRIBE, channel1, 2L),
+        asList(UNSUBSCRIBE, channel2, 1L));
     assertThat(subscriptions.findChannelNames()).isEmpty();
   }
 
@@ -324,7 +324,7 @@ public class SubscriptionsJUnitTest {
     assertThat(result).hasSize(1);
     @SuppressWarnings("unchecked")
     Collection<Object> firstItem = (Collection<Object>) result.iterator().next();
-    assertThat(firstItem).containsExactly(bUNSUBSCRIBE, channel, 1L);
+    assertThat(firstItem).containsExactly(UNSUBSCRIBE, channel, 1L);
     assertThat(subscriptions.findChannelNames()).isEmpty();
   }
 


### PR DESCRIPTION
Removed 'b' prefix on all byte arrays and added "_STRING" to string constants.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [NA] Have you written or updated unit tests to verify your changes?

- [NA] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
