### PR TITLE
GEODE-9873: Add AuthenticationExpiredException message to Radish error response

### DIFF
--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/ExpiringSecurityManager.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/ExpiringSecurityManager.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis;
+
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import org.apache.geode.examples.SimpleSecurityManager;
+import org.apache.geode.security.AuthenticationExpiredException;
+import org.apache.geode.security.AuthenticationFailedException;
+import org.apache.geode.security.ResourcePermission;
+
+public class ExpiringSecurityManager extends SimpleSecurityManager {
+  private final Set<String> expiredUsers = new HashSet<>();
+
+  @Override
+  public Object authenticate(final Properties credentials) throws AuthenticationFailedException {
+    String user = (String) super.authenticate(credentials);
+    if (expiredUsers.remove(user)) {
+      throw new AuthenticationExpiredException("User has expired.");
+    }
+
+    return user;
+  }
+
+  @Override
+  public boolean authorize(Object principal, ResourcePermission permission) {
+    String user = (String) principal;
+    if (expiredUsers.remove(user)) {
+      throw new AuthenticationExpiredException("User has expired.");
+    }
+
+    return super.authorize(principal, permission);
+  }
+
+  public void addExpiredUser(String user) {
+    expiredUsers.add(user);
+  }
+
+  public void reset() {
+    expiredUsers.clear();
+  }
+}

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/UserExpirationDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/UserExpirationDUnitTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis;
+
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.lettuce.core.cluster.RedisClusterClient;
+import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import redis.clients.jedis.BinaryJedisCluster;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+import org.apache.geode.test.dunit.rules.SerializableFunction;
+import org.apache.geode.test.junit.rules.ServerStarterRule;
+
+public class UserExpirationDUnitTest {
+
+  @ClassRule
+  public static RedisClusterStartupRule cluster = new RedisClusterStartupRule();
+
+  private static MemberVM server1;
+  private static MemberVM server2;
+  private static JedisCluster jedis;
+  private static final String USER = "data";
+  private static int redisPort;
+
+  @BeforeClass
+  public static void setup() {
+    MemberVM locator = cluster.startLocatorVM(0, x -> x
+        .withSecurityManager(ExpiringSecurityManager.class));
+
+    int locatorPort = locator.getPort();
+
+    SerializableFunction<ServerStarterRule> serverOperator = s -> s
+        .withCredential("cluster", "cluster")
+        .withConnectionToLocator(locatorPort);
+
+    server1 = cluster.startRedisVM(1, serverOperator);
+    server2 = cluster.startRedisVM(2, serverOperator);
+
+    redisPort = cluster.getRedisPort(1);
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, redisPort),
+        REDIS_CLIENT_TIMEOUT,
+        REDIS_CLIENT_TIMEOUT,
+        BinaryJedisCluster.DEFAULT_MAX_ATTEMPTS,
+        USER, USER, "test-client",
+        new GenericObjectPoolConfig<>());
+  }
+
+  @After
+  public void cleanup() {
+    resetExpiredUsers();
+    cluster.flushAll(USER, USER);
+  }
+
+  @Test
+  public void jedisReceivesAuthenticationExpiredError() {
+    jedis.set("foo", "bar");
+
+    expireUser(USER);
+
+    assertThatThrownBy(() -> jedis.get("foo")).hasMessageContaining("User has expired");
+  }
+
+  @Test
+  public void lettuceReceivesAuthenticationExpiredError() {
+    RedisClusterClient client = RedisClusterClient.create(
+        String.format("redis://%s:%s@localhost:%d", USER, USER, redisPort));
+    RedisClusterCommands<String, String> commands = client.connect().sync();
+
+    commands.set("foo", "bar");
+
+    expireUser(USER);
+
+    assertThatThrownBy(() -> commands.get("foo")).hasMessageContaining("User has expired");
+  }
+
+  private static void expireUser(String user) {
+    server1.invoke(() -> getSecurityManager().addExpiredUser(user));
+    server2.invoke(() -> getSecurityManager().addExpiredUser(user));
+  }
+
+  private static void resetExpiredUsers() {
+    server1.invoke(() -> getSecurityManager().reset());
+    server2.invoke(() -> getSecurityManager().reset());
+  }
+
+  private static ExpiringSecurityManager getSecurityManager() {
+    return (ExpiringSecurityManager) RedisClusterStartupRule.getCache()
+        .getSecurityService().getSecurityManager();
+  }
+}

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -64,6 +64,7 @@ import org.apache.geode.redis.internal.pubsub.PubSub;
 import org.apache.geode.redis.internal.services.RegionProvider;
 import org.apache.geode.redis.internal.services.locking.RedisSecurityService;
 import org.apache.geode.redis.internal.statistics.RedisStats;
+import org.apache.geode.security.AuthenticationExpiredException;
 import org.apache.geode.security.NotAuthorizedException;
 import org.apache.geode.security.ResourcePermission;
 import org.apache.geode.security.SecurityManager;
@@ -198,6 +199,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
               + rootCause.getMessage());
       channelInactive(ctx);
       return null;
+    } else if (rootCause instanceof AuthenticationExpiredException) {
+      return RedisResponse.error("Authentication expired: " + rootCause.getMessage());
     } else {
       if (logger.isErrorEnabled()) {
         logger.error("GeodeRedisServer-Unexpected error handler for {}", ctx.channel(), rootCause);


### PR DESCRIPTION
- For requests that result in an AuthenticationExpiredException, the
  response will be: `-ERR Authentication expired: <Exception message>`.
  Clients will be expected to handle this error and take the necessary
  action to re-authenticate.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
