### PR TITLE
GEODE-9862: pin Gradle use of jgit

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -38,6 +38,9 @@ dependencies {
   implementation('me.champeau.gradle:japicmp-gradle-plugin:0.3.0')
   implementation('junit:junit:4.13.2')
 
+  // Pin jgit to 5.13.0 to fix grgit having open dependencies on jgit, which rolled to java 11 with version 6.
+  runtimeOnly('org.eclipse.jgit:org.eclipse.jgit:5.13.0.202109080827-r')
+
   testAnnotationProcessor(this.project)
 }
 


### PR DESCRIPTION
* dependency of grgit used in GemFireVersion.properties

Authored-by: Robert Houghton <rhoughton@pivotal.io>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
