### PR TITLE
GEODE-9899: Fix synchronization for RedisSet

### DIFF
--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -60,6 +60,10 @@ public class RedisSet extends AbstractRedisData {
     }
   }
 
+  public RedisSet(int expectedSize) {
+    members = new MemberSet(expectedSize);
+  }
+
   /**
    * For deserialization only.
    */
@@ -261,7 +265,7 @@ public class RedisSet extends AbstractRedisData {
   }
 
   @VisibleForTesting
-  boolean membersRemove(byte[] memberToRemove) {
+  synchronized boolean membersRemove(byte[] memberToRemove) {
     return members.remove(memberToRemove);
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -69,10 +69,6 @@ public class RedisSet extends AbstractRedisData {
    */
   public RedisSet() {}
 
-  public RedisSet(int size) {
-    members = new RedisSet.MemberSet(size);
-  }
-
   public static Set<byte[]> sdiff(RegionProvider regionProvider, List<RedisKey> keys) {
     return calculateDiff(regionProvider, keys);
   }


### PR DESCRIPTION
- This adds synchronization for methods where there is interaction
  between core Geode functionality and Radish operations. Specifically
  where `toData` may be called (during GII) and regular operations that
  mutate the underlying data structure in a `RedisSet`.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
