### PR TITLE
GEODE-9887: Fix for deadlock during server shutdown

### DIFF
--- a/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderEventRemoteDispatcher.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderEventRemoteDispatcher.java
@@ -736,6 +736,11 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
               logger.debug("{}: Received null ack from remote site.", processor.getSender());
             }
             processor.handleException();
+
+            // Check if canceled before sleeping
+            if (checkCancelled()) {
+              break;
+            }
             try { // This wait is before trying to getting new connection to
                   // receive ack. Without this there will be continuous call to
                   // getConnection
@@ -750,7 +755,10 @@ public class GatewaySenderEventRemoteDispatcher implements GatewaySenderEventDis
           logger.fatal(
               "Stopping the processor because the following exception occurred while processing a batch:",
               e);
+        } else {
+          return;
         }
+
         sender.getLifeCycleLock().writeLock().lock();
         try {
           processor.stopProcessing();


### PR DESCRIPTION
This deadlock happens when server is shutdown gracefully.
"Distributed system shutdown hook" thread initiates shutdown threads
"ConcurrentParallelGatewaySenderEventProcessor Stopper Thread"
and waits for them to finish.
Every "ConcurrentParallelGatewaySenderEventProcessor Stopper Thread"
then set flag AckReaderThread.shutdown indicating that AckReaderThread
should be also shutdown and waits for it by joining the threads for max 15 seconds.
The "AckReaderThread for : Event Processor for GatewaySender_sender"
thread blocks during shutdown because it tries to acquire the lock that was
already acquired by "Distributed system shutdown hook" thread.
This deadlock only last for 15 seconds, because thread join
will expire for all  "ConcurrentParallelGatewaySenderEventProcessor
 Stopper Thread" threads forcing them to finish. Because these threads finished,
the "Distributed system shutdown hook" can continue the execution,
release the lock and conclude the shutdown. The problem here is that 
delay of 15 seconds can cause traffic loss if read-timeout on clients
is configured to lower value.

The fix:
When exception happen in AckReaderThread due to shutdown of the server
(e.g. CacheClosedException) then check if shutdown is already ongoing before
trying to acquire the lock and initiate shutdown of the dispatcher threads.
When server is shutting down that means that dispatcher threads are already
in the process of shutting down and there is no need for AckReaderThread 
to initiate the same thing again.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
