### PR TITLE
GEODE-9810: More robust waiting for native Redis cluster to start

### DIFF
--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/NativeRedisClusterTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/NativeRedisClusterTest.java
@@ -15,18 +15,25 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.ClassRule;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.exceptions.JedisClusterException;
+import redis.clients.jedis.exceptions.JedisConnectionException;
 import redis.clients.jedis.exceptions.JedisMovedDataException;
+
+import org.apache.geode.logging.internal.log4j.api.LogService;
 
 /**
  * This class serves merely as an example of using the {@link NativeRedisClusterTestRule}.
@@ -35,17 +42,24 @@ import redis.clients.jedis.exceptions.JedisMovedDataException;
  */
 public class NativeRedisClusterTest {
 
+  private static final Logger logger = LogService.getLogger();
+
   @ClassRule
   public static NativeRedisClusterTestRule cluster = new NativeRedisClusterTestRule();
 
   @Test
   public void testEachProxyReturnsExposedPorts() {
     for (Integer port : cluster.getExposedPorts()) {
-      try (Jedis jedis = new Jedis("localhost", port)) {
-        List<ClusterNode> nodes =
-            ClusterNodes.parseClusterNodes(jedis.clusterNodes()).getNodes();
+      try (Jedis jedis = new Jedis(BIND_ADDRESS, port, REDIS_CLIENT_TIMEOUT)) {
+        String rawClusterNodes = jedis.clusterNodes();
+        List<ClusterNode> nodes = ClusterNodes.parseClusterNodes(rawClusterNodes).getNodes();
         List<Integer> ports = nodes.stream().map(f -> (int) f.port).collect(Collectors.toList());
-        assertThat(ports).containsExactlyInAnyOrderElementsOf(cluster.getExposedPorts());
+
+        assertThat(ports).as(rawClusterNodes)
+            .containsExactlyInAnyOrderElementsOf(cluster.getExposedPorts());
+      } catch (JedisConnectionException | JedisClusterException jex) {
+        debugContainers();
+        throw jex;
       }
     }
   }
@@ -53,7 +67,8 @@ public class NativeRedisClusterTest {
   @Test
   public void testClusterAwareClient() {
     try (JedisCluster jedis =
-        new JedisCluster(new HostAndPort("localhost", cluster.getExposedPorts().get(0)))) {
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, cluster.getExposedPorts().get(0)),
+            REDIS_CLIENT_TIMEOUT)) {
       jedis.set("a", "0"); // slot 15495
       jedis.set("b", "1"); // slot 3300
       jedis.set("c", "2"); // slot 7365
@@ -64,16 +79,30 @@ public class NativeRedisClusterTest {
       jedis.set("h", "7"); // slot 11694
       jedis.set("i", "8"); // slot 15759
       jedis.set("j", "9"); // slot 3564
+    } catch (JedisConnectionException | JedisClusterException jex) {
+      debugContainers();
+      throw jex;
     }
   }
 
   @Test
   public void testMoved() {
     try (Jedis jedis =
-        new Jedis("localhost", cluster.getExposedPorts().get(0), 100000)) {
+        new Jedis(BIND_ADDRESS, cluster.getExposedPorts().get(0), REDIS_CLIENT_TIMEOUT)) {
       assertThatThrownBy(() -> jedis.set("a", "A"))
           .isInstanceOf(JedisMovedDataException.class)
           .hasMessageContaining("127.0.0.1");
+    }
+  }
+
+  private void debugContainers() {
+    cluster.dumpContainerLogs();
+    for (Integer port : cluster.getExposedPorts()) {
+      try (Jedis j = new Jedis(BIND_ADDRESS, port, REDIS_CLIENT_TIMEOUT)) {
+        System.out.println("============ Cluster node proxy port: " + port + " =============");
+        System.out.println(j.clusterInfo());
+        System.out.println(j.clusterNodes());
+      }
     }
   }
 

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/ClusterNodes.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/ClusterNodes.java
@@ -74,7 +74,8 @@ public class ClusterNodes {
     List<Pair<Long, Long>> slots = new ArrayList<>();
     if (primary) {
       // Sometimes we see a 'primary' without slots which seems to imply it hasn't yet transitioned
-      // to being a 'replica'.
+      // to being a 'replica'. Nevertheless, still keep the state as primary. Eventually the
+      // higher layers will call into here again until everything is stabilized.
       if (parts.length > 8) {
         for (int i = 8; i < parts.length; i++) {
           String[] startEnd = parts[i].split("-");
@@ -87,8 +88,6 @@ public class ClusterNodes {
           }
           slots.add(Pair.of(slotStart, slotEnd));
         }
-      } else {
-        primary = false;
       }
     }
 

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
@@ -15,10 +15,11 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
-import java.io.Serializable;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -41,7 +42,7 @@ import org.apache.geode.redis.internal.proxy.RedisProxy;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.junit.rules.IgnoreOnWindowsRule;
 
-public class NativeRedisClusterTestRule extends ExternalResource implements Serializable {
+public class NativeRedisClusterTestRule extends ExternalResource {
 
   private static final Logger logger = LogService.getLogger();
   private static final String REDIS_COMPOSE_YML = "/redis-cluster-compose.yml";
@@ -83,9 +84,13 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
 
         redisCluster.start();
 
-        int port = redisCluster.getServicePort("redis-node-0", REDIS_PORT);
-
-        waitForPrimaries(port, 3);
+        List<ClusterNode> nodes = null;
+        for (int i = 0; i < NODE_COUNT; i++) {
+          int port = redisCluster.getServicePort("redis-node-" + i, REDIS_PORT);
+          nodes = waitForRedisNodes(port, 3);
+        }
+        assert nodes != null;
+        nodes.forEach(logger::info);
 
         // Used when translating internal redis host:port to the external host:port which is
         // ultimately what command results will return.
@@ -127,16 +132,33 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
     return delegate.apply(containerStatement, description);
   }
 
-  private void waitForPrimaries(int port, int wantedPrimaries) {
+  public void dumpContainerLogs() {
+    dumpContainerLogs("redis-cluster-init_1");
+    for (int i = 0; i < NODE_COUNT; i++) {
+      dumpContainerLogs("redis-node-" + i + "_1");
+    }
+  }
+
+  private void dumpContainerLogs(String node) {
+    System.out.println("=================== Container: " + node + " =====================");
+    System.out.println(redisCluster.getContainerByServiceName(node).get().getLogs());
+  }
+
+  /**
+   * This method assumes that there is a replica for every primary.
+   */
+  private List<ClusterNode> waitForRedisNodes(int port, int wantedPrimaries) {
     List<ClusterNode> nodes = null;
     int primaryCount = 0;
+    int replicakount = 0;
 
-    try (Jedis jedis = new Jedis("localhost", port)) {
+    try (Jedis jedis = new Jedis(BIND_ADDRESS, port, REDIS_CLIENT_TIMEOUT)) {
       for (int i = 0; i < 60; i++) {
         nodes = ClusterNodes.parseClusterNodes(jedis.clusterNodes()).getNodes();
         primaryCount = nodes.stream().mapToInt(x -> x.primary ? 1 : 0).sum();
-        if (primaryCount == wantedPrimaries) {
-          break;
+        replicakount = nodes.stream().mapToInt(x -> x.primary ? 0 : 1).sum();
+        if (primaryCount == wantedPrimaries && replicakount == wantedPrimaries) {
+          return nodes;
         }
 
         try {
@@ -151,6 +173,12 @@ public class NativeRedisClusterTestRule extends ExternalResource implements Seri
     assertThat(primaryCount)
         .as("Incorrect primary node count")
         .isEqualTo(wantedPrimaries);
+
+    assertThat(replicakount)
+        .as("Incorrect replica node count")
+        .isEqualTo(wantedPrimaries);
+
+    return null;
   }
 
   public void flushAll() {

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/NativeRedisClusterTestRule.java
@@ -150,14 +150,14 @@ public class NativeRedisClusterTestRule extends ExternalResource {
   private List<ClusterNode> waitForRedisNodes(int port, int wantedPrimaries) {
     List<ClusterNode> nodes = null;
     int primaryCount = 0;
-    int replicakount = 0;
+    int replicaCount = 0;
 
     try (Jedis jedis = new Jedis(BIND_ADDRESS, port, REDIS_CLIENT_TIMEOUT)) {
       for (int i = 0; i < 60; i++) {
         nodes = ClusterNodes.parseClusterNodes(jedis.clusterNodes()).getNodes();
         primaryCount = nodes.stream().mapToInt(x -> x.primary ? 1 : 0).sum();
-        replicakount = nodes.stream().mapToInt(x -> x.primary ? 0 : 1).sum();
-        if (primaryCount == wantedPrimaries && replicakount == wantedPrimaries) {
+        replicaCount = nodes.stream().mapToInt(x -> x.primary ? 0 : 1).sum();
+        if (primaryCount == wantedPrimaries && replicaCount == wantedPrimaries) {
           return nodes;
         }
 
@@ -174,7 +174,7 @@ public class NativeRedisClusterTestRule extends ExternalResource {
         .as("Incorrect primary node count")
         .isEqualTo(wantedPrimaries);
 
-    assertThat(replicakount)
+    assertThat(replicaCount)
         .as("Incorrect replica node count")
         .isEqualTo(wantedPrimaries);
 


### PR DESCRIPTION
- This fix also addresses GEODE-9428 where CLUSTERDOWN is occasionally
  reported.
- The NativeRedisClusterTestRule now checks each node to make sure they
  are all reporting the correct node count instead of just one. Nodes
  are not always all ready at once.
- When processing CLUSTER INFO sometimes a 'master' reports with no
  slots which indicates it is transitioning or will become a replica.
  Originally we would mark such a node as a replica even before it had
  fully transitioned. However, this would cause problems since it then
  resulted in a too early report that the cluster was ready.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
