### PR TITLE
GEODE-9872: Make test framework code assign ports

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/DUnitLauncher.java
@@ -23,6 +23,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.USE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.util.internal.GeodeGlossary.GEMFIRE_PREFIX;
 
 import java.io.BufferedReader;
@@ -57,7 +58,6 @@ import org.apache.geode.distributed.Locator;
 import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.distributed.internal.membership.gms.membership.GMSJoinLeave;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.logging.internal.spi.LoggingProvider;
 import org.apache.geode.test.dunit.DUnitEnv;
 import org.apache.geode.test.dunit.Host;
@@ -205,7 +205,7 @@ public class DUnitLauncher {
     deleteDunitSuspectFiles();
 
     // create an RMI registry and add an object to share our tests config
-    int namingPort = AvailablePortHelper.getRandomAvailableTCPPort();
+    int namingPort = getRandomAvailableTCPPort();
     Registry registry = LocateRegistry.createRegistry(namingPort);
     System.setProperty(RMI_PORT_PARAM, "" + namingPort);
 
@@ -301,8 +301,11 @@ public class DUnitLauncher {
 
   private static int startLocator(Registry registry) throws IOException, NotBoundException {
     RemoteDUnitVMIF remote = (RemoteDUnitVMIF) registry.lookup("vm" + LOCATOR_VM_NUM);
+
+    int port = getRandomAvailableTCPPort();
     final File locatorLogFile =
-        LOCATOR_LOG_TO_DISK ? new File("locator-" + locatorPort + ".log") : new File("");
+        LOCATOR_LOG_TO_DISK ? new File("locator-" + port + ".log") : new File("");
+
     MethodInvokerResult result = remote.executeMethodOnObject(new SerializableCallable() {
       @Override
       public Object call() throws IOException {
@@ -322,9 +325,8 @@ public class DUnitLauncher {
         p.setProperty(DISABLE_AUTO_RECONNECT, "true");
 
         try {
-          Locator.startLocatorAndDS(0, locatorLogFile, p);
-          InternalLocator internalLocator = (InternalLocator) Locator.getLocator();
-          locatorPort = internalLocator.getPort();
+          Locator.startLocatorAndDS(port, locatorLogFile, p);
+          locatorPort = port;
         } finally {
           System.getProperties().remove(GMSJoinLeave.BYPASS_DISCOVERY_PROPERTY);
         }

--- a/geode-dunit/src/main/resources/org/apache/geode/test/dunit/internal/sanctioned-geode-dunit-serializables.txt
+++ b/geode-dunit/src/main/resources/org/apache/geode/test/dunit/internal/sanctioned-geode-dunit-serializables.txt
@@ -138,7 +138,7 @@ org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase,false,RootRegionN
 org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase$1,false,this$0:org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase,val$exceptionStringToIgnore:java/lang/String
 org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase$2,false,this$0:org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase,val$exceptionStringToIgnore:java/lang/String
 org/apache/geode/test/dunit/internal/DUnitHost,true,-8034165624503666383
-org/apache/geode/test/dunit/internal/DUnitLauncher$1,false,val$locatorLogFile:java/io/File
+org/apache/geode/test/dunit/internal/DUnitLauncher$1,false,val$locatorLogFile:java/io/File,val$port:int
 org/apache/geode/test/dunit/internal/IdentifiableCallable,false,delegate:org/apache/geode/test/dunit/SerializableCallableIF,id:long,name:java/lang/String
 org/apache/geode/test/dunit/internal/IdentifiableRunnable,false,delegate:org/apache/geode/test/dunit/SerializableRunnableIF,id:long,name:java/lang/String
 org/apache/geode/test/dunit/internal/InternalBlackboardImpl,false,gates:java/util/Map,mailboxes:java/util/Map


### PR DESCRIPTION
PROBLEM

`DistTXPersistentDebugDUnitTest ` failed in CI because it accidentally
connected to a locator from another test
(`ClusterConfigLocatorRestartDUnitTest`).

CAUSE

`ClusterConfigLocatorRestartDUnitTest` attempts to restart a
locator on a port in the ephemeral port range.

Here is the sequence of events:
1. `ClusterConfigLocatorRestartDUnitTest ` started a locator on an
   ephemeral port. In this CI run it got port 37877.
2. `ClusterConfigLocatorRestartDUnitTest` stopped the locator on port
   37877.
3. `DistTXPersistentDebugDUnitTest` started a locator on an ephemeral
   port. In this CI run it got 37877.
4. `ClusterConfigLocatorRestartDUnitTest ` attempted to restart the
   locator on port 37877. That port was already in use in
   `DistTXPersistentDebugDUnitTest`'s locator, and as a result the two
   tests became entangled.

CONTRIBUTING FACTORS

`DistTXPersistentDebugDUnitTest` uses `DUnitLauncher` to start its
locator. By default, `DUnitLauncher` starts its locator on an ephemeral
port.

`ClusterConfigLocatorRestartDUnitTest` uses `ClusterStartupRule` to
start several locators. By default, `ClusterStartupRule` starts each
locator on an ephemeral port.

SOLUTION

Change `DUnitLauncher` and `ClusterStartupRule` to assign locator ports
via `AvailablePortHelper` if the test does not specify a particular
port.

I considered changing only `ClusterConfigLogatorRestartDUnitTest` to
assign the port that it intends to reuse. But:
- That would fix only this one test, though an unknown number of tests
  similarly attempt to reuse ports assigned by framework code. Numerous
  of those tests have already been changed to assign ports explicitly,
  but an unknown number remain.
- It is quite reasonable for this test and others to assume that, if the
  test framework assigns a port on the test's behalf, then the test will
  enjoy exclusive use of that port for the entire life of the test. I
  think the key problem is not that tests make this assumption, but that
  the framework code violates it.

Changing the test framework classes that tacitly assign ports
(`DUnitLauncher` and `ClusterStartupRule`) makes them behave in a way
that tests expect.
