### PR TITLE
add ability to turn off buffer pooling

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/P2PMessagingConcurrencyDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/P2PMessagingConcurrencyDUnitTest.java
@@ -15,9 +15,6 @@
 
 package org.apache.geode.distributed.internal;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.BYTE_BUFFER_POOL_STRATEGY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductStringProperty;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -344,8 +341,8 @@ public class P2PMessagingConcurrencyDUnitTest {
      */
     props.setProperty("conserve-sockets", String.valueOf(conserveSockets));
 
-//    getProductStringProperty(BYTE_BUFFER_POOL_STRATEGY).map( poolType ->
-//      props.setProperty(GEODE_PREFIX + BYTE_BUFFER_POOL_STRATEGY, poolType));
+    // getProductStringProperty(BYTE_BUFFER_POOL_STRATEGY).map( poolType ->
+    // props.setProperty(GEODE_PREFIX + BYTE_BUFFER_POOL_STRATEGY, poolType));
 
     return props;
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/P2PMessagingConcurrencyDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/P2PMessagingConcurrencyDUnitTest.java
@@ -15,6 +15,9 @@
 
 package org.apache.geode.distributed.internal;
 
+import static org.apache.geode.internal.lang.SystemPropertyHelper.BYTE_BUFFER_POOL_STRATEGY;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductStringProperty;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -340,6 +343,9 @@ public class P2PMessagingConcurrencyDUnitTest {
      * careful: if you set a boolean it doesn't take hold! setting a String
      */
     props.setProperty("conserve-sockets", String.valueOf(conserveSockets));
+
+//    getProductStringProperty(BYTE_BUFFER_POOL_STRATEGY).map( poolType ->
+//      props.setProperty(GEODE_PREFIX + BYTE_BUFFER_POOL_STRATEGY, poolType));
 
     return props;
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketHostNameVerificationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketHostNameVerificationIntegrationTest.java
@@ -177,7 +177,7 @@ public class SSLSocketHostNameVerificationIntegrationTest {
       socketCreator.handshakeSSLSocketChannel(clientSocket.getChannel(),
           sslEngine, 0,
           ByteBuffer.allocate(sslEngine.getSession().getPacketBufferSize()),
-          new BufferPool(mock(DMStats.class)));
+          new BufferPoolImpl(mock(DMStats.class)));
 
       if (doEndPointIdentification && !addCertificateSAN) {
         fail("Failed to validate hostname in certificate SAN");
@@ -209,7 +209,7 @@ public class SSLSocketHostNameVerificationIntegrationTest {
                 sslEngine,
                 timeoutMillis,
                 ByteBuffer.allocate(sslEngine.getSession().getPacketBufferSize()),
-                new BufferPool(mock(DMStats.class)));
+                new BufferPoolImpl(mock(DMStats.class)));
       } catch (Throwable throwable) {
         serverException = throwable;
       } finally {

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/net/SSLSocketIntegrationTest.java
@@ -228,7 +228,7 @@ public class SSLSocketIntegrationTest {
     NioSslEngine engine =
         clusterSocketCreator.handshakeSSLSocketChannel(clientSocket.getChannel(),
             clusterSocketCreator.createSSLEngine("localhost", 1234, true), 0,
-            ByteBuffer.allocate(65535), new BufferPool(mock(DMStats.class)));
+            ByteBuffer.allocate(65535), new BufferPoolImpl(mock(DMStats.class)));
     clientChannel.configureBlocking(true);
 
     // transmit expected string from Client to Server
@@ -280,7 +280,7 @@ public class SSLSocketIntegrationTest {
             sc.handshakeSSLSocketChannel(socket.getChannel(), sslEngine,
                 timeoutMillis,
                 ByteBuffer.allocate(65535),
-                new BufferPool(mock(DMStats.class)));
+                new BufferPoolImpl(mock(DMStats.class)));
         final List<SNIServerName> serverNames = sslEngine.getSSLParameters().getServerNames();
         if (serverNames != null && serverNames.stream()
             .mapToInt(SNIServerName::getType)

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.distributed.internal.direct;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.BYTE_BUFFER_POOL_STRATEGY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductStringProperty;
 
 import java.io.IOException;
 import java.io.NotSerializableException;
@@ -53,7 +51,6 @@ import org.apache.geode.internal.cache.DirectReplyMessage;
 import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.net.BufferPool;
-import org.apache.geode.internal.net.BufferPoolImpl;
 import org.apache.geode.internal.net.BufferPoolNoOp;
 import org.apache.geode.internal.tcp.BaseMsgStreamer;
 import org.apache.geode.internal.tcp.ConnectExceptions;
@@ -122,12 +119,14 @@ public class DirectChannel {
     this.dm = dm;
     this.stats = dm.getStats();
 
-    final String poolType = getProductStringProperty(BYTE_BUFFER_POOL_STRATEGY).orElse("pool");
-    if ("none".equalsIgnoreCase(poolType)) {
-      this.bufferPool = new BufferPoolNoOp();
-    } else {
-      this.bufferPool = new BufferPoolImpl(stats);
-    }
+    // TODO: once this is tested enable it instead of unconditionally constructing the no-op pool
+    // final String poolType = getProductStringProperty(BYTE_BUFFER_POOL_STRATEGY).orElse("pool");
+    // if ("none".equalsIgnoreCase(poolType)) {
+    // this.bufferPool = new BufferPoolNoOp();
+    // } else {
+    // this.bufferPool = new BufferPoolImpl(stats);
+    // }
+    this.bufferPool = new BufferPoolNoOp();
 
     DistributionConfig dc = dm.getConfig();
     this.address = initAddress(dc);

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
@@ -114,6 +114,11 @@ public class SystemPropertyHelper {
   public static final String RE_AUTHENTICATE_WAIT_TIME = "reauthenticate.wait.time";
 
   /**
+   * Either "pool" or "none". Defaults to "pool".
+   */
+  public static final String BYTE_BUFFER_POOL_STRATEGY = "byte.buffer.pool.strategy";
+
+  /**
    * This method will try to look up "geode." and "gemfire." versions of the system property. It
    * will check and prefer "geode." setting first, then try to check "gemfire." setting.
    *

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
@@ -25,8 +25,10 @@ import org.apache.geode.internal.tcp.Connection;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 public interface BufferPool {
-  @VisibleForTesting int SMALL_BUFFER_SIZE = Connection.SMALL_BUFFER_SIZE;
-  @VisibleForTesting int MEDIUM_BUFFER_SIZE = DistributionConfig.DEFAULT_SOCKET_BUFFER_SIZE;
+  @VisibleForTesting
+  int SMALL_BUFFER_SIZE = Connection.SMALL_BUFFER_SIZE;
+  @VisibleForTesting
+  int MEDIUM_BUFFER_SIZE = DistributionConfig.DEFAULT_SOCKET_BUFFER_SIZE;
   /**
    * use direct ByteBuffers instead of heap ByteBuffers for NIO operations
    */
@@ -46,10 +48,10 @@ public interface BufferPool {
   void releaseReceiveBuffer(ByteBuffer bb);
 
   ByteBuffer expandReadBufferIfNeeded(BufferType type, ByteBuffer existing,
-                                      int desiredCapacity);
+      int desiredCapacity);
 
   ByteBuffer expandWriteBufferIfNeeded(BufferType type, ByteBuffer existing,
-                                       int desiredCapacity);
+      int desiredCapacity);
 
   ByteBuffer acquireDirectBuffer(BufferType type, int capacity);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
@@ -15,377 +15,55 @@
 
 package org.apache.geode.internal.net;
 
-import java.lang.ref.SoftReference;
 import java.nio.ByteBuffer;
-import java.util.IdentityHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 
 import org.jetbrains.annotations.NotNull;
 
-import org.apache.geode.InternalGemFireException;
 import org.apache.geode.annotations.VisibleForTesting;
-import org.apache.geode.distributed.internal.DMStats;
 import org.apache.geode.distributed.internal.DistributionConfig;
-import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.tcp.Connection;
-import org.apache.geode.unsafe.internal.sun.nio.ch.DirectBuffer;
 import org.apache.geode.util.internal.GeodeGlossary;
 
-public class BufferPool {
-  private final DMStats stats;
+public interface BufferPool {
+  @VisibleForTesting int SMALL_BUFFER_SIZE = Connection.SMALL_BUFFER_SIZE;
+  @VisibleForTesting int MEDIUM_BUFFER_SIZE = DistributionConfig.DEFAULT_SOCKET_BUFFER_SIZE;
+  /**
+   * use direct ByteBuffers instead of heap ByteBuffers for NIO operations
+   */
+  boolean useDirectBuffers = !Boolean.getBoolean("p2p.nodirectBuffers")
+      || Boolean.getBoolean(GeodeGlossary.GEMFIRE_PREFIX + "BufferPool.useHeapBuffers");
+
+  ByteBuffer acquireDirectSenderBuffer(int size);
+
+  ByteBuffer acquireDirectReceiveBuffer(int size);
+
+  ByteBuffer acquireNonDirectSenderBuffer(int size);
+
+  ByteBuffer acquireNonDirectReceiveBuffer(int size);
+
+  void releaseSenderBuffer(ByteBuffer bb);
+
+  void releaseReceiveBuffer(ByteBuffer bb);
+
+  ByteBuffer expandReadBufferIfNeeded(BufferType type, ByteBuffer existing,
+                                      int desiredCapacity);
+
+  ByteBuffer expandWriteBufferIfNeeded(BufferType type, ByteBuffer existing,
+                                       int desiredCapacity);
+
+  ByteBuffer acquireDirectBuffer(BufferType type, int capacity);
+
+  void releaseBuffer(BufferType type, @NotNull ByteBuffer buffer);
+
+  @VisibleForTesting
+  ByteBuffer getPoolableBuffer(ByteBuffer buffer);
 
   /**
-   * Buffers may be acquired from the Buffers pool
-   * or they may be allocated using Buffer.allocate(). This enum is used
-   * to note the different types. Tracked buffers come from the Buffers pool
-   * and need to be released when we're done using them.
+   * Buffers may be acquired from the Buffers pool or they may be allocated using Buffer.allocate().
+   * This enum is used to note the different types. Tracked buffers come from the Buffers pool and
+   * need to be released when we're done using them.
    */
   public enum BufferType {
     UNTRACKED, TRACKED_SENDER, TRACKED_RECEIVER
   }
-
-
-  public BufferPool(DMStats stats) {
-    this.stats = stats;
-  }
-
-  /**
-   * A list of soft references to small byte buffers.
-   */
-  private final ConcurrentLinkedQueue<BBSoftReference> bufferSmallQueue =
-      new ConcurrentLinkedQueue<>();
-
-  /**
-   * A list of soft references to middle byte buffers.
-   */
-  private final ConcurrentLinkedQueue<BBSoftReference> bufferMiddleQueue =
-      new ConcurrentLinkedQueue<>();
-
-  /**
-   * A list of soft references to large byte buffers.
-   */
-  private final ConcurrentLinkedQueue<BBSoftReference> bufferLargeQueue =
-      new ConcurrentLinkedQueue<>();
-
-  static final int SMALL_BUFFER_SIZE = Connection.SMALL_BUFFER_SIZE;
-
-
-  static final int MEDIUM_BUFFER_SIZE = DistributionConfig.DEFAULT_SOCKET_BUFFER_SIZE;
-
-
-  /**
-   * use direct ByteBuffers instead of heap ByteBuffers for NIO operations
-   */
-  public static final boolean useDirectBuffers = !Boolean.getBoolean("p2p.nodirectBuffers")
-      || Boolean.getBoolean(GeodeGlossary.GEMFIRE_PREFIX + "BufferPool.useHeapBuffers");
-
-  /**
-   * Should only be called by threads that have currently acquired send permission.
-   *
-   * @return a byte buffer to be used for sending on this connection.
-   */
-  public ByteBuffer acquireDirectSenderBuffer(int size) {
-    return acquireDirectBuffer(size, true);
-  }
-
-  public ByteBuffer acquireDirectReceiveBuffer(int size) {
-    return acquireDirectBuffer(size, false);
-  }
-
-  /**
-   * try to acquire direct buffer, if enabled by configuration
-   */
-  private ByteBuffer acquireDirectBuffer(int size, boolean send) {
-    ByteBuffer result;
-
-    if (useDirectBuffers) {
-      if (size <= MEDIUM_BUFFER_SIZE) {
-        result = acquirePredefinedFixedBuffer(send, size);
-      } else {
-        result = acquireLargeBuffer(send, size);
-      }
-      if (result.capacity() > size) {
-        result.position(0).limit(size);
-        result = result.slice();
-      }
-      return result;
-    }
-    // if we are using heap buffers then don't bother with keeping them around
-    result = ByteBuffer.allocate(size);
-    updateBufferStats(size, send, false);
-    return result;
-  }
-
-  public ByteBuffer acquireNonDirectSenderBuffer(int size) {
-    ByteBuffer result = ByteBuffer.allocate(size);
-    stats.incSenderBufferSize(size, false);
-    return result;
-  }
-
-  public ByteBuffer acquireNonDirectReceiveBuffer(int size) {
-    ByteBuffer result = ByteBuffer.allocate(size);
-    stats.incReceiverBufferSize(size, false);
-    return result;
-  }
-
-  /**
-   * Acquire direct buffer with predefined default capacity (SMALL_BUFFER_SIZE or
-   * MEDIUM_BUFFER_SIZE)
-   */
-  private ByteBuffer acquirePredefinedFixedBuffer(boolean send, int size) {
-    // set
-    int defaultSize;
-    ConcurrentLinkedQueue<BBSoftReference> bufferTempQueue;
-    ByteBuffer result;
-
-    if (size <= SMALL_BUFFER_SIZE) {
-      defaultSize = SMALL_BUFFER_SIZE;
-      bufferTempQueue = bufferSmallQueue;
-    } else {
-      defaultSize = MEDIUM_BUFFER_SIZE;
-      bufferTempQueue = bufferMiddleQueue;
-    }
-
-    BBSoftReference ref = bufferTempQueue.poll();
-    while (ref != null) {
-      ByteBuffer bb = ref.getBB();
-      if (bb == null) {
-        // it was garbage collected
-        updateBufferStats(-defaultSize, ref.getSend(), true);
-      } else {
-        bb.clear();
-        if (defaultSize > size) {
-          bb.limit(size);
-        }
-        return bb;
-      }
-      ref = bufferTempQueue.poll();
-    }
-    result = ByteBuffer.allocateDirect(defaultSize);
-    updateBufferStats(defaultSize, send, true);
-    if (defaultSize > size) {
-      result.limit(size);
-    }
-    return result;
-  }
-
-  private ByteBuffer acquireLargeBuffer(boolean send, int size) {
-    // set
-    ByteBuffer result;
-    IdentityHashMap<BBSoftReference, BBSoftReference> alreadySeen = null; // keys are used like a
-    // set
-    BBSoftReference ref = bufferLargeQueue.poll();
-    while (ref != null) {
-      ByteBuffer bb = ref.getBB();
-      if (bb == null) {
-        // it was garbage collected
-        int refSize = ref.consumeSize();
-        if (refSize > 0) {
-          updateBufferStats(-refSize, ref.getSend(), true);
-        }
-      } else if (bb.capacity() >= size) {
-        bb.clear();
-        if (bb.capacity() > size) {
-          bb.limit(size);
-        }
-        return bb;
-      } else {
-        // wasn't big enough so put it back in the queue
-        Assert.assertTrue(bufferLargeQueue.offer(ref));
-        if (alreadySeen == null) {
-          alreadySeen = new IdentityHashMap<>();
-        }
-        if (alreadySeen.put(ref, ref) != null) {
-          break;
-        }
-      }
-      ref = bufferLargeQueue.poll();
-    }
-    result = ByteBuffer.allocateDirect(size);
-    updateBufferStats(size, send, true);
-    return result;
-  }
-
-  public void releaseSenderBuffer(ByteBuffer bb) {
-    releaseBuffer(bb, true);
-  }
-
-  public void releaseReceiveBuffer(ByteBuffer bb) {
-    releaseBuffer(bb, false);
-  }
-
-  /**
-   * expand a buffer that's currently being read from
-   */
-  ByteBuffer expandReadBufferIfNeeded(BufferType type, ByteBuffer existing,
-      int desiredCapacity) {
-    if (existing.capacity() >= desiredCapacity) {
-      if (existing.position() > 0) {
-        existing.compact();
-        existing.flip();
-      }
-      return existing;
-    }
-    ByteBuffer newBuffer;
-    if (existing.isDirect()) {
-      newBuffer = acquireDirectBuffer(type, desiredCapacity);
-    } else {
-      newBuffer = acquireNonDirectBuffer(type, desiredCapacity);
-    }
-    newBuffer.clear();
-    newBuffer.put(existing);
-    newBuffer.flip();
-    releaseBuffer(type, existing);
-    return newBuffer;
-  }
-
-  /**
-   * expand a buffer that's currently being written to
-   */
-  ByteBuffer expandWriteBufferIfNeeded(BufferType type, ByteBuffer existing,
-      int desiredCapacity) {
-    if (existing.capacity() >= desiredCapacity) {
-      return existing;
-    }
-    ByteBuffer newBuffer;
-    if (existing.isDirect()) {
-      newBuffer = acquireDirectBuffer(type, desiredCapacity);
-    } else {
-      newBuffer = acquireNonDirectBuffer(type, desiredCapacity);
-    }
-    newBuffer.clear();
-    existing.flip();
-    newBuffer.put(existing);
-    releaseBuffer(type, existing);
-    return newBuffer;
-  }
-
-  ByteBuffer acquireDirectBuffer(BufferPool.BufferType type, int capacity) {
-    switch (type) {
-      case UNTRACKED:
-        return ByteBuffer.allocate(capacity);
-      case TRACKED_SENDER:
-        return acquireDirectSenderBuffer(capacity);
-      case TRACKED_RECEIVER:
-        return acquireDirectReceiveBuffer(capacity);
-    }
-    throw new IllegalArgumentException("Unexpected buffer type " + type.toString());
-  }
-
-  ByteBuffer acquireNonDirectBuffer(BufferPool.BufferType type, int capacity) {
-    switch (type) {
-      case UNTRACKED:
-        return ByteBuffer.allocate(capacity);
-      case TRACKED_SENDER:
-        return acquireNonDirectSenderBuffer(capacity);
-      case TRACKED_RECEIVER:
-        return acquireNonDirectReceiveBuffer(capacity);
-    }
-    throw new IllegalArgumentException("Unexpected buffer type " + type.toString());
-  }
-
-  void releaseBuffer(BufferPool.BufferType type, @NotNull ByteBuffer buffer) {
-    switch (type) {
-      case UNTRACKED:
-        return;
-      case TRACKED_SENDER:
-        releaseSenderBuffer(buffer);
-        return;
-      case TRACKED_RECEIVER:
-        releaseReceiveBuffer(buffer);
-        return;
-    }
-    throw new IllegalArgumentException("Unexpected buffer type " + type.toString());
-  }
-
-
-  /**
-   * Releases a previously acquired buffer.
-   */
-  private void releaseBuffer(ByteBuffer buffer, boolean send) {
-    if (buffer.isDirect()) {
-      buffer = getPoolableBuffer(buffer);
-      BBSoftReference bbRef = new BBSoftReference(buffer, send);
-      if (buffer.capacity() <= SMALL_BUFFER_SIZE) {
-        bufferSmallQueue.offer(bbRef);
-      } else if (buffer.capacity() <= MEDIUM_BUFFER_SIZE) {
-        bufferMiddleQueue.offer(bbRef);
-      } else {
-        bufferLargeQueue.offer(bbRef);
-      }
-    } else {
-      updateBufferStats(-buffer.capacity(), send, false);
-    }
-  }
-
-  /**
-   * If we hand out a buffer that is larger than the requested size we create a
-   * "slice" of the buffer having the requested capacity and hand that out instead.
-   * When we put the buffer back in the pool we need to find the original, non-sliced,
-   * buffer. This is held in DirectBuffer in its "attachment" field.
-   *
-   * This method is visible for use in debugging and testing. For debugging, invoke this method if
-   * you need to see the non-sliced buffer for some reason, such as logging its hashcode.
-   */
-  @VisibleForTesting
-  ByteBuffer getPoolableBuffer(final ByteBuffer buffer) {
-    final Object attachment = DirectBuffer.attachment(buffer);
-
-    if (null == attachment) {
-      return buffer;
-    }
-
-    if (attachment instanceof ByteBuffer) {
-      return (ByteBuffer) attachment;
-    }
-
-    throw new InternalGemFireException("direct byte buffer attachment was not a byte buffer but a "
-        + attachment.getClass().getName());
-  }
-
-  /**
-   * Update buffer stats.
-   */
-  private void updateBufferStats(int size, boolean send, boolean direct) {
-    if (send) {
-      stats.incSenderBufferSize(size, direct);
-    } else {
-      stats.incReceiverBufferSize(size, direct);
-    }
-  }
-
-  /**
-   * A soft reference that remembers the size of the byte buffer it refers to. TODO Dan - I really
-   * think this should be a weak reference. The JVM doesn't seem to clear soft references if it is
-   * getting low on direct memory.
-   */
-  private static class BBSoftReference extends SoftReference<ByteBuffer> {
-    private int size;
-    private final boolean send;
-
-    BBSoftReference(ByteBuffer bb, boolean send) {
-      super(bb);
-      size = bb.capacity();
-      this.send = send;
-    }
-
-    public int getSize() {
-      return size;
-    }
-
-    synchronized int consumeSize() {
-      int result = size;
-      size = 0;
-      return result;
-    }
-
-    public boolean getSend() {
-      return send;
-    }
-
-    public ByteBuffer getBB() {
-      return super.get();
-    }
-  }
-
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPoolImpl.java
@@ -1,0 +1,380 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.net;
+
+import java.lang.ref.SoftReference;
+import java.nio.ByteBuffer;
+import java.util.IdentityHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.apache.geode.InternalGemFireException;
+import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.distributed.internal.DMStats;
+import org.apache.geode.internal.Assert;
+import org.apache.geode.unsafe.internal.sun.nio.ch.DirectBuffer;
+
+public class BufferPoolImpl implements BufferPool {
+  private final DMStats stats;
+
+
+  public BufferPoolImpl(DMStats stats) {
+    System.out.println("BGB: using real buffer pool");
+    this.stats = stats;
+  }
+
+  /**
+   * A list of soft references to small byte buffers.
+   */
+  private final ConcurrentLinkedQueue<BBSoftReference> bufferSmallQueue =
+      new ConcurrentLinkedQueue<>();
+
+  /**
+   * A list of soft references to middle byte buffers.
+   */
+  private final ConcurrentLinkedQueue<BBSoftReference> bufferMiddleQueue =
+      new ConcurrentLinkedQueue<>();
+
+  /**
+   * A list of soft references to large byte buffers.
+   */
+  private final ConcurrentLinkedQueue<BBSoftReference> bufferLargeQueue =
+      new ConcurrentLinkedQueue<>();
+
+
+  /**
+   * Should only be called by threads that have currently acquired send permission.
+   *
+   * @return a byte buffer to be used for sending on this connection.
+   */
+  @Override
+  public ByteBuffer acquireDirectSenderBuffer(int size) {
+    return acquireDirectBuffer(size, true);
+  }
+
+  @Override
+  public ByteBuffer acquireDirectReceiveBuffer(int size) {
+    return acquireDirectBuffer(size, false);
+  }
+
+  /**
+   * try to acquire direct buffer, if enabled by configuration
+   */
+  private ByteBuffer acquireDirectBuffer(int size, boolean send) {
+    ByteBuffer result;
+
+    if (useDirectBuffers) {
+      if (size <= MEDIUM_BUFFER_SIZE) {
+        result = acquirePredefinedFixedBuffer(send, size);
+      } else {
+        result = acquireLargeBuffer(send, size);
+      }
+      if (result.capacity() > size) {
+        result.position(0).limit(size);
+        result = result.slice();
+      }
+      return result;
+    }
+    // if we are using heap buffers then don't bother with keeping them around
+    result = ByteBuffer.allocate(size);
+    updateBufferStats(size, send, false);
+    return result;
+  }
+
+  @Override
+  public ByteBuffer acquireNonDirectSenderBuffer(int size) {
+    ByteBuffer result = ByteBuffer.allocate(size);
+    stats.incSenderBufferSize(size, false);
+    return result;
+  }
+
+  @Override
+  public ByteBuffer acquireNonDirectReceiveBuffer(int size) {
+    ByteBuffer result = ByteBuffer.allocate(size);
+    stats.incReceiverBufferSize(size, false);
+    return result;
+  }
+
+  /**
+   * Acquire direct buffer with predefined default capacity (SMALL_BUFFER_SIZE or
+   * MEDIUM_BUFFER_SIZE)
+   */
+  private ByteBuffer acquirePredefinedFixedBuffer(boolean send, int size) {
+    // set
+    int defaultSize;
+    ConcurrentLinkedQueue<BBSoftReference> bufferTempQueue;
+    ByteBuffer result;
+
+    if (size <= SMALL_BUFFER_SIZE) {
+      defaultSize = SMALL_BUFFER_SIZE;
+      bufferTempQueue = bufferSmallQueue;
+    } else {
+      defaultSize = MEDIUM_BUFFER_SIZE;
+      bufferTempQueue = bufferMiddleQueue;
+    }
+
+    BBSoftReference ref = bufferTempQueue.poll();
+    while (ref != null) {
+      ByteBuffer bb = ref.getBB();
+      if (bb == null) {
+        // it was garbage collected
+        updateBufferStats(-defaultSize, ref.getSend(), true);
+      } else {
+        bb.clear();
+        if (defaultSize > size) {
+          bb.limit(size);
+        }
+        return bb;
+      }
+      ref = bufferTempQueue.poll();
+    }
+    result = ByteBuffer.allocateDirect(defaultSize);
+    updateBufferStats(defaultSize, send, true);
+    if (defaultSize > size) {
+      result.limit(size);
+    }
+    return result;
+  }
+
+  private ByteBuffer acquireLargeBuffer(boolean send, int size) {
+    // set
+    ByteBuffer result;
+    IdentityHashMap<BBSoftReference, BBSoftReference> alreadySeen = null; // keys are used like a
+    // set
+    BBSoftReference ref = bufferLargeQueue.poll();
+    while (ref != null) {
+      ByteBuffer bb = ref.getBB();
+      if (bb == null) {
+        // it was garbage collected
+        int refSize = ref.consumeSize();
+        if (refSize > 0) {
+          updateBufferStats(-refSize, ref.getSend(), true);
+        }
+      } else if (bb.capacity() >= size) {
+        bb.clear();
+        if (bb.capacity() > size) {
+          bb.limit(size);
+        }
+        return bb;
+      } else {
+        // wasn't big enough so put it back in the queue
+        Assert.assertTrue(bufferLargeQueue.offer(ref));
+        if (alreadySeen == null) {
+          alreadySeen = new IdentityHashMap<>();
+        }
+        if (alreadySeen.put(ref, ref) != null) {
+          break;
+        }
+      }
+      ref = bufferLargeQueue.poll();
+    }
+    result = ByteBuffer.allocateDirect(size);
+    updateBufferStats(size, send, true);
+    return result;
+  }
+
+  @Override
+  public void releaseSenderBuffer(ByteBuffer bb) {
+    releaseBuffer(bb, true);
+  }
+
+  @Override
+  public void releaseReceiveBuffer(ByteBuffer bb) {
+    releaseBuffer(bb, false);
+  }
+
+  /**
+   * expand a buffer that's currently being read from
+   */
+  @Override
+  public ByteBuffer expandReadBufferIfNeeded(BufferType type, ByteBuffer existing,
+                                             int desiredCapacity) {
+    if (existing.capacity() >= desiredCapacity) {
+      if (existing.position() > 0) {
+        existing.compact();
+        existing.flip();
+      }
+      return existing;
+    }
+    ByteBuffer newBuffer;
+    if (existing.isDirect()) {
+      newBuffer = acquireDirectBuffer(type, desiredCapacity);
+    } else {
+      newBuffer = acquireNonDirectBuffer(type, desiredCapacity);
+    }
+    newBuffer.clear();
+    newBuffer.put(existing);
+    newBuffer.flip();
+    releaseBuffer(type, existing);
+    return newBuffer;
+  }
+
+  /**
+   * expand a buffer that's currently being written to
+   */
+  @Override
+  public ByteBuffer expandWriteBufferIfNeeded(BufferType type, ByteBuffer existing,
+                                              int desiredCapacity) {
+    if (existing.capacity() >= desiredCapacity) {
+      return existing;
+    }
+    ByteBuffer newBuffer;
+    if (existing.isDirect()) {
+      newBuffer = acquireDirectBuffer(type, desiredCapacity);
+    } else {
+      newBuffer = acquireNonDirectBuffer(type, desiredCapacity);
+    }
+    newBuffer.clear();
+    existing.flip();
+    newBuffer.put(existing);
+    releaseBuffer(type, existing);
+    return newBuffer;
+  }
+
+  @Override
+  public ByteBuffer acquireDirectBuffer(BufferPoolImpl.BufferType type, int capacity) {
+    switch (type) {
+      case UNTRACKED:
+        return ByteBuffer.allocate(capacity);
+      case TRACKED_SENDER:
+        return acquireDirectSenderBuffer(capacity);
+      case TRACKED_RECEIVER:
+        return acquireDirectReceiveBuffer(capacity);
+    }
+    throw new IllegalArgumentException("Unexpected buffer type " + type.toString());
+  }
+
+  private ByteBuffer acquireNonDirectBuffer(BufferPoolImpl.BufferType type, int capacity) {
+    switch (type) {
+      case UNTRACKED:
+        return ByteBuffer.allocate(capacity);
+      case TRACKED_SENDER:
+        return acquireNonDirectSenderBuffer(capacity);
+      case TRACKED_RECEIVER:
+        return acquireNonDirectReceiveBuffer(capacity);
+    }
+    throw new IllegalArgumentException("Unexpected buffer type " + type.toString());
+  }
+
+
+  @Override
+  public void releaseBuffer(BufferPoolImpl.BufferType type, @NotNull ByteBuffer buffer) {
+    switch (type) {
+      case UNTRACKED:
+        return;
+      case TRACKED_SENDER:
+        releaseSenderBuffer(buffer);
+        return;
+      case TRACKED_RECEIVER:
+        releaseReceiveBuffer(buffer);
+        return;
+    }
+    throw new IllegalArgumentException("Unexpected buffer type " + type.toString());
+  }
+
+
+  /**
+   * Releases a previously acquired buffer.
+   */
+  private void releaseBuffer(ByteBuffer buffer, boolean send) {
+    if (buffer.isDirect()) {
+      buffer = getPoolableBuffer(buffer);
+      BBSoftReference bbRef = new BBSoftReference(buffer, send);
+      if (buffer.capacity() <= SMALL_BUFFER_SIZE) {
+        bufferSmallQueue.offer(bbRef);
+      } else if (buffer.capacity() <= MEDIUM_BUFFER_SIZE) {
+        bufferMiddleQueue.offer(bbRef);
+      } else {
+        bufferLargeQueue.offer(bbRef);
+      }
+    } else {
+      updateBufferStats(-buffer.capacity(), send, false);
+    }
+  }
+
+  /**
+   * If we hand out a buffer that is larger than the requested size we create a
+   * "slice" of the buffer having the requested capacity and hand that out instead.
+   * When we put the buffer back in the pool we need to find the original, non-sliced,
+   * buffer. This is held in DirectBuffer in its "attachment" field.
+   *
+   * This method is visible for use in debugging and testing. For debugging, invoke this method if
+   * you need to see the non-sliced buffer for some reason, such as logging its hashcode.
+   */
+  @Override
+  @VisibleForTesting
+  public ByteBuffer getPoolableBuffer(final ByteBuffer buffer) {
+    final Object attachment = DirectBuffer.attachment(buffer);
+
+    if (null == attachment) {
+      return buffer;
+    }
+
+    if (attachment instanceof ByteBuffer) {
+      return (ByteBuffer) attachment;
+    }
+
+    throw new InternalGemFireException("direct byte buffer attachment was not a byte buffer but a "
+        + attachment.getClass().getName());
+  }
+
+  /**
+   * Update buffer stats.
+   */
+  private void updateBufferStats(int size, boolean send, boolean direct) {
+    if (send) {
+      stats.incSenderBufferSize(size, direct);
+    } else {
+      stats.incReceiverBufferSize(size, direct);
+    }
+  }
+
+  /**
+   * A soft reference that remembers the size of the byte buffer it refers to. TODO Dan - I really
+   * think this should be a weak reference. The JVM doesn't seem to clear soft references if it is
+   * getting low on direct memory.
+   */
+  private static class BBSoftReference extends SoftReference<ByteBuffer> {
+    private int size;
+    private final boolean send;
+
+    BBSoftReference(ByteBuffer bb, boolean send) {
+      super(bb);
+      size = bb.capacity();
+      this.send = send;
+    }
+
+    public int getSize() {
+      return size;
+    }
+
+    synchronized int consumeSize() {
+      int result = size;
+      size = 0;
+      return result;
+    }
+
+    public boolean getSend() {
+      return send;
+    }
+
+    public ByteBuffer getBB() {
+      return super.get();
+    }
+  }
+
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPoolImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPoolImpl.java
@@ -202,7 +202,7 @@ public class BufferPoolImpl implements BufferPool {
    */
   @Override
   public ByteBuffer expandReadBufferIfNeeded(BufferType type, ByteBuffer existing,
-                                             int desiredCapacity) {
+      int desiredCapacity) {
     if (existing.capacity() >= desiredCapacity) {
       if (existing.position() > 0) {
         existing.compact();
@@ -228,7 +228,7 @@ public class BufferPoolImpl implements BufferPool {
    */
   @Override
   public ByteBuffer expandWriteBufferIfNeeded(BufferType type, ByteBuffer existing,
-                                              int desiredCapacity) {
+      int desiredCapacity) {
     if (existing.capacity() >= desiredCapacity) {
       return existing;
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPoolNoOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPoolNoOp.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.net;
+
+import static org.apache.geode.internal.net.BufferPool.BufferType.TRACKED_RECEIVER;
+import static org.apache.geode.internal.net.BufferPool.BufferType.TRACKED_SENDER;
+import static org.apache.geode.internal.net.BufferPool.BufferType.UNTRACKED;
+
+import java.nio.ByteBuffer;
+
+import org.jetbrains.annotations.NotNull;
+
+public class BufferPoolNoOp implements BufferPool {
+  public BufferPoolNoOp() {
+    System.out.println("BGB: using no-op buffer pool");
+  }
+  @Override
+  public ByteBuffer acquireDirectSenderBuffer(final int size) {
+    return acquireDirectBuffer(TRACKED_SENDER, size);
+  }
+
+  @Override
+  public ByteBuffer acquireDirectReceiveBuffer(final int size) {
+    return acquireDirectBuffer(TRACKED_RECEIVER, size);
+  }
+
+  @Override
+  public ByteBuffer acquireNonDirectSenderBuffer(final int size) {
+    return acquireNonDirectBuffer(UNTRACKED, size);
+  }
+
+  @Override
+  public ByteBuffer acquireNonDirectReceiveBuffer(final int size) {
+    return acquireNonDirectBuffer(UNTRACKED, size);
+  }
+
+  @Override
+  public void releaseSenderBuffer(final ByteBuffer bb) {
+    // no-op
+  }
+
+  @Override
+  public void releaseReceiveBuffer(final ByteBuffer bb) {
+    // no-op
+  }
+
+  @Override
+  public ByteBuffer expandReadBufferIfNeeded(final BufferType type, final ByteBuffer existing,
+                                             final int desiredCapacity) {
+    if (existing.capacity() >= desiredCapacity) {
+      if (existing.position() > 0) {
+        existing.compact();
+        existing.flip();
+      }
+      return existing;
+    }
+    ByteBuffer newBuffer;
+    if (existing.isDirect()) {
+      newBuffer = acquireDirectBuffer(type, desiredCapacity);
+    } else {
+      newBuffer = acquireNonDirectBuffer(type, desiredCapacity);
+    }
+    newBuffer.clear();
+    newBuffer.put(existing);
+    newBuffer.flip();
+    releaseBuffer(type, existing);
+    return newBuffer;
+  }
+
+  @Override
+  public ByteBuffer expandWriteBufferIfNeeded(final BufferType type, final ByteBuffer existing,
+                                              final int desiredCapacity) {
+    if (existing.capacity() >= desiredCapacity) {
+      return existing;
+    }
+    ByteBuffer newBuffer;
+    if (existing.isDirect()) {
+      newBuffer = acquireDirectBuffer(type, desiredCapacity);
+    } else {
+      newBuffer = acquireNonDirectBuffer(type, desiredCapacity);
+    }
+    newBuffer.clear();
+    existing.flip();
+    newBuffer.put(existing);
+    releaseBuffer(type, existing);
+    return newBuffer;
+  }
+
+  @Override
+  public ByteBuffer acquireDirectBuffer(final BufferType _ignored, final int capacity) {
+    System.out.println("BGB: acquire direct " + capacity);
+    // type is unimportant for our purposes since we aren't pooling or keeping stats
+    return ByteBuffer.allocateDirect(capacity);
+  }
+
+  @Override
+  public void releaseBuffer(final BufferType type, @NotNull final ByteBuffer buffer) {
+    // no-op
+  }
+
+  @Override
+  public ByteBuffer getPoolableBuffer(final ByteBuffer buffer) {
+    // since we aren't pooling the poolable buffer is just the buffer
+    return buffer;
+  }
+
+  private ByteBuffer acquireNonDirectBuffer(BufferType _ignored, int capacity) {
+    System.out.println("BGB: acquire non-direct " + capacity);
+    // type is unimportant for our purposes since we aren't pooling or keeping stats
+    return ByteBuffer.allocate(capacity);
+  }
+
+  }

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPoolNoOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPoolNoOp.java
@@ -27,6 +27,7 @@ public class BufferPoolNoOp implements BufferPool {
   public BufferPoolNoOp() {
     System.out.println("BGB: using no-op buffer pool");
   }
+
   @Override
   public ByteBuffer acquireDirectSenderBuffer(final int size) {
     return acquireDirectBuffer(TRACKED_SENDER, size);
@@ -59,7 +60,7 @@ public class BufferPoolNoOp implements BufferPool {
 
   @Override
   public ByteBuffer expandReadBufferIfNeeded(final BufferType type, final ByteBuffer existing,
-                                             final int desiredCapacity) {
+      final int desiredCapacity) {
     if (existing.capacity() >= desiredCapacity) {
       if (existing.position() > 0) {
         existing.compact();
@@ -82,7 +83,7 @@ public class BufferPoolNoOp implements BufferPool {
 
   @Override
   public ByteBuffer expandWriteBufferIfNeeded(final BufferType type, final ByteBuffer existing,
-                                              final int desiredCapacity) {
+      final int desiredCapacity) {
     if (existing.capacity() >= desiredCapacity) {
       return existing;
     }
@@ -101,7 +102,6 @@ public class BufferPoolNoOp implements BufferPool {
 
   @Override
   public ByteBuffer acquireDirectBuffer(final BufferType _ignored, final int capacity) {
-    System.out.println("BGB: acquire direct " + capacity);
     // type is unimportant for our purposes since we aren't pooling or keeping stats
     return ByteBuffer.allocateDirect(capacity);
   }
@@ -118,9 +118,8 @@ public class BufferPoolNoOp implements BufferPool {
   }
 
   private ByteBuffer acquireNonDirectBuffer(BufferType _ignored, int capacity) {
-    System.out.println("BGB: acquire non-direct " + capacity);
     // type is unimportant for our purposes since we aren't pooling or keeping stats
     return ByteBuffer.allocate(capacity);
   }
 
-  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioFilter.java
@@ -51,7 +51,7 @@ public interface NioFilter {
    * invoked before readAtLeast. A new buffer may be returned by this method.
    */
   ByteBuffer ensureWrappedCapacity(int amount, ByteBuffer wrappedBuffer,
-      BufferPool.BufferType bufferType);
+      BufferPoolImpl.BufferType bufferType);
 
   /**
    * read at least the indicated amount of bytes from the given socket. The buffer position will be

--- a/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/NioPlainEngine.java
@@ -57,7 +57,7 @@ public class NioPlainEngine implements NioFilter {
 
   @Override
   public ByteBuffer ensureWrappedCapacity(int amount, ByteBuffer wrappedBuffer,
-      BufferPool.BufferType bufferType) {
+      BufferPoolImpl.BufferType bufferType) {
     ByteBuffer buffer = wrappedBuffer;
 
     if (buffer == null) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgReader.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/MsgReader.java
@@ -25,7 +25,7 @@ import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.ReplyProcessor21;
 import org.apache.geode.internal.Assert;
 import org.apache.geode.internal.InternalDataSerializer;
-import org.apache.geode.internal.net.BufferPool;
+import org.apache.geode.internal.net.BufferPoolImpl;
 import org.apache.geode.internal.net.ByteBufferSharing;
 import org.apache.geode.internal.net.NioFilter;
 import org.apache.geode.internal.serialization.KnownVersion;
@@ -126,7 +126,7 @@ public class MsgReader {
 
   private ByteBufferSharing readAtLeast(int bytes) throws IOException {
     peerNetData = ioFilter.ensureWrappedCapacity(bytes, peerNetData,
-        BufferPool.BufferType.TRACKED_RECEIVER);
+        BufferPoolImpl.BufferType.TRACKED_RECEIVER);
     return ioFilter.readAtLeast(conn.getSocket().getChannel(), bytes, peerNetData);
   }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/net/BufferPoolTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/BufferPoolTest.java
@@ -32,7 +32,7 @@ public class BufferPoolTest {
 
   @Before
   public void setup() {
-    bufferPool = new BufferPool(mock(DMStats.class));
+    bufferPool = new BufferPoolImpl(mock(DMStats.class));
   }
 
   @Test
@@ -58,7 +58,7 @@ public class BufferPoolTest {
   private void createAndVerifyNewWriteBuffer(ByteBuffer buffer, boolean useDirectBuffer) {
     buffer.position(buffer.capacity());
     ByteBuffer newBuffer =
-        bufferPool.expandWriteBufferIfNeeded(BufferPool.BufferType.UNTRACKED, buffer, 500);
+        bufferPool.expandWriteBufferIfNeeded(BufferPoolImpl.BufferType.UNTRACKED, buffer, 500);
     assertEquals(buffer.position(), newBuffer.position());
     assertEquals(500, newBuffer.capacity());
     newBuffer.flip();
@@ -73,7 +73,7 @@ public class BufferPoolTest {
     buffer.position(0);
     buffer.limit(256);
     ByteBuffer newBuffer =
-        bufferPool.expandReadBufferIfNeeded(BufferPool.BufferType.UNTRACKED, buffer, 500);
+        bufferPool.expandReadBufferIfNeeded(BufferPoolImpl.BufferType.UNTRACKED, buffer, 500);
     assertEquals(0, newBuffer.position());
     assertEquals(500, newBuffer.capacity());
     for (int i = 0; i < 256; i++) {
@@ -91,7 +91,7 @@ public class BufferPoolTest {
     buffer.position(7);
     buffer.limit(16384);
     ByteBuffer newBuffer =
-        bufferPool.expandReadBufferIfNeeded(BufferPool.BufferType.UNTRACKED, buffer,
+        bufferPool.expandReadBufferIfNeeded(BufferPoolImpl.BufferType.UNTRACKED, buffer,
             40899);
     assertThat(newBuffer.capacity()).isGreaterThanOrEqualTo(40899);
     // buffer should be ready to read the same amount of data
@@ -106,7 +106,7 @@ public class BufferPoolTest {
     buffer.position(16384);
     buffer.limit(buffer.capacity());
     ByteBuffer newBuffer =
-        bufferPool.expandWriteBufferIfNeeded(BufferPool.BufferType.UNTRACKED, buffer,
+        bufferPool.expandWriteBufferIfNeeded(BufferPoolImpl.BufferType.UNTRACKED, buffer,
             40899);
     assertThat(newBuffer.capacity()).isGreaterThanOrEqualTo(40899);
     // buffer should have the same amount of data as the old one

--- a/geode-core/src/test/java/org/apache/geode/internal/net/ByteBufferConcurrencyTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/ByteBufferConcurrencyTest.java
@@ -50,10 +50,10 @@ public class ByteBufferConcurrencyTest {
   @Test
   public void concurrentDestructAndOpenCloseShouldReturnToPoolOnce(final ParallelExecutor executor)
       throws Exception {
-    final BufferPool poolMock = mock(BufferPool.class);
+    final BufferPool poolMock = mock(BufferPoolImpl.class);
     final ByteBuffer someBuffer = ByteBuffer.allocate(1);
     final ByteBufferVendor vendor =
-        new ByteBufferVendor(someBuffer, BufferPool.BufferType.TRACKED_SENDER,
+        new ByteBufferVendor(someBuffer, BufferPoolImpl.BufferType.TRACKED_SENDER,
             poolMock);
 
     final RunnableWithException useBuffer = () -> {
@@ -92,7 +92,7 @@ public class ByteBufferConcurrencyTest {
   public void concurrentDestructAndOpenShouldNotAllowUseOfReturnedBuffer(
       final ParallelExecutor executor)
       throws Exception {
-    final BufferPool poolMock = mock(BufferPool.class);
+    final BufferPool poolMock = mock(BufferPoolImpl.class);
     final AtomicBoolean returned = new AtomicBoolean(false);
     doAnswer(arguments -> {
       returned.set(true);
@@ -101,7 +101,7 @@ public class ByteBufferConcurrencyTest {
 
     final ByteBuffer someBuffer = ByteBuffer.allocate(1);
     final ByteBufferVendor vendor =
-        new ByteBufferVendor(someBuffer, BufferPool.BufferType.TRACKED_SENDER,
+        new ByteBufferVendor(someBuffer, BufferPoolImpl.BufferType.TRACKED_SENDER,
             poolMock);
 
     final RunnableWithException accessBufferAndVerify = () -> {
@@ -135,10 +135,10 @@ public class ByteBufferConcurrencyTest {
   @Test
   public void concurrentAccessToSharingShouldBeExclusive(final ParallelExecutor executor)
       throws Exception {
-    final BufferPool poolMock = mock(BufferPool.class);
+    final BufferPool poolMock = mock(BufferPoolImpl.class);
     final ByteBuffer someBuffer = ByteBuffer.allocate(1);
     final ByteBufferVendor vendor =
-        new ByteBufferVendor(someBuffer, BufferPool.BufferType.TRACKED_SENDER,
+        new ByteBufferVendor(someBuffer, BufferPoolImpl.BufferType.TRACKED_SENDER,
             poolMock);
 
     final AtomicBoolean inUse = new AtomicBoolean(false);
@@ -164,10 +164,10 @@ public class ByteBufferConcurrencyTest {
   public void concurrentAccessToSharingShouldBeExclusiveWithExtraCloses(
       final ParallelExecutor executor)
       throws Exception {
-    final BufferPool poolMock = mock(BufferPool.class);
+    final BufferPool poolMock = mock(BufferPoolImpl.class);
     final ByteBuffer someBuffer = ByteBuffer.allocate(1);
     final ByteBufferVendor vendor =
-        new ByteBufferVendor(someBuffer, BufferPool.BufferType.TRACKED_SENDER,
+        new ByteBufferVendor(someBuffer, BufferPoolImpl.BufferType.TRACKED_SENDER,
             poolMock);
 
     final AtomicBoolean inUse = new AtomicBoolean(false);

--- a/geode-core/src/test/java/org/apache/geode/internal/net/ByteBufferVendorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/ByteBufferVendorTest.java
@@ -43,9 +43,9 @@ public class ByteBufferVendorTest {
 
   @Before
   public void before() {
-    poolMock = mock(BufferPool.class);
+    poolMock = mock(BufferPoolImpl.class);
     sharingVendor =
-        new ByteBufferVendor(mock(ByteBuffer.class), BufferPool.BufferType.TRACKED_SENDER,
+        new ByteBufferVendor(mock(ByteBuffer.class), BufferPoolImpl.BufferType.TRACKED_SENDER,
             poolMock);
     clientHasOpenedResource = new CountDownLatch(1);
     clientMayComplete = new CountDownLatch(1);

--- a/geode-core/src/test/java/org/apache/geode/internal/net/NioPlainEngineTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/NioPlainEngineTest.java
@@ -42,7 +42,7 @@ public class NioPlainEngineTest {
   @Before
   public void setUp() throws Exception {
     mockStats = mock(DMStats.class);
-    bufferPool = new BufferPool(mockStats);
+    bufferPool = new BufferPoolImpl(mockStats);
     nioEngine = new NioPlainEngine(bufferPool);
   }
 
@@ -62,7 +62,7 @@ public class NioPlainEngineTest {
     nioEngine.lastReadPosition = 10;
     int requestedCapacity = 210;
     ByteBuffer result = nioEngine.ensureWrappedCapacity(requestedCapacity, wrappedBuffer,
-        BufferPool.BufferType.TRACKED_RECEIVER);
+        BufferPoolImpl.BufferType.TRACKED_RECEIVER);
     verify(mockStats, times(2)).incReceiverBufferSize(any(Long.class), any(Boolean.class));
     assertThat(result.capacity()).isGreaterThanOrEqualTo(requestedCapacity);
     assertThat(result).isGreaterThanOrEqualTo(wrappedBuffer);
@@ -86,7 +86,7 @@ public class NioPlainEngineTest {
     nioEngine.lastReadPosition = consumedDataPresentInBuffer + unconsumedDataPresentInBuffer;
     ByteBuffer result =
         wrappedBuffer = nioEngine.ensureWrappedCapacity(requestedCapacity, wrappedBuffer,
-            BufferPool.BufferType.UNTRACKED);
+            BufferPoolImpl.BufferType.UNTRACKED);
     assertThat(result.capacity()).isEqualTo(requestedCapacity + unconsumedDataPresentInBuffer);
     assertThat(result).isSameAs(wrappedBuffer);
     // make sure that data was transferred to the new buffer

--- a/geode-core/src/test/java/org/apache/geode/internal/net/NioSslEngineTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/NioSslEngineTest.java
@@ -82,7 +82,7 @@ public class NioSslEngineTest {
 
     mockStats = mock(DMStats.class);
 
-    final BufferPool bufferPool = new BufferPool(mockStats);
+    final BufferPool bufferPool = new BufferPoolImpl(mockStats);
     spyBufferPool = spy(bufferPool);
     nioSslEngine = new NioSslEngine(mockEngine, spyBufferPool);
     spyNioSslEngine = spy(nioSslEngine);
@@ -125,7 +125,7 @@ public class NioSslEngineTest {
     verify(mockEngine, atLeast(2)).getHandshakeStatus();
     verify(mockEngine, times(3)).wrap(any(ByteBuffer.class), any(ByteBuffer.class));
     verify(mockEngine, times(3)).unwrap(any(ByteBuffer.class), any(ByteBuffer.class));
-    verify(spyBufferPool, times(2)).expandWriteBufferIfNeeded(any(BufferPool.BufferType.class),
+    verify(spyBufferPool, times(2)).expandWriteBufferIfNeeded(any(BufferPoolImpl.BufferType.class),
         any(ByteBuffer.class), any(Integer.class));
     verify(spyNioSslEngine, times(1)).handleBlockingTasks();
     verify(mockChannel, times(3)).read(any(ByteBuffer.class));
@@ -212,7 +212,7 @@ public class NioSslEngineTest {
       try (final ByteBufferSharing outputSharing2 = spyNioSslEngine.wrap(appData)) {
         ByteBuffer wrappedBuffer = outputSharing2.getBuffer();
 
-        verify(spyBufferPool, times(1)).expandWriteBufferIfNeeded(any(BufferPool.BufferType.class),
+        verify(spyBufferPool, times(1)).expandWriteBufferIfNeeded(any(BufferPoolImpl.BufferType.class),
             any(ByteBuffer.class), any(Integer.class));
         appData.flip();
         assertThat(wrappedBuffer).isEqualTo(appData);
@@ -424,14 +424,14 @@ public class NioSslEngineTest {
   public void ensureWrappedCapacityOfSmallMessage() {
     ByteBuffer buffer = ByteBuffer.allocate(netBufferSize);
     assertThat(
-        nioSslEngine.ensureWrappedCapacity(10, buffer, BufferPool.BufferType.UNTRACKED))
+        nioSslEngine.ensureWrappedCapacity(10, buffer, BufferPoolImpl.BufferType.UNTRACKED))
             .isEqualTo(buffer);
   }
 
   @Test
   public void ensureWrappedCapacityWithNoBuffer() {
     assertThat(
-        nioSslEngine.ensureWrappedCapacity(10, null, BufferPool.BufferType.UNTRACKED)
+        nioSslEngine.ensureWrappedCapacity(10, null, BufferPoolImpl.BufferType.UNTRACKED)
             .capacity())
                 .isEqualTo(netBufferSize);
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/net/NioSslEngineTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/net/NioSslEngineTest.java
@@ -212,7 +212,8 @@ public class NioSslEngineTest {
       try (final ByteBufferSharing outputSharing2 = spyNioSslEngine.wrap(appData)) {
         ByteBuffer wrappedBuffer = outputSharing2.getBuffer();
 
-        verify(spyBufferPool, times(1)).expandWriteBufferIfNeeded(any(BufferPoolImpl.BufferType.class),
+        verify(spyBufferPool, times(1)).expandWriteBufferIfNeeded(
+            any(BufferPoolImpl.BufferType.class),
             any(ByteBuffer.class), any(Integer.class));
         appData.flip();
         assertThat(wrappedBuffer).isEqualTo(appData);

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/ConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/ConnectionTest.java
@@ -47,7 +47,7 @@ import org.apache.geode.distributed.internal.DistributionManager;
 import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
 import org.apache.geode.internal.monitoring.executor.AbstractExecutor;
-import org.apache.geode.internal.net.BufferPool;
+import org.apache.geode.internal.net.BufferPoolImpl;
 import org.apache.geode.internal.net.SocketCloser;
 import org.apache.geode.test.junit.categories.MembershipTest;
 
@@ -85,7 +85,7 @@ public class ConnectionTest {
     ThreadsMonitoring threadMonitoring = mock(ThreadsMonitoring.class);
     AbstractExecutor abstractExecutor = mock(AbstractExecutor.class);
 
-    when(connectionTable.getBufferPool()).thenReturn(new BufferPool(dmStats));
+    when(connectionTable.getBufferPool()).thenReturn(new BufferPoolImpl(dmStats));
     when(connectionTable.getConduit()).thenReturn(tcpConduit);
     when(connectionTable.getDM()).thenReturn(distributionManager);
     when(connectionTable.getSocketCloser()).thenReturn(socketCloser);
@@ -114,7 +114,7 @@ public class ConnectionTest {
     TCPConduit tcpConduit = mock(TCPConduit.class);
 
     when(connectionTable.getConduit()).thenReturn(tcpConduit);
-    when(connectionTable.getBufferPool()).thenReturn(mock(BufferPool.class));
+    when(connectionTable.getBufferPool()).thenReturn(mock(BufferPoolImpl.class));
     when(distributionConfig.getMemberTimeout()).thenReturn(100);
     when(tcpConduit.getSocketId()).thenReturn(new InetSocketAddress(getLocalHost(), 12345));
 
@@ -136,7 +136,7 @@ public class ConnectionTest {
     SocketCloser socketCloser = mock(SocketCloser.class);
     TCPConduit tcpConduit = mock(TCPConduit.class);
 
-    when(connectionTable.getBufferPool()).thenReturn(new BufferPool(dmStats));
+    when(connectionTable.getBufferPool()).thenReturn(new BufferPoolImpl(dmStats));
     when(connectionTable.getConduit()).thenReturn(tcpConduit);
     when(connectionTable.getDM()).thenReturn(distributionManager);
     when(connectionTable.getSocketCloser()).thenReturn(socketCloser);

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/MsgStreamerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/MsgStreamerTest.java
@@ -39,11 +39,12 @@ import org.apache.geode.distributed.internal.DistributionMessage;
 import org.apache.geode.distributed.internal.SerialAckedMessage;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.net.BufferPool;
+import org.apache.geode.internal.net.BufferPoolImpl;
 import org.apache.geode.internal.serialization.KnownVersion;
 
 public class MsgStreamerTest {
   private DMStats stats = mock(DMStats.class);
-  private BufferPool pool = spy(new BufferPool(stats));
+  private BufferPool pool = spy(new BufferPoolImpl(stats));
   Connection connection1 = mock(Connection.class);
   Connection connection2 = mock(Connection.class);
 

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/TCPConduitTest.java
@@ -46,7 +46,7 @@ import org.apache.geode.distributed.internal.direct.DirectChannel;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.distributed.internal.membership.api.Membership;
 import org.apache.geode.internal.inet.LocalHostUtil;
-import org.apache.geode.internal.net.BufferPool;
+import org.apache.geode.internal.net.BufferPoolImpl;
 import org.apache.geode.internal.net.SSLConfig;
 import org.apache.geode.internal.net.SocketCreator;
 
@@ -77,7 +77,7 @@ public class TCPConduitTest {
   public void closedConduitDoesNotThrowNPEWhenAskedForBufferPool() {
     directChannel.getDM(); // Mockito demands that this mock be used in this test
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPoolImpl.class),
             new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
@@ -89,7 +89,7 @@ public class TCPConduitTest {
   public void getConnectionThrowsAlertingIOException_ifCaughtIOException_whileAlerting()
       throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPoolImpl.class),
             new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
@@ -113,7 +113,7 @@ public class TCPConduitTest {
   @Test
   public void getConnectionRethrows_ifCaughtIOException_whileNotAlerting() throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPoolImpl.class),
             new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
@@ -138,7 +138,7 @@ public class TCPConduitTest {
   @Test
   public void getConnectionRethrows_ifCaughtIOException_whenMemberDoesNotExist() throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPoolImpl.class),
             new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
@@ -159,7 +159,7 @@ public class TCPConduitTest {
   @Test
   public void getConnectionRethrows_ifCaughtIOException_whenMemberIsShunned() throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPoolImpl.class),
             new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
@@ -183,7 +183,7 @@ public class TCPConduitTest {
   public void getConnectionThrowsDistributedSystemDisconnectedException_ifCaughtIOException_whenShutdownIsInProgress()
       throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPoolImpl.class),
             new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);
@@ -209,7 +209,7 @@ public class TCPConduitTest {
   public void getConnectionThrowsDistributedSystemDisconnectedException_ifCaughtIOException_whenShutdownIsInProgress_andCancelIsInProgress()
       throws Exception {
     TCPConduit tcpConduit =
-        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPool.class),
+        new TCPConduit(membership, 0, localHost, false, directChannel, mock(BufferPoolImpl.class),
             new Properties(),
             TCPConduit -> connectionTable, socketCreator, doNothing(), false);
     InternalDistributedMember member = mock(InternalDistributedMember.class);


### PR DESCRIPTION
Working on a P2P messaging bug. Adding ability to turn off pooling of `ByteBuffer`s by setting new system property: `-Dgeode.byte.buffer.pool.strategy=none`

I haven't fully tested the system property switch yet, so **for now (11/3/2021) this PR unconditionally uses a no-op buffer pool**. To make it unconditional:

- [ ] figure out how to pass along system property from test invocation to DUnit VM invocations in `P2PMessagingConcurrencyDUnitTest`
- [ ] uncomment `geode.byte.buffer.pool.strategy` system property handling logic
- [ ] run `P2PMessagingConcurrencyDUnitTest` with `-Dgeode.byte.buffer.pool.strategy=none` and verify the no-op `BufferPoolNoOp` is used (and the test passes)

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
