### PR TITLE
GEODE-9911: Allow ExecutorServiceRule to name threads

### DIFF
--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ExecutorServiceRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ExecutorServiceRule.java
@@ -102,7 +102,8 @@ public class ExecutorServiceRule extends SerializableExternalResource {
 
   public static BiFunction<Integer, Integer, String> DEFAULT_THREAD_NAME_FUNCTION =
       (poolNumber, threadNumber) -> String.format("pool-%d-thread-%d", poolNumber, threadNumber);
-  private BiFunction<Integer, Integer, String> threadNameFunction = DEFAULT_THREAD_NAME_FUNCTION;
+  private transient BiFunction<Integer, Integer, String> threadNameFunction =
+      DEFAULT_THREAD_NAME_FUNCTION;
 
   /**
    * Returns a {@code Builder} to configure a new {@code ExecutorServiceRule}.

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ExecutorServiceRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ExecutorServiceRule.java
@@ -30,6 +30,7 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
 import org.apache.geode.test.junit.rules.serializable.SerializableExternalResource;
@@ -99,6 +100,10 @@ public class ExecutorServiceRule extends SerializableExternalResource {
   protected transient volatile DedicatedThreadFactory threadFactory;
   protected transient volatile ExecutorService executor;
 
+  public static BiFunction<Integer, Integer, String> DEFAULT_THREAD_NAME_FUNCTION =
+      (poolNumber, threadNumber) -> String.format("pool-%d-thread-%d", poolNumber, threadNumber);
+  private BiFunction<Integer, Integer, String> threadNameFunction = DEFAULT_THREAD_NAME_FUNCTION;
+
   /**
    * Returns a {@code Builder} to configure a new {@code ExecutorServiceRule}.
    */
@@ -156,7 +161,7 @@ public class ExecutorServiceRule extends SerializableExternalResource {
 
   @Override
   public void before() {
-    threadFactory = new DedicatedThreadFactory();
+    threadFactory = new DedicatedThreadFactory(threadNameFunction);
     if (threadCount > 0) {
       executor = Executors.newFixedThreadPool(threadCount, threadFactory);
     } else {
@@ -177,6 +182,20 @@ public class ExecutorServiceRule extends SerializableExternalResource {
     if (!awaitTerminationBeforeShutdown) {
       enableAwaitTermination();
     }
+  }
+
+  /**
+   * This method can be used to customize the names of the threads created by the Executor.
+   *
+   * @param fn The function used to produce the thread name. The function receives the pool number
+   *        and thread number as arguments. By default, these values are applied to the format
+   *        string "pool-%d-thread-%d" respectively.
+   * @return the name of the thread to be created
+   * @see #DEFAULT_THREAD_NAME_FUNCTION
+   */
+  public ExecutorServiceRule withThreadNameFunction(BiFunction<Integer, Integer, String> fn) {
+    threadNameFunction = fn;
+    return this;
   }
 
   private void enableAwaitTermination() {
@@ -359,23 +378,26 @@ public class ExecutorServiceRule extends SerializableExternalResource {
    * a {@code Set<WeakReference<Thread>>} to track the {@code Thread}s in the factory's
    * {@code ThreadGroup} excluding subgroups.
    */
-  public static class DedicatedThreadFactory implements ThreadFactory {
+  static class DedicatedThreadFactory implements ThreadFactory {
 
     private static final AtomicInteger POOL_NUMBER = new AtomicInteger(1);
 
     private final ThreadGroup group;
     private final AtomicInteger threadNumber = new AtomicInteger(1);
-    private final String namePrefix;
     private final Set<WeakReference<Thread>> directThreads = new HashSet<>();
+    private final BiFunction<Integer, Integer, String> threadNameFunction;
 
-    public DedicatedThreadFactory() {
+    private DedicatedThreadFactory(BiFunction<Integer, Integer, String> threadNameFunction) {
+      this.threadNameFunction = threadNameFunction;
       group = new ThreadGroup(ExecutorServiceRule.class.getSimpleName() + "-ThreadGroup");
-      namePrefix = "pool-" + POOL_NUMBER.getAndIncrement() + "-thread-";
+      POOL_NUMBER.getAndIncrement();
     }
 
     @Override
     public Thread newThread(Runnable r) {
-      Thread t = new Thread(group, r, namePrefix + threadNumber.getAndIncrement(), 0);
+      String threadName =
+          threadNameFunction.apply(POOL_NUMBER.get(), threadNumber.getAndIncrement());
+      Thread t = new Thread(group, r, threadName, 0);
       if (t.isDaemon()) {
         t.setDaemon(false);
       }


### PR DESCRIPTION
- This can be used in tests to create custom named executor threads. For
  example, something like:
  ```
  @Rule
  public ExecutorServiceRule executor = new ExecutorServiceRule()
      .withThreadNameFunction((p, t) -> "CUSTOMNAME-pool-%d-thread-%d");
  ```

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
