### PR TITLE
GEODE-9877: Use ServerSocket to create interfering port

### DIFF
--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/GeodeRedisServerStartupAcceptanceTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/GeodeRedisServerStartupAcceptanceTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.BindException;
 import java.net.InetSocketAddress;
-import java.net.Socket;
+import java.net.ServerSocket;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -45,7 +45,7 @@ import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
 import org.apache.geode.test.junit.categories.IgnoreInRepeatTestTasks;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 
-public class GeodeRedisServerStartupDUnitTest {
+public class GeodeRedisServerStartupAcceptanceTest {
 
   @Rule
   public RedisClusterStartupRule cluster = new RedisClusterStartupRule();
@@ -111,8 +111,9 @@ public class GeodeRedisServerStartupDUnitTest {
     int port = AvailablePortHelper.getRandomAvailableTCPPort();
 
     addIgnoredException("Could not start server compatible with Redis");
-    try (Socket interferingSocket = new Socket()) {
+    try (ServerSocket interferingSocket = new ServerSocket()) {
       interferingSocket.bind(new InetSocketAddress("localhost", port));
+
       assertThatThrownBy(() -> cluster.startServerVM(0, s -> s
           .withProperty(GEODE_FOR_REDIS_PORT, "" + port)
           .withProperty(GEODE_FOR_REDIS_BIND_ADDRESS, "localhost")

--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/GeodeRedisServerStartupUsingGfshAcceptanceTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/GeodeRedisServerStartupUsingGfshAcceptanceTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.Socket;
+import java.net.ServerSocket;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -29,7 +29,7 @@ import org.apache.geode.test.junit.rules.gfsh.GfshExecution;
 import org.apache.geode.test.junit.rules.gfsh.GfshRule;
 import org.apache.geode.test.junit.rules.gfsh.GfshScript;
 
-public class GeodeRedisServerStartUpAcceptanceTest {
+public class GeodeRedisServerStartupUsingGfshAcceptanceTest {
 
   @Rule
   public GfshRule gfshRule = new GfshRule();
@@ -47,7 +47,7 @@ public class GeodeRedisServerStartUpAcceptanceTest {
         "--geode-for-redis-port", String.valueOf(port));
     GfshExecution execution;
 
-    try (Socket interferingSocket = new Socket()) {
+    try (ServerSocket interferingSocket = new ServerSocket()) {
       interferingSocket.bind(new InetSocketAddress("localhost", port));
       execution = GfshScript.of(startServerCommand)
           .expectFailure()
@@ -69,7 +69,7 @@ public class GeodeRedisServerStartUpAcceptanceTest {
         "--geode-for-redis-port", String.valueOf(port));
     GfshExecution execution;
 
-    try (Socket interferingSocket = new Socket()) {
+    try (ServerSocket interferingSocket = new ServerSocket()) {
       interferingSocket.bind(new InetSocketAddress("0.0.0.0", port));
       execution = GfshScript.of(startServerCommand)
           .expectFailure()


### PR DESCRIPTION
- For some unknown reason `startupFailsGivenPortAlreadyInUse` started to
  fail after a seemingly innocuous Ubuntu base image bump. The problem
  may also have been triggered by arbitrary test ordering changes since
  the test did not fail on its own, but only in conjunction with running
  other tests beforehand.
  Specifically, the test was failing when binding the interfering port
  (bind exception). The port used was always in the TIME_WAIT state left
  from previous tests.
  Using a `ServerSocket`, instead of a regular socket, fixes the problem
  since it actually 'uses' the port and implicitly allows for port
  reuse.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
