### PR TITLE
GEODE-9758: Move ClassUtils to geode-common

### DIFF
--- a/geode-common/src/main/java/org/apache/geode/internal/lang/utils/ClassUtils.java
+++ b/geode-common/src/main/java/org/apache/geode/internal/lang/utils/ClassUtils.java
@@ -13,7 +13,7 @@
  * the License.
  */
 
-package org.apache.geode.internal.lang;
+package org.apache.geode.internal.lang.utils;
 
 import org.apache.geode.annotations.Immutable;
 

--- a/geode-common/src/test/java/org/apache/geode/internal/lang/utils/ClassUtilsTest.java
+++ b/geode-common/src/test/java/org/apache/geode/internal/lang/utils/ClassUtilsTest.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.internal.lang;
+package org.apache.geode.internal.lang.utils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -22,20 +22,20 @@ import static org.junit.Assert.assertTrue;
 import java.util.Calendar;
 import java.util.Date;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
-
 
 /**
  * The ClassUtilsJUnitTest class is a test suite with test cases to test the contract and
  * functionality of the ClassUtils class.
  * <p/>
  *
- * @see org.apache.geode.internal.lang.ClassUtils
+ * @see ClassUtils
  * @see org.junit.Assert
  * @see org.junit.Test
  * @since GemFire 7.0
  */
-public class ClassUtilsJUnitTest {
+public class ClassUtilsTest {
 
   @Test
   public void testForNameWithExistingClass() {

--- a/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/AbstractLauncher.java
@@ -18,9 +18,9 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.apache.commons.lang3.StringUtils.lowerCase;
 import static org.apache.geode.distributed.ConfigurationProperties.NAME;
-import static org.apache.geode.internal.lang.ClassUtils.forName;
 import static org.apache.geode.internal.lang.StringUtils.defaultString;
 import static org.apache.geode.internal.lang.SystemUtils.CURRENT_DIRECTORY;
+import static org.apache.geode.internal.lang.utils.ClassUtils.forName;
 
 import java.io.File;
 import java.io.FileReader;

--- a/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
@@ -105,7 +105,7 @@ import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.OldClientSupportService;
 import org.apache.geode.internal.cache.tier.sockets.Part;
 import org.apache.geode.internal.classloader.ClassPathLoader;
-import org.apache.geode.internal.lang.ClassUtils;
+import org.apache.geode.internal.lang.utils.ClassUtils;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.serialization.BasicSerializable;
 import org.apache.geode.internal.serialization.DSCODE;

--- a/geode-core/src/test/java/org/apache/geode/internal/InternalDataSerializerSerializationAcceptlistTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/InternalDataSerializerSerializationAcceptlistTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal;
 import static java.util.Collections.emptySet;
 import static org.apache.geode.distributed.internal.DistributionConfig.SERIALIZABLE_OBJECT_FILTER_NAME;
 import static org.apache.geode.distributed.internal.DistributionConfig.VALIDATE_SERIALIZABLE_OBJECTS_NAME;
-import static org.apache.geode.internal.lang.ClassUtils.isClassAvailable;
+import static org.apache.geode.internal.lang.utils.ClassUtils.isClassAvailable;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.junit.Assume.assumeTrue;

--- a/geode-core/src/test/java/org/apache/geode/internal/InternalDataSerializerShiroAcceptListTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/InternalDataSerializerShiroAcceptListTest.java
@@ -16,7 +16,7 @@ package org.apache.geode.internal;
 
 import static java.util.Collections.emptySet;
 import static org.apache.geode.distributed.internal.DistributionConfig.VALIDATE_SERIALIZABLE_OBJECTS_NAME;
-import static org.apache.geode.internal.lang.ClassUtils.isClassAvailable;
+import static org.apache.geode.internal.lang.utils.ClassUtils.isClassAvailable;
 import static org.apache.geode.internal.serialization.KnownVersion.CURRENT;
 import static org.junit.Assume.assumeTrue;
 

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeDiskStoreCommand.java
@@ -23,7 +23,7 @@ import org.springframework.shell.core.annotation.CliOption;
 
 import org.apache.geode.cache.execute.ResultCollector;
 import org.apache.geode.distributed.DistributedMember;
-import org.apache.geode.internal.lang.ClassUtils;
+import org.apache.geode.internal.lang.utils.ClassUtils;
 import org.apache.geode.management.cli.CliMetaData;
 import org.apache.geode.management.cli.ConverterHint;
 import org.apache.geode.management.cli.GfshCommand;

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/shell/Gfsh.java
@@ -16,7 +16,6 @@ package org.apache.geode.management.internal.cli.shell;
 
 import static java.lang.System.lineSeparator;
 import static org.apache.geode.internal.util.ProductVersionUtil.getDistributionVersion;
-import static org.apache.geode.internal.util.ProductVersionUtil.getFullVersion;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -50,7 +49,7 @@ import org.springframework.shell.event.ShellStatus.Status;
 import org.apache.geode.annotations.internal.MakeNotStatic;
 import org.apache.geode.annotations.internal.MutableForTesting;
 import org.apache.geode.internal.SystemDescription;
-import org.apache.geode.internal.lang.ClassUtils;
+import org.apache.geode.internal.lang.utils.ClassUtils;
 import org.apache.geode.internal.logging.Banner;
 import org.apache.geode.internal.process.signal.AbstractSignalNotificationHandler;
 import org.apache.geode.internal.serialization.KnownVersion;

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/CompiledClassUtils.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/CompiledClassUtils.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.codeAnalysis;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -300,11 +302,11 @@ public class CompiledClassUtils {
     String line;
     while ((line = in.readLine()) != null) {
       line = line.trim();
-      if (line.startsWith("#") || line.startsWith("//")) {
+      if (isBlank(line) || line.startsWith("#") || line.startsWith("//")) {
         // comment line
-      } else {
-        result.add(new ClassAndVariableDetails(line));
+        continue;
       }
+      result.add(new ClassAndVariableDetails(line));
     }
     return result;
   }

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/SerializationDependenciesTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/SerializationDependenciesTest.java
@@ -43,6 +43,7 @@ public class SerializationDependenciesTest {
           resideInAPackage("org.apache.geode.internal.serialization..")
               .or(not(resideInAPackage("org.apache.geode..")))
               .or(resideInAPackage("org.apache.geode.annotations.."))
-              .or(resideInAPackage("org.apache.geode.logging.."))
+              .or(resideInAPackage("org.apache.geode.internal.lang.utils.."))
+              .or(resideInAPackage("org.apache.geode.logging.internal.log4j.api.."))
               .or(resideInAPackage("org.apache.geode.test..")));
 }

--- a/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/util/NumberUtils.java
+++ b/geode-web-api/src/main/java/org/apache/geode/rest/internal/web/util/NumberUtils.java
@@ -17,7 +17,7 @@ package org.apache.geode.rest.internal.web.util;
 
 import org.springframework.util.StringUtils;
 
-import org.apache.geode.internal.lang.ClassUtils;
+import org.apache.geode.internal.lang.utils.ClassUtils;
 
 /**
  * The NumberUtils class is a utility class for working with numbers.


### PR DESCRIPTION
Serialization filtering pull requests can be very large so it may be
better to submit this change separately to help with reviews.

This PR consists of just the one commit below on top of #7165.

Please review only this commit:

[GEODE-9758: Move ClassUtils to geode-common ](https://github.com/apache/geode/pull/7166/commits/e2c65a14f6adba10ed4596c59850b9fee9ab4002)

Move ClassUtils to geode-common so that geode-serialization
can use ClassUtils.

Remove "JUnit" from the name of a couple tests.