### PR TITLE
GEODE-9819: fix durable client socket leak

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientNotifier.java
@@ -131,9 +131,34 @@ public class CacheClientNotifier {
   @MakeNotStatic
   private static volatile CacheClientNotifier ccnSingleton;
 
-  private final SocketMessageWriter socketMessageWriter = new SocketMessageWriter();
+  private final SocketMessageWriter socketMessageWriter;
   private final ClientRegistrationEventQueueManager clientRegistrationEventQueueManager;
   private final CacheClientProxyFactory cacheClientProxyFactory;
+
+  @VisibleForTesting
+  static CacheClientNotifier getInstance(InternalCache cache,
+      ClientRegistrationEventQueueManager clientRegistrationEventQueueManager,
+      StatisticsClock statisticsClock,
+      CacheServerStats acceptorStats,
+      int maximumMessageCount,
+      int messageTimeToLive,
+      ConnectionListener listener,
+      OverflowAttributes overflowAttributes,
+      boolean isGatewayReceiver,
+      SocketMessageWriter socketMessageWriter) {
+    if (ccnSingleton == null) {
+      ccnSingleton = new CacheClientNotifier(cache, clientRegistrationEventQueueManager,
+          statisticsClock, acceptorStats, maximumMessageCount, messageTimeToLive, listener,
+          isGatewayReceiver, new CacheClientProxyFactory(), socketMessageWriter);
+    }
+
+    if (!isGatewayReceiver && ccnSingleton.getHaContainer() == null) {
+      // Gateway receiver might have create CCN instance without HaContainer
+      // In this case, the HaContainer should be lazily created here
+      ccnSingleton.initHaContainer(overflowAttributes);
+    }
+    return ccnSingleton;
+  }
 
   /**
    * Factory method to construct a CacheClientNotifier {@code CacheClientNotifier} instance.
@@ -151,18 +176,9 @@ public class CacheClientNotifier {
       ConnectionListener listener,
       OverflowAttributes overflowAttributes,
       boolean isGatewayReceiver) {
-    if (ccnSingleton == null) {
-      ccnSingleton = new CacheClientNotifier(cache, clientRegistrationEventQueueManager,
-          statisticsClock, acceptorStats, maximumMessageCount, messageTimeToLive, listener,
-          isGatewayReceiver, new CacheClientProxyFactory());
-    }
-
-    if (!isGatewayReceiver && ccnSingleton.getHaContainer() == null) {
-      // Gateway receiver might have create CCN instance without HaContainer
-      // In this case, the HaContainer should be lazily created here
-      ccnSingleton.initHaContainer(overflowAttributes);
-    }
-    return ccnSingleton;
+    return getInstance(cache, clientRegistrationEventQueueManager, statisticsClock,
+        acceptorStats, maximumMessageCount, messageTimeToLive, listener, overflowAttributes,
+        isGatewayReceiver, new SocketMessageWriter());
   }
 
   public static CacheClientNotifier getInstance() {
@@ -446,15 +462,19 @@ public class CacheClientNotifier {
       if (logger.isDebugEnabled()) {
         logger.debug("CacheClientNotifier: Successfully registered {}", cacheClientProxy);
       }
+      performPostAuthorization(cacheClientProxy, clientProxyMembershipID, member,
+          sysProps,
+          subjectOrPrincipal);
     } else {
+      try {
+        // prevent leak by closing socket
+        socket.close();
+      } catch (IOException ignore) {
+      }
       logger.warn(
           "CacheClientNotifier: Unsuccessfully registered client with identifier {} and response code {}",
           new Object[] {clientProxyMembershipID, responseByte});
     }
-
-    performPostAuthorization(cacheClientProxy, clientProxyMembershipID, member,
-        sysProps,
-        subjectOrPrincipal);
   }
 
   private void handleAuthenticationException(final ClientProxyMembershipID clientProxyMembershipID,
@@ -1720,7 +1740,9 @@ public class CacheClientNotifier {
       int messageTimeToLive,
       ConnectionListener listener,
       boolean isGatewayReceiver,
-      CacheClientProxyFactory cacheClientProxyFactory) {
+      CacheClientProxyFactory cacheClientProxyFactory,
+      SocketMessageWriter socketMessageWriter) {
+    this.socketMessageWriter = socketMessageWriter;
     this.cacheClientProxyFactory = cacheClientProxyFactory;
     // Set the Cache
     setCache(cache);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcher.java
@@ -41,7 +41,6 @@ import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.cache.RegionExistsException;
 import org.apache.geode.cache.query.internal.cq.InternalCqQuery;
-import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.ClientServerObserver;
 import org.apache.geode.internal.cache.ClientServerObserverHolder;
 import org.apache.geode.internal.cache.Conflatable;
@@ -156,7 +155,7 @@ public class MessageDispatcher extends LoggingThread {
           .putProxy(HARegionQueue.createRegionName(proxy.getHARegionName()), proxy);
       boolean createDurableQueue = proxy.proxyID.isDurable();
       boolean canHandleDelta =
-          InternalDistributedSystem.getAnyInstance().getConfig().getDeltaPropagation()
+          proxy.getCache().getInternalDistributedSystem().getConfig().getDeltaPropagation()
               && !(proxy.clientConflation == Handshake.CONFLATION_ON);
       if ((createDurableQueue || canHandleDelta) && logger.isDebugEnabled()) {
         logger.debug("Creating a {} subscription queue for {}",


### PR DESCRIPTION
Added unit test that reproduced the socket leak.
This involved some change to the product classes
to make them unit testable.
Fixed the leak by making sure socket.close is called
if the response code was not successful.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
