### PR TITLE
GEODE-9803: Fix the flaky "Failed To find authenticated user" problem

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
@@ -447,6 +447,8 @@ public class MessageDispatcher extends LoggingThread {
           } else {
             long elapsedTime = System.currentTimeMillis() - waitForReAuthenticationStartTime;
             if (elapsedTime > reAuthenticateWaitTime) {
+              // reset the timer here since we are no longer waiting for re-auth to happen anymore
+              waitForReAuthenticationStartTime = -1;
               synchronized (_stopDispatchingLock) {
                 logger.warn("Client did not re-authenticate back successfully in " + elapsedTime
                     + "ms. Unregister this client proxy.");

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -905,14 +905,14 @@ public class ServerConnection implements Runnable {
 
     Subject subject = clientUserAuths.getSubject(uniqueId);
     if (subject == null) {
-      logger.warn(
+      secureLogger.warn(
           "Failed to bind the subject of uniqueId {} for message {} with {} : Possible re-authentication required",
           uniqueId, messageType, getName());
       throw new AuthenticationRequiredException("Failed to find the authenticated user.");
     }
 
     ThreadState threadState = securityService.bindSubject(subject);
-    logger.debug("Bound {} with uniqueId {} for message {} with {}", subject.getPrincipal(),
+    secureLogger.debug("Bound {} with uniqueId {} for message {} with {}", subject.getPrincipal(),
         uniqueId, messageType, getName());
 
     return threadState;
@@ -1027,7 +1027,8 @@ public class ServerConnection implements Runnable {
       }
     }
     if (unregisterClient) {
-      // last serverconnection call all close on auth objects
+      // last server connection call all close on auth objects
+      secureLogger.debug("ServerConnection.handleTermination clean client auths");
       cleanClientAuths();
     }
     clientUserAuths = null;
@@ -1197,7 +1198,8 @@ public class ServerConnection implements Runnable {
     CacheClientProxy clientProxy =
         getAcceptor().getCacheClientNotifier().getClientProxy(getProxyID());
     // update the subject (in single user mode) in clientProxy if exists
-    if (clientProxy != null && clientProxy.getSubject() != null) {
+    if (clientProxy != null && clientProxy.getSubject() != null
+        && clientProxy.isWaitingForReAuthentication()) {
       secureLogger.debug("update subject on client proxy {} with uniqueId {}", clientProxy,
           uniqueId);
       clientProxy.setSubject(subject);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
@@ -18,6 +18,7 @@
 package org.apache.geode.internal.cache.tier.sockets;
 
 import static org.apache.geode.internal.lang.SystemPropertyHelper.RE_AUTHENTICATE_WAIT_TIME;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -153,6 +154,7 @@ public class MessageDispatcherTest {
     // since we keep throwing the AuthenticationExpiredException, we will eventually call this
     verify(dispatcher).pauseOrUnregisterProxy(any(AuthenticationExpiredException.class));
     verify(dispatcher, never()).dispatchResidualMessages();
+    assertThat(dispatcher.isWaitingForReAuthentication()).isFalse();
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -234,8 +234,14 @@ public class ServerConnectionTest {
     assertThat(userId).isEqualTo(123L);
     verify(proxy, never()).setSubject(any());
 
-    // if proxy has existing subject, then that subject will be updated
+    // if proxy has existing subject, but the proxy is not waitingForReAuth, subject won't be
+    // updated
     when(proxy.getSubject()).thenReturn(subject);
+    connection.putSubject(subject, 123L);
+    verify(proxy, never()).setSubject(any());
+
+    // if proxy has existing subject, and the proxy is waitingForReAuth, then subject is updated
+    when(proxy.isWaitingForReAuthentication()).thenReturn(true);
     connection.putSubject(subject, 123L);
     verify(proxy).setSubject(any());
   }


### PR DESCRIPTION
* Only to update suject on the ClientCacheProxy if it's waiting for re-auth
* logout the subject in one place when we close the dispatcher
