### PR TITLE
GEODE-9824: Initialize AvailablePortHelper safely

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/AvailablePortHelperIntegrationTest.java
@@ -177,6 +177,7 @@ public class AvailablePortHelperIntegrationTest {
       int[] ports = getRandomAvailableTCPPorts(3);
 
       assertThat(ports)
+          .as("for jvmIndex " + i)
           .isEqualTo(previousPorts);
     }
   }


### PR DESCRIPTION
PROBLEMS

- In test JVMs, `AvailablePortHelper` initialized its next candidate
  port by selecting a random port within the available port range. This
  often caused the test JVM's first few candidates to overlap with the
  first few candidates of a child VM.
- `AvailablePortHelper` updated its next candidate port in non-atomic
  way, making it possible for multiple threads to receive the same port
  number.

SOLUTION

Change `AvailablePortHelper` to:
- Initialize its next candidate port to `AVAILABLE_PORT_LOWER_BOUND`
  instead of randomly selecting an initial candidate.
- Update its next candidate port atomically by calling
  `AtomicInteger.getAndUpdate(...)`.
