### PR TITLE
GEODE-9829: Add SINTER command to Redis supported commands.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ plugins {
   id "nebula.lint" version "17.1.1" apply false
   id "com.palantir.docker" version "0.28.0" apply false
   id "io.spring.dependency-management" version "1.0.11.RELEASE" apply false
-  id "org.ajoberstar.grgit" version "4.1.0" apply false
+  id "org.ajoberstar.grgit" version "4.1.1" apply false
   id "org.nosphere.apache.rat" version "0.7.0" apply false
   id "org.sonarqube" version "3.3" apply false
   id "me.champeau.gradle.japicmp" apply false // Version defined in buildSrc/build.gradle

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -22,9 +22,7 @@ plugins {
 
 repositories {
   mavenCentral()
-  maven {
-    url "https://plugins.gradle.org/m2/"
-  }
+  gradlePluginPortal()
 }
 
 dependencies {

--- a/geode-docs/tools_modules/geode_for_redis.html.md.erb
+++ b/geode-docs/tools_modules/geode_for_redis.html.md.erb
@@ -114,6 +114,7 @@ If the server is functioning properly, you should see a response of `PONG`.
  - SCARD <br/>
  - SDIFF <br/>
  - SDIFFSTORE <br/>
+ - SINTER <br/>
  - SISMEMBER <br/>
  - SET <br/>
  - SETNX <br/>

--- a/geode-for-redis/README.md
+++ b/geode-for-redis/README.md
@@ -202,6 +202,7 @@ Geode for Redis implements a subset of the full Redis command set.
 - SCARD
 - SDIFF
 - SDIFFSTORE
+- SINTER
 - SISMEMBER
 - SET  
 - SETEX

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -390,6 +390,11 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   }
 
   @Test
+  public void testSinter() {
+    runMultiKeyCommandAndAssertHitsAndMisses(SET_KEY, (k1, k2) -> jedis.sinter(k1, k2));
+  }
+
+  @Test
   public void testSismember() {
     runCommandAndAssertHitsAndMisses(SET_KEY, k -> jedis.sismember(k, "member"));
   }
@@ -547,11 +552,6 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
   @Test
   public void testSscan() {
     runCommandAndAssertHitsAndMisses(SET_KEY, k -> jedis.sscan(k, "0"));
-  }
-
-  @Test
-  public void testSinter() {
-    runMultiKeyCommandAndAssertHitsAndMisses(SET_KEY, (k1, k2) -> jedis.sinter(k1, k2));
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterIntegrationTest.java
@@ -40,9 +40,9 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
   private JedisCluster jedis;
   private static final int REDIS_CLIENT_TIMEOUT =
       Math.toIntExact(GeodeAwaitility.getTimeout().toMillis());
-  private static final String SET1 = "{user1}set1";
-  private static final String SET2 = "{user1}set2";
-  private static final String SET3 = "{user1}set3";
+  private static final String SET1 = "{tag1}set1";
+  private static final String SET2 = "{tag1}set2";
+  private static final String SET3 = "{tag1}set3";
 
   @Before
   public void setUp() {
@@ -85,9 +85,9 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
     String nonSet = "apple";
     jedis.sadd(SET1, firstSet);
-    jedis.set("{user1}nonSet", nonSet);
+    jedis.set("{tag1}nonSet", nonSet);
 
-    assertThatThrownBy(() -> jedis.sinter(SET1, "{user1}nonSet")).hasMessageContaining(
+    assertThatThrownBy(() -> jedis.sinter(SET1, "{tag1}nonSet")).hasMessageContaining(
         ERROR_WRONG_TYPE);
   }
 
@@ -155,38 +155,38 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
     String[] secondSet = new String[] {"apple", "microsoft", "linux", "peach"};
     String[] thirdSet = new String[] {"luigi", "bowser", "peach", "mario"};
-    jedis.sadd("{user1}set1", firstSet);
-    jedis.sadd("{user1}set2", secondSet);
-    jedis.sadd("{user1}set3", thirdSet);
+    jedis.sadd("{tag1}set1", firstSet);
+    jedis.sadd("{tag1}set2", secondSet);
+    jedis.sadd("{tag1}set3", thirdSet);
 
     Long resultSize =
-        jedis.sinterstore("{user1}result", "{user1}set1", "{user1}set2", "{user1}set3");
-    Set<String> resultSet = jedis.smembers("{user1}result");
+        jedis.sinterstore("{tag1}result", "{tag1}set1", "{tag1}set2", "{tag1}set3");
+    Set<String> resultSet = jedis.smembers("{tag1}result");
 
     String[] expected = new String[] {"peach"};
     assertThat(resultSize).isEqualTo(expected.length);
     assertThat(resultSet).containsExactlyInAnyOrder(expected);
 
-    Long otherResultSize = jedis.sinterstore("{user1}set1", "{user1}set1", "{user1}set2");
-    Set<String> otherResultSet = jedis.smembers("{user1}set1");
+    Long otherResultSize = jedis.sinterstore("{tag1}set1", "{tag1}set1", "{tag1}set2");
+    Set<String> otherResultSet = jedis.smembers("{tag1}set1");
     String[] otherExpected = new String[] {"apple", "peach"};
     assertThat(otherResultSize).isEqualTo(otherExpected.length);
     assertThat(otherResultSet).containsExactlyInAnyOrder(otherExpected);
 
     Long emptySetSize =
-        jedis.sinterstore("{user1}newEmpty", "{user1}nonexistent", "{user1}set2", "{user1}set3");
-    Set<String> emptyResultSet = jedis.smembers("{user1}newEmpty");
+        jedis.sinterstore("{tag1}newEmpty", "{tag1}nonexistent", "{tag1}set2", "{tag1}set3");
+    Set<String> emptyResultSet = jedis.smembers("{tag1}newEmpty");
     assertThat(emptySetSize).isEqualTo(0L);
     assertThat(emptyResultSet).isEmpty();
 
     emptySetSize =
-        jedis.sinterstore("{user1}set1", "{user1}nonexistent", "{user1}set2", "{user1}set3");
-    emptyResultSet = jedis.smembers("{user1}set1");
+        jedis.sinterstore("{tag1}set1", "{tag1}nonexistent", "{tag1}set2", "{tag1}set3");
+    emptyResultSet = jedis.smembers("{tag1}set1");
     assertThat(emptySetSize).isEqualTo(0L);
     assertThat(emptyResultSet).isEmpty();
 
-    Long copySetSize = jedis.sinterstore("{user1}copySet", "{user1}set2", "{user1}newEmpty");
-    Set<String> copyResultSet = jedis.smembers("{user1}copySet");
+    Long copySetSize = jedis.sinterstore("{tag1}copySet", "{tag1}set2", "{tag1}newEmpty");
+    Set<String> copyResultSet = jedis.smembers("{tag1}copySet");
     assertThat(copySetSize).isEqualTo(0);
     assertThat(copyResultSet).isEmpty();
   }
@@ -194,12 +194,12 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
   @Test
   public void testSInterStore_withNonExistentKeys() {
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
-    jedis.sadd("{user1}set1", firstSet);
+    jedis.sadd("{tag1}set1", firstSet);
 
     Long resultSize =
-        jedis.sinterstore("{user1}set1", "{user1}nonExistent1", "{user1}nonExistent2");
+        jedis.sinterstore("{tag1}set1", "{tag1}nonExistent1", "{tag1}nonExistent2");
     assertThat(resultSize).isEqualTo(0);
-    assertThat(jedis.exists("{user1}set1")).isFalse();
+    assertThat(jedis.exists("{tag1}set1")).isFalse();
   }
 
   @Test
@@ -207,20 +207,20 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.set("string1", "stringValue");
 
     Long resultSize =
-        jedis.sinterstore("{user1}string1", "{user1}nonExistent1", "{user1}nonExistent2");
+        jedis.sinterstore("{tag1}string1", "{tag1}nonExistent1", "{tag1}nonExistent2");
     assertThat(resultSize).isEqualTo(0);
-    assertThat(jedis.exists("{user1}set1")).isFalse();
+    assertThat(jedis.exists("{tag1}set1")).isFalse();
   }
 
   @Test
   public void testSInterStore_withNonSetKey() {
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
-    jedis.sadd("{user1}set1", firstSet);
-    jedis.set("{user1}string1", "value1");
+    jedis.sadd("{tag1}set1", firstSet);
+    jedis.set("{tag1}string1", "value1");
 
-    assertThatThrownBy(() -> jedis.sinterstore("{user1}set1", "{user1}string1"))
+    assertThatThrownBy(() -> jedis.sinterstore("{tag1}set1", "{tag1}string1"))
         .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
-    assertThat(jedis.exists("{user1}set1")).isTrue();
+    assertThat(jedis.exists("{tag1}set1")).isTrue();
   }
 
   @Test

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
@@ -245,6 +245,8 @@ public enum RedisCommandType {
       new Parameter().min(2).lastKey(-1).flags(READONLY, SORT_FOR_SCRIPT)),
   SDIFFSTORE(new SDiffStoreExecutor(), SUPPORTED,
       new Parameter().min(3).lastKey(-1).flags(WRITE, DENYOOM)),
+  SINTER(new SInterExecutor(), SUPPORTED,
+      new Parameter().min(2).lastKey(-1).flags(READONLY, SORT_FOR_SCRIPT)),
   SISMEMBER(new SIsMemberExecutor(), SUPPORTED, new Parameter().exact(3).flags(READONLY, FAST)),
   SMEMBERS(new SMembersExecutor(), SUPPORTED,
       new Parameter().exact(2).flags(READONLY, SORT_FOR_SCRIPT)),
@@ -346,8 +348,6 @@ public enum RedisCommandType {
 
   /**************** Sets *****************/
 
-  SINTER(new SInterExecutor(), UNSUPPORTED,
-      new Parameter().min(2).lastKey(-1).flags(READONLY, SORT_FOR_SCRIPT)),
   SINTERSTORE(new SInterStoreExecutor(), UNSUPPORTED,
       new Parameter().min(3).lastKey(-1).flags(WRITE, DENYOOM)),
   SPOP(new SPopExecutor(), UNSUPPORTED,

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/set/SetOpExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/set/SetOpExecutor.java
@@ -56,7 +56,7 @@ public abstract class SetOpExecutor implements CommandExecutor {
     }
 
     /*
-     * SINTER, SINTERSTORE, SUNION, SUNIONSTORE currently use the else part of the code
+     * SINTERSTORE, SUNION, SUNIONSTORE currently use the else part of the code
      * for their implementation.
      * TODO: Once the above commands have been implemented remove the if else and
      * refactor so the implementation is in the executor. After delete doActualSetOperation,

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/set/SetOpExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/set/SetOpExecutor.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.commands.executor.set;
 import static java.util.Collections.emptySet;
 import static org.apache.geode.redis.internal.data.RedisSet.sdiff;
 import static org.apache.geode.redis.internal.data.RedisSet.sdiffstore;
+import static org.apache.geode.redis.internal.data.RedisSet.sinter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -73,8 +74,11 @@ public abstract class SetOpExecutor implements CommandExecutor {
       Set<byte[]> resultSet = context.lockedExecute(setKeys.get(0), new ArrayList<>(setKeys),
           () -> sdiff(regionProvider, setKeys));
       return RedisResponse.array(resultSet, true);
+    } else if (command.isOfType(RedisCommandType.SINTER)) {
+      Set<byte[]> resultSet = context.lockedExecute(setKeys.get(0), new ArrayList<>(setKeys),
+          () -> sinter(regionProvider, setKeys));
+      return RedisResponse.array(resultSet, true);
     }
-
     return doActualSetOperation(command, context, setKeys);
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -129,8 +129,8 @@ public class RedisSet extends AbstractRedisData {
   }
 
   public static Set<byte[]> sinter(RegionProvider regionProvider, List<RedisKey> keys) {
-    List<RedisSet> sets = createRedisSetList(keys, regionProvider);
-    RedisSet smallestSet = findSmallest(sets);
+    List<RedisSet> sets = new ArrayList<>(keys.size() - 1);
+    RedisSet smallestSet = findSmallest(sets, keys, regionProvider);
     if (smallestSet.scard() == 0) {
       return Collections.emptySet();
     }
@@ -150,9 +150,12 @@ public class RedisSet extends AbstractRedisData {
     return result;
   }
 
-  private static RedisSet findSmallest(List<RedisSet> sets) {
+  private static RedisSet findSmallest(List<RedisSet> sets, List<RedisKey> keys,
+      RegionProvider regionProvider) {
     RedisSet smallestSet = NULL_REDIS_SET;
-    for (RedisSet set : sets) {
+    for (RedisKey key : keys) {
+      RedisSet set = regionProvider.getTypedRedisData(REDIS_SET, key, true);
+
       if (smallestSet == NULL_REDIS_SET) {
         smallestSet = set;
       } else if (smallestSet.scard() > set.scard()) {
@@ -161,16 +164,6 @@ public class RedisSet extends AbstractRedisData {
       }
     }
     return smallestSet;
-  }
-
-  private static List<RedisSet> createRedisSetList(List<RedisKey> keys,
-      RegionProvider regionProvider) {
-    List<RedisSet> sets = new ArrayList<>(keys.size());
-    for (RedisKey key : keys) {
-      RedisSet redisSet = regionProvider.getTypedRedisData(REDIS_SET, key, true);
-      sets.add(redisSet);
-    }
-    return sets;
   }
 
   @VisibleForTesting

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -150,15 +150,12 @@ public class RedisSet extends AbstractRedisData {
 
     MemberSet result = new MemberSet(smallestSet.scard());
     for (byte[] member : smallestSet.members) {
-      boolean addToSet = true;
       for (RedisSet otherSet : sets) {
-        if (!otherSet.members.contains(member)) {
-          addToSet = false;
+        if (otherSet.members.contains(member)) {
+          result.add(member);
+        } else {
           break;
         }
-      }
-      if (addToSet) {
-        result.add(member);
       }
     }
     return result;

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -129,8 +129,8 @@ public class RedisSet extends AbstractRedisData {
   }
 
   public static Set<byte[]> sinter(RegionProvider regionProvider, List<RedisKey> keys) {
-    List<RedisSet> sets = new ArrayList<>(keys.size() - 1);
-    RedisSet smallestSet = findSmallest(sets, keys, regionProvider);
+    List<RedisSet> sets = createRedisSetList(keys, regionProvider);
+    RedisSet smallestSet = findSmallest(sets);
     if (smallestSet.scard() == 0) {
       return Collections.emptySet();
     }
@@ -150,20 +150,26 @@ public class RedisSet extends AbstractRedisData {
     return result;
   }
 
-  private static RedisSet findSmallest(List<RedisSet> sets, List<RedisKey> keys,
-      RegionProvider regionProvider) {
+  private static RedisSet findSmallest(List<RedisSet> sets) {
     RedisSet smallestSet = NULL_REDIS_SET;
-    for (RedisKey key : keys) {
-      RedisSet set = regionProvider.getTypedRedisData(REDIS_SET, key, true);
-
+    for (RedisSet set : sets) {
       if (smallestSet == NULL_REDIS_SET) {
         smallestSet = set;
       } else if (smallestSet.scard() > set.scard()) {
-        sets.add(smallestSet);
         smallestSet = set;
       }
     }
     return smallestSet;
+  }
+
+  private static List<RedisSet> createRedisSetList(List<RedisKey> keys,
+      RegionProvider regionProvider) {
+    List<RedisSet> sets = new ArrayList<>(keys.size());
+    for (RedisKey key : keys) {
+      RedisSet redisSet = regionProvider.getTypedRedisData(REDIS_SET, key, true);
+      sets.add(redisSet);
+    }
+    return sets;
   }
 
   @VisibleForTesting

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -150,12 +150,15 @@ public class RedisSet extends AbstractRedisData {
 
     MemberSet result = new MemberSet(smallestSet.scard());
     for (byte[] member : smallestSet.members) {
+      boolean addToSet = true;
       for (RedisSet otherSet : sets) {
-        if (otherSet.members.contains(member)) {
-          result.add(member);
-        } else {
+        if (!otherSet.members.contains(member)) {
+          addToSet = false;
           break;
         }
+      }
+      if (addToSet) {
+        result.add(member);
       }
     }
     return result;

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -130,7 +130,7 @@ public class RedisSet extends AbstractRedisData {
 
   public static Set<byte[]> sinter(RegionProvider regionProvider, List<RedisKey> keys) {
     List<RedisSet> sets = createRedisSetList(keys, regionProvider);
-    RedisSet smallestSet = findSmallest(sets);
+    final RedisSet smallestSet = findSmallest(sets);
     if (smallestSet.scard() == 0) {
       return Collections.emptySet();
     }
@@ -138,11 +138,15 @@ public class RedisSet extends AbstractRedisData {
     MemberSet result = new MemberSet(smallestSet.scard());
     for (byte[] member : smallestSet.members) {
       boolean addToSet = true;
-      for (RedisSet otherSet : sets)
-        if (!otherSet.equals(smallestSet) && !otherSet.members.contains(member)) {
+      for (RedisSet otherSet : sets) {
+        if (otherSet == smallestSet) {
+          continue;
+        }
+        if (!otherSet.members.contains(member)) {
           addToSet = false;
           break;
         }
+      }
       if (addToSet) {
         result.add(member);
       }


### PR DESCRIPTION
SINTER command is implemented and integration tests and added to test this
command.

Co-authored-by: Bala Kaza Venkata <bkazavenkata@vmware.com>
Co-authored-by: Steve Sienkowski <ssienkowski@vmware.com>
Co-authored-by: Kristen Oduca <koduca@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
