### PR TITLE
GEODE-9825: Disparate socket-buffer-size Results in "IOException: Unknown header byte" and Hangs

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/P2PMessagingConcurrencyDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/P2PMessagingConcurrencyDUnitTest.java
@@ -128,7 +128,8 @@ public class P2PMessagingConcurrencyDUnitTest {
       "false, true, 32768, 32768",
       "false, true, 65536, 32768",
       "false, false, 32768, 32768",
-      "false, false, 65536, 32768"})
+      "false, false, 65536, 32768"
+  })
   public void testP2PMessaging(
       final boolean conserveSockets,
       final boolean useTLS,

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/P2PMessagingConcurrencyDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/P2PMessagingConcurrencyDUnitTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
 
-import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.jetbrains.annotations.NotNull;
 import org.junit.ClassRule;
@@ -50,6 +49,7 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.DistributedExecutorServiceRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.MembershipTest;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 import org.apache.geode.test.version.VersionManager;
 
 /**
@@ -66,7 +66,7 @@ import org.apache.geode.test.version.VersionManager;
  *
  */
 @Category({MembershipTest.class})
-@RunWith(JUnitParamsRunner.class)
+@RunWith(GeodeParamsRunner.class)
 public class P2PMessagingConcurrencyDUnitTest {
 
   // how many messages will each sender generate?

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -2846,6 +2846,9 @@ public class Connection implements Runnable {
                       "Allocating larger network read buffer, new size is {} old size was {}.",
                       allocSize, oldBufferSize);
                   inputBuffer = inputSharing.expandReadBufferIfNeeded(allocSize);
+                  // we're returning to the caller (done == true) so make buffer writable
+                  inputBuffer.position(inputBuffer.limit());
+                  inputBuffer.limit(inputBuffer.capacity());
                 } else {
                   if (inputBuffer.position() != 0) {
                     inputBuffer.compact();

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -2846,15 +2846,12 @@ public class Connection implements Runnable {
                       "Allocating larger network read buffer, new size is {} old size was {}.",
                       allocSize, oldBufferSize);
                   inputBuffer = inputSharing.expandReadBufferIfNeeded(allocSize);
-                  // we're returning to the caller (done == true) so make buffer writable
-                  inputBuffer.position(inputBuffer.limit());
-                  inputBuffer.limit(inputBuffer.capacity());
+                  makeReadableBufferWriteable(inputBuffer);
                 } else {
                   if (inputBuffer.position() != 0) {
                     inputBuffer.compact();
                   } else {
-                    inputBuffer.position(inputBuffer.limit());
-                    inputBuffer.limit(inputBuffer.capacity());
+                    makeReadableBufferWriteable(inputBuffer);
                   }
                 }
               }
@@ -2866,6 +2863,11 @@ public class Connection implements Runnable {
         }
       }
     }
+  }
+
+  private void makeReadableBufferWriteable(final ByteBuffer inputBuffer) {
+    inputBuffer.position(inputBuffer.limit());
+    inputBuffer.limit(inputBuffer.capacity());
   }
 
   private boolean readHandshakeForReceiver(final DataInput dis) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -2770,6 +2770,9 @@ public class Connection implements Runnable {
   /**
    * processes the current NIO buffer. If there are complete messages in the buffer, they are
    * deserialized and passed to TCPConduit for further processing
+   *
+   * pre-condition: inputBuffer (from inputSharing.getBuffer()) is in WRITABLE mode
+   * post-condition: inputBuffer is in WRITABLE mode
    */
   private void processInputBuffer(AbstractExecutor threadMonitorExecutor)
       throws ConnectionException, IOException {


### PR DESCRIPTION
[GEODE-9825](https://issues.apache.org/jira/browse/GEODE-9825)

When `Connection.processInputBuffer()` needed to expand the input buffer, it was also destroying unprocessed data. This resulted in `IOException: "Unknown header byte..."` and hangs.

The `P2PMessagingConcurrencyDUnitTest` has been enhanced to test a matrix of configurations:

[conserve-sockets, useTLS, socket-buffer-size for sender, socket-buffer-size for receiver]

```
      "true, true, 32768, 32768",
      "true, true, 65536, 32768",
      "true, true, 32768, 65536",
      "true, true, 1024, 1024",
      "true, false, 32768, 32768",
      "true, false, 65536, 32768",
      "true, false, 32768, 65536",
      "true, false, 1024, 1024",
      "false, true, 32768, 32768",
      "false, true, 65536, 32768",
      "false, true, 32768, 65536",
      "false, true, 1024, 1024",
      "false, false, 32768, 32768",
      "false, false, 65536, 32768",
      "false, false, 32768, 65536",
      "false, false, 1024, 1024",
```

Without the fix in this PR, these were the test results:

<img width="640" alt="image" src="https://user-images.githubusercontent.com/4002/142896770-24feed32-20c5-486f-acbb-29ee651bbaab.png">

With the fix to `Connection.java` all these tests pass.

## TODO
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?