### PR TITLE
regionMap is not cleared in one edge case

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/Oplog.java
@@ -5719,6 +5719,7 @@ public class Oplog implements CompactableOplog, Flushable {
       cancelKrf();
       close();
       deleteFiles(getHasDeletes());
+      regionMap.close();
     } finally {
       unlockCompactor();
     }
@@ -5947,8 +5948,6 @@ public class Oplog implements CompactableOplog, Flushable {
     if (!compactFailed) {
       // all data has been copied forward to new oplog so no live entries remain
       getTotalLiveCount().set(0);
-      // No need for regionMap as there are no more live entries and .crf will be deleted
-      regionMap.close();
       // Need to still remove the oplog even if it had nothing to compact.
       handleNoLiveValues();
     }


### PR DESCRIPTION
The regionMap is not cleared in case when Oplog have 0 live entries at
the moment when it is rolled out. In this case Oplog is not compacted,
but it is closed early as there are no live entries and there is no
need to wait for compactor thread to delete .crf file. When Oplog is
closed early then cleanupAfterCompaction function (where regionMap
close is called) is not called and therefore regionMap is not cleared
in this case.


<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
