### PR TITLE
GEODE-10075 Fix jacoco code coverage reports

### DIFF
--- a/buildSrc/src/main/java/org/apache/geode/gradle/testing/isolation/WorkingDirectoryIsolator.java
+++ b/buildSrc/src/main/java/org/apache/geode/gradle/testing/isolation/WorkingDirectoryIsolator.java
@@ -71,7 +71,7 @@ public class WorkingDirectoryIsolator implements Consumer<ProcessBuilder> {
         .ifPresent(i -> updateGradleWorkerClasspathFile(command, i, newWorkingDirectory));
 
     upgradeRelativePaths(command);
-    log.warn("WorkingDirectoryIsolator updated command. New Working directory: {}, Command: {}", newWorkingDirectory, command);
+    log.debug("WorkingDirectoryIsolator updated command. New Working directory: {}, Command: {}", newWorkingDirectory, command);
   }
 
   /**

--- a/buildSrc/src/test/java/org/apache/geode/gradle/testing/isolation/WorkingDirectoryIsolatorTest.java
+++ b/buildSrc/src/test/java/org/apache/geode/gradle/testing/isolation/WorkingDirectoryIsolatorTest.java
@@ -1,0 +1,32 @@
+package org.apache.geode.gradle.testing.isolation;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.util.Arrays;
+
+import org.junit.Test;
+
+public class WorkingDirectoryIsolatorTest {
+
+  @Test
+  public void updatesRelativeUnixPaths() {
+    ProcessBuilder processBuilder = new ProcessBuilder();
+    processBuilder.directory(new File(""));
+    processBuilder.command("/bin/java", "-javaagent:../some/jacocoagent.jar=destfile=../jacoco/integrationTest.exec", "GradleWorkerMain");
+    new WorkingDirectoryIsolator().accept(processBuilder);
+
+    assertEquals(Arrays.asList("/bin/java", "-javaagent:../../some/jacocoagent.jar=destfile=../../jacoco/integrationTest.exec", "GradleWorkerMain"), processBuilder.command());
+  }
+
+  @Test
+  public void updatesRelativeWindowsPaths() {
+    ProcessBuilder processBuilder = new ProcessBuilder();
+    processBuilder.directory(new File(""));
+    processBuilder.command("/bin/java", "-javaagent:..\\some\\jacocoagent.jar=destfile=..\\jacoco\\integrationTest.exec", "GradleWorkerMain");
+    new WorkingDirectoryIsolator().accept(processBuilder);
+
+    assertEquals(Arrays.asList("/bin/java", "-javaagent:..\\..\\some\\jacocoagent.jar=destfile=..\\..\\jacoco\\integrationTest.exec", "GradleWorkerMain"), processBuilder.command());
+  }
+
+}

--- a/buildSrc/src/test/java/org/apache/geode/gradle/testing/isolation/WorkingDirectoryIsolatorTest.java
+++ b/buildSrc/src/test/java/org/apache/geode/gradle/testing/isolation/WorkingDirectoryIsolatorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
 package org.apache.geode.gradle.testing.isolation;
 
 import static org.junit.Assert.assertEquals;

--- a/gradle/code-analysis.gradle
+++ b/gradle/code-analysis.gradle
@@ -58,12 +58,6 @@ if (project.hasProperty("staticAnalysis")) {
 if (project.hasProperty("codeCoverage")) {
   apply plugin: 'jacoco'
 
-  configurations.jacocoAnt {
-    dependencies.all { dep ->
-      dep.transitive = true
-    }
-  }
-
   task mergeIntegrationTestCoverage(type: JacocoMerge) {
     description 'Merges Distributed and Integration test coverage results'
 
@@ -75,20 +69,12 @@ if (project.hasProperty("codeCoverage")) {
 
   }
 
-  jacocoTestReport {
-    reports {
-      csv.enabled false
-      sourceSets project.sourceSets.main
-      html.destination "${buildDir}/jacocoTestHtml"
-    }
-  }
-
   task jacocoIntegrationTestReport(type: JacocoReport) {
     reports {
       csv.enabled false
       sourceSets project.sourceSets.main
-      html.destination "${buildDir}/jacocoIntegrationTestHtml"
-      executionData = fileTree(dir: 'build/jacoco', include: '**/integrationTest.exec')
+      html.outputLocation  = project.file("${buildDir}/reports/jacoco/integrationTest")
+      executionData fileTree(dir: 'build/jacoco', include: '**/integrationTest.exec')
     }
   }
 
@@ -96,8 +82,8 @@ if (project.hasProperty("codeCoverage")) {
     reports {
       csv.enabled false
       sourceSets project.sourceSets.main
-      html.destination "${buildDir}/jacocoDistributedTestHtml"
-      executionData = fileTree(dir: 'build/jacoco', include: '**/distributedTest.exec')
+      html.outputLocation = project.file("${buildDir}/reports/jacoco/distributedTest")
+      executionData fileTree(dir: 'build/jacoco', include: '**/distributedTest.exec')
     }
   }
 
@@ -105,8 +91,8 @@ if (project.hasProperty("codeCoverage")) {
     reports {
       csv.enabled false
       sourceSets project.sourceSets.main
-      html.destination "${buildDir}/jacocoOverallTestHtml"
-      executionData = fileTree(dir: 'build/jacoco', include: '**/*.exec')
+      html.outputLocation = project.file("${buildDir}/reports/jacoco/all")
+      executionData fileTree(dir: 'build/jacoco', include: '**/*.exec')
     }
   }
 }


### PR DESCRIPTION
We haven't been maintaining this gradle build support, but it is useful to be
able to get code coverage from distributed test runs, eg.

./gradlew geode-core:distributedTest -PcodeCoverage \
     --tests XXX geode-core:jacocoDistributedTestReport
