### PR TITLE
GEODE-9900: ensure AuthenticationExpiredException handling

### DIFF
--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
@@ -269,8 +269,11 @@ public class AuthExpirationBackwardCompatibleDUnitTest {
 
     Region<Object, Object> region = server.getCache().getRegion("/region");
     region.put("1", "value1");
-    clientVM.invoke(() -> await().untilAsserted(() -> assertThat(CQLISTENER0.getKeys())
-        .containsExactly("1")));
+    clientVM.invoke(() -> {
+      await().untilAsserted(
+          () -> assertThat(CQLISTENER0.getKeys())
+              .containsExactly("1"));
+    });
 
     // expire the current user
     ExpirableSecurityManager securityManager = getSecurityManager();
@@ -600,8 +603,10 @@ public class AuthExpirationBackwardCompatibleDUnitTest {
     region.put("2", "value2");
 
     // client will get both keys
-    clientVM.invoke(
-        () -> await().untilAsserted(() -> assertThat(myListener.keys).containsExactly("1", "2")));
+    clientVM.invoke( () -> {
+      await().untilAsserted(
+          () -> assertThat(myListener.keys).containsExactly("1", "2"));
+    });
 
     // user1 should not be used to put key2 to the region in any cases
     assertThat(getSecurityManager().getAuthorizedOps().get("user1"))

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
@@ -603,7 +603,7 @@ public class AuthExpirationBackwardCompatibleDUnitTest {
     region.put("2", "value2");
 
     // client will get both keys
-    clientVM.invoke( () -> {
+    clientVM.invoke(() -> {
       await().untilAsserted(
           () -> assertThat(myListener.keys).containsExactly("1", "2"));
     });

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
@@ -422,7 +422,7 @@ public class AuthExpirationBackwardCompatibleDUnitTest {
   }
 
   @Test
-  public void stopCQ() throws Exception {
+  public void stopAndCloseCQ() throws Exception {
     int serverPort = server.getPort();
     clientVM = cluster.startClientVM(0, clientVersion,
         c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
@@ -64,8 +64,8 @@ import org.apache.geode.test.version.VersionManager;
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class AuthExpirationBackwardCompatibleDUnitTest {
-  private static final String test_start_version = "1.14.0";
-  private static final String feature_start_version = "1.15.0";
+  private static String test_start_version = "1.14.0";
+  private static String feature_start_version = "1.15.0";
   private static RegionService user0Service;
   private static RegionService user1Service;
 

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/AuthExpirationBackwardCompatibleDUnitTest.java
@@ -488,7 +488,9 @@ public class AuthExpirationBackwardCompatibleDUnitTest {
 
     // refresh user before we expire user1, otherwise we might still be using expired
     // users in some client operations
-    clientVM.invoke(() -> UpdatableUserAuthInitialize.setUser("user2"));
+    clientVM.invoke(() -> {
+      UpdatableUserAuthInitialize.setUser("user2");
+    });
 
     getSecurityManager().addExpiredUser("user1");
     region.put("2", "value2");

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/CloseCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/CloseCQ.java
@@ -113,11 +113,7 @@ public class CloseCQ extends BaseCQCommand {
           serverConnection);
       return;
     } catch (AuthenticationExpiredException e) {
-      if (serverConnection.getTransientFlag(REQUIRES_CHUNKED_RESPONSE)) {
-        writeChunkedException(clientMessage, e, serverConnection);
-      } else {
-        writeException(clientMessage, e, false, serverConnection);
-      }
+      writeChunkedException(clientMessage, e, serverConnection);
       return;
     } catch (Exception e) {
       String err =

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/CloseCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/CloseCQ.java
@@ -33,6 +33,7 @@ import org.apache.geode.internal.cache.tier.sockets.Message;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
 import org.apache.geode.internal.security.AuthorizeRequest;
 import org.apache.geode.internal.security.SecurityService;
+import org.apache.geode.security.AuthenticationExpiredException;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 
@@ -110,6 +111,13 @@ public class CloseCQ extends BaseCQCommand {
     } catch (CqException cqe) {
       sendCqResponse(MessageType.CQ_EXCEPTION_TYPE, "", clientMessage.getTransactionId(), cqe,
           serverConnection);
+      return;
+    } catch (AuthenticationExpiredException e) {
+      if (serverConnection.getTransientFlag(REQUIRES_CHUNKED_RESPONSE)) {
+        writeChunkedException(clientMessage, e, serverConnection);
+      } else {
+        writeException(clientMessage, e, false, serverConnection);
+      }
       return;
     } catch (Exception e) {
       String err =

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/StopCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/StopCQ.java
@@ -126,7 +126,6 @@ public class StopCQ extends BaseCQCommand {
           String.format("Exception while stopping CQ named %s :", cqName);
       sendCqResponse(MessageType.CQ_EXCEPTION_TYPE, err, clientMessage.getTransactionId(), e,
           serverConnection);
-      writeChunkedException(clientMessage, e, serverConnection);
       return;
     }
 

--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/StopCQ.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/command/StopCQ.java
@@ -115,11 +115,7 @@ public class StopCQ extends BaseCQCommand {
           serverConnection);
       return;
     } catch (AuthenticationExpiredException e) {
-      if (serverConnection.getTransientFlag(REQUIRES_CHUNKED_RESPONSE)) {
-        writeChunkedException(clientMessage, e, serverConnection);
-      } else {
-        writeException(clientMessage, e, false, serverConnection);
-      }
+      writeChunkedException(clientMessage, e, serverConnection);
       return;
     } catch (Exception e) {
       String err =

--- a/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/CloseCQTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/CloseCQTest.java
@@ -15,14 +15,19 @@
 
 package org.apache.geode.internal.cache.tier.sockets.command;
 
-import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.Rule;
 import org.junit.Test;
 
 import org.apache.geode.cache.query.cq.internal.command.CloseCQ;
+import org.apache.geode.internal.cache.tier.MessageType;
+import org.apache.geode.internal.cache.tier.sockets.ChunkedMessage;
+import org.apache.geode.security.AuthenticationExpiredException;
 import org.apache.geode.security.ResourcePermission.Operation;
 import org.apache.geode.security.ResourcePermission.Resource;
 import org.apache.geode.test.dunit.rules.CQUnitTestRule;
@@ -34,12 +39,26 @@ public class CloseCQTest {
 
   @Test
   public void needDataReadRegionToClose() throws Exception {
-    CloseCQ closeCQ = mock(CloseCQ.class);
-    doCallRealMethod().when(closeCQ).cmdExecute(cqRule.message, cqRule.connection,
-        cqRule.securityService, 0);
+    CloseCQ closeCQ = (CloseCQ) CloseCQ.getCommand();
 
     closeCQ.cmdExecute(cqRule.message, cqRule.connection, cqRule.securityService, 0);
 
     verify(cqRule.securityService).authorize(Resource.DATA, Operation.READ, "regionName");
+  }
+
+  @Test
+  public void callsWriteChunkedExceptionOnAuthorizationExpiredException() throws Exception {
+    AuthenticationExpiredException authenticationExpiredException =
+        new AuthenticationExpiredException("ouch");
+    CloseCQ closeCQ = (CloseCQ) CloseCQ.getCommand();
+    ChunkedMessage chunkedMessage = mock(ChunkedMessage.class);
+    when(cqRule.connection.getChunkedResponseMessage()).thenReturn(chunkedMessage);
+    doThrow(authenticationExpiredException).when(cqRule.securityService).authorize(Resource.DATA,
+        Operation.READ, "regionName");
+
+    closeCQ.cmdExecute(cqRule.message, cqRule.connection, cqRule.securityService, 0);
+
+    verify(chunkedMessage).setMessageType(MessageType.EXCEPTION);
+    verify(chunkedMessage).sendChunk(same(cqRule.connection));
   }
 }


### PR DESCRIPTION
- in CloseCQ command
- minor modification in response writing in StopCQ command where we now
  check if need to use chunked response
- triage involved checking all other commands that require authorization on their handling of `AuthenticationExpiredException` (either direct or bubble up)