### PR TITLE
GEODE-9905: [1.14] Bump log4j from 2.16.0 to 2.17.0

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -622,31 +622,31 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jcl</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jul</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.16.0</version>
+        <version>2.17.0</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -40,7 +40,7 @@ class DependencyConstraints implements Plugin<Project> {
     deps.put("fastutil.version", "8.5.2")
     deps.put("javax.transaction-api.version", "1.3")
     deps.put("jgroups.version", "3.6.14.Final")
-    deps.put("log4j.version", "2.16.0")
+    deps.put("log4j.version", "2.17.0")
     deps.put("micrometer.version", "1.6.3")
     deps.put("shiro.version", "1.8.0")
     deps.put("slf4j-api.version", "1.7.30")

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1041,11 +1041,11 @@ lib/jline-2.12.jar
 lib/jna-5.6.0.jar
 lib/jna-platform-5.6.0.jar
 lib/jopt-simple-5.0.4.jar
-lib/log4j-api-2.16.0.jar
-lib/log4j-core-2.16.0.jar
-lib/log4j-jcl-2.16.0.jar
-lib/log4j-jul-2.16.0.jar
-lib/log4j-slf4j-impl-2.16.0.jar
+lib/log4j-api-2.17.0.jar
+lib/log4j-core-2.17.0.jar
+lib/log4j-jcl-2.17.0.jar
+lib/log4j-jul-2.17.0.jar
+lib/log4j-slf4j-impl-2.17.0.jar
 lib/lucene-analyzers-common-6.6.6.jar
 lib/lucene-analyzers-phonetic-6.6.6.jar
 lib/lucene-core-6.6.6.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -27,8 +27,8 @@ httpcore-4.4.14.jar
 HikariCP-4.0.1.jar
 commons-lang3-3.11.jar
 jaxb-api-2.3.1.jar
-log4j-jcl-2.16.0.jar
-log4j-api-2.16.0.jar
+log4j-jcl-2.17.0.jar
+log4j-api-2.17.0.jar
 spring-shell-1.2.0.RELEASE.jar
 rmiio-2.1.2.jar
 antlr-2.7.7.jar
@@ -77,9 +77,9 @@ jetty-io-9.4.39.v20210325.jar
 jetty-xml-9.4.39.v20210325.jar
 jetty-util-9.4.39.v20210325.jar
 jetty-util-ajax-9.4.39.v20210325.jar
-log4j-slf4j-impl-2.16.0.jar
-log4j-core-2.16.0.jar
-log4j-jul-2.16.0.jar
+log4j-slf4j-impl-2.17.0.jar
+log4j-core-2.17.0.jar
+log4j-jul-2.17.0.jar
 lucene-analyzers-phonetic-6.6.6.jar
 lucene-analyzers-common-6.6.6.jar
 lucene-queryparser-6.6.6.jar

--- a/geode-docs/managing/logging/configuring_log4j2.html.md.erb
+++ b/geode-docs/managing/logging/configuring_log4j2.html.md.erb
@@ -36,16 +36,16 @@ You can also configure Log4j 2 to work with various popular and commonly used lo
 
 For example, if you are using:
 
--   **Commons Logging**, download "Commons Logging Bridge" (`log4j-jcl-2.16.0.jar`)
--   **SLF4J**, download "SLFJ4 Binding" (`log4j-slf4j-impl-2.16.0.jar`)
--   **java.util.logging**, download the "JUL adapter" (`log4j-jul-2.16.0.jar`)
+-   **Commons Logging**, download "Commons Logging Bridge" (`log4j-jcl-2.17.0.jar`)
+-   **SLF4J**, download "SLFJ4 Binding" (`log4j-slf4j-impl-2.17.0.jar`)
+-   **java.util.logging**, download the "JUL adapter" (`log4j-jul-2.17.0.jar`)
 
 See [http://logging.apache.org/log4j/2.x/faq.html](http://logging.apache.org/log4j/2.x/faq.html) for more examples.
 
-All three of the above JAR files are in the full distribution of Log4J 2.16.0 which can be downloaded at [http://logging.apache.org/log4j/2.x/download.html](http://logging.apache.org/log4j/2.x/download.html). Download the appropriate bridge, adapter, or binding JARs to ensure that <%=vars.product_name%> logging is integrated with every logging API used in various third-party libraries or in your own applications.
+All three of the above JAR files are in the full distribution of Log4J 2.17.0 which can be downloaded at [http://logging.apache.org/log4j/2.x/download.html](http://logging.apache.org/log4j/2.x/download.html). Download the appropriate bridge, adapter, or binding JARs to ensure that <%=vars.product_name%> logging is integrated with every logging API used in various third-party libraries or in your own applications.
 
 **Note:**
-<%=vars.product_name_long%> has been tested with Log4j 2.16.0. As newer versions of Log4j 2 come out, you can find 2.16.0 under Previous Releases on that page.
+<%=vars.product_name_long%> has been tested with Log4j 2.17.0. As newer versions of Log4j 2 come out, you can find 2.17.0 under Previous Releases on that page.
 
 ## Customizing Your Own log4j2.xml File
 

--- a/geode-docs/managing/logging/how_logging_works.html.md.erb
+++ b/geode-docs/managing/logging/how_logging_works.html.md.erb
@@ -21,9 +21,9 @@ limitations under the License.
 
 <%=vars.product_name%> uses [Apache Log4j 2](http://logging.apache.org/log4j/2.x/) API and Core libraries as the basis for its logging system. Log4j 2 API is a popular and powerful front-end logging API used by all the <%=vars.product_name%> classes to generate log statements. Log4j 2 Core is a backend implementation for logging; you can route any of the front-end logging API libraries to log to this backend. <%=vars.product_name%> uses the Core backend to run three custom Log4j 2 Appenders: **GeodeConsole**, **GeodeLogWriter**, and **GeodeAlert**.
 
-<%=vars.product_name%> has been tested with Log4j 2.16.0.
+<%=vars.product_name%> has been tested with Log4j 2.17.0.
 <%=vars.product_name%> requires the 
-`log4j-api-2.16.0.jar` and `log4j-core-2.16.0.jar`
+`log4j-api-2.17.0.jar` and `log4j-core-2.17.0.jar`
 JAR files to be in the classpath.
 Both of these JARs are distributed in the `<path-to-product>/lib` directory and included in the appropriate `*-dependencies.jar` convenience libraries.
 

--- a/geode-wan/build.gradle
+++ b/geode-wan/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   implementation(project(':geode-tcp-server'))
   implementation(project(':geode-core'))
 
-  compileOnly('org.apache.logging.log4j:log4j-api:2.16.0')
+  compileOnly('org.apache.logging.log4j:log4j-api:2.17.0')
   
   testImplementation(project(':geode-junit'))
   testImplementation('org.assertj:assertj-core')


### PR DESCRIPTION
(cherry picked from commit 45714b36b04f89b56c81e97cb03fc0fbf95f58c9)
