### PR TITLE
GEODE-9867: do not process the message if the connection is terminated

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -349,6 +349,12 @@ public class ServerConnection implements Runnable {
     return executeFunctionOnLocalNodeOnly.get();
   }
 
+  @VisibleForTesting
+  void setServerConnectionCollection(
+      ServerConnectionCollection serverConnectionCollection) {
+    this.serverConnectionCollection = serverConnectionCollection;
+  }
+
   private boolean verifyClientConnection() {
     synchronized (handshakeMonitor) {
       if (handshake == null) {
@@ -816,6 +822,12 @@ public class ServerConnection implements Runnable {
       return;
     }
 
+    if (isTerminated()) {
+      // Client is being terminated, don't try to process message.
+      processMessages = false;
+      return;
+    }
+
     ThreadState threadState = null;
     resumeThreadMonitoring();
     try {
@@ -930,7 +942,8 @@ public class ServerConnection implements Runnable {
     }
   }
 
-  private void resumeThreadMonitoring() {
+  @VisibleForTesting
+  void resumeThreadMonitoring() {
     if (threadMonitorExecutor != null) {
       threadMonitorExecutor.resumeMonitoring();
     }
@@ -966,6 +979,7 @@ public class ServerConnection implements Runnable {
       }
       terminated = true;
     }
+
     setNotProcessingMessage();
     boolean clientDeparted = false;
     boolean cleanupStats = false;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -262,4 +262,18 @@ public class ServerConnectionTest {
     assertThatThrownBy(() -> spy.getUniqueIdBytes(requestMessage, -1))
         .isInstanceOf(CacheClosedException.class);
   }
+
+  @Test
+  public void doNormalMessageShouldNotProcessMessageWhenTerminated() {
+    ServerConnection spy = spy(serverConnection);
+    ServerConnectionCollection serverConnections = mock(ServerConnectionCollection.class);
+    spy.setServerConnectionCollection(serverConnections);
+    when(serverConnections.incrementConnectionsProcessing()).thenReturn(true);
+
+    doReturn(true).when(spy).isTerminated();
+
+    spy.doNormalMessage();
+    assertThat(spy.getProcessMessages()).isFalse();
+    verify(spy, never()).resumeThreadMonitoring();
+  }
 }


### PR DESCRIPTION
Connection would continue to process message even after it's been marked as terminated by the message dispatcher