### PR TITLE
GEODE-9060: Remove the member from a copy of replicates as GII candid…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
@@ -876,8 +876,40 @@ public class PersistentRecoveryOrderDUnitTest extends CacheTestCase {
         Throwable thrown = catchThrowable(() -> {
           createReplicateRegion(regionName, getDiskDirs(getVMId()));
         });
-        assertThat(thrown).isInstanceOf(ConflictingPersistentDataException.class);
+        assertThat(thrown)
+            .isInstanceOf(ConflictingPersistentDataException.class)
+            .hasMessageContaining("was not part of the same distributed system as the local data");
       }
+    });
+  }
+
+  @Test
+  public void testRecoverableSplitBrain() {
+    vm2.invoke(() -> {
+      createReplicateRegion(regionName, getDiskDirs(getVMId()));
+    });
+    vm0.invoke(() -> {
+      createReplicateRegion(regionName, getDiskDirs(getVMId()));
+      putEntry("A", "B");
+      getCache().getRegion(regionName).close();
+    });
+
+    vm1.invoke(() -> {
+      createReplicateRegion(regionName, getDiskDirs(getVMId()));
+      validateEntry("A", "B");
+      updateEntry("A", "C");
+      getCache().getRegion(regionName).close();
+    });
+
+    // VM0 doesn't know that VM1 ever existed so it will start up.
+    vm0.invoke(() -> {
+      createReplicateRegion(regionName, getDiskDirs(getVMId()));
+      validateEntry("A", "C");
+    });
+
+    vm1.invoke(() -> {
+      createReplicateRegion(regionName, getDiskDirs(getVMId()));
+      validateEntry("A", "C");
     });
   }
 


### PR DESCRIPTION
…… (#6246)

* GEODE-9060: Remove the member from a copy of replicates as GII candidate if
it's not part of the same distributed system, but leave original replicates
unchanged.

(cherry picked from commit 76a5afddc9eaecea9f0b4528a910eb6761e1a3a1)

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
