### PR TITLE
GEODE-9820: stopCQ should handle general exception same way as ExecuteCQ61

### DIFF
--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/StopCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/StopCQ.java
@@ -111,10 +111,7 @@ public class StopCQ extends BaseCQCommand {
           serverConnection);
       return;
     } catch (Exception e) {
-      String err =
-          String.format("Exception while stopping CQ named %s :", cqName);
-      sendCqResponse(MessageType.CQ_EXCEPTION_TYPE, err, clientMessage.getTransactionId(), e,
-          serverConnection);
+      writeChunkedException(clientMessage, e, serverConnection);
       return;
     }
 


### PR DESCRIPTION
Problem:
StopCQ with expired credentials does not trigger re-authentication.

Cause:
the server side doesn't send the AuthenticationExpiredException to the client with the `MessageType.EXCEPTION`, rather it only sends down only the error message with `MessageType.CQ_EXCEPTION_TYPE`, that's now how it's generally handled. 