### PR TITLE
GEODE-9811: Turn UnavailableSecurityManagerException into CacheClosedException

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.ShiroException;
+import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.subject.support.SubjectThreadState;
@@ -36,6 +37,8 @@ import org.apache.shiro.util.ThreadContext;
 import org.apache.shiro.util.ThreadState;
 
 import org.apache.geode.GemFireIOException;
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.internal.cache.EntryEventImpl;
 import org.apache.geode.internal.security.shiro.GeodeAuthenticationToken;
 import org.apache.geode.internal.security.shiro.SecurityManagerProvider;
@@ -117,14 +120,23 @@ public class IntegratedSecurityService implements SecurityService {
       }
     }
 
-    // in other cases like rest call, client operations, we get it from the current thread
-    currentUser = SecurityUtils.getSubject();
+    try {
+      // in other cases like rest call, client operations, we get it from the current thread
+      currentUser = getCurrentUser();
+    } catch (UnavailableSecurityManagerException e) {
+      throw new CacheClosedException("Cache is closed.", e);
+    }
 
     if (currentUser == null || currentUser.getPrincipal() == null) {
       throw new AuthenticationRequiredException("Failed to find the authenticated user.");
     }
 
     return currentUser;
+  }
+
+  @VisibleForTesting
+  Subject getCurrentUser() {
+    return SecurityUtils.getSubject();
   }
 
   /**
@@ -153,7 +165,7 @@ public class IntegratedSecurityService implements SecurityService {
     // this makes sure it starts with a clean user object
     ThreadContext.remove();
 
-    Subject currentUser = SecurityUtils.getSubject();
+    Subject currentUser = getCurrentUser();
     GeodeAuthenticationToken token = new GeodeAuthenticationToken(credentials);
     try {
       logger.debug("Logging in " + token.getPrincipal());

--- a/geode-core/src/test/java/org/apache/geode/internal/security/IntegratedSecurityServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/security/IntegratedSecurityServiceTest.java
@@ -19,11 +19,13 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.Properties;
 
 import org.apache.shiro.ShiroException;
+import org.apache.shiro.UnavailableSecurityManagerException;
 import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.Subject;
 import org.apache.shiro.subject.SubjectContext;
@@ -34,6 +36,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.internal.security.shiro.GeodeAuthenticationToken;
 import org.apache.geode.internal.security.shiro.SecurityManagerProvider;
 import org.apache.geode.security.AuthenticationExpiredException;
@@ -218,5 +221,14 @@ public class IntegratedSecurityServiceTest {
         .isInstanceOf(AuthenticationFailedException.class)
         .hasCauseInstanceOf(RuntimeException.class)
         .hasMessageContaining("Authentication error. Please check your credentials.");
+  }
+
+  @Test
+  public void getSubjectShouldThrowCacheClosedExceptionIfSecurityManagerUnavailable() {
+    IntegratedSecurityService spy = spy(securityService);
+    doThrow(new UnavailableSecurityManagerException("test")).when(spy).getCurrentUser();
+    assertThatThrownBy(() -> spy.getSubject())
+        .isInstanceOf(CacheClosedException.class)
+        .hasMessageContaining("Cache is closed");
   }
 }


### PR DESCRIPTION
The client will receive this exception instead so that it can try to talk to another available server
