### PR TITLE
GEODE-9870: Avoid Radish MOVED error during flushAll in AuthWhileServersRestartDUnitTest

### DIFF
--- a/geode-for-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/test/dunit/rules/RedisClusterStartupRule.java
@@ -30,6 +30,8 @@ import org.apache.logging.log4j.core.config.Configurator;
 import redis.clients.jedis.Jedis;
 
 import org.apache.geode.cache.Region;
+import org.apache.geode.cache.control.RebalanceFactory;
+import org.apache.geode.cache.control.ResourceManager;
 import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.logging.internal.log4j.api.FastLogger;
@@ -249,6 +251,21 @@ public class RedisClusterStartupRule extends ClusterStartupRule {
           return key;
         }
         i++;
+      }
+    });
+  }
+
+  /**
+   * Rebalance all regions for the cluster. This implicitly uses VM1.
+   */
+  public void rebalanceAllRegions() {
+    getMember(1).invoke("Running rebalance", () -> {
+      ResourceManager manager = ClusterStartupRule.getCache().getResourceManager();
+      RebalanceFactory factory = manager.createRebalanceFactory();
+      try {
+        factory.start().getResults();
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
       }
     });
   }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
@@ -50,6 +50,7 @@ public class AuthWhileServersRestartDUnitTest {
   @ClassRule
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
+  private static MemberVM server1;
   private static int redisServerPort;
   private static SerializableFunction<ServerStarterRule> operatorForVM3;
   private static final String KEY = "key";
@@ -65,7 +66,7 @@ public class AuthWhileServersRestartDUnitTest {
         .withCredential("cluster", "cluster")
         .withConnectionToLocator(locatorPort);
 
-    clusterStartUp.startRedisVM(1, serverOperator);
+    server1 = clusterStartUp.startRedisVM(1, serverOperator);
     clusterStartUp.startRedisVM(2, serverOperator);
 
     int server3Port = AvailablePortHelper.getRandomAvailableTCPPort();
@@ -85,6 +86,9 @@ public class AuthWhileServersRestartDUnitTest {
 
   @After
   public void after() {
+    // Make sure that no buckets are moving before calling flushAll, otherwise we might get
+    // a MOVED exception.
+    clusterStartUp.rebalanceAllRegions();
     clusterStartUp.flushAll("data", "data");
   }
 

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
@@ -50,7 +50,6 @@ public class AuthWhileServersRestartDUnitTest {
   @ClassRule
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
-  private static MemberVM server1;
   private static int redisServerPort;
   private static SerializableFunction<ServerStarterRule> operatorForVM3;
   private static final String KEY = "key";
@@ -66,7 +65,7 @@ public class AuthWhileServersRestartDUnitTest {
         .withCredential("cluster", "cluster")
         .withConnectionToLocator(locatorPort);
 
-    server1 = clusterStartUp.startRedisVM(1, serverOperator);
+    clusterStartUp.startRedisVM(1, serverOperator);
     clusterStartUp.startRedisVM(2, serverOperator);
 
     int server3Port = AvailablePortHelper.getRandomAvailableTCPPort();


### PR DESCRIPTION

- Since servers have been stopped and restarted, as part of the test,
  buckets may be moving. Occasionally this may still be the case when
  the test is done and flushAll is cleaning up. To avoid that, make sure
  that everything is rebalanced before flushAll is called.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
