### PR TITLE
GEODE-9758: Add serial filter config and utils

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -317,7 +317,7 @@ dependencies {
   implementation(project(':geode-logging'))
   implementation(project(':geode-membership'))
   implementation(project(':geode-unsafe'))
-  implementation(project(':geode-serialization'))
+  api(project(':geode-serialization'))
   implementation(project(':geode-tcp-server'))
 
   //geode-management currently has pieces of the public API

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/ValidateSerializableObjectsDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/ValidateSerializableObjectsDistributedTest.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.cache;
+
+import static java.util.Arrays.asList;
+import static org.apache.geode.cache.RegionShortcut.REPLICATE;
+import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
+import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
+import static org.apache.geode.distributed.ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS;
+import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
+import static org.apache.geode.test.dunit.VM.getVM;
+import static org.apache.geode.test.dunit.rules.DistributedRule.getLocatorPort;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.NotSerializableException;
+import java.io.Serializable;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.InternalGemFireException;
+import org.apache.geode.SerializationException;
+import org.apache.geode.cache.util.CacheListenerAdapter;
+import org.apache.geode.distributed.ServerLauncher;
+import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.dunit.rules.DistributedReference;
+import org.apache.geode.test.dunit.rules.DistributedRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTemporaryFolder;
+
+@SuppressWarnings("serial")
+public class ValidateSerializableObjectsDistributedTest implements Serializable {
+
+  private VM server1;
+  private VM server2;
+
+  private File server1Dir;
+  private File server2Dir;
+  private int locatorPort;
+
+  @Rule
+  public DistributedRule distributedRule = new DistributedRule();
+  @Rule
+  public DistributedReference<ServerLauncher> server = new DistributedReference<>();
+  @Rule
+  public SerializableTemporaryFolder temporaryFolder = new SerializableTemporaryFolder();
+
+  @Before
+  public void setUp() throws IOException {
+    server1 = getVM(0);
+    server2 = getVM(1);
+
+    server1Dir = temporaryFolder.newFolder("server1");
+    server2Dir = temporaryFolder.newFolder("server2");
+
+    locatorPort = getLocatorPort();
+
+    server1.invoke(() -> {
+      server.set(startServer("server1", server1Dir));
+    });
+    server2.invoke(() -> {
+      server.set(startServer("server2", server2Dir));
+    });
+
+    asList(server1, server2).forEach(vm -> vm.invoke(() -> {
+      server.get().getCache()
+          .createRegionFactory(REPLICATE)
+          .addCacheListener(new CacheListenerAdapter<Object, Object>() {
+            @Override
+            public void afterCreate(EntryEvent<Object, Object> event) {
+              // cache listener afterCreate causes all creates to deserialize the value which causes
+              // the tests to pass if serialization filter is configured
+              assertThat(event.getNewValue()).isNotNull();
+            }
+          })
+          .create("region");
+    }));
+
+  }
+
+  @Test
+  public void stringIsAllowed() {
+    server1.invoke(() -> {
+      Region<Object, Object> region = server.get().getCache().getRegion("region");
+      region.put("key", "value");
+    });
+  }
+
+  @Test
+  public void primitiveIsAllowed() {
+    server1.invoke(() -> {
+      Region<Object, Object> region = server.get().getCache().getRegion("region");
+      region.put(1, 1);
+    });
+  }
+
+  @Test
+  public void nonSerializableThrowsNotSerializableException() {
+    server1.invoke(() -> {
+      Region<Object, Object> region = server.get().getCache().getRegion("region");
+      Throwable thrown = catchThrowable(() -> {
+        region.put(new Object(), new Object());
+      });
+      assertThat(thrown).hasCauseExactlyInstanceOf(NotSerializableException.class);
+    });
+  }
+
+  @Test
+  public void nonAllowedIsNotPropagatedToOtherServer() {
+    addIgnoredException(InvalidClassException.class);
+    addIgnoredException(SerializationException.class);
+
+    server1.invoke(() -> {
+      Region<Object, Object> region = server.get().getCache().getRegion("region");
+      region.put("key", new SerializableClass());
+    });
+
+    server2.invoke(() -> {
+      Region<Object, Object> region = server.get().getCache().getRegion("region");
+      Throwable thrown = catchThrowable(() -> {
+        region.get("key");
+      });
+      assertThat(thrown)
+          .isInstanceOf(SerializationException.class)
+          .hasCauseInstanceOf(InvalidClassException.class);
+    });
+  }
+
+  @Test
+  public void nonAllowedDoesNotThrow() {
+    addIgnoredException(InvalidClassException.class);
+    addIgnoredException(IOException.class);
+
+    server1.invoke(() -> {
+      Region<Object, Object> region = server.get().getCache().getRegion("region");
+      Throwable thrown = catchThrowable(() -> {
+        region.put(new SerializableClass(), new SerializableClass());
+      });
+      assertThat(thrown).isInstanceOf(InternalGemFireException.class);
+    });
+  }
+
+  private ServerLauncher startServer(String serverName, File serverDir) {
+    ServerLauncher serverLauncher = new ServerLauncher.Builder()
+        .setDisableDefaultServer(true)
+        .setDeletePidFileOnStop(true)
+        .setMemberName(serverName)
+        .setWorkingDirectory(serverDir.getAbsolutePath())
+        .setServerPort(0)
+        .set(ENABLE_CLUSTER_CONFIGURATION, "false")
+        .set(LOCATORS, "localHost[" + locatorPort + "]")
+        .set(VALIDATE_SERIALIZABLE_OBJECTS, "true")
+        .build();
+
+    serverLauncher.start();
+
+    return serverLauncher;
+  }
+
+  public static class SerializableClass implements Serializable {
+  }
+}

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorIntegrationTest.java
@@ -15,84 +15,56 @@
 package org.apache.geode.distributed;
 
 import static org.apache.geode.distributed.ConfigurationProperties.ENABLE_CLUSTER_CONFIGURATION;
-import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_HTTP_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_START;
-import static org.apache.geode.distributed.ConfigurationProperties.LOCATOR_WAIT_TIME;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
-import static org.apache.geode.util.internal.GeodeGlossary.GEMFIRE_PREFIX;
+import static org.apache.geode.internal.security.SecurableCommunicationChannel.LOCATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
-import java.util.function.IntSupplier;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import org.apache.geode.distributed.internal.InternalLocator;
-import org.apache.geode.distributed.internal.ServerLocation;
 import org.apache.geode.distributed.internal.tcpserver.HostAndPort;
 import org.apache.geode.distributed.internal.tcpserver.TcpClient;
 import org.apache.geode.distributed.internal.tcpserver.TcpSocketFactory;
-import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.InternalDataSerializer;
-import org.apache.geode.internal.cache.GemFireCacheImpl;
+import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.net.SocketCreatorFactory;
-import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.logging.internal.OSProcess;
+import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.internal.JmxManagerAdvisor.JmxManagerProfile;
+import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.management.internal.configuration.messages.SharedConfigurationStatusRequest;
 import org.apache.geode.test.junit.categories.MembershipTest;
-import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
 
-@Category({MembershipTest.class})
-@RunWith(Parameterized.class)
-@UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
+@Category(MembershipTest.class)
 public class LocatorIntegrationTest {
 
   private Locator locator;
-  private File tmpFile;
+  private File logFile;
   private int port;
-
-  @Parameters
-  public static Collection<Object> data() {
-    return Arrays.asList(new Object[] {
-        (IntSupplier) () -> 0,
-        (IntSupplier) AvailablePortHelper::getRandomAvailableTCPPort});
-  }
-
-  @Parameter
-  public IntSupplier portSupplier;
-
-  @Rule
-  public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Before
   public void setUp() throws IOException {
-    tmpFile = File.createTempFile("locator", ".log");
-    port = portSupplier.getAsInt();
-    deleteLocatorViewFile(port);
+    logFile = temporaryFolder.newFile("locator.log");
   }
 
   @After
@@ -100,21 +72,22 @@ public class LocatorIntegrationTest {
     if (locator != null) {
       locator.stop();
     }
-    assertThat(Locator.hasLocator()).isFalse();
+    deleteLocatorViewFile(port);
   }
 
   /**
    * Fix: locator creates "locator0view.dat" file when started with port 0
    */
   @Test
-  public void testThatLocatorDoesNotCreateFileWithZeroPort() throws Exception {
+  public void doesNotCreateZeroPortViewFileForEphemeralPort() throws Exception {
     deleteLocatorViewFile(0);
 
     Properties configProperties = new Properties();
-    configProperties.setProperty(MCAST_PORT, "0");
     configProperties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
-    configProperties.setProperty(LOCATOR_WAIT_TIME, "1"); // seconds
+    configProperties.setProperty(HTTP_SERVICE_PORT, "0");
+    configProperties.setProperty(JMX_MANAGER, "false");
     configProperties.setProperty(LOG_FILE, "");
+    configProperties.setProperty(MCAST_PORT, "0");
 
     locator = Locator.startLocatorAndDS(port, null, configProperties);
 
@@ -123,75 +96,121 @@ public class LocatorIntegrationTest {
     assertThat(viewFile).doesNotExist();
   }
 
+  @Test
+  public void locatorStartsOnSpecifiedPort() throws IOException {
+    Properties configProperties = new Properties();
+    configProperties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
+    configProperties.setProperty(HTTP_SERVICE_PORT, "0");
+    configProperties.setProperty(JMX_MANAGER, "false");
+    configProperties.setProperty(LOG_FILE, "");
+    configProperties.setProperty(MCAST_PORT, "0");
+
+    port = getRandomAvailableTCPPort();
+    locator = Locator.startLocatorAndDS(port, null, configProperties);
+
+    port = locator.getPort();
+    assertThat(port).isEqualTo(port);
+  }
+
+  @Test
+  public void locatorStartsOnEphemeralPort() throws IOException {
+    Properties configProperties = new Properties();
+    configProperties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
+    configProperties.setProperty(HTTP_SERVICE_PORT, "0");
+    configProperties.setProperty(JMX_MANAGER, "false");
+    configProperties.setProperty(LOG_FILE, "");
+    configProperties.setProperty(MCAST_PORT, "0");
+
+    locator = Locator.startLocatorAndDS(0, null, configProperties);
+
+    port = locator.getPort();
+    assertThat(port).isNotZero();
+  }
+
   /**
    * Fix: if jmx-manager-start is true in a locator then gfsh connect will fail
    */
   @Test
-  public void testGfshConnectShouldSucceedIfJmxManagerStartIsTrueInLocator() throws Exception {
+  public void gfshConnectsIfJmxManagerStartIsTrue() throws Exception {
     int jmxPort = getRandomAvailableTCPPort();
 
     Properties configProperties = new Properties();
-    configProperties.setProperty(MCAST_PORT, "0");
-    configProperties.setProperty(JMX_MANAGER_PORT, "" + jmxPort);
-    configProperties.setProperty(JMX_MANAGER_START, "true");
-    configProperties.setProperty(JMX_MANAGER_HTTP_PORT, "0");
     configProperties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
+    configProperties.setProperty(HTTP_SERVICE_PORT, "0");
+    configProperties.setProperty(JMX_MANAGER_PORT, String.valueOf(jmxPort));
+    configProperties.setProperty(JMX_MANAGER_START, "true");
     configProperties.setProperty(LOG_FILE, "");
-
-    // not needed
-    System.setProperty(GEMFIRE_PREFIX + "disableManagement", "false");
+    configProperties.setProperty(MCAST_PORT, "0");
 
     locator = Locator.startLocatorAndDS(port, null, configProperties);
-    List<JmxManagerProfile> alreadyManaging =
-        GemFireCacheImpl.getInstance().getJmxManagerAdvisor().adviseAlreadyManaging();
+    InternalLocator internalLocator = (InternalLocator) locator;
+    InternalCache cache = internalLocator.getCache();
+    List<JmxManagerProfile> alreadyManaging = cache.getJmxManagerAdvisor().adviseAlreadyManaging();
 
     assertThat(alreadyManaging).hasSize(1);
-    assertThat(alreadyManaging.get(0).getDistributedMember())
-        .isEqualTo(GemFireCacheImpl.getInstance().getMyId());
+    assertThat(alreadyManaging.get(0).getDistributedMember()).isEqualTo(cache.getMyId());
   }
 
   @Test
-  public void testHandlersAreWaitedOn() throws Exception {
+  public void hasHandlerForSharedConfigurationStatusRequest() throws Exception {
     Properties configProperties = new Properties();
-    configProperties.setProperty(MCAST_PORT, "0");
     configProperties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
-    configProperties.setProperty(LOCATOR_WAIT_TIME, "1"); // seconds
+    configProperties.setProperty(HTTP_SERVICE_PORT, "0");
+    configProperties.setProperty(JMX_MANAGER, "false");
     configProperties.setProperty(LOG_FILE, "");
+    configProperties.setProperty(MCAST_PORT, "0");
 
     locator = Locator.startLocatorAndDS(port, null, configProperties);
 
     InternalLocator internalLocator = (InternalLocator) locator;
 
     // the locator should always install a SharedConfigurationStatusRequest handler
-    assertThat(internalLocator.hasHandlerForClass(SharedConfigurationStatusRequest.class)).isTrue();
+    boolean hasHandler = internalLocator.hasHandlerForClass(SharedConfigurationStatusRequest.class);
+    assertThat(hasHandler).isTrue();
   }
 
   @Test
-  public void testBasicInfo() throws Exception {
-    locator = Locator.startLocator(port, tmpFile);
-    int boundPort = port == 0 ? locator.getPort() : port;
-    TcpClient client = new TcpClient(SocketCreatorFactory
-        .getSocketCreatorForComponent(SecurableCommunicationChannel.LOCATOR),
+  public void infoRequestIncludesActualPortWhenSpecifiedPortIsZero() throws Exception {
+    locator = Locator.startLocator(0, logFile);
+    port = locator.getPort();
+    TcpClient client = new TcpClient(
+        SocketCreatorFactory.getSocketCreatorForComponent(LOCATOR),
         InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
         InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer(),
         TcpSocketFactory.DEFAULT);
-    String[] info = client.getInfo(new HostAndPort("localhost", boundPort));
+
+    String[] info = client.getInfo(new HostAndPort("localhost", port));
 
     assertThat(info).isNotNull();
     assertThat(info.length).isGreaterThanOrEqualTo(1);
   }
 
   @Test
-  public void testNoThreadLeftBehind() throws Exception {
+  public void infoRequestIncludesActualPortWhenSpecifiedIsNonZero() throws Exception {
+    locator = Locator.startLocator(getRandomAvailableTCPPort(), logFile);
+    port = locator.getPort();
+    TcpClient client = new TcpClient(
+        SocketCreatorFactory.getSocketCreatorForComponent(LOCATOR),
+        InternalDataSerializer.getDSFIDSerializer().getObjectSerializer(),
+        InternalDataSerializer.getDSFIDSerializer().getObjectDeserializer(),
+        TcpSocketFactory.DEFAULT);
+
+    String[] info = client.getInfo(new HostAndPort("localhost", port));
+
+    assertThat(info).isNotNull();
+    assertThat(info.length).isGreaterThanOrEqualTo(1);
+  }
+
+  @Test
+  public void threadsAreCleanedUpWhenStartFails() throws Exception {
     Properties configProperties = new Properties();
+    configProperties.setProperty(LOG_FILE, "");
     configProperties.setProperty(MCAST_PORT, "0");
-    configProperties.setProperty(JMX_MANAGER_START, "false");
-    configProperties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
 
     int threadCount = Thread.activeCount();
 
     Throwable thrown = catchThrowable(
-        () -> locator = Locator.startLocatorAndDS(-2, new File(""), configProperties));
+        () -> locator = Locator.startLocatorAndDS(-2, null, configProperties));
 
     assertThat(thrown).isInstanceOf(IllegalArgumentException.class);
 
@@ -206,22 +225,31 @@ public class LocatorIntegrationTest {
     assertThat(threadCount)
         .as("Expected " + threadCount + " threads or fewer but found " + Thread.activeCount()
             + ". Check log file for a thread dump.")
+        .withThreadDumpOnError()
         .isGreaterThanOrEqualTo(Thread.activeCount());
   }
 
   /**
-   * Make sure two ServerLocation objects on different hosts but with the same port are not equal
-   *
-   * <p>
-   * Fix: LoadBalancing directs all traffic to a single cache server if all servers are started on
-   * the same port
+   * Validates that Locator.startLocatorAndDS does not start a JMX Manager by default. Only the
+   * LocatorLauncher starts one by default.
    */
   @Test
-  public void testServerLocationOnDifferentHostsShouldNotTestEqual() {
-    ServerLocation serverLocation1 = new ServerLocation("host1", 777);
-    ServerLocation serverLocation2 = new ServerLocation("host2", 777);
+  public void doesNotStartJmxManagerByDefault() throws Exception {
+    Properties configProperties = new Properties();
+    configProperties.setProperty(ENABLE_CLUSTER_CONFIGURATION, "false");
+    configProperties.setProperty(HTTP_SERVICE_PORT, "0");
+    configProperties.setProperty(LOG_FILE, "");
+    configProperties.setProperty(MCAST_PORT, "0");
 
-    assertThat(serverLocation1).isNotEqualTo(serverLocation2);
+    locator = Locator.startLocatorAndDS(port, null, configProperties);
+
+    InternalLocator internalLocator = (InternalLocator) locator;
+    InternalCache cache = internalLocator.getCache();
+    SystemManagementService managementService =
+        (SystemManagementService) ManagementService.getManagementService(cache);
+
+    boolean isManager = managementService.isManager();
+    assertThat(isManager).isFalse();
   }
 
   private void deleteLocatorViewFile(int portNumber) {

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/DistributionConfig.java
@@ -212,6 +212,7 @@ import org.apache.geode.internal.Config;
 import org.apache.geode.internal.ConfigSource;
 import org.apache.geode.internal.logging.LogWriterImpl;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
+import org.apache.geode.internal.serialization.filter.SerializableObjectConfig;
 import org.apache.geode.internal.statistics.StatisticsConfig;
 import org.apache.geode.internal.tcp.Connection;
 import org.apache.geode.logging.internal.spi.LogConfig;
@@ -228,7 +229,8 @@ import org.apache.geode.util.internal.GeodeGlossary;
  * @see Config
  * @since GemFire 2.1
  */
-public interface DistributionConfig extends Config, LogConfig, StatisticsConfig {
+public interface DistributionConfig
+    extends Config, LogConfig, StatisticsConfig, SerializableObjectConfig {
 
   /**
    * The static String definition of the prefix used to defined ssl-* properties

--- a/geode-core/src/main/java/org/apache/geode/internal/DistributedSerializableObjectConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/DistributedSerializableObjectConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
+import static org.apache.geode.distributed.ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS;
+
+import java.util.Properties;
+
+import org.apache.geode.internal.serialization.filter.SerializableObjectConfig;
+
+/**
+ * Simple implementation of {@code SerializableObjectConfig} for use when an instance of
+ * {@code DistributionConfig} is not available.
+ */
+public class DistributedSerializableObjectConfig implements SerializableObjectConfig {
+
+  private final Properties config;
+
+  public DistributedSerializableObjectConfig(Properties config) {
+    this.config = requireNonNull(config);
+  }
+
+  @Override
+  public boolean getValidateSerializableObjects() {
+    return "true".equalsIgnoreCase(config.getProperty(VALIDATE_SERIALIZABLE_OBJECTS));
+  }
+
+  @Override
+  public void setValidateSerializableObjects(boolean value) {
+    config.setProperty(VALIDATE_SERIALIZABLE_OBJECTS, Boolean.valueOf(value).toString());
+  }
+
+  @Override
+  public String getSerializableObjectFilter() {
+    return config.getProperty(SERIALIZABLE_OBJECT_FILTER);
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/InternalDataSerializer.java
@@ -89,7 +89,6 @@ import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.execute.Function;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DMStats;
-import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.distributed.internal.LonerDistributionManager;
 import org.apache.geode.distributed.internal.SerialDistributionMessage;
@@ -123,6 +122,7 @@ import org.apache.geode.internal.serialization.SerializationVersions;
 import org.apache.geode.internal.serialization.StaticSerialization;
 import org.apache.geode.internal.serialization.VersionedDataStream;
 import org.apache.geode.internal.serialization.filter.SanctionedSerializablesService;
+import org.apache.geode.internal.serialization.filter.SerializableObjectConfig;
 import org.apache.geode.internal.util.concurrent.CopyOnWriteHashMap;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.pdx.NonPortableClassException;
@@ -411,24 +411,24 @@ public abstract class InternalDataSerializer extends DataSerializer {
    * Initializes the optional serialization "accept list" if the user has requested it in the
    * DistributionConfig
    *
-   * @param distributionConfig the DistributedSystem configuration
+   * @param serializableConfig the DistributedSystem configuration
    */
-  public static void initializeSerializationFilter(DistributionConfig distributionConfig) {
-    initializeSerializationFilter(distributionConfig, loadSanctionedSerializablesServices());
+  public static void initializeSerializationFilter(SerializableObjectConfig serializableConfig) {
+    initializeSerializationFilter(serializableConfig, loadSanctionedSerializablesServices());
   }
 
   /**
    * Initializes the optional serialization "accept list" if the user has requested it in the
    * DistributionConfig
    *
-   * @param distributionConfig the DistributedSystem configuration
+   * @param serializableConfig the DistributedSystem configuration
    * @param services SanctionedSerializablesService that might have classes to acceptlist
    */
   @VisibleForTesting
-  public static void initializeSerializationFilter(DistributionConfig distributionConfig,
+  public static void initializeSerializationFilter(SerializableObjectConfig serializableConfig,
       Collection<SanctionedSerializablesService> services) {
     logger.info("initializing InternalDataSerializer with {} services", services.size());
-    if (distributionConfig.getValidateSerializableObjects()) {
+    if (serializableConfig.getValidateSerializableObjects()) {
       if (!ClassUtils.isClassAvailable("sun.misc.ObjectInputFilter")
           && !ClassUtils.isClassAvailable("java.io.ObjectInputFilter")) {
         throw new GemFireConfigException(
@@ -436,7 +436,7 @@ public abstract class InternalDataSerializer extends DataSerializer {
       }
       serializationFilter =
           new ObjectInputStreamFilterWrapper(SANCTIONED_SERIALIZABLES_DEPENDENCIES_PATTERN
-              + distributionConfig.getSerializableObjectFilter() + ";!*", services);
+              + serializableConfig.getSerializableObjectFilter() + ";!*", services);
     } else {
       clearSerializationFilter();
     }

--- a/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/distributed/internal/DistributionConfigJUnitTest.java
@@ -60,6 +60,7 @@ import org.junit.experimental.categories.Category;
 
 import org.apache.geode.UnmodifiableException;
 import org.apache.geode.internal.ConfigSource;
+import org.apache.geode.internal.serialization.filter.SerializableObjectConfig;
 import org.apache.geode.security.TestPostProcessor;
 import org.apache.geode.security.TestSecurityManager;
 import org.apache.geode.test.junit.categories.MembershipTest;
@@ -491,5 +492,12 @@ public class DistributionConfigJUnitTest {
     props.put(SECURITY_AUTH_TOKEN_ENABLED_COMPONENTS, "MANAGEment");
     DistributionConfig config = new DistributionConfigImpl(props);
     assertThat(config.getSecurityAuthTokenEnabledComponents()).containsExactly("MANAGEMENT");
+  }
+
+  @Test
+  public void isASerializableObjectConfig() {
+    DistributionConfig config = new DistributionConfigImpl(new Properties());
+
+    assertThat(config).isInstanceOf(SerializableObjectConfig.class);
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/DistributedSerializableObjectConfigTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/DistributedSerializableObjectConfigTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal;
+
+import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
+import static org.apache.geode.distributed.ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import java.util.Properties;
+
+import org.junit.Test;
+
+import org.apache.geode.internal.serialization.filter.SerializableObjectConfig;
+
+public class DistributedSerializableObjectConfigTest {
+
+  @Test
+  public void getValidateSerializableObjects_returnsTrue_whenPropertyIsTrue() {
+    Properties properties = spy(new Properties());
+    SerializableObjectConfig config = new DistributedSerializableObjectConfig(properties);
+    when(properties.getProperty(VALIDATE_SERIALIZABLE_OBJECTS)).thenReturn("true");
+
+    boolean result = config.getValidateSerializableObjects();
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void setValidateSerializableObjects_setsPropertyValue() {
+    Properties properties = spy(new Properties());
+    SerializableObjectConfig config = new DistributedSerializableObjectConfig(properties);
+
+    config.setValidateSerializableObjects(true);
+
+    assertThat(properties.getProperty(VALIDATE_SERIALIZABLE_OBJECTS)).isEqualTo("true");
+  }
+
+  @Test
+  public void getSerializableObjectFilter_returnsPropertyValue() {
+    Properties properties = spy(new Properties());
+    SerializableObjectConfig config = new DistributedSerializableObjectConfig(properties);
+    when(properties.getProperty(SERIALIZABLE_OBJECT_FILTER)).thenReturn("!*");
+
+    String result = config.getSerializableObjectFilter();
+
+    assertThat(result).isEqualTo("!*");
+  }
+}

--- a/geode-core/src/test/resources/expected-pom.xml
+++ b/geode-core/src/test/resources/expected-pom.xml
@@ -78,6 +78,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.geode</groupId>
+      <artifactId>geode-serialization</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geode</groupId>
       <artifactId>geode-management</artifactId>
       <scope>compile</scope>
     </dependency>
@@ -225,11 +230,6 @@
     <dependency>
       <groupId>org.apache.geode</groupId>
       <artifactId>geode-unsafe</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.geode</groupId>
-      <artifactId>geode-serialization</artifactId>
       <scope>runtime</scope>
     </dependency>
     <dependency>

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesTestBase.java
@@ -16,6 +16,7 @@ package org.apache.geode.codeAnalysis;
 
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
 import static org.apache.geode.distributed.ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS;
+import static org.apache.geode.internal.InternalDataSerializer.initializeSerializationFilter;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -52,8 +53,7 @@ import org.apache.geode.DataSerializable;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.codeAnalysis.decode.CompiledClass;
 import org.apache.geode.codeAnalysis.decode.CompiledField;
-import org.apache.geode.distributed.internal.DistributionConfigImpl;
-import org.apache.geode.internal.InternalDataSerializer;
+import org.apache.geode.internal.DistributedSerializableObjectConfig;
 import org.apache.geode.internal.serialization.BufferDataOutputStream;
 import org.apache.geode.internal.serialization.DataSerializableFixedID;
 import org.apache.geode.internal.serialization.KnownVersion;
@@ -333,7 +333,7 @@ public abstract class AnalyzeSerializablesTestBase
     properties.setProperty(VALIDATE_SERIALIZABLE_OBJECTS, "true");
     properties.setProperty(SERIALIZABLE_OBJECT_FILTER, "!*");
 
-    InternalDataSerializer.initializeSerializationFilter(new DistributionConfigImpl(properties));
+    initializeSerializationFilter(new DistributedSerializableObjectConfig(properties));
   }
 
   @Override

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/filter/ObjectInputFilterUtils.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/filter/ObjectInputFilterUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.serialization.filter;
+
+import java.util.function.Function;
+
+import org.apache.geode.internal.lang.utils.ClassUtils;
+
+public class ObjectInputFilterUtils {
+
+  private ObjectInputFilterUtils() {
+    // do not instantiate
+  }
+
+  public static boolean supportsObjectInputFilter() {
+    return supportsObjectInputFilter(ClassUtils::isClassAvailable);
+  }
+
+  static boolean supportsObjectInputFilter(Function<String, Boolean> isClassAvailable) {
+    return isClassAvailable.apply("sun.misc.ObjectInputFilter") ||
+        isClassAvailable.apply("java.io.ObjectInputFilter");
+  }
+}

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/filter/SerializableObjectConfig.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/filter/SerializableObjectConfig.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.serialization.filter;
+
+/**
+ * Defines the configuration properties for serialization filtering in Geode.
+ */
+public interface SerializableObjectConfig {
+
+  default String getSerializableObjectFilterIfEnabled() {
+    return getValidateSerializableObjects() ? getSerializableObjectFilter() : null;
+  }
+
+  boolean getValidateSerializableObjects();
+
+  void setValidateSerializableObjects(boolean value);
+
+  String getSerializableObjectFilter();
+}

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/filter/ObjectInputFilterUtilsTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/filter/ObjectInputFilterUtilsTest.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.serialization.filter;
+
+import static org.apache.commons.lang3.JavaVersion.JAVA_1_8;
+import static org.apache.commons.lang3.JavaVersion.JAVA_9;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
+import static org.apache.geode.internal.serialization.filter.ObjectInputFilterUtils.supportsObjectInputFilter;
+import static org.apache.geode.util.internal.UncheckedUtils.uncheckedCast;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+
+import org.junit.Test;
+
+public class ObjectInputFilterUtilsTest {
+
+  @Test
+  public void supportsObjectInputFilter_delegatesToClassUtils() {
+    Function<String, Boolean> isClassAvailable = uncheckedCast(mock(Function.class));
+    when(isClassAvailable.apply(anyString())).thenReturn(true);
+
+    supportsObjectInputFilter(isClassAvailable);
+
+    verify(isClassAvailable).apply(anyString());
+  }
+
+  @Test
+  public void supportsObjectInputFilter_checksSunMisc() {
+    Function<String, Boolean> isClassAvailable = uncheckedCast(mock(Function.class));
+    when(isClassAvailable.apply(anyString())).thenReturn(false);
+
+    supportsObjectInputFilter(isClassAvailable);
+
+    verify(isClassAvailable).apply("sun.misc.ObjectInputFilter");
+  }
+
+  @Test
+  public void supportsObjectInputFilter_checksJavaIo() {
+    Function<String, Boolean> isClassAvailable = uncheckedCast(mock(Function.class));
+    when(isClassAvailable.apply(anyString())).thenReturn(false);
+
+    supportsObjectInputFilter(isClassAvailable);
+
+    verify(isClassAvailable).apply("java.io.ObjectInputFilter");
+  }
+
+  @Test
+  public void supportsObjectInputFilter_checksSunMiscAndJavaIo() {
+    Function<String, Boolean> isClassAvailable = uncheckedCast(mock(Function.class));
+    when(isClassAvailable.apply(anyString())).thenReturn(false);
+
+    supportsObjectInputFilter(isClassAvailable);
+
+    verify(isClassAvailable).apply("sun.misc.ObjectInputFilter");
+    verify(isClassAvailable).apply("java.io.ObjectInputFilter");
+  }
+
+  @Test
+  public void supportsObjectInputFilter_returnsTrue_onJava8() {
+    assumeThat(isJavaVersionAtMost(JAVA_1_8)).isTrue();
+
+    boolean result = supportsObjectInputFilter();
+
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  public void supportsObjectInputFilter_returnsTrue_onJava9orGreater() {
+    assumeThat(isJavaVersionAtLeast(JAVA_9)).isTrue();
+
+    boolean result = supportsObjectInputFilter();
+
+    assertThat(result).isTrue();
+  }
+}

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/filter/SerializableObjectConfigTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/filter/SerializableObjectConfigTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.serialization.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import org.junit.Test;
+
+public class SerializableObjectConfigTest {
+
+  @Test
+  public void getSerializableObjectFilterIfEnabled_returnsFilter_ifValidateIsTrue() {
+    SerializableObjectConfig config = spy(SerializableObjectConfig.class);
+    when(config.getSerializableObjectFilter()).thenReturn("filter-string");
+    when(config.getValidateSerializableObjects()).thenReturn(true);
+
+    String result = config.getSerializableObjectFilterIfEnabled();
+
+    assertThat(result).isEqualTo("filter-string");
+  }
+
+  @Test
+  public void getSerializableObjectFilterIfEnabled_returnsNull_ifValidateIsFalse() {
+    SerializableObjectConfig config = spy(SerializableObjectConfig.class);
+    when(config.getSerializableObjectFilter()).thenReturn("filter-string");
+    when(config.getValidateSerializableObjects()).thenReturn(false);
+
+    String result = config.getSerializableObjectFilterIfEnabled();
+
+    assertThat(result).isNull();
+  }
+}


### PR DESCRIPTION
1. Add SerializableObjectConfig to geode-serialization and change DistributionConfig to extend it. geode-serialization is upstream from geode-core and cannot reference DistributionConfig.
2. Add ObjectInputFilterUtils to refactor redundant code that checks if ObjectInputFilter is supported.
3. Add Jianxia's improvements to LocatorIntegrationTest.
4. Add ValidateSerializableObjectsDistributedTest to test validate-serializable-objects.