### PR TITLE
GEODE-9863: Point redis benchmarks at geode-for-redis-benchmark-baseline branch

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -36,9 +36,7 @@ benchmarks:
     max_in_flight: 3
     timeout: 12h
   - title: 'radish'
-    # The current radish baseline version is taken from the commit:
-    #   GEODE-9773: move RedisPropertiesTest to match the location of the source class
-    baseline_branch: '80bd4419998c9334d68c9a4863a800e83fad8870'
+    baseline_branch: 'geode-for-redis-benchmark-baseline'
     baseline_version: ''
     flag: '-PtestJVM=/usr/lib/jvm/bellsoft-java11-amd64 -Pbenchmark.withRedisCluster=geode -Pbenchmark.withServerCount=2'
     options: '--tests=org.apache.geode.benchmark.redis.tests.*'


### PR DESCRIPTION


- In the future, when the baseline needs to be moved, this branch can
  simply be reset to the required SHA.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
