### PR TITLE
GEODE-9669: Improve reporting of Radish mem_fragmentation_ratio

### DIFF
--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisInfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisInfoStatsIntegrationTest.java
@@ -28,7 +28,6 @@ import org.assertj.core.data.Offset;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
@@ -142,7 +141,6 @@ public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisInte
     assertThat(Long.valueOf(getInfo(jedis).get(USED_MEMORY))).isGreaterThan(0);
   }
 
-  @Ignore("tracked by GEODE-9669") // currently we return 1.0
   @Test
   public void memFragmentation_shouldBeGreaterThanOne() {
     for (int i = 0; i < 10000; i++) {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractAppendMemoryIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractAppendMemoryIntegrationTest.java
@@ -49,6 +49,7 @@ public abstract class AbstractAppendMemoryIntegrationTest implements RedisIntegr
     int listSize = 100_000;
     String key = "key";
 
+    System.gc();
     Long startingMemValue = getUsedMemory(jedis);
 
     jedis.set(key, "initial");

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractAppendMemoryIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractAppendMemoryIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
 import java.util.Map;
 
 import org.junit.After;
@@ -59,7 +60,8 @@ public abstract class AbstractAppendMemoryIntegrationTest implements RedisIntegr
     info = RedisTestHelper.getInfo(jedis);
     Long finalMemValue = Long.valueOf(info.get("used_memory"));
 
-    assertThat(finalMemValue).isGreaterThan(previousMemValue);
+    GeodeAwaitility.await().atMost(Duration.ofSeconds(20))
+        .untilAsserted(() -> assertThat(finalMemValue).isGreaterThan(previousMemValue));
   }
 
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/InfoExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/InfoExecutor.java
@@ -133,26 +133,28 @@ public class InfoExecutor implements CommandExecutor {
    * requires. So, effectively an indication of memory pressure. If this number goes below 1.0 it
    * would indicate that the process has started to swap memory which is bad.
    * <p/>
-   * In a similar sense, the calculation for fragmentation here is a ratio of the amount of memory
-   * available to the partitioned region (Java heap) vs. the amount of memory consumed by data in
-   * the region. This ratio can only approach 1.0 and cannot go lower. However, the closer to 1.0
-   * the greater the likelihood of incurring GC pauses will be. This is analogous to swapping and
-   * will have a very similar effect.
+   * In a similar sense, the calculation for fragmentation here is a ratio of the maximum amount
+   * of memory available to the JVM (Java heap) vs. the amount of memory used by the JVM. This
+   * ratio can only approach 1.0 and cannot go lower. However, the closer to 1.0, the greater the
+   * likelihood of incurring GC pauses. This is analogous to swapping and will have a very
+   * similar effect in that it will adversely impact performance.
+   * <p/>
+   * Used memory is derived from {@link Runtime} memory and is calculated as
+   * {@code totalMemory() - freeMemory()}.
    */
   private String getMemorySection(ExecutionHandlerContext context) {
-    PartitionedRegion pr = (PartitionedRegion) context.getRegionProvider().getDataRegion();
-    long usedMemory = pr.getDataStore().currentAllocatedMemory();
+    long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 
     String fragmentationRatio;
     if (usedMemory != 0) {
-      fragmentationRatio =
-          String.format("%.2f", (pr.getLocalMaxMemory() * ONE_MEGABYTE) / (float) usedMemory);
+      fragmentationRatio = String.format("%.2f",
+          Runtime.getRuntime().maxMemory() / (float) usedMemory);
     } else {
       fragmentationRatio = "1.0";
     }
 
     return "# Memory\r\n" +
-        "maxmemory:" + pr.getLocalMaxMemory() * ONE_MEGABYTE + "\r\n" +
+        "maxmemory:" + Runtime.getRuntime().maxMemory() + "\r\n" +
         "used_memory:" + usedMemory + "\r\n" +
         "mem_fragmentation_ratio:" + fragmentationRatio + "\r\n";
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/InfoExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/InfoExecutor.java
@@ -76,7 +76,7 @@ public class InfoExecutor implements CommandExecutor {
     } else if (Arrays.equals(bytes, CLIENTS)) {
       return getClientsSection(context);
     } else if (Arrays.equals(bytes, MEMORY)) {
-      return getMemorySection(context);
+      return getMemorySection();
     } else if (Arrays.equals(bytes, KEYSPACE)) {
       return getKeyspaceSection(context);
     } else if (Arrays.equals(bytes, DEFAULT) || Arrays.equals(bytes, ALL)) {
@@ -141,7 +141,7 @@ public class InfoExecutor implements CommandExecutor {
    * Used memory is derived from {@link Runtime} memory and is calculated as
    * {@code totalMemory() - freeMemory()}.
    */
-  private String getMemorySection(ExecutionHandlerContext context) {
+  private String getMemorySection() {
     long usedMemory = Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
 
     String fragmentationRatio;
@@ -191,7 +191,7 @@ public class InfoExecutor implements CommandExecutor {
     final String SECTION_SEPARATOR = "\r\n";
     return getServerSection(context) + SECTION_SEPARATOR +
         getClientsSection(context) + SECTION_SEPARATOR +
-        getMemorySection(context) + SECTION_SEPARATOR +
+        getMemorySection() + SECTION_SEPARATOR +
         getPersistenceSection() + SECTION_SEPARATOR +
         getStatsSection(context) + SECTION_SEPARATOR +
         getKeyspaceSection(context) + SECTION_SEPARATOR +

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/InfoExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/InfoExecutor.java
@@ -31,7 +31,6 @@ import java.text.DecimalFormat;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.redis.internal.commands.Command;
 import org.apache.geode.redis.internal.commands.executor.CommandExecutor;
 import org.apache.geode.redis.internal.commands.executor.RedisResponse;


### PR DESCRIPTION
- For this implementation, this value is the ratio of memory available
  to the partitioned region (Java heap) vs. the memory used by data in
  the region.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
