### PR TITLE
GEODE-9879: Extract SystemProperty to geode-common

### DIFF
--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -33,6 +33,9 @@ dependencies {
   implementation('com.fasterxml.jackson.core:jackson-databind')
 
   // test
+  testImplementation('com.github.stefanbirkner:system-rules') {
+    exclude module: 'junit-dep'
+  }
   testImplementation('junit:junit')
   testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
   testImplementation('org.assertj:assertj-core')

--- a/geode-common/src/main/java/org/apache/geode/internal/lang/SystemProperty.java
+++ b/geode-common/src/main/java/org/apache/geode/internal/lang/SystemProperty.java
@@ -18,7 +18,7 @@ import java.util.Optional;
 
 public class SystemProperty {
 
-  public static final String GEODE_PREFIX = "geode.";
+  private static final String GEODE_PREFIX = "geode.";
   public static final String GEMFIRE_PREFIX = "gemfire.";
   public static final String DEFAULT_PREFIX = GEODE_PREFIX;
 
@@ -99,7 +99,7 @@ public class SystemProperty {
     return property != null ? Optional.of(property) : Optional.empty();
   }
 
-  private static String getProperty(String name) {
+  public static String getProperty(String name) {
     String property = getGeodeProperty(name);
     return property != null ? property : getGemfireProperty(name);
   }

--- a/geode-common/src/main/java/org/apache/geode/internal/lang/SystemProperty.java
+++ b/geode-common/src/main/java/org/apache/geode/internal/lang/SystemProperty.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.lang;
+
+import java.util.Optional;
+
+public class SystemProperty {
+
+  public static final String GEODE_PREFIX = "geode.";
+  public static final String GEMFIRE_PREFIX = "gemfire.";
+  public static final String DEFAULT_PREFIX = GEODE_PREFIX;
+
+  /**
+   * This method will try to look up "geode." and "gemfire." versions of the system property. It
+   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
+   *
+   * @param name system property name set in Geode
+   * @return an Optional containing the Boolean value of the system property
+   */
+  public static Optional<Boolean> getProductBooleanProperty(String name) {
+    String property = getProperty(name);
+    return property != null ? Optional.of(Boolean.parseBoolean(property)) : Optional.empty();
+  }
+
+  /**
+   * This method will try to look up "geode." and "gemfire." versions of the system property. It
+   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
+   *
+   * @param name system property name set in Geode
+   * @return an Optional containing the Integer value of the system property
+   */
+  public static Optional<Integer> getProductIntegerProperty(String name) {
+    Integer propertyValue = Integer.getInteger(DEFAULT_PREFIX + name);
+    if (propertyValue == null) {
+      propertyValue = Integer.getInteger(GEMFIRE_PREFIX + name);
+    }
+
+    if (propertyValue != null) {
+      return Optional.of(propertyValue);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * This method will try to look up "geode." and "gemfire." versions of the system property. It
+   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
+   *
+   * @param name system property name set in Geode
+   * @return the integer value of the system property if exits or the default value
+   */
+  public static Integer getProductIntegerProperty(String name, int defaultValue) {
+    return getProductIntegerProperty(name).orElse(defaultValue);
+  }
+
+  /**
+   * This method will try to look up "geode." and "gemfire." versions of the system property. It
+   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
+   *
+   * @param name system property name set in Geode
+   * @return an Optional containing the Long value of the system property
+   */
+  public static Optional<Long> getProductLongProperty(String name) {
+    Long propertyValue = Long.getLong(DEFAULT_PREFIX + name);
+    if (propertyValue == null) {
+      propertyValue = Long.getLong(GEMFIRE_PREFIX + name);
+    }
+
+    if (propertyValue != null) {
+      return Optional.of(propertyValue);
+    }
+    return Optional.empty();
+  }
+
+  public static Long getProductLongProperty(String name, long defaultValue) {
+    return getProductLongProperty(name).orElse(defaultValue);
+  }
+
+  /**
+   * This method will try to look up "geode." and "gemfire." versions of the system property. It
+   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
+   *
+   * @param name system property name set in Geode
+   * @return an Optional containing the String value of the system property
+   */
+  public static Optional<String> getProductStringProperty(String name) {
+    String property = getProperty(name);
+    return property != null ? Optional.of(property) : Optional.empty();
+  }
+
+  private static String getProperty(String name) {
+    String property = getGeodeProperty(name);
+    return property != null ? property : getGemfireProperty(name);
+  }
+
+  private static String getGeodeProperty(String name) {
+    return System.getProperty(DEFAULT_PREFIX + name);
+  }
+
+  private static String getGemfireProperty(String name) {
+    return System.getProperty(GEMFIRE_PREFIX + name);
+  }
+
+  private SystemProperty() {
+    // do not instantiate
+  }
+}

--- a/geode-common/src/test/java/org/apache/geode/internal/lang/SystemPropertyTest.java
+++ b/geode-common/src/test/java/org/apache/geode/internal/lang/SystemPropertyTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.lang;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+public class SystemPropertyTest {
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Test
+  public void getIntegerPropertyPrefersGeodePrefix() {
+    String testProperty = "testIntegerProperty";
+    String gemfirePrefixProperty = "gemfire." + testProperty;
+    String geodePrefixProperty = "geode." + testProperty;
+    System.setProperty(geodePrefixProperty, "1");
+    System.setProperty(gemfirePrefixProperty, "0");
+    assertThat(SystemProperty.getProductIntegerProperty(testProperty).get()).isEqualTo(1);
+    System.clearProperty(geodePrefixProperty);
+    System.clearProperty(gemfirePrefixProperty);
+  }
+
+  @Test
+  public void getIntegerPropertyReturnsGemfirePrefixIfGeodeMissing() {
+    String testProperty = "testIntegerProperty";
+    String gemfirePrefixProperty = "gemfire." + testProperty;
+    System.setProperty(gemfirePrefixProperty, "1");
+    assertThat(SystemProperty.getProductIntegerProperty(testProperty).get()).isEqualTo(1);
+    System.clearProperty(gemfirePrefixProperty);
+  }
+
+  @Test
+  public void getIntegerPropertyWithDefaultValue() {
+    String testProperty = "testIntegerProperty";
+    assertThat(SystemProperty.getProductIntegerProperty(testProperty, 1000)).isEqualTo(1000);
+  }
+
+  @Test
+  public void getLongPropertyWithoutDefaultReturnsGemfirePrefixIfGeodeMissing() {
+    String testProperty = "testLongProperty";
+    String gemfirePrefixProperty = "gemfire." + testProperty;
+    System.setProperty(gemfirePrefixProperty, "1");
+    assertThat(SystemProperty.getProductLongProperty(testProperty).get()).isEqualTo(1);
+    System.clearProperty(gemfirePrefixProperty);
+  }
+
+  @Test
+  public void getLongPropertyWithDefaultValue() {
+    String testProperty = "testIntegerProperty";
+    assertThat(SystemProperty.getProductLongProperty(testProperty, 1000)).isEqualTo(1000);
+  }
+
+  @Test
+  public void getIntegerPropertyReturnsEmptyOptionalIfPropertiesMissing() {
+    String testProperty = "notSetProperty";
+    assertThat(SystemProperty.getProductIntegerProperty(testProperty).isPresent()).isFalse();
+  }
+
+  @Test
+  public void getBooleanPropertyReturnsEmptyOptionalIfProperiesMissing() {
+    String testProperty = "notSetProperty";
+    assertThat(SystemProperty.getProductBooleanProperty(testProperty).isPresent()).isFalse();
+  }
+
+  @Test
+  public void getBooleanPropertyPrefersGeodePrefix() {
+    String testProperty = "testBooleanProperty";
+    String gemfirePrefixProperty = "gemfire." + testProperty;
+    String geodePrefixProperty = "geode." + testProperty;
+    System.setProperty(geodePrefixProperty, "true");
+    System.setProperty(gemfirePrefixProperty, "false");
+    assertThat(SystemProperty.getProductBooleanProperty(testProperty).get()).isTrue();
+    System.clearProperty(geodePrefixProperty);
+    System.clearProperty(gemfirePrefixProperty);
+  }
+
+  @Test
+  public void getBooleanPropertyReturnsGemfirePrefixIfGeodeMissing() {
+    String testProperty = "testBooleanProperty";
+    String gemfirePrefixProperty = "gemfire." + testProperty;
+    System.setProperty(gemfirePrefixProperty, "true");
+    assertThat(SystemProperty.getProductBooleanProperty(testProperty).get()).isTrue();
+    System.clearProperty(gemfirePrefixProperty);
+  }
+}

--- a/geode-common/src/test/java/org/apache/geode/internal/lang/SystemPropertyTest.java
+++ b/geode-common/src/test/java/org/apache/geode/internal/lang/SystemPropertyTest.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.internal.lang;
 
+import static org.apache.geode.internal.lang.SystemProperty.getProductBooleanProperty;
+import static org.apache.geode.internal.lang.SystemProperty.getProductIntegerProperty;
+import static org.apache.geode.internal.lang.SystemProperty.getProductLongProperty;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
@@ -32,9 +35,8 @@ public class SystemPropertyTest {
     String geodePrefixProperty = "geode." + testProperty;
     System.setProperty(geodePrefixProperty, "1");
     System.setProperty(gemfirePrefixProperty, "0");
-    assertThat(SystemProperty.getProductIntegerProperty(testProperty).get()).isEqualTo(1);
-    System.clearProperty(geodePrefixProperty);
-    System.clearProperty(gemfirePrefixProperty);
+
+    assertThat(getProductIntegerProperty(testProperty).get()).isEqualTo(1);
   }
 
   @Test
@@ -42,14 +44,15 @@ public class SystemPropertyTest {
     String testProperty = "testIntegerProperty";
     String gemfirePrefixProperty = "gemfire." + testProperty;
     System.setProperty(gemfirePrefixProperty, "1");
-    assertThat(SystemProperty.getProductIntegerProperty(testProperty).get()).isEqualTo(1);
-    System.clearProperty(gemfirePrefixProperty);
+
+    assertThat(getProductIntegerProperty(testProperty).get()).isEqualTo(1);
   }
 
   @Test
   public void getIntegerPropertyWithDefaultValue() {
     String testProperty = "testIntegerProperty";
-    assertThat(SystemProperty.getProductIntegerProperty(testProperty, 1000)).isEqualTo(1000);
+
+    assertThat(getProductIntegerProperty(testProperty, 1000)).isEqualTo(1000);
   }
 
   @Test
@@ -57,26 +60,29 @@ public class SystemPropertyTest {
     String testProperty = "testLongProperty";
     String gemfirePrefixProperty = "gemfire." + testProperty;
     System.setProperty(gemfirePrefixProperty, "1");
-    assertThat(SystemProperty.getProductLongProperty(testProperty).get()).isEqualTo(1);
-    System.clearProperty(gemfirePrefixProperty);
+
+    assertThat(getProductLongProperty(testProperty).get()).isEqualTo(1);
   }
 
   @Test
   public void getLongPropertyWithDefaultValue() {
     String testProperty = "testIntegerProperty";
-    assertThat(SystemProperty.getProductLongProperty(testProperty, 1000)).isEqualTo(1000);
+
+    assertThat(getProductLongProperty(testProperty, 1000)).isEqualTo(1000);
   }
 
   @Test
   public void getIntegerPropertyReturnsEmptyOptionalIfPropertiesMissing() {
     String testProperty = "notSetProperty";
-    assertThat(SystemProperty.getProductIntegerProperty(testProperty).isPresent()).isFalse();
+
+    assertThat(getProductIntegerProperty(testProperty).isPresent()).isFalse();
   }
 
   @Test
   public void getBooleanPropertyReturnsEmptyOptionalIfProperiesMissing() {
     String testProperty = "notSetProperty";
-    assertThat(SystemProperty.getProductBooleanProperty(testProperty).isPresent()).isFalse();
+
+    assertThat(getProductBooleanProperty(testProperty).isPresent()).isFalse();
   }
 
   @Test
@@ -86,9 +92,8 @@ public class SystemPropertyTest {
     String geodePrefixProperty = "geode." + testProperty;
     System.setProperty(geodePrefixProperty, "true");
     System.setProperty(gemfirePrefixProperty, "false");
-    assertThat(SystemProperty.getProductBooleanProperty(testProperty).get()).isTrue();
-    System.clearProperty(geodePrefixProperty);
-    System.clearProperty(gemfirePrefixProperty);
+
+    assertThat(getProductBooleanProperty(testProperty).get()).isTrue();
   }
 
   @Test
@@ -96,7 +101,7 @@ public class SystemPropertyTest {
     String testProperty = "testBooleanProperty";
     String gemfirePrefixProperty = "gemfire." + testProperty;
     System.setProperty(gemfirePrefixProperty, "true");
-    assertThat(SystemProperty.getProductBooleanProperty(testProperty).get()).isTrue();
-    System.clearProperty(gemfirePrefixProperty);
+
+    assertThat(getProductBooleanProperty(testProperty).get()).isTrue();
   }
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/BrokenSerializationConsistencyRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/BrokenSerializationConsistencyRegressionTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.cache.RegionShortcut.REPLICATE;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,6 +34,7 @@ import org.apache.geode.DataSerializable;
 import org.apache.geode.ToDataException;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.pdx.PdxReader;
 import org.apache.geode.pdx.PdxSerializable;
 import org.apache.geode.pdx.PdxWriter;
@@ -67,11 +67,11 @@ public class BrokenSerializationConsistencyRegressionTest implements Serializabl
   public void setUpAll() {
     vm0 = getVM(0);
 
-    System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
     createReplicateRegions();
 
     vm0.invoke(() -> {
-      System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+      System.setProperty(SystemProperty.DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
       createReplicateRegions();
     });
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/BrokenSerializationConsistencyRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/BrokenSerializationConsistencyRegressionTest.java
@@ -15,8 +15,8 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.cache.RegionShortcut.REPLICATE;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -67,11 +67,11 @@ public class BrokenSerializationConsistencyRegressionTest implements Serializabl
   public void setUpAll() {
     vm0 = getVM(0);
 
-    System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+    System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
     createReplicateRegions();
 
     vm0.invoke(() -> {
-      System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+      System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
       createReplicateRegions();
     });
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
@@ -15,8 +15,8 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.distributed.ConfigurationProperties.DELTA_PROPAGATION;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -113,9 +113,9 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
   @Test
 
   public void testCopyOnReadWithBridgeServer() {
-    System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+    System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
     Invoke.invokeInEveryVM(
-        () -> System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true"));
+        () -> System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true"));
 
     createBridgeServer(server, rName, ports[0]);
     // Put an instance of SerializationCounter to assert copy-on-read behavior

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientDeserializationCopyOnReadRegressionTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.internal.cache;
 
 import static org.apache.geode.distributed.ConfigurationProperties.DELTA_PROPAGATION;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +50,7 @@ import org.apache.geode.internal.cache.ha.HARegionQueue;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
@@ -113,9 +113,10 @@ public class ClientDeserializationCopyOnReadRegressionTest extends ClientServerT
   @Test
 
   public void testCopyOnReadWithBridgeServer() {
-    System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
     Invoke.invokeInEveryVM(
-        () -> System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true"));
+        () -> System.setProperty(SystemProperty.DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION,
+            "true"));
 
     createBridgeServer(server, rName, ports[0]);
     // Put an instance of SerializationCounter to assert copy-on-read behavior

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/CompactOfflineDiskStoreDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/CompactOfflineDiskStoreDUnitTest.java
@@ -23,7 +23,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -190,7 +190,7 @@ public class CompactOfflineDiskStoreDUnitTest implements Serializable {
   private static void startServer(String name, File workingDirectory, int serverPort,
       String locators, boolean parallelDiskStoreRecovery) {
 
-    System.setProperty(GEODE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
+    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
         String.valueOf(parallelDiskStoreRecovery));
 
     SERVER.set(new ServerLauncher.Builder()

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/CompactOfflineDiskStoreDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/CompactOfflineDiskStoreDUnitTest.java
@@ -23,7 +23,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -49,6 +48,7 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.dunit.VM;
@@ -190,7 +190,8 @@ public class CompactOfflineDiskStoreDUnitTest implements Serializable {
   private static void startServer(String name, File workingDirectory, int serverPort,
       String locators, boolean parallelDiskStoreRecovery) {
 
-    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
+    System.setProperty(
+        SystemProperty.DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
         String.valueOf(parallelDiskStoreRecovery));
 
     SERVER.set(new ServerLauncher.Builder()

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -29,6 +29,7 @@ import static org.apache.geode.distributed.internal.DistributionConfig.CLIENT_CO
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.internal.cache.CacheServerImpl.generateNameForClientMsgsRegion;
 import static org.apache.geode.internal.cache.tier.sockets.CacheClientProxyFactory.INTERNAL_FACTORY_PROPERTY;
+import static org.apache.geode.internal.lang.SystemProperty.GEMFIRE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.apache.geode.test.dunit.VM.getController;
@@ -95,7 +96,6 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientProxyFactory.Inte
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ClientUserAuths;
 import org.apache.geode.internal.cache.tier.sockets.MessageDispatcher;
-import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.statistics.StatisticsClock;
@@ -1417,8 +1417,7 @@ public class DeltaPropagationDUnitTest implements Serializable {
     }
 
     private void doCreate() throws IOException {
-      System.setProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
-          "true");
+      System.setProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints", "true");
 
       Properties clientProperties = getDistributedSystemProperties();
       clientProperties.setProperty(LOCATORS, "");

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DeltaPropagationDUnitTest.java
@@ -29,7 +29,6 @@ import static org.apache.geode.distributed.internal.DistributionConfig.CLIENT_CO
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.internal.cache.CacheServerImpl.generateNameForClientMsgsRegion;
 import static org.apache.geode.internal.cache.tier.sockets.CacheClientProxyFactory.INTERNAL_FACTORY_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEMFIRE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
 import static org.apache.geode.test.dunit.VM.getController;
@@ -96,6 +95,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientProxyFactory.Inte
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ClientUserAuths;
 import org.apache.geode.internal.cache.tier.sockets.MessageDispatcher;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.statistics.StatisticsClock;
@@ -1417,7 +1417,8 @@ public class DeltaPropagationDUnitTest implements Serializable {
     }
 
     private void doCreate() throws IOException {
-      System.setProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints", "true");
+      System.setProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
+          "true");
 
       Properties clientProperties = getDistributedSystemProperties();
       clientProperties.setProperty(LOCATORS, "");

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ParallelDiskStoreRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ParallelDiskStoreRecoveryDUnitTest.java
@@ -24,7 +24,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -216,7 +216,7 @@ public class ParallelDiskStoreRecoveryDUnitTest implements Serializable {
   private static void startServer(String name, File workingDirectory, int serverPort,
       String locators, boolean parallelDiskStoreRecovery) {
 
-    System.setProperty(GEODE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
+    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
         String.valueOf(parallelDiskStoreRecovery));
 
     SERVER.set(new ServerLauncher.Builder()

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ParallelDiskStoreRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ParallelDiskStoreRecoveryDUnitTest.java
@@ -24,7 +24,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -50,6 +49,7 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.dunit.VM;
@@ -216,7 +216,8 @@ public class ParallelDiskStoreRecoveryDUnitTest implements Serializable {
   private static void startServer(String name, File workingDirectory, int serverPort,
       String locators, boolean parallelDiskStoreRecovery) {
 
-    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
+    System.setProperty(
+        SystemProperty.DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
         String.valueOf(parallelDiskStoreRecovery));
 
     SERVER.set(new ServerLauncher.Builder()

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleHopDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleHopDUnitTest.java
@@ -22,6 +22,7 @@ import static org.apache.geode.cache.RegionShortcut.PARTITION;
 import static org.apache.geode.cache.RegionShortcut.PARTITION_PERSISTENT;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.internal.lang.SystemProperty.GEMFIRE_PREFIX;
 import static org.apache.geode.management.ManagementService.getExistingManagementService;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
@@ -84,7 +85,6 @@ import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.internal.cache.BucketAdvisor.ServerBucketProfile;
 import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
 import org.apache.geode.internal.cache.execute.util.TypedFunctionService;
-import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.membership.MembershipEvent;
 import org.apache.geode.management.membership.UniversalMembershipListenerAdapter;
@@ -1088,8 +1088,7 @@ public class PartitionedRegionSingleHopDUnitTest implements Serializable {
 
   private String createPool(long pingInterval, boolean prSingleHopEnabled,
       boolean subscriptionEnabled, boolean useServerPool, int... ports) {
-    System.setProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
-        "true");
+    System.setProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints", "true");
     String poolName = PARTITIONED_REGION_NAME;
     try {
       PoolFactory poolFactory = PoolManager.createFactory()
@@ -1115,7 +1114,7 @@ public class PartitionedRegionSingleHopDUnitTest implements Serializable {
 
       poolFactory.create(poolName);
     } finally {
-      System.clearProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints");
+      System.clearProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints");
     }
 
     return poolName;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleHopDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionSingleHopDUnitTest.java
@@ -22,7 +22,6 @@ import static org.apache.geode.cache.RegionShortcut.PARTITION;
 import static org.apache.geode.cache.RegionShortcut.PARTITION_PERSISTENT;
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEMFIRE_PREFIX;
 import static org.apache.geode.management.ManagementService.getExistingManagementService;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.getTimeout;
@@ -85,6 +84,7 @@ import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.internal.cache.BucketAdvisor.ServerBucketProfile;
 import org.apache.geode.internal.cache.execute.InternalFunctionInvocationTargetException;
 import org.apache.geode.internal.cache.execute.util.TypedFunctionService;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.membership.MembershipEvent;
 import org.apache.geode.management.membership.UniversalMembershipListenerAdapter;
@@ -1088,7 +1088,8 @@ public class PartitionedRegionSingleHopDUnitTest implements Serializable {
 
   private String createPool(long pingInterval, boolean prSingleHopEnabled,
       boolean subscriptionEnabled, boolean useServerPool, int... ports) {
-    System.setProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints", "true");
+    System.setProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
+        "true");
     String poolName = PARTITIONED_REGION_NAME;
     try {
       PoolFactory poolFactory = PoolManager.createFactory()
@@ -1114,7 +1115,7 @@ public class PartitionedRegionSingleHopDUnitTest implements Serializable {
 
       poolFactory.create(poolName);
     } finally {
-      System.clearProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints");
+      System.clearProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints");
     }
 
     return poolName;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ValidateOfflineDiskStoreDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ValidateOfflineDiskStoreDUnitTest.java
@@ -23,7 +23,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -51,6 +50,7 @@ import org.apache.geode.cache.client.ClientRegionShortcut;
 import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.test.dunit.VM;
@@ -194,7 +194,8 @@ public class ValidateOfflineDiskStoreDUnitTest implements Serializable {
   private static void startServer(String name, File workingDirectory, int serverPort,
       String locators) {
 
-    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
+    System.setProperty(
+        SystemProperty.DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
         "true");
 
     SERVER.set(new ServerLauncher.Builder()

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ValidateOfflineDiskStoreDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ValidateOfflineDiskStoreDUnitTest.java
@@ -23,7 +23,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MAX_WAIT_TIME_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.MEMBER_TIMEOUT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
@@ -194,7 +194,7 @@ public class ValidateOfflineDiskStoreDUnitTest implements Serializable {
   private static void startServer(String name, File workingDirectory, int serverPort,
       String locators) {
 
-    System.setProperty(GEODE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
+    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY,
         "true");
 
     SERVER.set(new ServerLauncher.Builder()

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
@@ -17,7 +17,7 @@ package org.apache.geode.internal.cache.control;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.REDUNDANCY_ZONE;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -217,7 +217,7 @@ public class RebalanceOperationComplexDistributedTest implements Serializable {
       if (!temporaryDirectory.exists()) {
         Files.createDirectory(temporaryDirectory.toPath());
       }
-      System.setProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, path);
+      System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, path);
     });
 
     clusterStartupRule.startServerVM(index, s -> s.withProperty("cache-xml-file",

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationComplexDistributedTest.java
@@ -17,7 +17,6 @@ package org.apache.geode.internal.cache.control;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.apache.geode.distributed.ConfigurationProperties.REDUNDANCY_ZONE;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -44,6 +43,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.control.ResourceManager;
 import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.VM;
@@ -217,7 +217,7 @@ public class RebalanceOperationComplexDistributedTest implements Serializable {
       if (!temporaryDirectory.exists()) {
         Files.createDirectory(temporaryDirectory.toPath());
       }
-      System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, path);
+      System.setProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, path);
     });
 
     clusterStartupRule.startServerVM(index, s -> s.withProperty("cache-xml-file",

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
@@ -21,7 +21,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.internal.cache.CacheServerImpl.generateNameForClientMsgsRegion;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEMFIRE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.NetworkUtils.getServerHostName;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -63,6 +62,7 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessage;
 import org.apache.geode.internal.cache.tier.sockets.ConflationDUnitTestHelper;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
@@ -209,7 +209,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createClientCache(String host, Integer port1, Integer port2, String rLevel,
       Boolean addListener) throws Exception {
-    System.setProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
+    System.setProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
         "true");
 
     Properties props = new Properties();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARQueueNewImplDUnitTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.internal.cache.CacheServerImpl.generateNameForClientMsgsRegion;
+import static org.apache.geode.internal.lang.SystemProperty.GEMFIRE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.NetworkUtils.getServerHostName;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +63,6 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessage;
 import org.apache.geode.internal.cache.tier.sockets.ConflationDUnitTestHelper;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
-import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
@@ -209,8 +209,7 @@ public class HARQueueNewImplDUnitTest extends JUnit4DistributedTestCase {
 
   public static void createClientCache(String host, Integer port1, Integer port2, String rLevel,
       Boolean addListener) throws Exception {
-    System.setProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
-        "true");
+    System.setProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints", "true");
 
     Properties props = new Properties();
     props.setProperty(MCAST_PORT, "0");

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueExpiryRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueExpiryRegressionTest.java
@@ -18,7 +18,6 @@ import static org.apache.geode.cache30.ClientServerTestCase.configureConnectionP
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.cache.tier.sockets.ConflationDUnitTestHelper.setIsSlowStart;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Host.getHost;
@@ -44,6 +43,7 @@ import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.Region;
 import org.apache.geode.cache.Scope;
 import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.CacheTestCase;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
@@ -129,7 +129,8 @@ public class HARegionQueueExpiryRegressionTest extends CacheTestCase {
   }
 
   private int createServerCache() throws IOException {
-    System.setProperty(DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, String.valueOf(1));
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY,
+        String.valueOf(1));
     System.setProperty("slowStartTimeForTesting", String.valueOf(DISPATCHER_SLOWSTART_TIME));
 
     AttributesFactory factory = new AttributesFactory();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueExpiryRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueExpiryRegressionTest.java
@@ -18,7 +18,7 @@ import static org.apache.geode.cache30.ClientServerTestCase.configureConnectionP
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.cache.tier.sockets.ConflationDUnitTestHelper.setIsSlowStart;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Host.getHost;
@@ -129,7 +129,7 @@ public class HARegionQueueExpiryRegressionTest extends CacheTestCase {
   }
 
   private int createServerCache() throws IOException {
-    System.setProperty(GEODE_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, String.valueOf(1));
+    System.setProperty(DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, String.valueOf(1));
     System.setProperty("slowStartTimeForTesting", String.valueOf(DISPATCHER_SLOWSTART_TIME));
 
     AttributesFactory factory = new AttributesFactory();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueThreadIdExpiryRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueThreadIdExpiryRegressionTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.cache.RegionShortcut.REPLICATE;
 import static org.apache.geode.cache.client.ClientRegionShortcut.CACHING_PROXY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.THREAD_ID_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -39,6 +38,7 @@ import org.apache.geode.cache.client.ClientRegionFactory;
 import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientNotifier;
 import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.CacheRule;
 import org.apache.geode.test.dunit.rules.ClientCacheRule;
@@ -110,8 +110,10 @@ public class HARegionQueueThreadIdExpiryRegressionTest implements Serializable {
   }
 
   private int createCacheServer() throws IOException {
-    System.setProperty(DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, EXPIRY_TIME_SECONDS);
-    System.setProperty(DEFAULT_PREFIX + THREAD_ID_EXPIRY_TIME_PROPERTY, EXPIRY_TIME_SECONDS);
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY,
+        EXPIRY_TIME_SECONDS);
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + THREAD_ID_EXPIRY_TIME_PROPERTY,
+        EXPIRY_TIME_SECONDS);
 
     cacheRule.createCache();
     cacheRule.getCache().setMessageSyncInterval(MESSAGE_SYNC_INTERVAL_SECONDS);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueThreadIdExpiryRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HARegionQueueThreadIdExpiryRegressionTest.java
@@ -16,7 +16,7 @@ package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.cache.RegionShortcut.REPLICATE;
 import static org.apache.geode.cache.client.ClientRegionShortcut.CACHING_PROXY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.THREAD_ID_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -110,8 +110,8 @@ public class HARegionQueueThreadIdExpiryRegressionTest implements Serializable {
   }
 
   private int createCacheServer() throws IOException {
-    System.setProperty(GEODE_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, EXPIRY_TIME_SECONDS);
-    System.setProperty(GEODE_PREFIX + THREAD_ID_EXPIRY_TIME_PROPERTY, EXPIRY_TIME_SECONDS);
+    System.setProperty(DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, EXPIRY_TIME_SECONDS);
+    System.setProperty(DEFAULT_PREFIX + THREAD_ID_EXPIRY_TIME_PROPERTY, EXPIRY_TIME_SECONDS);
 
     cacheRule.createCache();
     cacheRule.getCache().setMessageSyncInterval(MESSAGE_SYNC_INTERVAL_SECONDS);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/RedundancyLevelPart1DUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/RedundancyLevelPart1DUnitTest.java
@@ -18,6 +18,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.internal.lang.SystemProperty.GEMFIRE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
 import static org.apache.geode.test.dunit.VM.getController;
@@ -55,7 +56,6 @@ import org.apache.geode.internal.cache.ClientServerObserverAdapter;
 import org.apache.geode.internal.cache.ClientServerObserverHolder;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheServer;
-import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
@@ -132,8 +132,7 @@ public class RedundancyLevelPart1DUnitTest implements Serializable {
     server2 = hostname + port2;
     server3 = hostname + port3;
 
-    System.setProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
-        "true");
+    System.setProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints", "true");
   }
 
   @After

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/RedundancyLevelPart1DUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/RedundancyLevelPart1DUnitTest.java
@@ -18,7 +18,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEMFIRE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.Disconnect.disconnectAllFromDS;
 import static org.apache.geode.test.dunit.VM.getController;
@@ -56,6 +55,7 @@ import org.apache.geode.internal.cache.ClientServerObserverAdapter;
 import org.apache.geode.internal.cache.ClientServerObserverHolder;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.InternalCacheServer;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
@@ -132,7 +132,8 @@ public class RedundancyLevelPart1DUnitTest implements Serializable {
     server2 = hostname + port2;
     server3 = hostname + port3;
 
-    System.setProperty(GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints", "true");
+    System.setProperty(SystemProperty.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
+        "true");
   }
 
   @After

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -1350,7 +1350,7 @@ public class HARegionQueueJUnitTest {
    */
   @Test
   public void testExpiryUsingSystemProperty() throws Exception {
-    System.setProperty(GEODE_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, "1");
+    System.setProperty(DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, "1");
 
     HARegionQueueAttributes haa = new HARegionQueueAttributes();
     HARegionQueue regionQueue = createHARegionQueue(testName.getMethodName(), haa);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/ha/HARegionQueueJUnitTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.internal.statistics.StatisticsClockFactory.disabledClock;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
@@ -80,6 +79,7 @@ import org.apache.geode.internal.cache.tier.sockets.CacheClientProxy;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 import org.apache.geode.internal.cache.tier.sockets.ClientUpdateMessageImpl;
 import org.apache.geode.internal.cache.tier.sockets.HAEventWrapper;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.dunit.ThreadUtils;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
@@ -1350,7 +1350,7 @@ public class HARegionQueueJUnitTest {
    */
   @Test
   public void testExpiryUsingSystemProperty() throws Exception {
-    System.setProperty(DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, "1");
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY, "1");
 
     HARegionQueueAttributes haa = new HARegionQueueAttributes();
     HARegionQueue regionQueue = createHARegionQueue(testName.getMethodName(), haa);

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirsIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirsIntegrationTest.java
@@ -18,7 +18,6 @@ package org.apache.geode.internal.cache.persistence;
 
 import static org.apache.geode.internal.cache.persistence.DefaultDiskDirs.getDefaultDiskDirs;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
@@ -27,6 +26,7 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.junit.categories.PersistenceTest;
 
 @Category({PersistenceTest.class})
@@ -40,7 +40,7 @@ public class DefaultDiskDirsIntegrationTest {
 
   @Test
   public void getDefaultDiskDirsReturnsOverriddenValue() {
-    System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY,
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY,
         temporaryFolder.getRoot().getAbsolutePath());
     assertThat(getDefaultDiskDirs()[0]).exists().isEqualTo(temporaryFolder.getRoot());
   }

--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirsIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirsIntegrationTest.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.persistence;
 
 import static org.apache.geode.internal.cache.persistence.DefaultDiskDirs.getDefaultDiskDirs;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
@@ -40,7 +40,7 @@ public class DefaultDiskDirsIntegrationTest {
 
   @Test
   public void getDefaultDiskDirsReturnsOverriddenValue() {
-    System.setProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY,
+    System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY,
         temporaryFolder.getRoot().getAbsolutePath());
     assertThat(getDefaultDiskDirs()[0]).exists().isEqualTo(temporaryFolder.getRoot());
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueryOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueryOp.java
@@ -31,6 +31,7 @@ import org.apache.geode.internal.cache.tier.sockets.ChunkedMessage;
 import org.apache.geode.internal.cache.tier.sockets.Message;
 import org.apache.geode.internal.cache.tier.sockets.ObjectPartList;
 import org.apache.geode.internal.cache.tier.sockets.Part;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -132,7 +133,7 @@ public class QueryOp {
           // connection to the same server and retried the query to it, that it would also
           // workaround this issue and it would not have the limitations of needing multiple servers
           // and would not depend on the retry-attempts configuration.
-          boolean enableQueryRetryOnPdxSerializationException = SystemPropertyHelper
+          boolean enableQueryRetryOnPdxSerializationException = SystemProperty
               .getProductBooleanProperty(
                   SystemPropertyHelper.ENABLE_QUERY_RETRY_ON_PDX_SERIALIZATION_EXCEPTION)
               .orElse(false);

--- a/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/wan/GatewaySender.java
@@ -17,6 +17,7 @@ package org.apache.geode.cache.wan;
 import java.util.List;
 
 import org.apache.geode.annotations.Immutable;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.util.internal.GeodeGlossary;
 
@@ -181,7 +182,7 @@ public interface GatewaySender {
    * gateway sender queue when group-transaction-events is true.
    */
   int GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS =
-      SystemPropertyHelper.getProductIntegerProperty(
+      SystemProperty.getProductIntegerProperty(
           SystemPropertyHelper.GET_TRANSACTION_EVENTS_FROM_QUEUE_WAIT_TIME_MS).orElse(1);
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventSerialization.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntryEventSerialization.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.lang.SystemProperty.getProductBooleanProperty;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductBooleanProperty;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/EvictionListBuilder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/EvictionListBuilder.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.cache.eviction;
 
 import java.util.Optional;
 
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 
 public class EvictionListBuilder {
@@ -27,7 +28,7 @@ public class EvictionListBuilder {
   public EvictionListBuilder(EvictionController evictionController) {
     this.controller = evictionController;
     Optional<Boolean> asyncScan =
-        SystemPropertyHelper.getProductBooleanProperty(SystemPropertyHelper.EVICTION_SCAN_ASYNC);
+        SystemProperty.getProductBooleanProperty(SystemPropertyHelper.EVICTION_SCAN_ASYNC);
     evictionScanAsync = asyncScan.orElse(true);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSorting.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithAsyncSorting.java
@@ -27,6 +27,7 @@ import org.apache.geode.internal.cache.BucketRegion;
 import org.apache.geode.internal.cache.RegionEntry;
 import org.apache.geode.internal.cache.RegionEntryContext;
 import org.apache.geode.internal.cache.versions.RegionVersionVector;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
@@ -47,7 +48,7 @@ public class LRUListWithAsyncSorting extends AbstractEvictionList {
   private static final Logger logger = LogService.getLogger();
 
   @Immutable
-  private static final Optional<Integer> EVICTION_SCAN_MAX_THREADS = SystemPropertyHelper
+  private static final Optional<Integer> EVICTION_SCAN_MAX_THREADS = SystemProperty
       .getProductIntegerProperty(SystemPropertyHelper.EVICTION_SCAN_MAX_THREADS);
 
   @MakeNotStatic
@@ -87,7 +88,7 @@ public class LRUListWithAsyncSorting extends AbstractEvictionList {
   }
 
   private double calculateScanThreshold() {
-    Optional<Integer> configuredThresholdPercent = SystemPropertyHelper
+    Optional<Integer> configuredThresholdPercent = SystemProperty
         .getProductIntegerProperty(SystemPropertyHelper.EVICTION_SCAN_THRESHOLD_PERCENT);
 
     int thresholdPercent =

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithSyncSorting.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/eviction/LRUListWithSyncSorting.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.apache.logging.log4j.Logger;
 
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -36,7 +37,7 @@ public class LRUListWithSyncSorting extends AbstractEvictionList {
 
   private int readMaxEntriesProperty() {
     int result = -1;
-    Optional<Integer> optionalMaxEntries = SystemPropertyHelper
+    Optional<Integer> optionalMaxEntries = SystemProperty
         .getProductIntegerProperty(SystemPropertyHelper.EVICTION_SEARCH_MAX_ENTRIES);
     if (optionalMaxEntries.isPresent()) {
       result = optionalMaxEntries.get();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/HARegionQueue.java
@@ -15,9 +15,9 @@
 package org.apache.geode.internal.cache.ha;
 
 import static org.apache.geode.cache.Region.SEPARATOR_CHAR;
+import static org.apache.geode.internal.lang.SystemProperty.getProductIntegerProperty;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.HA_REGION_QUEUE_EXPIRY_TIME_PROPERTY;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.THREAD_ID_EXPIRY_TIME_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductIntegerProperty;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirs.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirs.java
@@ -16,8 +16,8 @@
  */
 package org.apache.geode.internal.cache.persistence;
 
+import static org.apache.geode.internal.lang.SystemProperty.getProductStringProperty;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductStringProperty;
 
 import java.io.File;
 import java.util.Optional;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
@@ -51,7 +51,7 @@ import org.apache.geode.internal.cache.ha.HAContainerWrapper;
 import org.apache.geode.internal.cache.ha.HARegionQueue;
 import org.apache.geode.internal.cache.ha.HARegionQueueAttributes;
 import org.apache.geode.internal.cache.ha.HARegionQueueStats;
-import org.apache.geode.internal.lang.SystemPropertyHelper;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.logging.log4j.LogMarker;
 import org.apache.geode.internal.security.SecurityService;
 import org.apache.geode.internal.serialization.ByteArrayDataInput;
@@ -601,7 +601,7 @@ public class MessageDispatcher extends LoggingThread {
   @NotNull
   @VisibleForTesting
   protected Long getSystemProperty(String key, long defaultValue) {
-    return SystemPropertyHelper.getProductLongProperty(key, defaultValue);
+    return SystemProperty.getProductLongProperty(key, defaultValue);
   }
 
   @NotNull

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -162,6 +162,7 @@ import org.apache.geode.internal.cache.wan.AbstractGatewaySender;
 import org.apache.geode.internal.cache.wan.InternalGatewaySenderFactory;
 import org.apache.geode.internal.cache.wan.WANServiceProvider;
 import org.apache.geode.internal.jndi.JNDIInvoker;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.internal.logging.InternalLogWriter;
 import org.apache.geode.internal.logging.LocalLogWriter;
@@ -193,7 +194,7 @@ public class CacheCreation implements InternalCache {
   private static final RegionAttributes defaults = new AttributesFactory().create();
 
   @Immutable
-  private static final Optional<Boolean> parallelDiskStoreRecovery = SystemPropertyHelper
+  private static final Optional<Boolean> parallelDiskStoreRecovery = SystemProperty
       .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/config/JAXBService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/config/JAXBService.java
@@ -42,6 +42,7 @@ import org.xml.sax.helpers.XMLReaderFactory;
 
 import org.apache.geode.cache.configuration.XSDRootElement;
 import org.apache.geode.internal.classloader.ClassPathLoader;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.management.internal.util.ClasspathScanLoadHelper;
 
@@ -94,7 +95,8 @@ public class JAXBService {
 
   static Set<String> getPackagesToScan() {
     Set<String> packages = new HashSet<>();
-    String sysProperty = SystemPropertyHelper.getProperty(SystemPropertyHelper.PACKAGES_TO_SCAN);
+    String sysProperty =
+        SystemProperty.getProductStringProperty(SystemPropertyHelper.PACKAGES_TO_SCAN).get();
     if (sysProperty != null) {
       packages = Arrays.stream(sysProperty.split(",")).collect(Collectors.toSet());
     } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/config/JAXBService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/config/JAXBService.java
@@ -16,6 +16,9 @@
  */
 package org.apache.geode.internal.config;
 
+import static org.apache.geode.internal.lang.SystemProperty.getProperty;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.PACKAGES_TO_SCAN;
+
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.net.URL;
@@ -42,8 +45,6 @@ import org.xml.sax.helpers.XMLReaderFactory;
 
 import org.apache.geode.cache.configuration.XSDRootElement;
 import org.apache.geode.internal.classloader.ClassPathLoader;
-import org.apache.geode.internal.lang.SystemProperty;
-import org.apache.geode.internal.lang.SystemPropertyHelper;
 import org.apache.geode.management.internal.util.ClasspathScanLoadHelper;
 
 public class JAXBService {
@@ -95,8 +96,7 @@ public class JAXBService {
 
   static Set<String> getPackagesToScan() {
     Set<String> packages = new HashSet<>();
-    String sysProperty =
-        SystemProperty.getProductStringProperty(SystemPropertyHelper.PACKAGES_TO_SCAN).get();
+    String sysProperty = getProperty(PACKAGES_TO_SCAN);
     if (sysProperty != null) {
       packages = Arrays.stream(sysProperty.split(",")).collect(Collectors.toSet());
     } else {

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
@@ -14,6 +14,10 @@
  */
 package org.apache.geode.internal.lang;
 
+import static org.apache.geode.internal.lang.SystemProperty.getProductBooleanProperty;
+
+import org.apache.geode.internal.cache.eviction.LRUListWithAsyncSorting;
+
 /**
  * The SystemPropertyHelper class is an helper class for accessing system properties used in geode.
  * The method name to get the system property should be the same as the system property name.
@@ -24,7 +28,7 @@ public class SystemPropertyHelper {
 
   /**
    * When set to "true" enables asynchronous eviction algorithm (defaults to true). For more details
-   * see {@link org.apache.geode.internal.cache.eviction.LRUListWithAsyncSorting}.
+   * see {@link LRUListWithAsyncSorting}.
    *
    * @since Geode 1.4.0
    */
@@ -33,7 +37,7 @@ public class SystemPropertyHelper {
   /**
    * This property allows the maximum number of threads used for asynchronous eviction scanning to
    * be configured. It defaults to "Math.max((Runtime.getRuntime().availableProcessors() / 4), 1)".
-   * For more details see {@link org.apache.geode.internal.cache.eviction.LRUListWithAsyncSorting}.
+   * For more details see {@link LRUListWithAsyncSorting}.
    *
    * @since Geode 1.4.0
    */
@@ -44,7 +48,7 @@ public class SystemPropertyHelper {
    * started. If the number of entries that have been recently used since the previous scan divided
    * by total number of entries exceeds the threshold then a scan is started. The default threshold
    * is 25. If the threshold is less than 0 or greater than 100 then the default threshold is used.
-   * For more details see {@link org.apache.geode.internal.cache.eviction.LRUListWithAsyncSorting}.
+   * For more details see {@link LRUListWithAsyncSorting}.
    *
    * @since Geode 1.4.0
    */
@@ -80,6 +84,8 @@ public class SystemPropertyHelper {
   /**
    * a comma separated string to list out the packages to scan. If not specified, the entire
    * classpath is scanned.
+   *
+   * <p>
    * This is used by the FastPathScanner to scan for:
    * 1. XSDRootElement annotation
    *
@@ -111,29 +117,31 @@ public class SystemPropertyHelper {
    * As of Geode 1.4.0, a region set operation will be in a transaction even if it is the first
    * operation in the transaction.
    *
+   * <p>
    * In previous releases, a region set operation is not in a transaction if it is the first
    * operation of the transaction.
    *
+   * <p>
    * Setting this system property to true will restore the previous behavior.
    *
    * @since Geode 1.4.0
    */
   public static boolean restoreSetOperationTransactionBehavior() {
-    return SystemProperty.getProductBooleanProperty("restoreSetOperationTransactionBehavior")
-        .orElse(false);
+    return getProductBooleanProperty("restoreSetOperationTransactionBehavior").orElse(false);
   }
 
   /**
    * As of Geode 1.4.0, idle expiration on a replicate or partitioned region will now do a
    * distributed check for a more recent last access time on one of the other copies of the region.
    *
+   * <p>
    * This system property can be set to true to turn off this new check and restore the previous
    * behavior of only using the local last access time as the basis for expiration.
    *
    * @since Geode 1.4.0
    */
   public static boolean restoreIdleExpirationBehavior() {
-    return SystemProperty.getProductBooleanProperty("restoreIdleExpirationBehavior").orElse(false);
+    return getProductBooleanProperty("restoreIdleExpirationBehavior").orElse(false);
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
@@ -14,9 +14,6 @@
  */
 package org.apache.geode.internal.lang;
 
-import java.util.Optional;
-
-
 /**
  * The SystemPropertyHelper class is an helper class for accessing system properties used in geode.
  * The method name to get the system property should be the same as the system property name.
@@ -25,8 +22,10 @@ import java.util.Optional;
  */
 public class SystemPropertyHelper {
 
-  public static final String GEODE_PREFIX = "geode.";
-  public static final String GEMFIRE_PREFIX = "gemfire.";
+  @SuppressWarnings("unused")
+  public static final String GEODE_PREFIX = SystemProperty.GEODE_PREFIX;
+  public static final String GEMFIRE_PREFIX = SystemProperty.GEMFIRE_PREFIX;
+  public static final String DEFAULT_PREFIX = SystemProperty.DEFAULT_PREFIX;
 
   /**
    * When set to "true" enables asynchronous eviction algorithm (defaults to true). For more details
@@ -114,98 +113,6 @@ public class SystemPropertyHelper {
   public static final String RE_AUTHENTICATE_WAIT_TIME = "reauthenticate.wait.time";
 
   /**
-   * This method will try to look up "geode." and "gemfire." versions of the system property. It
-   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
-   *
-   * @param name system property name set in Geode
-   * @return an Optional containing the Boolean value of the system property
-   */
-  public static Optional<Boolean> getProductBooleanProperty(String name) {
-    String property = getProperty(name);
-    return property != null ? Optional.of(Boolean.parseBoolean(property)) : Optional.empty();
-  }
-
-  /**
-   * This method will try to look up "geode." and "gemfire." versions of the system property. It
-   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
-   *
-   * @param name system property name set in Geode
-   * @return an Optional containing the Integer value of the system property
-   */
-  public static Optional<Integer> getProductIntegerProperty(String name) {
-    Integer propertyValue = Integer.getInteger(GEODE_PREFIX + name);
-    if (propertyValue == null) {
-      propertyValue = Integer.getInteger(GEMFIRE_PREFIX + name);
-    }
-
-    if (propertyValue != null) {
-      return Optional.of(propertyValue);
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  /**
-   * This method will try to look up "geode." and "gemfire." versions of the system property. It
-   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
-   *
-   * @param name system property name set in Geode
-   * @return an Optional containing the Long value of the system property
-   */
-  public static Optional<Long> getProductLongProperty(String name) {
-    Long propertyValue = Long.getLong(GEODE_PREFIX + name);
-    if (propertyValue == null) {
-      propertyValue = Long.getLong(GEMFIRE_PREFIX + name);
-    }
-
-    if (propertyValue != null) {
-      return Optional.of(propertyValue);
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  /**
-   * This method will try to look up "geode." and "gemfire." versions of the system property. It
-   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
-   *
-   * @param name system property name set in Geode
-   * @return the integer value of the system property if exits or the default value
-   */
-  public static Integer getProductIntegerProperty(String name, int defaultValue) {
-    return getProductIntegerProperty(name).orElse(defaultValue);
-  }
-
-  public static Long getProductLongProperty(String name, long defaultValue) {
-    return getProductLongProperty(name).orElse(defaultValue);
-  }
-
-  /**
-   * This method will try to look up "geode." and "gemfire." versions of the system property. It
-   * will check and prefer "geode." setting first, then try to check "gemfire." setting.
-   *
-   * @param name system property name set in Geode
-   * @return an Optional containing the String value of the system property
-   */
-  public static Optional<String> getProductStringProperty(String name) {
-    String property = getProperty(name);
-    return property != null ? Optional.of(property) : Optional.empty();
-  }
-
-  public static String getProperty(String name) {
-    String property = getGeodeProperty(name);
-    return property != null ? property : getGemfireProperty(name);
-  }
-
-  private static String getGeodeProperty(String name) {
-    return System.getProperty(GEODE_PREFIX + name);
-  }
-
-  private static String getGemfireProperty(String name) {
-    return System.getProperty(GEMFIRE_PREFIX + name);
-  }
-
-  /**
    * As of Geode 1.4.0, a region set operation will be in a transaction even if it is the first
    * operation in the transaction.
    *
@@ -217,7 +124,8 @@ public class SystemPropertyHelper {
    * @since Geode 1.4.0
    */
   public static boolean restoreSetOperationTransactionBehavior() {
-    return getProductBooleanProperty("restoreSetOperationTransactionBehavior").orElse(false);
+    return SystemProperty.getProductBooleanProperty("restoreSetOperationTransactionBehavior")
+        .orElse(false);
   }
 
   /**
@@ -230,7 +138,7 @@ public class SystemPropertyHelper {
    * @since Geode 1.4.0
    */
   public static boolean restoreIdleExpirationBehavior() {
-    return getProductBooleanProperty("restoreIdleExpirationBehavior").orElse(false);
+    return SystemProperty.getProductBooleanProperty("restoreIdleExpirationBehavior").orElse(false);
   }
 
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/lang/SystemPropertyHelper.java
@@ -22,11 +22,6 @@ package org.apache.geode.internal.lang;
  */
 public class SystemPropertyHelper {
 
-  @SuppressWarnings("unused")
-  public static final String GEODE_PREFIX = SystemProperty.GEODE_PREFIX;
-  public static final String GEMFIRE_PREFIX = SystemProperty.GEMFIRE_PREFIX;
-  public static final String DEFAULT_PREFIX = SystemProperty.DEFAULT_PREFIX;
-
   /**
    * When set to "true" enables asynchronous eviction algorithm (defaults to true). For more details
    * see {@link org.apache.geode.internal.cache.eviction.LRUListWithAsyncSorting}.

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/CoreLoggingExecutors.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/CoreLoggingExecutors.java
@@ -16,6 +16,7 @@ package org.apache.geode.internal.logging;
 
 import static java.lang.Integer.getInteger;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.geode.internal.lang.SystemProperty.GEMFIRE_PREFIX;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -37,7 +38,6 @@ import org.apache.geode.distributed.internal.PooledExecutorWithDMStats;
 import org.apache.geode.distributed.internal.QueueStatHelper;
 import org.apache.geode.distributed.internal.SerialQueuedExecutorWithDMStats;
 import org.apache.geode.internal.ScheduledThreadPoolExecutorWithKeepAlive;
-import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
 import org.apache.geode.logging.internal.executors.LoggingThreadFactory;
@@ -214,7 +214,7 @@ public class CoreLoggingExecutors {
   }
 
   private static int getIdleThreadTimeoutMillis() {
-    return getInteger(SystemProperty.GEMFIRE_PREFIX + IDLE_THREAD_TIMEOUT_MILLIS_PROPERTY,
+    return getInteger(GEMFIRE_PREFIX + IDLE_THREAD_TIMEOUT_MILLIS_PROPERTY,
         DEFAULT_IDLE_THREAD_TIMEOUT_MILLIS);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/logging/CoreLoggingExecutors.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/logging/CoreLoggingExecutors.java
@@ -16,7 +16,6 @@ package org.apache.geode.internal.logging;
 
 import static java.lang.Integer.getInteger;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEMFIRE_PREFIX;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -38,6 +37,7 @@ import org.apache.geode.distributed.internal.PooledExecutorWithDMStats;
 import org.apache.geode.distributed.internal.QueueStatHelper;
 import org.apache.geode.distributed.internal.SerialQueuedExecutorWithDMStats;
 import org.apache.geode.internal.ScheduledThreadPoolExecutorWithKeepAlive;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.monitoring.ThreadsMonitoring;
 import org.apache.geode.logging.internal.executors.LoggingExecutors;
 import org.apache.geode.logging.internal.executors.LoggingThreadFactory;
@@ -214,7 +214,7 @@ public class CoreLoggingExecutors {
   }
 
   private static int getIdleThreadTimeoutMillis() {
-    return getInteger(GEMFIRE_PREFIX + IDLE_THREAD_TIMEOUT_MILLIS_PROPERTY,
+    return getInteger(SystemProperty.GEMFIRE_PREFIX + IDLE_THREAD_TIMEOUT_MILLIS_PROPERTY,
         DEFAULT_IDLE_THREAD_TIMEOUT_MILLIS);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/logging/internal/Configuration.java
+++ b/geode-core/src/main/java/org/apache/geode/logging/internal/Configuration.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.logging.internal;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.logging.internal.spi.LogLevelUpdateOccurs.ONLY_WHEN_USING_DEFAULT_CONFIG;
 import static org.apache.geode.logging.internal.spi.LogLevelUpdateScope.GEODE_LOGGERS;
 
@@ -52,13 +52,13 @@ public class Configuration implements LogConfigListener {
    * System property that may be used to override which {@code LogLevelUpdateOccurs} to use.
    */
   public static final String LOG_LEVEL_UPDATE_OCCURS_PROPERTY =
-      GEODE_PREFIX + "LOG_LEVEL_UPDATE_OCCURS";
+      DEFAULT_PREFIX + "LOG_LEVEL_UPDATE_OCCURS";
 
   /**
    * System property that may be used to override which {@code LogLevelUpdateScope} to use.
    */
   static final String LOG_LEVEL_UPDATE_SCOPE_PROPERTY =
-      GEODE_PREFIX + "LOG_LEVEL_UPDATE_SCOPE";
+      DEFAULT_PREFIX + "LOG_LEVEL_UPDATE_SCOPE";
 
   private final LogLevelUpdateOccurs logLevelUpdateOccurs;
   private final LogLevelUpdateScope logLevelUpdateScope;

--- a/geode-core/src/main/java/org/apache/geode/logging/internal/Configuration.java
+++ b/geode-core/src/main/java/org/apache/geode/logging/internal/Configuration.java
@@ -14,11 +14,11 @@
  */
 package org.apache.geode.logging.internal;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.logging.internal.spi.LogLevelUpdateOccurs.ONLY_WHEN_USING_DEFAULT_CONFIG;
 import static org.apache.geode.logging.internal.spi.LogLevelUpdateScope.GEODE_LOGGERS;
 
 import org.apache.geode.annotations.VisibleForTesting;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.logging.internal.spi.LogConfig;
 import org.apache.geode.logging.internal.spi.LogConfigListener;
 import org.apache.geode.logging.internal.spi.LogConfigSupplier;
@@ -52,13 +52,13 @@ public class Configuration implements LogConfigListener {
    * System property that may be used to override which {@code LogLevelUpdateOccurs} to use.
    */
   public static final String LOG_LEVEL_UPDATE_OCCURS_PROPERTY =
-      DEFAULT_PREFIX + "LOG_LEVEL_UPDATE_OCCURS";
+      SystemProperty.DEFAULT_PREFIX + "LOG_LEVEL_UPDATE_OCCURS";
 
   /**
    * System property that may be used to override which {@code LogLevelUpdateScope} to use.
    */
   static final String LOG_LEVEL_UPDATE_SCOPE_PROPERTY =
-      DEFAULT_PREFIX + "LOG_LEVEL_UPDATE_SCOPE";
+      SystemProperty.DEFAULT_PREFIX + "LOG_LEVEL_UPDATE_SCOPE";
 
   private final LogLevelUpdateOccurs logLevelUpdateOccurs;
   private final LogLevelUpdateScope logLevelUpdateScope;

--- a/geode-core/src/main/java/org/apache/geode/logging/internal/LoggingProviderLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/logging/internal/LoggingProviderLoader.java
@@ -14,7 +14,7 @@
  */
 package org.apache.geode.logging.internal;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 
 import java.util.Collection;
 import java.util.SortedMap;
@@ -47,7 +47,7 @@ public class LoggingProviderLoader {
    */
   @VisibleForTesting
   public static final String LOGGING_PROVIDER_NAME_PROPERTY =
-      GEODE_PREFIX + "LOGGING_PROVIDER_NAME";
+      DEFAULT_PREFIX + "LOGGING_PROVIDER_NAME";
 
   public LoggingProvider load() {
     // 1: use LOGGING_PROVIDER_NAME_PROPERTY if set

--- a/geode-core/src/main/java/org/apache/geode/logging/internal/LoggingProviderLoader.java
+++ b/geode-core/src/main/java/org/apache/geode/logging/internal/LoggingProviderLoader.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.logging.internal;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
-
 import java.util.Collection;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -25,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.classloader.ClassPathLoader;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.internal.util.CollectingServiceLoader;
 import org.apache.geode.internal.util.ListCollectingServiceLoader;
 import org.apache.geode.logging.internal.spi.LoggingProvider;
@@ -47,7 +46,7 @@ public class LoggingProviderLoader {
    */
   @VisibleForTesting
   public static final String LOGGING_PROVIDER_NAME_PROPERTY =
-      DEFAULT_PREFIX + "LOGGING_PROVIDER_NAME";
+      SystemProperty.DEFAULT_PREFIX + "LOGGING_PROVIDER_NAME";
 
   public LoggingProvider load() {
     // 1: use LOGGING_PROVIDER_NAME_PROPERTY if set

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventSerializationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventSerializationTest.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.internal.cache;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -36,6 +35,7 @@ import org.mockito.ArgumentCaptor;
 
 import org.apache.geode.SerializationException;
 import org.apache.geode.cache.Scope;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.pdx.internal.PdxInstanceImpl;
 
 public class EntryEventSerializationTest {
@@ -50,7 +50,7 @@ public class EntryEventSerializationTest {
 
   @Before
   public void setUp() {
-    System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
 
     region = mock(InternalRegion.class);
     event = mock(InternalEntryEvent.class);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventSerializationTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/EntryEventSerializationTest.java
@@ -14,8 +14,8 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.EARLY_ENTRY_EVENT_SERIALIZATION;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -50,7 +50,7 @@ public class EntryEventSerializationTest {
 
   @Before
   public void setUp() {
-    System.setProperty(GEODE_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
+    System.setProperty(DEFAULT_PREFIX + EARLY_ENTRY_EVENT_SERIALIZATION, "true");
 
     region = mock(InternalRegion.class);
     event = mock(InternalEntryEvent.class);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirsTest.java
@@ -18,7 +18,7 @@ package org.apache.geode.internal.cache.persistence;
 
 import static org.apache.geode.internal.cache.persistence.DefaultDiskDirs.getDefaultDiskDirs;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -40,7 +40,7 @@ public class DefaultDiskDirsTest {
 
   @Test
   public void getDefaultDiskDirsReturnsOverriddenValue() {
-    System.setProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, "/FullyQualifiedPath");
+    System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, "/FullyQualifiedPath");
     assertThat(getDefaultDiskDirs()).isEqualTo(new File[] {new File("/FullyQualifiedPath")});
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirsTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/DefaultDiskDirsTest.java
@@ -18,7 +18,6 @@ package org.apache.geode.internal.cache.persistence;
 
 import static org.apache.geode.internal.cache.persistence.DefaultDiskDirs.getDefaultDiskDirs;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -26,6 +25,8 @@ import java.io.File;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+import org.apache.geode.internal.lang.SystemProperty;
 
 
 public class DefaultDiskDirsTest {
@@ -40,7 +41,8 @@ public class DefaultDiskDirsTest {
 
   @Test
   public void getDefaultDiskDirsReturnsOverriddenValue() {
-    System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, "/FullyQualifiedPath");
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY,
+        "/FullyQualifiedPath");
     assertThat(getDefaultDiskDirs()).isEqualTo(new File[] {new File("/FullyQualifiedPath")});
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceInitialImageAdvisorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceInitialImageAdvisorTest.java
@@ -20,7 +20,6 @@ import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.geode.internal.cache.persistence.MembershipChangeListenerFactory.cancelCondition;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -58,6 +57,7 @@ import org.apache.geode.distributed.internal.ReplyException;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor;
 import org.apache.geode.internal.cache.CacheDistributionAdvisor.InitialImageAdvice;
+import org.apache.geode.internal.lang.SystemProperty;
 
 public class PersistenceInitialImageAdvisorTest {
 
@@ -73,7 +73,8 @@ public class PersistenceInitialImageAdvisorTest {
 
   @Before
   public void setUp() {
-    System.setProperty(DEFAULT_PREFIX + PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS, String.valueOf(15));
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS,
+        String.valueOf(15));
 
     persistenceAdvisor = mock(InternalPersistenceAdvisor.class);
     cacheDistributionAdvisor = mock(CacheDistributionAdvisor.class, RETURNS_DEEP_STUBS);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceInitialImageAdvisorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/persistence/PersistenceInitialImageAdvisorTest.java
@@ -20,7 +20,7 @@ import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.geode.internal.cache.persistence.MembershipChangeListenerFactory.cancelCondition;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
@@ -73,7 +73,7 @@ public class PersistenceInitialImageAdvisorTest {
 
   @Before
   public void setUp() {
-    System.setProperty(GEODE_PREFIX + PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS, String.valueOf(15));
+    System.setProperty(DEFAULT_PREFIX + PERSISTENT_VIEW_RETRY_TIMEOUT_SECONDS, String.valueOf(15));
 
     persistenceAdvisor = mock(InternalPersistenceAdvisor.class);
     cacheDistributionAdvisor = mock(CacheDistributionAdvisor.class, RETURNS_DEEP_STUBS);

--- a/geode-core/src/test/java/org/apache/geode/internal/lang/SystemPropertyHelperTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/lang/SystemPropertyHelperTest.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.internal.lang;
 
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEMFIRE_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
@@ -88,35 +86,44 @@ public class SystemPropertyHelperTest {
             .isFalse();
 
     // with geode prefix
-    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
+    System.setProperty(
+        SystemProperty.DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
     assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isTrue();
-    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
+    System.setProperty(
+        SystemProperty.DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
     assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isFalse();
 
     // with gemfire prefix
-    System.clearProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
-    System.setProperty(GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
+    System.clearProperty(
+        SystemProperty.DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
+    System.setProperty(
+        SystemProperty.GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
     assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isTrue();
-    System.setProperty(GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
+    System.setProperty(
+        SystemProperty.GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
     assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isFalse();
 
     // with geode and gemfire prefix
-    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
-    System.setProperty(GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
+    System.setProperty(
+        SystemProperty.DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
+    System.setProperty(
+        SystemProperty.GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
     assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isTrue();
 
     System.clearProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
-    System.clearProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
-    System.clearProperty(GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
+    System.clearProperty(
+        SystemProperty.DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
+    System.clearProperty(
+        SystemProperty.GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/lang/SystemPropertyHelperTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/lang/SystemPropertyHelperTest.java
@@ -14,15 +14,22 @@
  */
 package org.apache.geode.internal.lang;
 
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.GEMFIRE_PREFIX;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 
 public class SystemPropertyHelperTest {
-  private String restoreSetOperationTransactionBehavior = "restoreSetOperationTransactionBehavior";
+
+  private final String restoreSetOperationTransactionBehavior =
+      "restoreSetOperationTransactionBehavior";
+
+  @Rule
+  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   @Test
   public void testRestoreSetOperationTransactionBehaviorDefaultToFalse() {
@@ -54,137 +61,62 @@ public class SystemPropertyHelperTest {
   }
 
   @Test
-  public void getIntegerPropertyPrefersGeodePrefix() {
-    String testProperty = "testIntegerProperty";
-    String gemfirePrefixProperty = "gemfire." + testProperty;
-    String geodePrefixProperty = "geode." + testProperty;
-    System.setProperty(geodePrefixProperty, "1");
-    System.setProperty(gemfirePrefixProperty, "0");
-    assertThat(SystemPropertyHelper.getProductIntegerProperty(testProperty).get()).isEqualTo(1);
-    System.clearProperty(geodePrefixProperty);
-    System.clearProperty(gemfirePrefixProperty);
-  }
-
-  @Test
-  public void getIntegerPropertyReturnsGemfirePrefixIfGeodeMissing() {
-    String testProperty = "testIntegerProperty";
-    String gemfirePrefixProperty = "gemfire." + testProperty;
-    System.setProperty(gemfirePrefixProperty, "1");
-    assertThat(SystemPropertyHelper.getProductIntegerProperty(testProperty).get()).isEqualTo(1);
-    System.clearProperty(gemfirePrefixProperty);
-  }
-
-  @Test
-  public void getIntegerPropertyWithDefaultValue() {
-    String testProperty = "testIntegerProperty";
-    assertThat(SystemPropertyHelper.getProductIntegerProperty(testProperty, 1000)).isEqualTo(1000);
-  }
-
-  @Test
-  public void getLongPropertyWithoutDefaultReturnsGemfirePrefixIfGeodeMissing() {
-    String testProperty = "testLongProperty";
-    String gemfirePrefixProperty = "gemfire." + testProperty;
-    System.setProperty(gemfirePrefixProperty, "1");
-    assertThat(SystemPropertyHelper.getProductLongProperty(testProperty).get()).isEqualTo(1);
-    System.clearProperty(gemfirePrefixProperty);
-  }
-
-  @Test
-  public void getLongPropertyWithDefaultValue() {
-    String testProperty = "testIntegerProperty";
-    assertThat(SystemPropertyHelper.getProductLongProperty(testProperty, 1000)).isEqualTo(1000);
-  }
-
-  @Test
-  public void getIntegerPropertyReturnsEmptyOptionalIfPropertiesMissing() {
-    String testProperty = "notSetProperty";
-    assertThat(SystemPropertyHelper.getProductIntegerProperty(testProperty).isPresent()).isFalse();
-  }
-
-  @Test
-  public void getBooleanPropertyReturnsEmptyOptionalIfProperiesMissing() {
-    String testProperty = "notSetProperty";
-    assertThat(SystemPropertyHelper.getProductBooleanProperty(testProperty).isPresent()).isFalse();
-  }
-
-  @Test
-  public void getBooleanPropertyPrefersGeodePrefix() {
-    String testProperty = "testBooleanProperty";
-    String gemfirePrefixProperty = "gemfire." + testProperty;
-    String geodePrefixProperty = "geode." + testProperty;
-    System.setProperty(geodePrefixProperty, "true");
-    System.setProperty(gemfirePrefixProperty, "false");
-    assertThat(SystemPropertyHelper.getProductBooleanProperty(testProperty).get()).isTrue();
-    System.clearProperty(geodePrefixProperty);
-    System.clearProperty(gemfirePrefixProperty);
-  }
-
-  @Test
-  public void getBooleanPropertyReturnsGemfirePrefixIfGeodeMissing() {
-    String testProperty = "testBooleanProperty";
-    String gemfirePrefixProperty = "gemfire." + testProperty;
-    System.setProperty(gemfirePrefixProperty, "true");
-    assertThat(SystemPropertyHelper.getProductBooleanProperty(testProperty).get()).isTrue();
-    System.clearProperty(gemfirePrefixProperty);
-  }
-
-  @Test
   public void getBooleanPropertyReturnsEnableRetryOnPdxSerializationException() {
     String testProperty = "enableQueryRetryOnPdxSerializationException";
     String gemfirePrefixProperty = "gemfire." + testProperty;
     System.setProperty(gemfirePrefixProperty, "true");
-    assertThat(SystemPropertyHelper.getProductBooleanProperty(testProperty).get()).isTrue();
+    assertThat(SystemProperty.getProductBooleanProperty(testProperty).get()).isTrue();
     System.clearProperty(gemfirePrefixProperty);
-    assertThat(SystemPropertyHelper.getProductBooleanProperty(testProperty).orElse(false))
+    assertThat(SystemProperty.getProductBooleanProperty(testProperty).orElse(false))
         .isFalse();
   }
 
   @Test
   public void getBooleanPropertyParallelDiskStoreRecovery() {
     // default
-    assertThat(SystemPropertyHelper
+    assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).isPresent())
             .isFalse();
-    assertThat(SystemPropertyHelper
+    assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).orElse(true))
             .isTrue();
 
     // without geode or gemfire prefix
     System.setProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
-    assertThat(SystemPropertyHelper
+    assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).isPresent())
             .isFalse();
 
     // with geode prefix
-    System.setProperty(GEODE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
-    assertThat(SystemPropertyHelper
+    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
+    assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isTrue();
-    System.setProperty(GEODE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
-    assertThat(SystemPropertyHelper
+    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
+    assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isFalse();
 
     // with gemfire prefix
-    System.clearProperty(GEODE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
+    System.clearProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
     System.setProperty(GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
-    assertThat(SystemPropertyHelper
+    assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isTrue();
     System.setProperty(GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
-    assertThat(SystemPropertyHelper
+    assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isFalse();
 
     // with geode and gemfire prefix
-    System.setProperty(GEODE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
+    System.setProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "true");
     System.setProperty(GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY, "false");
-    assertThat(SystemPropertyHelper
+    assertThat(SystemProperty
         .getProductBooleanProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY).get())
             .isTrue();
 
     System.clearProperty(SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
-    System.clearProperty(GEODE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
+    System.clearProperty(DEFAULT_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
     System.clearProperty(GEMFIRE_PREFIX + SystemPropertyHelper.PARALLEL_DISK_STORE_RECOVERY);
   }
 }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryWithRangeIndexDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryWithRangeIndexDUnitTest.java
@@ -22,7 +22,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_P
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_START;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEMFIRE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.apache.geode.test.dunit.VM.getVMId;
@@ -44,6 +43,7 @@ import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.distributed.internal.InternalLocator;
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
@@ -191,7 +191,7 @@ public class QueryWithRangeIndexDUnitTest implements Serializable {
 
   private static void startServer(File workingDirectory, int serverPort,
       String locators) {
-    System.setProperty(GEMFIRE_PREFIX + "Query.INDEX_THRESHOLD_SIZE", "10000");
+    System.setProperty(SystemProperty.GEMFIRE_PREFIX + "Query.INDEX_THRESHOLD_SIZE", "10000");
     ServerLauncher serverLauncher = new ServerLauncher.Builder()
         .setDeletePidFileOnStop(Boolean.TRUE)
         .setMemberName(serverName)

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryWithRangeIndexDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryWithRangeIndexDUnitTest.java
@@ -22,6 +22,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_P
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_START;
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
+import static org.apache.geode.internal.lang.SystemProperty.GEMFIRE_PREFIX;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.VM.getVM;
 import static org.apache.geode.test.dunit.VM.getVMId;
@@ -43,7 +44,6 @@ import org.apache.geode.cache.query.data.Portfolio;
 import org.apache.geode.distributed.LocatorLauncher;
 import org.apache.geode.distributed.ServerLauncher;
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
@@ -191,7 +191,7 @@ public class QueryWithRangeIndexDUnitTest implements Serializable {
 
   private static void startServer(File workingDirectory, int serverPort,
       String locators) {
-    System.setProperty(SystemProperty.GEMFIRE_PREFIX + "Query.INDEX_THRESHOLD_SIZE", "10000");
+    System.setProperty(GEMFIRE_PREFIX + "Query.INDEX_THRESHOLD_SIZE", "10000");
     ServerLauncher serverLauncher = new ServerLauncher.Builder()
         .setDeletePidFileOnStop(Boolean.TRUE)
         .setMemberName(serverName)

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedDiskDirRuleDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedDiskDirRuleDistributedTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.test.dunit.rules.tests;
 
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.dunit.VM.getAllVMs;
 import static org.apache.geode.test.dunit.VM.getController;
 import static org.apache.geode.test.dunit.VM.getVM;
@@ -30,6 +29,7 @@ import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedDiskDirRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
@@ -50,7 +50,8 @@ public class DistributedDiskDirRuleDistributedTest implements Serializable {
   public void setsDefaultDiskDirsPropertyInEveryVm() {
     for (VM vm : toArray(getAllVMs(), getController())) {
       vm.invoke(() -> {
-        String propertyValue = System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
+        String propertyValue =
+            System.getProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
 
         assertThat(propertyValue)
             .isEqualTo(distributedDiskDirRule.getDiskDirFor(vm).getAbsolutePath());
@@ -64,7 +65,8 @@ public class DistributedDiskDirRuleDistributedTest implements Serializable {
 
     for (VM vm : toArray(getAllVMs(), getController())) {
       String propertyValue =
-          vm.invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+          vm.invoke(
+              () -> System.getProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
       assertThat(propertyValues).doesNotContain(propertyValue);
       propertyValues.add(propertyValue);
     }
@@ -77,7 +79,8 @@ public class DistributedDiskDirRuleDistributedTest implements Serializable {
     VM newVM = getVM(getVMCount());
 
     String propertyValue =
-        newVM.invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+        newVM.invoke(
+            () -> System.getProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
 
     assertThat(propertyValue).isNotNull();
   }
@@ -85,12 +88,14 @@ public class DistributedDiskDirRuleDistributedTest implements Serializable {
   @Test
   public void defaultDiskDirsPropertyIsKeptInBouncedVm() {
     String propertyValueBeforeBounce =
-        getVM(0).invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+        getVM(0).invoke(
+            () -> System.getProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
 
     getVM(0).bounce();
 
     String propertyValueAfterBounce =
-        getVM(0).invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+        getVM(0).invoke(
+            () -> System.getProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
     assertThat(propertyValueAfterBounce).isEqualTo(propertyValueBeforeBounce);
   }
 }

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedDiskDirRuleDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/rules/tests/DistributedDiskDirRuleDistributedTest.java
@@ -15,7 +15,7 @@
 package org.apache.geode.test.dunit.rules.tests;
 
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.dunit.VM.getAllVMs;
 import static org.apache.geode.test.dunit.VM.getController;
 import static org.apache.geode.test.dunit.VM.getVM;
@@ -50,7 +50,7 @@ public class DistributedDiskDirRuleDistributedTest implements Serializable {
   public void setsDefaultDiskDirsPropertyInEveryVm() {
     for (VM vm : toArray(getAllVMs(), getController())) {
       vm.invoke(() -> {
-        String propertyValue = System.getProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
+        String propertyValue = System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
 
         assertThat(propertyValue)
             .isEqualTo(distributedDiskDirRule.getDiskDirFor(vm).getAbsolutePath());
@@ -64,7 +64,7 @@ public class DistributedDiskDirRuleDistributedTest implements Serializable {
 
     for (VM vm : toArray(getAllVMs(), getController())) {
       String propertyValue =
-          vm.invoke(() -> System.getProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+          vm.invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
       assertThat(propertyValues).doesNotContain(propertyValue);
       propertyValues.add(propertyValue);
     }
@@ -77,7 +77,7 @@ public class DistributedDiskDirRuleDistributedTest implements Serializable {
     VM newVM = getVM(getVMCount());
 
     String propertyValue =
-        newVM.invoke(() -> System.getProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+        newVM.invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
 
     assertThat(propertyValue).isNotNull();
   }
@@ -85,12 +85,12 @@ public class DistributedDiskDirRuleDistributedTest implements Serializable {
   @Test
   public void defaultDiskDirsPropertyIsKeptInBouncedVm() {
     String propertyValueBeforeBounce =
-        getVM(0).invoke(() -> System.getProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+        getVM(0).invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
 
     getVM(0).bounce();
 
     String propertyValueAfterBounce =
-        getVM(0).invoke(() -> System.getProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+        getVM(0).invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
     assertThat(propertyValueAfterBounce).isEqualTo(propertyValueBeforeBounce);
   }
 }

--- a/geode-dunit/src/integrationTest/java/org/apache/geode/test/junit/rules/DiskDirRuleIntegrationTest.java
+++ b/geode-dunit/src/integrationTest/java/org/apache/geode/test/junit/rules/DiskDirRuleIntegrationTest.java
@@ -16,7 +16,7 @@ package org.apache.geode.test.junit.rules;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -74,7 +74,7 @@ public class DiskDirRuleIntegrationTest {
 
   @Test
   public void setsDefaultDiskDirsSystemProperty() {
-    String propertyValue = System.getProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
+    String propertyValue = System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
 
     assertThat(propertyValue).isEqualTo(diskDirRule.getDiskDir().getAbsolutePath());
   }

--- a/geode-dunit/src/integrationTest/java/org/apache/geode/test/junit/rules/DiskDirRuleIntegrationTest.java
+++ b/geode-dunit/src/integrationTest/java/org/apache/geode/test/junit/rules/DiskDirRuleIntegrationTest.java
@@ -16,7 +16,6 @@ package org.apache.geode.test.junit.rules;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -30,6 +29,7 @@ import org.junit.rules.TestName;
 import org.apache.geode.cache.CacheFactory;
 import org.apache.geode.internal.cache.DiskStoreImpl;
 import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.lang.SystemProperty;
 
 /**
  * Integration tests for {@link DiskDirRule}.
@@ -74,7 +74,8 @@ public class DiskDirRuleIntegrationTest {
 
   @Test
   public void setsDefaultDiskDirsSystemProperty() {
-    String propertyValue = System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
+    String propertyValue =
+        System.getProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
 
     assertThat(propertyValue).isEqualTo(diskDirRule.getDiskDir().getAbsolutePath());
   }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedDiskDirRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedDiskDirRule.java
@@ -18,7 +18,6 @@ package org.apache.geode.test.dunit.rules;
 
 import static org.apache.geode.internal.lang.SystemProperty.getProductStringProperty;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.dunit.VM.DEFAULT_VM_COUNT;
 import static org.apache.geode.test.dunit.VM.getCurrentVMNum;
 
@@ -32,6 +31,7 @@ import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.junit.runner.Description;
 
+import org.apache.geode.internal.lang.SystemProperty;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.VMEventListener;
 import org.apache.geode.test.dunit.internal.DUnitLauncher;
@@ -119,7 +119,8 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
    */
   public File getDiskDirFor(VM vm) {
     return new File(
-        vm.invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY)));
+        vm.invoke(
+            () -> System.getProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY)));
   }
 
   @Override
@@ -177,7 +178,8 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
       Files.createDirectory(diskDir.toPath());
     }
 
-    System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, diskDir.getAbsolutePath());
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY,
+        diskDir.getAbsolutePath());
   }
 
   private void doAfter() {
@@ -186,9 +188,10 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
           + getCurrentVMNum() + ". Rule does not support VM.bounce().");
     }
     if (data.originalValue() == null) {
-      System.clearProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
+      System.clearProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
     } else {
-      System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, data.originalValue());
+      System.setProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY,
+          data.originalValue());
     }
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedDiskDirRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/rules/DistributedDiskDirRule.java
@@ -16,9 +16,9 @@
  */
 package org.apache.geode.test.dunit.rules;
 
+import static org.apache.geode.internal.lang.SystemProperty.getProductStringProperty;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductStringProperty;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 import static org.apache.geode.test.dunit.VM.DEFAULT_VM_COUNT;
 import static org.apache.geode.test.dunit.VM.getCurrentVMNum;
 
@@ -118,7 +118,8 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
    * Returns the current default disk dirs value for the specified VM.
    */
   public File getDiskDirFor(VM vm) {
-    return new File(vm.invoke(() -> System.getProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY)));
+    return new File(
+        vm.invoke(() -> System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY)));
   }
 
   @Override
@@ -176,7 +177,7 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
       Files.createDirectory(diskDir.toPath());
     }
 
-    System.setProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, diskDir.getAbsolutePath());
+    System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, diskDir.getAbsolutePath());
   }
 
   private void doAfter() {
@@ -185,9 +186,9 @@ public class DistributedDiskDirRule extends DiskDirRule implements SerializableT
           + getCurrentVMNum() + ". Rule does not support VM.bounce().");
     }
     if (data.originalValue() == null) {
-      System.clearProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
+      System.clearProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
     } else {
-      System.setProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, data.originalValue());
+      System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, data.originalValue());
     }
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/DiskDirRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/DiskDirRule.java
@@ -16,9 +16,9 @@
  */
 package org.apache.geode.test.junit.rules;
 
+import static org.apache.geode.internal.lang.SystemProperty.getProductStringProperty;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.GEODE_PREFIX;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.getProductStringProperty;
+import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -73,7 +73,7 @@ public class DiskDirRule extends DescribedExternalResource {
    * Returns the current default disk dirs value.
    */
   public File getDiskDir() {
-    return new File(System.getProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+    return new File(System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
   }
 
   @Override
@@ -85,15 +85,15 @@ public class DiskDirRule extends DescribedExternalResource {
 
     File diskDir = temporaryFolder.newFolder(getDiskDirName(description.getClassName()));
 
-    System.setProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, diskDir.getAbsolutePath());
+    System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, diskDir.getAbsolutePath());
   }
 
   @Override
   protected void after(Description description) {
     if (originalValue == null) {
-      System.clearProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
+      System.clearProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
     } else {
-      System.setProperty(GEODE_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, originalValue);
+      System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, originalValue);
     }
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/DiskDirRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/DiskDirRule.java
@@ -18,7 +18,6 @@ package org.apache.geode.test.junit.rules;
 
 import static org.apache.geode.internal.lang.SystemProperty.getProductStringProperty;
 import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_DISK_DIRS_PROPERTY;
-import static org.apache.geode.internal.lang.SystemPropertyHelper.DEFAULT_PREFIX;
 
 import java.io.File;
 import java.lang.reflect.Method;
@@ -27,6 +26,8 @@ import java.util.Optional;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestName;
 import org.junit.runner.Description;
+
+import org.apache.geode.internal.lang.SystemProperty;
 
 /**
  * JUnit Rule that overrides the default DiskDirs directory. Internally, TemporaryFolder and
@@ -73,7 +74,7 @@ public class DiskDirRule extends DescribedExternalResource {
    * Returns the current default disk dirs value.
    */
   public File getDiskDir() {
-    return new File(System.getProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
+    return new File(System.getProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY));
   }
 
   @Override
@@ -85,15 +86,16 @@ public class DiskDirRule extends DescribedExternalResource {
 
     File diskDir = temporaryFolder.newFolder(getDiskDirName(description.getClassName()));
 
-    System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, diskDir.getAbsolutePath());
+    System.setProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY,
+        diskDir.getAbsolutePath());
   }
 
   @Override
   protected void after(Description description) {
     if (originalValue == null) {
-      System.clearProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
+      System.clearProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY);
     } else {
-      System.setProperty(DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, originalValue);
+      System.setProperty(SystemProperty.DEFAULT_PREFIX + DEFAULT_DISK_DIRS_PROPERTY, originalValue);
     }
   }
 


### PR DESCRIPTION
PROBLEM

SystemPropertyHelper combines dual-prefix property lookup with
product system property definitions. Property lookup is currently
limited to geode-core and not useable from modules that are upstream
from geode-core.

SOLUTION

Extract part of SystemPropertyHelper to geode-common for use in
modules that are upstream from geode-core.

Define new DEFAULT_PREFIX that maps to GEODE_PREFIX and use that
everywhere that GEODE_PREFIX was previously used.

NOTE

This PR does not include the new code in geode-serialization that will
be using SystemProperty after it moves to geode-common. That will be
in a separate PR of its own.

Also, I didn't actually write any new code for this PR. All of the changes
are just moving, extracting, and formatting code.