### PR TITLE
GEODE-9817: Enable customized source set paths for ClassAnalysisRule

### DIFF
--- a/geode-connectors/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeConnectorsSerializablesIntegrationTest.java
+++ b/geode-connectors/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeConnectorsSerializablesIntegrationTest.java
@@ -23,7 +23,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
 public class AnalyzeConnectorsSerializablesIntegrationTest
-    extends AnalyzeSerializablesJUnitTestBase {
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeCoreSerializablesIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeCoreSerializablesIntegrationTest.java
@@ -22,7 +22,8 @@ import org.apache.geode.internal.CoreSanctionedSerializablesService;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzeCoreSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeCoreSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-cq/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeCQSerializablesIntegrationTest.java
+++ b/geode-cq/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeCQSerializablesIntegrationTest.java
@@ -23,7 +23,8 @@ import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category({ClientSubscriptionTest.class, SerializationTest.class})
-public class AnalyzeCQSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeCQSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-dunit/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeDUnitSerializablesIntegrationTest.java
+++ b/geode-dunit/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeDUnitSerializablesIntegrationTest.java
@@ -27,7 +27,9 @@ import org.apache.geode.test.dunit.internal.Master;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzeDUnitSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeDUnitSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
+
   private static final Logger logger = LogService.getLogger();
 
   private static final Set<Class<?>> IGNORE_CLASSES = new HashSet<>();

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeRedisSerializablesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeRedisSerializablesIntegrationTest.java
@@ -22,7 +22,8 @@ import org.apache.geode.redis.internal.RedisSanctionedSerializablesService;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzeRedisSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeRedisSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeGfshSerializablesIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeGfshSerializablesIntegrationTest.java
@@ -22,7 +22,8 @@ import org.apache.geode.gfsh.internal.management.GfshSanctionedSerializablesServ
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzeGfshSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeGfshSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-junit/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeJUnitSerializablesIntegrationTest.java
+++ b/geode-junit/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeJUnitSerializablesIntegrationTest.java
@@ -28,7 +28,8 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 import org.apache.geode.test.junit.internal.JUnitSanctionedSerializablesService;
 
 @Category(SerializationTest.class)
-public class AnalyzeJUnitSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeJUnitSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   private static final Set<Class<?>> IGNORE_CLASSES = new HashSet<>(asList(
       PortfolioNoDS.class, PortfolioPdx.class));

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeDataSerializablesTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeDataSerializablesTestBase.java
@@ -52,8 +52,8 @@ import org.apache.geode.test.junit.categories.SerializationTest;
  * Subclasses must provide serialization/deserialization methods.
  *
  * <p>
- * Most tests should subclass {@link AnalyzeSerializablesTestBase} instead of this
- * class because it ties into geode-core serialization and saves a lot of work.
+ * Most tests should subclass {@link AnalyzeSerializablesWithClassAnalysisRuleTestBase} instead of
+ * this class because it ties into geode-core serialization and saves a lot of work.
  */
 @Category({SerializationTest.class})
 public abstract class AnalyzeDataSerializablesTestBase {
@@ -204,7 +204,6 @@ public abstract class AnalyzeDataSerializablesTestBase {
         } catch (InstantiationException | IllegalAccessException | NullPointerException e) {
           // okay - it's in the excludedClasses.txt file after all
           // IllegalAccessException means that the constructor is private.
-          // throw new AssertionError("Unable to instantiate " + excludedClass.getName(), e);
           continue;
         }
         serializeAndDeserializeObject(excludedInstance);
@@ -339,28 +338,13 @@ public abstract class AnalyzeDataSerializablesTestBase {
   }
 
   File createEmptyFile(String fileName) throws IOException {
-    final String workingDir = System.getProperty("user.dir");
-    final String filePath;
-    // if (isIntelliJDir(workingDir)) {
-    // String buildDir = workingDir.replace(getModuleName(), "");
-    // buildDir =
-    // Paths.get(buildDir, "out", "production", "geode." + getModuleName() + ".integrationTest")
-    // .toString();
-    // filePath = buildDir + File.separator + fileName;
-    // } else {
-    filePath = fileName;
-    // }
-    File file = new File(filePath);
+    File file = new File(fileName);
     if (file.exists()) {
       assertThat(file.delete()).isTrue();
     }
     assertThat(file.createNewFile()).isTrue();
     assertThat(file).exists().canWrite();
     return file;
-  }
-
-  private boolean isIntelliJDir(final String workingDir) {
-    return !workingDir.contains("build");
   }
 
   /**

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeDataSerializablesWithClassAnalysisRuleTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeDataSerializablesWithClassAnalysisRuleTestBase.java
@@ -14,24 +14,27 @@
  */
 package org.apache.geode.codeAnalysis;
 
-import java.util.Optional;
+import java.util.Map;
 
-import org.junit.experimental.categories.Category;
+import org.junit.AfterClass;
+import org.junit.Rule;
 
-import org.apache.geode.internal.serialization.SerializationSanctionedSerializablesService;
-import org.apache.geode.test.junit.categories.SerializationTest;
+import org.apache.geode.codeAnalysis.decode.CompiledClass;
+import org.apache.geode.test.junit.rules.ClassAnalysisRule;
 
-@Category(SerializationTest.class)
-public class AnalyzeSerializationSerializablesIntegrationTest
-    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
+public abstract class AnalyzeDataSerializablesWithClassAnalysisRuleTestBase
+    extends AnalyzeDataSerializablesTestBase {
 
-  @Override
-  protected String getModuleName() {
-    return "geode-serialization";
+  @Rule
+  public ClassAnalysisRule classProvider = new ClassAnalysisRule(getModuleName());
+
+  @AfterClass
+  public static void afterClass() {
+    ClassAnalysisRule.clearCache();
   }
 
   @Override
-  protected Optional<Class<?>> getModuleClass() {
-    return Optional.of(SerializationSanctionedSerializablesService.class);
+  protected Map<String, CompiledClass> loadClasses() {
+    return classProvider.getClasses();
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesTestBase.java
@@ -26,10 +26,10 @@ import java.io.Externalizable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InvalidClassException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.nio.file.Path;
 import java.rmi.RemoteException;
@@ -42,8 +42,10 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.rules.ErrorCollector;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializable;
@@ -64,8 +66,8 @@ import org.apache.geode.unsafe.internal.sun.reflect.ReflectionFactory;
  * InternalDataSerializer. It also performs initialization of the Geode TypeRegistry
  */
 @Category(SerializationTest.class)
-public abstract class AnalyzeSerializablesJUnitTestBase
-    extends AnalyzeDataSerializablesJUnitTestBase {
+public abstract class AnalyzeSerializablesTestBase
+    extends AnalyzeDataSerializablesTestBase {
 
   private static final String ACTUAL_SERIALIZABLES_DAT = "actualSerializables.dat";
 
@@ -73,6 +75,9 @@ public abstract class AnalyzeSerializablesJUnitTestBase
       "sanctioned-" + getModuleName() + "-serializables.txt";
 
   protected final List<ClassAndVariableDetails> expectedSerializables = new ArrayList<>();
+
+  @Rule
+  public ErrorCollector errorCollector = new ErrorCollector();
 
   @Before
   public void setUp() throws Exception {
@@ -202,12 +207,19 @@ public abstract class AnalyzeSerializablesJUnitTestBase
             isThrowable ? sanctionedClass.getDeclaredConstructor(String.class)
                 : sanctionedClass.getDeclaredConstructor((Class<?>[]) null);
         constructor.setAccessible(true);
-        sanctionedInstance =
-            isThrowable ? constructor.newInstance("test throwable") : constructor.newInstance();
+        if (isThrowable) {
+          sanctionedInstance = constructor.newInstance("test throwable");
+        } else {
+          sanctionedInstance = constructor.newInstance();
+        }
         serializeAndDeserializeSanctionedObject(sanctionedInstance);
         continue;
-      } catch (NoSuchMethodException | InstantiationException | IllegalAccessException e) {
+      } catch (NoSuchMethodException | InstantiationException | IllegalAccessException
+          | NullPointerException | InvocationTargetException e) {
         // fall through
+      } catch (Exception e) {
+        errorCollector.addError(e);
+        continue;
       }
       try {
         Class<?> superClass = sanctionedClass;
@@ -339,22 +351,23 @@ public abstract class AnalyzeSerializablesJUnitTestBase
 
   private void serializeAndDeserializeSanctionedObject(Object object) throws Exception {
     BufferDataOutputStream outputStream = new BufferDataOutputStream(KnownVersion.CURRENT);
+
     try {
       serializeObject(object, outputStream);
     } catch (RemoteException e) {
-      fail(object.getClass().getName() +
-          " is a java.rmi.server.RemoteObject which is not supported by AnalyzeSerializables", e);
-    } catch (IOException e) {
-      // some classes, such as BackupLock, are Serializable because the extend something
-      // like ReentrantLock but we never serialize them & it doesn't work to try to do so
-      throw new AssertionError("Not Serializable: " + object.getClass().getName(), e);
+      // java.rmi.server.RemoteObject which is not supported by AnalyzeSerializables
+    } catch (Exception e) {
+      errorCollector.addError(
+          new AssertionError("Not Serializable: " + object.getClass().getName(), e));
     }
+
     try {
       deserializeObject(outputStream);
     } catch (CancelException e) {
       // PDX classes fish for a PDXRegistry and find that there is no cache
-    } catch (InvalidClassException e) {
-      fail("I was unable to deserialize " + object.getClass().getName(), e);
+    } catch (Exception e) {
+      errorCollector.addError(
+          new AssertionError("I was unable to deserialize " + object.getClass().getName(), e));
     }
   }
 

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesTestBase.java
@@ -358,7 +358,7 @@ public abstract class AnalyzeSerializablesTestBase
       // java.rmi.server.RemoteObject which is not supported by AnalyzeSerializables
     } catch (Exception e) {
       errorCollector.addError(
-          new AssertionError("Not Serializable: " + object.getClass().getName(), e));
+          new AssertionError("I was unable to serialize " + object.getClass().getName(), e));
     }
 
     try {

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesWithClassAnalysisRuleTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesWithClassAnalysisRuleTestBase.java
@@ -14,24 +14,30 @@
  */
 package org.apache.geode.codeAnalysis;
 
-import java.util.Optional;
+import java.util.Map;
 
+import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.internal.serialization.SerializationSanctionedSerializablesService;
+import org.apache.geode.codeAnalysis.decode.CompiledClass;
 import org.apache.geode.test.junit.categories.SerializationTest;
+import org.apache.geode.test.junit.rules.ClassAnalysisRule;
 
 @Category(SerializationTest.class)
-public class AnalyzeSerializationSerializablesIntegrationTest
-    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
+public abstract class AnalyzeSerializablesWithClassAnalysisRuleTestBase
+    extends AnalyzeSerializablesTestBase {
 
-  @Override
-  protected String getModuleName() {
-    return "geode-serialization";
+  @Rule
+  public ClassAnalysisRule classProvider = new ClassAnalysisRule(getModuleName());
+
+  @AfterClass
+  public static void afterClass() {
+    ClassAnalysisRule.clearCache();
   }
 
   @Override
-  protected Optional<Class<?>> getModuleClass() {
-    return Optional.of(SerializationSanctionedSerializablesService.class);
+  protected Map<String, CompiledClass> loadClasses() {
+    return classProvider.getClasses();
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/SanctionedSerializablesServiceIntegrationTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/SanctionedSerializablesServiceIntegrationTestBase.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.codeAnalysis;
+
+import static org.apache.geode.internal.serialization.SanctionedSerializables.loadSanctionedSerializablesServices;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+
+import org.junit.Test;
+
+import org.apache.geode.internal.serialization.SanctionedSerializablesService;
+
+public abstract class SanctionedSerializablesServiceIntegrationTestBase {
+
+  protected abstract SanctionedSerializablesService getService();
+
+  protected abstract ServiceResourceExpectation getServiceResourceExpectation();
+
+  protected enum ServiceResourceExpectation {
+    NULL,
+    EMPTY,
+    NON_EMPTY
+  }
+
+  @Test
+  public void serviceIsLoaded() {
+    Collection<SanctionedSerializablesService> services = loadSanctionedSerializablesServices();
+    SanctionedSerializablesService service = getService();
+
+    boolean found = false;
+    for (SanctionedSerializablesService aService : services) {
+      if (service.getClass().equals(aService.getClass())) {
+        found = true;
+        break;
+      }
+    }
+
+    assertThat(found)
+        .as("Services " + services + " contains " + getService().getClass().getSimpleName())
+        .isTrue();
+  }
+
+  @Test
+  public void serviceResourceExists() {
+    SanctionedSerializablesService service = getService();
+
+    URL url = service.getSanctionedSerializablesURL();
+
+    switch (getServiceResourceExpectation()) {
+      case NULL:
+        assertThat(url).isNull();
+        break;
+      case EMPTY:
+      case NON_EMPTY:
+        assertThat(url).isNotNull();
+    }
+  }
+
+  @Test
+  public void serviceResourceIsLoaded() throws IOException {
+    SanctionedSerializablesService service = getService();
+
+    Collection<String> serializables = service.getSerializationAcceptlist();
+
+    switch (getServiceResourceExpectation()) {
+      case NULL:
+      case EMPTY:
+        assertThat(serializables).isEmpty();
+        break;
+      case NON_EMPTY:
+        assertThat(serializables).isNotEmpty();
+    }
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ClassAnalysisRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ClassAnalysisRule.java
@@ -109,20 +109,10 @@ public class ClassAnalysisRule implements TestRule {
     String alternateBuildDirName =
         Paths.get(getModuleName(), "build", "classes", sourceSet).toString();
 
-    // check for <module>/out/production/classes/**
-    String ideaBuildDirName =
-        Paths.get(getModuleName(), "out", "production", "classes").toString();
-
-    // check for <module>/out/production/geode.<module>.<sourceSet>/**
-    String ideaFQCNBuildDirName =
-        Paths.get("out", "production", "geode." + getModuleName() + "." + sourceSet).toString();
-
     String buildDir = null;
     for (File entry : entries) {
       if (entry.toString().endsWith(gradleBuildDirName)
-          || entry.toString().endsWith(alternateBuildDirName)
-          || entry.toString().endsWith(ideaBuildDirName)
-          || entry.toString().endsWith(ideaFQCNBuildDirName)) {
+          || entry.toString().endsWith(alternateBuildDirName)) {
         buildDir = entry.toString();
         break;
       }

--- a/geode-junit/src/main/resources/org/apache/geode/test/junit/internal/sanctioned-geode-junit-serializables.txt
+++ b/geode-junit/src/main/resources/org/apache/geode/test/junit/internal/sanctioned-geode-junit-serializables.txt
@@ -36,6 +36,7 @@ org/apache/geode/cache/snapshot/RegionGenerator$SerializationType,false
 org/apache/geode/cache/ssl/CertificateMaterial,false,certificate:java/security/cert/X509Certificate,issuer:java/security/cert/X509Certificate,keyPair:java/security/KeyPair
 org/apache/geode/cache30/MyGatewayTransportFilter1,false
 org/apache/geode/cache30/MyGatewayTransportFilter2,false
+org/apache/geode/codeAnalysis/SanctionedSerializablesServiceIntegrationTestBase$ServiceResourceExpectation,false
 org/apache/geode/internal/cache/SerializableObject,false,i:int,str:java/lang/String
 org/apache/geode/internal/cache/UnitTestValueHolder,false,value:java/lang/Object
 org/apache/geode/internal/cache/execute/MyFunctionExecutionException,false

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeLuceneSerializablesIntegrationTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeLuceneSerializablesIntegrationTest.java
@@ -23,7 +23,8 @@ import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category({LuceneTest.class, SerializationTest.class})
-public class AnalyzeLuceneSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeLuceneSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-management/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeManagementSerializablesIntegrationTest.java
+++ b/geode-management/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeManagementSerializablesIntegrationTest.java
@@ -23,7 +23,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
 public class AnalyzeManagementSerializablesIntegrationTest
-    extends AnalyzeSerializablesJUnitTestBase {
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-membership/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeMembershipSerializablesIntegrationTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeMembershipSerializablesIntegrationTest.java
@@ -36,7 +36,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
  */
 @Category({MembershipTest.class, SerializationTest.class})
 public class AnalyzeMembershipSerializablesIntegrationTest
-    extends AnalyzeDataSerializablesJUnitTestBase {
+    extends AnalyzeDataSerializablesWithClassAnalysisRuleTestBase {
 
   private final DSFIDSerializer dsfidSerializer =
       new DSFIDSerializerFactory().create();

--- a/geode-memcached/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeMemcachedSerializablesIntegrationTest.java
+++ b/geode-memcached/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeMemcachedSerializablesIntegrationTest.java
@@ -23,7 +23,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
 public class AnalyzeMemcachedSerializablesIntegrationTest
-    extends AnalyzeSerializablesJUnitTestBase {
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-pulse/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzePulseSerializablesIntegrationTest.java
+++ b/geode-pulse/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzePulseSerializablesIntegrationTest.java
@@ -21,7 +21,8 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzePulseSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzePulseSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-wan/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeWANSerializablesIntegrationTest.java
+++ b/geode-wan/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeWANSerializablesIntegrationTest.java
@@ -23,7 +23,8 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 import org.apache.geode.test.junit.categories.WanTest;
 
 @Category({WanTest.class, SerializationTest.class})
-public class AnalyzeWANSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeWANSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-web-api/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeWebApiSerializablesIntegrationTest.java
+++ b/geode-web-api/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeWebApiSerializablesIntegrationTest.java
@@ -23,7 +23,8 @@ import org.apache.geode.test.junit.categories.RestAPITest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category({RestAPITest.class, SerializationTest.class})
-public class AnalyzeWebApiSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeWebApiSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {


### PR DESCRIPTION
Adds support for pluggable source set paths to ClassAnalysisRule.

PROBLEM

Modules external to Geode must be structured the same as Geode
source code in order to use ClassAnalysisRule and the
Analyze*Serializables tests. This is necessary to better facilitate
pluggability of modules that need to provide sanctioned serializable 
lists.

SOLUTION

Add source set path customization to ClassAnalysisRule, introduce
a new layer of Analyze*Serializables test base classes that can be
directly extended in order to customize source set paths in
ClassAnalysisRule. Also includes improvements to some iterating
of classes during analysis.