### PR TITLE
GEODE-9811: Turn UnavailableSecurityManagerException into CacheClosedException (part 2)

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/security/IntegratedSecurityService.java
@@ -165,11 +165,14 @@ public class IntegratedSecurityService implements SecurityService {
     // this makes sure it starts with a clean user object
     ThreadContext.remove();
 
-    Subject currentUser = getCurrentUser();
+    Subject currentUser;
     GeodeAuthenticationToken token = new GeodeAuthenticationToken(credentials);
     try {
       logger.debug("Logging in " + token.getPrincipal());
+      currentUser = getCurrentUser();
       currentUser.login(token);
+    } catch (UnavailableSecurityManagerException e) {
+      throw new CacheClosedException("Cache is closed.");
     } catch (ShiroException e) {
       logger.info("error logging in: " + token.getPrincipal());
       Throwable cause = e.getCause();

--- a/geode-core/src/test/java/org/apache/geode/internal/security/IntegratedSecurityServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/security/IntegratedSecurityServiceTest.java
@@ -231,4 +231,13 @@ public class IntegratedSecurityServiceTest {
         .isInstanceOf(CacheClosedException.class)
         .hasMessageContaining("Cache is closed");
   }
+
+  @Test
+  public void loginShouldThrowCacheClosedExceptionIfSecurityManagerUnavailable() {
+    IntegratedSecurityService spy = spy(securityService);
+    doThrow(new UnavailableSecurityManagerException("test")).when(spy).getCurrentUser();
+    assertThatThrownBy(() -> spy.login(new Properties()))
+        .isInstanceOf(CacheClosedException.class)
+        .hasMessageContaining("Cache is closed");
+  }
 }


### PR DESCRIPTION
* fix this in the login method as well. CacheClosedException should be thrown all the way back to the client.
