### PR TITLE
GEODE-9932: Change naming convention for Redish hash tags in tests

### DIFF
--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/PartitionedRegionStatsUpdateTest.java
@@ -42,9 +42,9 @@ public class PartitionedRegionStatsUpdateTest {
 
   private static JedisCluster jedis;
 
-  private static final String STRING_KEY = "{user1}string key";
-  private static final String SET_KEY = "{user1}set key";
-  private static final String HASH_KEY = "{user1}hash key";
+  private static final String STRING_KEY = "{tag1}string key";
+  private static final String SET_KEY = "{tag1}set key";
+  private static final String HASH_KEY = "{tag1}hash key";
   private static final String LONG_APPEND_VALUE = String.valueOf(Integer.MAX_VALUE);
   private static final String FIELD = "field";
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractDelIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractDelIntegrationTest.java
@@ -71,9 +71,9 @@ public abstract class AbstractDelIntegrationTest implements RedisIntegrationTest
 
   @Test
   public void testDel_deletingMultipleKeys_returnsCountOfOnlyDeletedKeys() {
-    String key1 = "{user1}firstKey";
-    String key2 = "{user1}secondKey";
-    String key3 = "{user1}thirdKey";
+    String key1 = "{tag1}firstKey";
+    String key2 = "{tag1}secondKey";
+    String key3 = "{tag1}thirdKey";
 
     jedis.set(key1, "value1");
     jedis.set(key2, "value2");

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExistsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExistsIntegrationTest.java
@@ -146,13 +146,13 @@ public abstract class AbstractExistsIntegrationTest implements RedisIntegrationT
 
   @Test
   public void shouldReturnTotalNumber_givenMultipleKeys() {
-    String key1 = "{user1}key1";
-    String key2 = "{user1}key2";
+    String key1 = "{tag1}key1";
+    String key2 = "{tag1}key2";
 
     jedis.set(key1, "value1");
     jedis.set(key2, "value2");
 
-    assertThat(jedis.exists(toArray(key1, "{user1}doesNotExist1", key2, "{user1}doesNotExist2")))
+    assertThat(jedis.exists(toArray(key1, "{tag1}doesNotExist1", key2, "{tag1}doesNotExist2")))
         .isEqualTo(2L);
   }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireIntegrationTest.java
@@ -177,9 +177,9 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
   @Test
   public void callingSDIFFSTOREonExistingKey_ShouldClearExpirationTime() {
 
-    String key1 = "{user1}key1";
-    String key2 = "{user1}key2";
-    String key3 = "{user1}key3";
+    String key1 = "{tag1}key1";
+    String key2 = "{tag1}key2";
+    String key3 = "{tag1}key3";
     String value1 = "value1";
     String value2 = "value2";
     String value3 = "value3";
@@ -200,9 +200,9 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
 
   @Test
   public void callingSINTERSTOREonExistingKey_ShouldClearExpirationTime() {
-    String key1 = "{user1}key1";
-    String key2 = "{user1}key2";
-    String key3 = "{user1}key3";
+    String key1 = "{tag1}key1";
+    String key2 = "{tag1}key2";
+    String key3 = "{tag1}key3";
     String value1 = "value1";
     String value2 = "value2";
     String value3 = "value3";
@@ -223,9 +223,9 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
 
   @Test
   public void callingSUNIONSTOREonExistingKey_ShouldClearExpirationTime() {
-    String key1 = "{user1}key1";
-    String key2 = "{user1}key2";
-    String key3 = "{user1}key3";
+    String key1 = "{tag1}key1";
+    String key2 = "{tag1}key2";
+    String key3 = "{tag1}key3";
     String value1 = "value1";
     String value2 = "value2";
     String value3 = "value3";
@@ -278,8 +278,8 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
 
   @Test
   public void callingRENAMEonExistingKey_shouldTransferExpirationTimeToNewKeyName_GivenNewName_Not_InUse() {
-    String key = "{user1}key";
-    String newKeyName = "{user1}new key name";
+    String key = "{tag1}key";
+    String newKeyName = "{tag1}new key name";
     String value = "value";
     jedis.set(key, value);
     jedis.expire(key, 20L);
@@ -292,8 +292,8 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
 
   @Test
   public void callingRENAMEonExistingKey_shouldTransferExpirationTimeToNewKeyName_GivenNewName_is_InUse_ButNo_ExpirationSet() {
-    String key = "{user1}key";
-    String key2 = "{user1}key2";
+    String key = "{tag1}key";
+    String key2 = "{tag1}key2";
     String value = "value";
 
     jedis.set(key, value);
@@ -309,8 +309,8 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
 
   @Test
   public void callingRENAMEonExistingKey_shouldTransferExpirationTimeToNewKeyName_GivenNewName_is_InUse_AndHas_ExpirationSet() {
-    String key = "{user1}key";
-    String key2 = "{user1}key2";
+    String key = "{tag1}key";
+    String key2 = "{tag1}key2";
     String value = "value";
 
     jedis.set(key, value);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPexpireIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPexpireIntegrationTest.java
@@ -100,9 +100,9 @@ public abstract class AbstractPexpireIntegrationTest implements RedisIntegration
 
   @Test
   public void should_passivelyExpireKeys() {
-    jedis.sadd("{user1}key", "value");
-    jedis.pexpire("{user1}key", 100);
+    jedis.sadd("{tag1}key", "value");
+    jedis.pexpire("{tag1}key", 100);
 
-    GeodeAwaitility.await().until(() -> jedis.keys("{user1}key").isEmpty());
+    GeodeAwaitility.await().until(() -> jedis.keys("{tag1}key").isEmpty());
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameIntegrationTest.java
@@ -72,53 +72,53 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
 
   @Test
   public void shouldRename_givenNewKey() {
-    jedis.set("{user1}foo", "bar");
-    assertThat(jedis.rename("{user1}foo", "{user1}newfoo")).isEqualTo("OK");
-    assertThat(jedis.get("{user1}newfoo")).isEqualTo("bar");
+    jedis.set("{tag1}foo", "bar");
+    assertThat(jedis.rename("{tag1}foo", "{tag1}newfoo")).isEqualTo("OK");
+    assertThat(jedis.get("{tag1}newfoo")).isEqualTo("bar");
   }
 
   @Test
   public void shouldDeleteOldKey_whenRenamed() {
-    jedis.set("{user1}foo", "bar");
-    jedis.rename("{user1}foo", "{user1}newfoo");
-    assertThat(jedis.get("{user1}foo")).isNull();
+    jedis.set("{tag1}foo", "bar");
+    jedis.rename("{tag1}foo", "{tag1}newfoo");
+    assertThat(jedis.get("{tag1}foo")).isNull();
   }
 
   @Test
   public void shouldReturnError_givenNonexistantKey() {
-    assertThatThrownBy(() -> jedis.rename("{user1}foo", "{user1}newfoo"))
+    assertThatThrownBy(() -> jedis.rename("{tag1}foo", "{tag1}newfoo"))
         .hasMessageContaining(RedisConstants.ERROR_NO_SUCH_KEY);
   }
 
   @Test
   public void shouldRename_withHash() {
-    jedis.hset("{user1}foo", "field", "va");
-    jedis.rename("{user1}foo", "{user1}newfoo");
-    assertThat(jedis.hget("{user1}newfoo", "field")).isEqualTo("va");
+    jedis.hset("{tag1}foo", "field", "va");
+    jedis.rename("{tag1}foo", "{tag1}newfoo");
+    assertThat(jedis.hget("{tag1}newfoo", "field")).isEqualTo("va");
   }
 
   @Test
   public void shouldRename_withSet() {
-    jedis.sadd("{user1}foo", "data");
-    jedis.rename("{user1}foo", "{user1}newfoo");
-    assertThat(jedis.smembers("{user1}newfoo")).containsExactly("data");
+    jedis.sadd("{tag1}foo", "data");
+    jedis.rename("{tag1}foo", "{tag1}newfoo");
+    assertThat(jedis.smembers("{tag1}newfoo")).containsExactly("data");
   }
 
   @Test
   public void shouldReturnOkay_withSameSourceAndTargetKey() {
-    jedis.set("{user1}blue", "moon");
-    assertThat(jedis.rename("{user1}blue", "{user1}blue")).isEqualTo("OK");
-    assertThat(jedis.get("{user1}blue")).isEqualTo("moon");
+    jedis.set("{tag1}blue", "moon");
+    assertThat(jedis.rename("{tag1}blue", "{tag1}blue")).isEqualTo("OK");
+    assertThat(jedis.get("{tag1}blue")).isEqualTo("moon");
   }
 
   @Test
   public void shouldRename_withExistingTargetKey() {
-    jedis.set("{user1}foo1", "bar1");
-    jedis.set("{user1}foo12", "bar2");
-    String result = jedis.rename("{user1}foo1", "{user1}foo12");
+    jedis.set("{tag1}foo1", "bar1");
+    jedis.set("{tag1}foo12", "bar2");
+    String result = jedis.rename("{tag1}foo1", "{tag1}foo12");
     assertThat(result).isEqualTo("OK");
-    assertThat(jedis.get("{user1}foo12")).isEqualTo("bar1");
-    assertThat(jedis.get("{user1}foo1")).isNull();
+    assertThat(jedis.get("{tag1}foo12")).isEqualTo("bar1");
+    assertThat(jedis.get("{tag1}foo1")).isNull();
   }
 
   @Test
@@ -145,8 +145,8 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     int numStringsFirstKey = 500000;
     int numStringsSecondKey = 30000;
 
-    String k1 = "{user1}k1";
-    String k2 = "{user1}k2";
+    String k1 = "{tag1}k1";
+    String k2 = "{tag1}k2";
 
     Runnable initAction = () -> {
       flushAll();
@@ -247,17 +247,17 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   public void shouldError_givenKeyDeletedDuringRename() {
     int iterations = 2000;
 
-    jedis.set("{user1}oldKey", "foo");
+    jedis.set("{tag1}oldKey", "foo");
 
     try {
       new ConcurrentLoopingThreads(iterations,
-          i -> jedis.rename("{user1}oldKey", "{user1}newKey"),
-          i -> jedis.del("{user1}oldKey"))
+          i -> jedis.rename("{tag1}oldKey", "{tag1}newKey"),
+          i -> jedis.del("{tag1}oldKey"))
               .runWithAction(() -> {
-                assertThat(jedis.get("{user1}newKey")).isEqualTo("foo");
-                assertThat(jedis.exists("{user1}oldKey")).isFalse();
+                assertThat(jedis.get("{tag1}newKey")).isEqualTo("foo");
+                assertThat(jedis.exists("{tag1}oldKey")).isFalse();
                 flushAll();
-                jedis.set("{user1}oldKey", "foo");
+                jedis.set("{tag1}oldKey", "foo");
               });
     } catch (RuntimeException e) {
       assertThat(e).hasMessageContaining(ERROR_NO_SUCH_KEY);
@@ -280,14 +280,14 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   }
 
   private List<String> getKeysOnDifferentStripes() {
-    String key1 = "{user1}keyz" + new Random().nextInt();
+    String key1 = "{tag1}keyz" + new Random().nextInt();
 
     RedisKey key1RedisKey = new RedisKey(key1.getBytes());
     StripedCoordinator stripedCoordinator = new LockingStripedCoordinator();
     int iterator = 0;
     String key2;
     do {
-      key2 = "{user1}key" + iterator;
+      key2 = "{tag1}key" + iterator;
       iterator++;
     } while (stripedCoordinator.compareStripes(key1RedisKey,
         new RedisKey(key2.getBytes())) == 0);
@@ -297,14 +297,14 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
 
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {
     Random random = new Random();
-    String key1 = "{user1}keyz" + random.nextInt();
+    String key1 = "{tag1}keyz" + random.nextInt();
     RedisKey key1RedisKey = new RedisKey(key1.getBytes());
     StripedCoordinator stripedCoordinator = new LockingStripedCoordinator();
     Set<String> keys = new HashSet<>();
     keys.add(key1);
 
     do {
-      String key2 = "{user1}key" + random.nextInt();
+      String key2 = "{tag1}key" + random.nextInt();
       if (stripedCoordinator.compareStripes(key1RedisKey,
           new RedisKey(key2.getBytes())) == 0) {
         keys.add(key2);
@@ -363,12 +363,12 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     String key1;
     RedisKey key1RedisKey;
     do {
-      key1 = "{user1}keyz" + new Random().nextInt();
+      key1 = "{tag1}keyz" + new Random().nextInt();
       key1RedisKey = new RedisKey(key1.getBytes());
     } while (stripedCoordinator.compareStripes(key1RedisKey, toAvoid) == 0 && keys.add(key1));
 
     do {
-      String key2 = "{user1}key" + new Random().nextInt();
+      String key2 = "{tag1}key" + new Random().nextInt();
 
       if (stripedCoordinator.compareStripes(key1RedisKey,
           new RedisKey(key2.getBytes())) == 0) {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameNXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameNXIntegrationTest.java
@@ -72,57 +72,57 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
 
   @Test
   public void shouldRename_givenNewKey() {
-    jedis.set("{user1}foo", "bar");
-    long result = jedis.renamenx("{user1}foo", "{user1}newfoo");
+    jedis.set("{tag1}foo", "bar");
+    long result = jedis.renamenx("{tag1}foo", "{tag1}newfoo");
     assertThat(result).isEqualTo(1L);
-    assertThat(jedis.get("{user1}newfoo")).isEqualTo("bar");
+    assertThat(jedis.get("{tag1}newfoo")).isEqualTo("bar");
   }
 
   @Test
   public void shouldDeleteOldKey_whenRenamed() {
-    jedis.set("{user1}foo", "bar");
-    long result = jedis.renamenx("{user1}foo", "{user1}newfoo");
+    jedis.set("{tag1}foo", "bar");
+    long result = jedis.renamenx("{tag1}foo", "{tag1}newfoo");
     assertThat(result).isEqualTo(1L);
-    assertThat(jedis.get("{user1}foo")).isNull();
+    assertThat(jedis.get("{tag1}foo")).isNull();
   }
 
   @Test
   public void shouldReturnError_givenNonexistantKey() {
-    assertThatThrownBy(() -> jedis.renamenx("{user1}foo", "{user1}newfoo"))
+    assertThatThrownBy(() -> jedis.renamenx("{tag1}foo", "{tag1}newfoo"))
         .hasMessageContaining(ERROR_NO_SUCH_KEY);
   }
 
   @Test
   public void shouldRename_withHash() {
-    jedis.hset("{user1}foo", "field", "va");
-    long result = jedis.renamenx("{user1}foo", "{user1}newfoo");
+    jedis.hset("{tag1}foo", "field", "va");
+    long result = jedis.renamenx("{tag1}foo", "{tag1}newfoo");
     assertThat(result).isEqualTo(1L);
-    assertThat(jedis.hget("{user1}newfoo", "field")).isEqualTo("va");
+    assertThat(jedis.hget("{tag1}newfoo", "field")).isEqualTo("va");
   }
 
   @Test
   public void shouldRename_withSet() {
-    jedis.sadd("{user1}foo", "data");
-    long result = jedis.renamenx("{user1}foo", "{user1}newfoo");
+    jedis.sadd("{tag1}foo", "data");
+    long result = jedis.renamenx("{tag1}foo", "{tag1}newfoo");
     assertThat(result).isEqualTo(1L);
-    assertThat(jedis.smembers("{user1}newfoo")).containsExactly("data");
+    assertThat(jedis.smembers("{tag1}newfoo")).containsExactly("data");
   }
 
   @Test
   public void shouldReturnZero_withSameSourceAndTargetKey() {
-    jedis.set("{user1}blue", "moon");
-    assertThat(jedis.renamenx("{user1}blue", "{user1}blue")).isEqualTo(0L);
-    assertThat(jedis.get("{user1}blue")).isEqualTo("moon");
+    jedis.set("{tag1}blue", "moon");
+    assertThat(jedis.renamenx("{tag1}blue", "{tag1}blue")).isEqualTo(0L);
+    assertThat(jedis.get("{tag1}blue")).isEqualTo("moon");
   }
 
   @Test
   public void shouldNotRename_withExistingTargetKey() {
-    jedis.set("{user1}foo1", "bar1");
-    jedis.set("{user1}foo12", "bar2");
-    long result = jedis.renamenx("{user1}foo1", "{user1}foo12");
+    jedis.set("{tag1}foo1", "bar1");
+    jedis.set("{tag1}foo12", "bar2");
+    long result = jedis.renamenx("{tag1}foo1", "{tag1}foo12");
     assertThat(result).isEqualTo(0L);
-    assertThat(jedis.get("{user1}foo12")).isEqualTo("bar2");
-    assertThat(jedis.get("{user1}foo1")).isEqualTo("bar1");
+    assertThat(jedis.get("{tag1}foo12")).isEqualTo("bar2");
+    assertThat(jedis.get("{tag1}foo1")).isEqualTo("bar1");
   }
 
   @Test
@@ -149,8 +149,8 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
     int numStringsFirstKey = 500000;
     int numStringsSecondKey = 30000;
 
-    String k1 = "{user1}k1";
-    String k2 = "{user1}k2";
+    String k1 = "{tag1}k1";
+    String k2 = "{tag1}k2";
 
     Runnable initAction = () -> {
       flushAll();
@@ -245,27 +245,27 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
 
     final AtomicReference<RuntimeException> renameException = new AtomicReference<>(null);
 
-    jedis.set("{user1}oldKey", "foo");
+    jedis.set("{tag1}oldKey", "foo");
 
     try {
       new ConcurrentLoopingThreads(iterations,
           i -> {
             try {
-              jedis.renamenx("{user1}oldKey", "{user1}newKey");
+              jedis.renamenx("{tag1}oldKey", "{tag1}newKey");
             } catch (RuntimeException e) {
               renameException.set(e);
             }
           },
-          i -> jedis.del("{user1}oldKey"))
+          i -> jedis.del("{tag1}oldKey"))
               .runWithAction(() -> {
                 RuntimeException e = renameException.get();
                 if (e != null) {
                   throw e;
                 }
-                assertThat(jedis.get("{user1}newKey")).isEqualTo("foo");
-                assertThat(jedis.exists("{user1}oldKey")).isFalse();
+                assertThat(jedis.get("{tag1}newKey")).isEqualTo("foo");
+                assertThat(jedis.exists("{tag1}oldKey")).isFalse();
                 flushAll();
-                jedis.set("{user1}oldKey", "foo");
+                jedis.set("{tag1}oldKey", "foo");
               });
     } catch (RuntimeException e) {
       assertThat(e).hasMessageContaining(ERROR_NO_SUCH_KEY);
@@ -288,14 +288,14 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
   }
 
   private List<String> getKeysOnDifferentStripes() {
-    String key1 = "{user1}keyz" + new Random().nextInt();
+    String key1 = "{tag1}keyz" + new Random().nextInt();
 
     RedisKey key1RedisKey = new RedisKey(key1.getBytes());
     StripedCoordinator stripedCoordinator = new LockingStripedCoordinator();
     int iterator = 0;
     String key2;
     do {
-      key2 = "{user1}key" + iterator;
+      key2 = "{tag1}key" + iterator;
       iterator++;
     } while (stripedCoordinator.compareStripes(key1RedisKey,
         new RedisKey(key2.getBytes())) == 0);
@@ -305,14 +305,14 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
 
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {
     Random random = new Random();
-    String key1 = "{user1}keyz" + random.nextInt();
+    String key1 = "{tag1}keyz" + random.nextInt();
     RedisKey key1RedisKey = new RedisKey(key1.getBytes());
     StripedCoordinator stripedCoordinator = new LockingStripedCoordinator();
     Set<String> keys = new HashSet<>();
     keys.add(key1);
 
     do {
-      String key2 = "{user1}key" + random.nextInt();
+      String key2 = "{tag1}key" + random.nextInt();
       if (stripedCoordinator.compareStripes(key1RedisKey,
           new RedisKey(key2.getBytes())) == 0) {
         keys.add(key2);
@@ -371,12 +371,12 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
     String key1;
     RedisKey key1RedisKey;
     do {
-      key1 = "{user1}keyz" + new Random().nextInt();
+      key1 = "{tag1}keyz" + new Random().nextInt();
       key1RedisKey = new RedisKey(key1.getBytes());
     } while (stripedCoordinator.compareStripes(key1RedisKey, toAvoid) == 0 && keys.add(key1));
 
     do {
-      String key2 = "{user1}key" + new Random().nextInt();
+      String key2 = "{tag1}key" + new Random().nextInt();
 
       if (stripedCoordinator.compareStripes(key1RedisKey,
           new RedisKey(key2.getBytes())) == 0) {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
@@ -173,7 +173,7 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
 
     do {
       result =
-          (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, cursor, "COUNT", "2",
+          (List<Object>) jedis.sendCommand("{tag1}a", Protocol.Command.SCAN, cursor, "COUNT", "2",
               "COUNT", "1");
       allKeysFromScan.addAll((List<byte[]>) result.get(1));
       cursor = new String((byte[]) result.get(0));
@@ -206,7 +206,7 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
     jedis.hset("{tag1}c", "potato", "sweet");
 
     List<Object> result =
-        (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, "0", "MATCH", "{tag1}b*",
+        (List<Object>) jedis.sendCommand("{tag1}a", Protocol.Command.SCAN, "0", "MATCH", "{tag1}b*",
             "MATCH", "{tag1}a*");
 
     assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
@@ -112,16 +112,16 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
 
   @Test
   public void givenOneKeyInRegion_returnsKey() {
-    jedis.set("{user1}a", "1");
-    ScanResult<String> result = jedis.scan("0", new ScanParams().match("{user1}*"));
+    jedis.set("{tag1}a", "1");
+    ScanResult<String> result = jedis.scan("0", new ScanParams().match("{tag1}*"));
 
     assertThat(result.isCompleteIteration()).isTrue();
-    assertThat(result.getResult()).containsExactly("{user1}a");
+    assertThat(result.getResult()).containsExactly("{tag1}a");
   }
 
   @Test
   public void givenEmptyRegion_returnsEmptyArray() {
-    ScanResult<String> result = jedis.scan("0", new ScanParams().match("{user1}*"));
+    ScanResult<String> result = jedis.scan("0", new ScanParams().match("{tag1}*"));
 
     assertThat(result.isCompleteIteration()).isTrue();
     assertThat(result.getResult()).isEmpty();
@@ -129,24 +129,24 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
 
   @Test
   public void givenMultipleKeysInRegion_returnsAllKeys() {
-    jedis.set("{user1}a", "1");
-    jedis.sadd("{user1}b", "green", "orange");
-    jedis.hset("{user1}c", "potato", "sweet");
-    ScanResult<String> result = jedis.scan("0", new ScanParams().match("{user1}*"));
+    jedis.set("{tag1}a", "1");
+    jedis.sadd("{tag1}b", "green", "orange");
+    jedis.hset("{tag1}c", "potato", "sweet");
+    ScanResult<String> result = jedis.scan("0", new ScanParams().match("{tag1}*"));
 
     assertThat(result.isCompleteIteration()).isTrue();
-    assertThat(result.getResult()).containsExactlyInAnyOrder("{user1}a", "{user1}b", "{user1}c");
+    assertThat(result.getResult()).containsExactlyInAnyOrder("{tag1}a", "{tag1}b", "{tag1}c");
   }
 
   @Test
   public void givenCount_returnsAllKeysWithoutDuplicates() {
-    jedis.set("{user1}a", "1");
-    jedis.sadd("{user1}b", "green", "orange");
-    jedis.hset("{user1}c", "potato", "sweet");
+    jedis.set("{tag1}a", "1");
+    jedis.sadd("{tag1}b", "green", "orange");
+    jedis.hset("{tag1}c", "potato", "sweet");
 
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
-    scanParams.match("{user1}*");
+    scanParams.match("{tag1}*");
     String cursor = "0";
     ScanResult<String> result;
     List<String> allKeysFromScan = new ArrayList<>();
@@ -157,15 +157,15 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a", "{user1}b", "{user1}c");
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{tag1}a", "{tag1}b", "{tag1}c");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void givenMultipleCounts_returnsAllKeysWithoutDuplicates() {
-    jedis.set("{user1}a", "1");
-    jedis.sadd("{user1}b", "green", "orange");
-    jedis.hset("{user1}c", "potato", "sweet");
+    jedis.set("{tag1}a", "1");
+    jedis.sadd("{tag1}b", "green", "orange");
+    jedis.hset("{tag1}c", "potato", "sweet");
 
     String cursor = "0";
     List<Object> result;
@@ -180,46 +180,46 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
     } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
 
     assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a".getBytes(),
-        "{user1}b".getBytes(), "{user1}c".getBytes());
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{tag1}a".getBytes(),
+        "{tag1}b".getBytes(), "{tag1}c".getBytes());
   }
 
   @Test
   public void givenMatch_returnsAllMatchingKeysWithoutDuplicates() {
-    jedis.set("{user1}a", "1");
-    jedis.sadd("{user1}b", "green", "orange");
-    jedis.hset("{user1}c", "potato", "sweet");
+    jedis.set("{tag1}a", "1");
+    jedis.sadd("{tag1}b", "green", "orange");
+    jedis.hset("{tag1}c", "potato", "sweet");
     ScanParams scanParams = new ScanParams();
-    scanParams.match("{user1}a*");
+    scanParams.match("{tag1}a*");
 
     ScanResult<String> result = jedis.scan("0", scanParams);
 
     assertThat(result.isCompleteIteration()).isTrue();
-    assertThat(result.getResult()).containsExactly("{user1}a");
+    assertThat(result.getResult()).containsExactly("{tag1}a");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void givenMultipleMatches_returnsKeysMatchingLastMatchParameter() {
-    jedis.set("{user1}a", "1");
-    jedis.sadd("{user1}b", "green", "orange");
-    jedis.hset("{user1}c", "potato", "sweet");
+    jedis.set("{tag1}a", "1");
+    jedis.sadd("{tag1}b", "green", "orange");
+    jedis.hset("{tag1}c", "potato", "sweet");
 
     List<Object> result =
-        (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, "0", "MATCH", "{user1}b*",
-            "MATCH", "{user1}a*");
+        (List<Object>) jedis.sendCommand("user1", Protocol.Command.SCAN, "0", "MATCH", "{tag1}b*",
+            "MATCH", "{tag1}a*");
 
     assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat((List<byte[]>) result.get(1)).containsExactly("{user1}a".getBytes());
+    assertThat((List<byte[]>) result.get(1)).containsExactly("{tag1}a".getBytes());
   }
 
   @Test
   public void givenMatchAndCount_returnsAllMatchingKeysWithoutDuplicates() {
-    jedis.set("{user1}a", "1");
-    jedis.sadd("{user1}apple", "green", "orange");
-    jedis.hset("{user1}c", "potato", "sweet");
+    jedis.set("{tag1}a", "1");
+    jedis.sadd("{tag1}apple", "green", "orange");
+    jedis.hset("{tag1}c", "potato", "sweet");
     ScanParams scanParams = new ScanParams();
-    scanParams.match("{user1}a*");
+    scanParams.match("{tag1}a*");
     scanParams.count(1);
 
     String cursor = "0";
@@ -233,15 +233,15 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
     } while (!result.isCompleteIteration());
 
     assertThat(result.isCompleteIteration()).isTrue();
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a", "{user1}apple");
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{tag1}a", "{tag1}apple");
   }
 
   @Test
   @SuppressWarnings("unchecked")
   public void givenMultipleCountsAndMatches_returnsKeysMatchingLastMatchParameter() {
-    jedis.set("{user1}a", "1");
-    jedis.sadd("{user1}b", "green", "orange");
-    jedis.hset("{user1}aardvark", "potato", "sweet");
+    jedis.set("{tag1}a", "1");
+    jedis.sadd("{tag1}b", "green", "orange");
+    jedis.hset("{tag1}aardvark", "potato", "sweet");
 
     String cursor = "0";
     List<Object> result;
@@ -249,34 +249,34 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
 
     do {
       result =
-          (List<Object>) jedis.sendCommand("{user1}", Protocol.Command.SCAN, cursor, "COUNT", "37",
-              "MATCH", "{user1}b*", "COUNT", "2", "COUNT", "1", "MATCH", "{user1}a*");
+          (List<Object>) jedis.sendCommand("{tag1}", Protocol.Command.SCAN, cursor, "COUNT", "37",
+              "MATCH", "{tag1}b*", "COUNT", "2", "COUNT", "1", "MATCH", "{tag1}a*");
       allKeysFromScan.addAll((List<byte[]>) result.get(1));
       cursor = new String((byte[]) result.get(0));
     } while (!Arrays.equals((byte[]) result.get(0), "0".getBytes()));
 
     assertThat((byte[]) result.get(0)).isEqualTo("0".getBytes());
-    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{user1}a".getBytes(),
-        "{user1}aardvark".getBytes());
+    assertThat(allKeysFromScan).containsExactlyInAnyOrder("{tag1}a".getBytes(),
+        "{tag1}aardvark".getBytes());
   }
 
   @Test
   public void givenNegativeCursor_returnsKeysUsingAbsoluteValueOfCursor() {
-    jedis.set("{user1}a", "1");
-    jedis.sadd("{user1}b", "green", "orange");
-    jedis.hset("{user1}c", "potato", "sweet");
+    jedis.set("{tag1}a", "1");
+    jedis.sadd("{tag1}b", "green", "orange");
+    jedis.hset("{tag1}c", "potato", "sweet");
 
     List<String> allEntries = new ArrayList<>();
 
     String cursor = "-100";
     ScanResult<String> result;
     do {
-      result = jedis.scan(cursor, new ScanParams().match("{user1}*"));
+      result = jedis.scan(cursor, new ScanParams().match("{tag1}*"));
       allEntries.addAll(result.getResult());
       cursor = result.getCursor();
     } while (!result.isCompleteIteration());
 
-    assertThat(allEntries).containsExactlyInAnyOrder("{user1}a", "{user1}b", "{user1}c");
+    assertThat(allEntries).containsExactlyInAnyOrder("{tag1}a", "{tag1}b", "{tag1}c");
   }
 
   @Test
@@ -295,7 +295,7 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
   public void givenInvalidRegexSyntax_returnsEmptyArray() {
     ScanParams scanParams = new ScanParams();
     scanParams.count(1);
-    scanParams.match("{user1}\\p");
+    scanParams.match("{tag1}\\p");
 
     ScanResult<String> result = jedis.scan("0", scanParams);
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractUnlinkIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractUnlinkIntegrationTest.java
@@ -71,9 +71,9 @@ public abstract class AbstractUnlinkIntegrationTest implements RedisIntegrationT
 
   @Test
   public void testUnlink_unlinkingMultipleKeys_returnsCountOfOnlyUnlinkedKeys() {
-    String key1 = "{user1}firstKey";
-    String key2 = "{user1}secondKey";
-    String key3 = "{user1}thirdKey";
+    String key1 = "{tag1}firstKey";
+    String key2 = "{tag1}secondKey";
+    String key3 = "{tag1}thirdKey";
 
     jedis.set(key1, "value1");
     jedis.set(key2, "value2");

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/ScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/ScanIntegrationTest.java
@@ -41,15 +41,15 @@ public class ScanIntegrationTest extends AbstractScanIntegrationTest {
   public void givenDifferentCursorThanSpecifiedByPreviousScan_returnsAllKeys() {
     List<String> keyList = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
-      String key = "{user1}" + i;
+      String key = "{tag1}" + i;
       jedis.set(key, "a");
       keyList.add(key);
     }
 
-    ScanResult<String> result = jedis.scan("0", new ScanParams().count(5).match("{user1}*"));
+    ScanResult<String> result = jedis.scan("0", new ScanParams().count(5).match("{tag1}*"));
     assertThat(result.isCompleteIteration()).isFalse();
 
-    result = jedis.scan("100", new ScanParams().match("{user1}*"));
+    result = jedis.scan("100", new ScanParams().match("{tag1}*"));
 
     assertThat(result.getResult()).containsExactlyInAnyOrder(keyList.toArray(new String[0]));
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSCardIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSCardIntegrationTest.java
@@ -35,7 +35,7 @@ import org.apache.geode.redis.RedisIntegrationTest;
 
 public abstract class AbstractSCardIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
-  private static final String key = "{user1}setKey";
+  private static final String key = "{tag1}setKey";
 
   @Before
   public void setUp() {
@@ -62,7 +62,7 @@ public abstract class AbstractSCardIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void scardNonExistentSet_returnsZero() {
-    assertThat(jedis.scard("{user1}nonExistentSet")).isEqualTo(0);
+    assertThat(jedis.scard("{tag1}nonExistentSet")).isEqualTo(0);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffIntegrationTest.java
@@ -38,8 +38,8 @@ import org.apache.geode.redis.RedisIntegrationTest;
 
 public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
-  private static final String setKey = "{user1}setkey";
-  private static final String nonExistentSetKey = "{user1}nonExistentSet";
+  private static final String setKey = "{tag1}setkey";
+  private static final String nonExistentSetKey = "{tag1}nonExistentSet";
 
   @Before
   public void setUp() {
@@ -70,7 +70,7 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void sdiffWithMultipleNonExistentSet_returnsEmptySet() {
-    assertThat(jedis.sdiff("{user1}nonExistentSet1", "{user1}nonExistentSet2")).isEmpty();
+    assertThat(jedis.sdiff("{tag1}nonExistentSet1", "{tag1}nonExistentSet2")).isEmpty();
   }
 
   @Test
@@ -90,19 +90,19 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
   public void sdiffWithSetsWithDifferentValues_returnsFirstSetValues() {
     String[] firstValues = createKeyValuesSet();
     String[] secondValues = new String[] {"windows", "microsoft", "linux"};
-    jedis.sadd("{user1}setkey2", secondValues);
+    jedis.sadd("{tag1}setkey2", secondValues);
 
-    assertThat(jedis.sdiff(setKey, "{user1}setkey2")).containsExactlyInAnyOrder(firstValues);
+    assertThat(jedis.sdiff(setKey, "{tag1}setkey2")).containsExactlyInAnyOrder(firstValues);
   }
 
   @Test
   public void sdiffWithSetsWithSomeSharedValues_returnsDiffOfSets() {
     createKeyValuesSet();
     String[] secondValues = new String[] {"apple", "bottoms", "boots", "fur", "peach"};
-    jedis.sadd("{user1}setkey2", secondValues);
+    jedis.sadd("{tag1}setkey2", secondValues);
 
     Set<String> result =
-        jedis.sdiff(setKey, "{user1}setkey2");
+        jedis.sdiff(setKey, "{tag1}setkey2");
     String[] expected = new String[] {"orange", "plum", "pear"};
     assertThat(result).containsExactlyInAnyOrder(expected);
   }
@@ -110,8 +110,8 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
   @Test
   public void sdiffWithSetsWithAllSharedValues_returnsEmptySet() {
     String[] values = createKeyValuesSet();
-    jedis.sadd("{user1}setkey2", values);
-    assertThat(jedis.sdiff(setKey, "{user1}setkey2")).isEmpty();
+    jedis.sadd("{tag1}setkey2", values);
+    assertThat(jedis.sdiff(setKey, "{tag1}setkey2")).isEmpty();
   }
 
   @Test
@@ -120,11 +120,11 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
     String[] secondValues = new String[] {"apple", "bottoms", "boots", "fur", "peach"};
     String[] thirdValues = new String[] {"queen", "opera", "boho", "orange"};
 
-    jedis.sadd("{user1}setkey2", secondValues);
-    jedis.sadd("{user1}setkey3", thirdValues);
+    jedis.sadd("{tag1}setkey2", secondValues);
+    jedis.sadd("{tag1}setkey3", thirdValues);
 
     String[] expected = new String[] {"pear", "plum"};
-    assertThat(jedis.sdiff(setKey, "{user1}setkey2", "{user1}setkey3"))
+    assertThat(jedis.sdiff(setKey, "{tag1}setkey2", "{tag1}setkey3"))
         .containsExactlyInAnyOrder(expected);
   }
 
@@ -132,17 +132,17 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
   public void sdiffSetsNotModified_returnSetValues() {
     String[] firstValues = createKeyValuesSet();
     String[] secondValues = new String[] {"apple", "bottoms", "boots", "fur", "peach"};
-    jedis.sadd("{user1}setkey2", secondValues);
-    jedis.sdiff(setKey, "{user1}setkey2");
+    jedis.sadd("{tag1}setkey2", secondValues);
+    jedis.sdiff(setKey, "{tag1}setkey2");
     assertThat(jedis.smembers(setKey)).containsExactlyInAnyOrder(firstValues);
-    assertThat(jedis.smembers("{user1}setkey2")).containsExactlyInAnyOrder(secondValues);
+    assertThat(jedis.smembers("{tag1}setkey2")).containsExactlyInAnyOrder(secondValues);
   }
 
   @Test
   public void sdiffNonExistentSetsNotModified_returnEmptySet() {
-    jedis.sdiff(nonExistentSetKey, "{user1}nonExisistent2");
+    jedis.sdiff(nonExistentSetKey, "{tag1}nonExisistent2");
     assertThat(jedis.smembers(nonExistentSetKey)).isEmpty();
-    assertThat(jedis.smembers("{user1}nonExisistent2")).isEmpty();
+    assertThat(jedis.smembers("{tag1}nonExisistent2")).isEmpty();
   }
 
   @Test
@@ -172,25 +172,25 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
     String[] values = new String[] {"pear", "apple", "plum", "orange", "peach"};
     Set<String> valuesList = new HashSet<>(Arrays.asList(values));
 
-    jedis.sadd("{user1}firstset", values);
-    jedis.sadd("{user1}secondset", values);
+    jedis.sadd("{tag1}firstset", values);
+    jedis.sadd("{tag1}secondset", values);
 
     final AtomicReference<Set<String>> sdiffResultReference = new AtomicReference<>();
     new ConcurrentLoopingThreads(1000,
-        i -> jedis.srem("{user1}secondset", values),
-        i -> sdiffResultReference.set(jedis.sdiff("{user1}firstset", "{user1}secondset")))
+        i -> jedis.srem("{tag1}secondset", values),
+        i -> sdiffResultReference.set(jedis.sdiff("{tag1}firstset", "{tag1}secondset")))
             .runWithAction(() -> {
               assertThat(sdiffResultReference).satisfiesAnyOf(
                   sdiffResult -> assertThat(sdiffResult.get()).isEmpty(),
                   sdiffResult -> assertThat(sdiffResult.get())
                       .containsExactlyInAnyOrderElementsOf(valuesList));
-              jedis.sadd("{user1}secondset", values);
+              jedis.sadd("{tag1}secondset", values);
             });
   }
 
   private String[] createKeyValuesSet() {
     String[] values = new String[] {"pear", "apple", "plum", "orange", "peach"};
-    jedis.sadd("{user1}setkey", values);
+    jedis.sadd("{tag1}setkey", values);
     return values;
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffStoreIntegrationTest.java
@@ -36,12 +36,12 @@ import org.apache.geode.redis.RedisIntegrationTest;
 public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
 
-  private static final String destinationKey = "{user1}destinationKey";
+  private static final String destinationKey = "{tag1}destinationKey";
   private static final String[] destinationMembers =
       {"six", "seven", "eight", "nine", "ten", "one", "two"};
-  private static final String setKey = "{user1}setKey";
+  private static final String setKey = "{tag1}setKey";
   private static final String[] setMembers = {"one", "two", "three", "four", "five"};
-  private static final String nonExistentSetKey = "{user1}nonExistentSet";
+  private static final String nonExistentSetKey = "{tag1}nonExistentSet";
 
   @Before
   public void setUp() {
@@ -61,8 +61,8 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
 
   @Test
   public void sdiffstore_DifferentKeyType_returnsWrongTypeError() {
-    jedis.set("{user1}ding", "{user1}dong");
-    assertThatThrownBy(() -> jedis.sdiffstore(destinationKey, "{user1}ding"))
+    jedis.set("{tag1}ding", "{tag1}dong");
+    assertThatThrownBy(() -> jedis.sdiffstore(destinationKey, "{tag1}ding"))
         .hasMessageContaining(ERROR_WRONG_TYPE);
   }
 
@@ -97,7 +97,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
 
   @Test
   public void sdiffstoreWithNonExistentDest_withOverlappingSets_returnsSDiffSizeAndStoresSDiff() {
-    String key = "{user1}key";
+    String key = "{tag1}key";
     String[] result = {"three", "four", "five"};
     jedis.sadd(setKey, setMembers);
     jedis.sadd(key, destinationMembers);
@@ -107,7 +107,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
 
   @Test
   public void sdiffstoreWithNonExistentDest_withNonOverlappingSets_returnsSDiffSizeAndStoresSDiff() {
-    String key = "{user1}key";
+    String key = "{tag1}key";
     String[] members = {"nine", "twelve"};
     jedis.sadd(setKey, setMembers);
     jedis.sadd(key, members);
@@ -117,7 +117,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
 
   @Test
   public void sdiffstoreWithNonExistentDest_withIdenticalSets_returnsZeroAndDestKeyDoesNotExist() {
-    String key = "{user1}key";
+    String key = "{tag1}key";
     jedis.sadd(setKey, setMembers);
     jedis.sadd(key, setMembers);
     assertThat(jedis.sdiffstore(destinationKey, setKey, key)).isEqualTo(0);
@@ -126,7 +126,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
 
   @Test
   public void sdiffstoreWithNonExistentDest_withNonexistentSets_returnsZeroAndDestKeyDoesNotExist() {
-    assertThat(jedis.sdiffstore(destinationKey, nonExistentSetKey, "{user1}nonExistentKey2"))
+    assertThat(jedis.sdiffstore(destinationKey, nonExistentSetKey, "{tag1}nonExistentKey2"))
         .isEqualTo(0);
     assertThat(jedis.exists(destinationKey)).isFalse();
   }
@@ -134,7 +134,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
   // Destination Key has members
   @Test
   public void sdiffstoreWithExistentDest_withOverlappingSets_returnsSDiffSizeAndStoresSDiff() {
-    String key = "{user1}key";
+    String key = "{tag1}key";
     String[] result = {"three", "four", "five"};
     jedis.sadd(destinationKey, destinationMembers);
     jedis.sadd(setKey, setMembers);
@@ -145,7 +145,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
 
   @Test
   public void sdiffstoreWithExistentDest_withIdenticalSets_returnsZeroAndDestKeyDoesNotExist() {
-    String key = "{user1}key";
+    String key = "{tag1}key";
     jedis.sadd(destinationKey, destinationMembers);
     jedis.sadd(setKey, setMembers);
     jedis.sadd(key, setMembers);
@@ -155,7 +155,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
 
   @Test
   public void sdiffstoreWithDifferentDestKeyType_withExistentSet_returnsSDiffSizeAndStoresSDiff() {
-    jedis.set(destinationKey, "{user1}destMember");
+    jedis.set(destinationKey, "{tag1}destMember");
     jedis.sadd(setKey, setMembers);
     assertThat(jedis.sdiffstore(destinationKey, setKey)).isEqualTo(setMembers.length);
     assertThat(jedis.smembers(destinationKey)).containsExactlyInAnyOrder(setMembers);
@@ -163,15 +163,15 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
 
   @Test
   public void sdiffstoreWithDifferentDestKeyType_withNonExistentSet_returnsZeroAndDestKeyDoesNotExist() {
-    jedis.set(destinationKey, "{user1}destMember");
+    jedis.set(destinationKey, "{tag1}destMember");
     assertThat(jedis.sdiffstore(destinationKey, nonExistentSetKey)).isEqualTo(0);
     assertThat(jedis.exists(destinationKey)).isFalse();
   }
 
   @Test
   public void ensureSetConsistency_whenRunningConcurrently() {
-    String firstKey = "{user1}firstset";
-    String secondKey = "{user1}secondset";
+    String firstKey = "{tag1}firstset";
+    String secondKey = "{tag1}secondset";
     jedis.sadd(firstKey, setMembers);
     jedis.sadd(secondKey, setMembers);
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterIntegrationTest.java
@@ -64,21 +64,21 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
     String[] secondSet = new String[] {"apple", "microsoft", "linux", "peach"};
     String[] thirdSet = new String[] {"luigi", "bowser", "peach", "mario"};
-    jedis.sadd("{user1}set1", firstSet);
-    jedis.sadd("{user1}set2", secondSet);
-    jedis.sadd("{user1}set3", thirdSet);
+    jedis.sadd("{tag1}set1", firstSet);
+    jedis.sadd("{tag1}set2", secondSet);
+    jedis.sadd("{tag1}set3", thirdSet);
 
-    Set<String> resultSet = jedis.sinter("{user1}set1", "{user1}set2", "{user1}set3");
+    Set<String> resultSet = jedis.sinter("{tag1}set1", "{tag1}set2", "{tag1}set3");
 
     String[] expected = new String[] {"peach"};
     assertThat(resultSet).containsExactlyInAnyOrder(expected);
 
-    Set<String> emptyResultSet = jedis.sinter("{user1}nonexistent", "{user1}set2", "{user1}set3");
+    Set<String> emptyResultSet = jedis.sinter("{tag1}nonexistent", "{tag1}set2", "{tag1}set3");
     assertThat(emptyResultSet).isEmpty();
 
-    jedis.sadd("{user1}newEmpty", "born2die");
-    jedis.srem("{user1}newEmpty", "born2die");
-    Set<String> otherEmptyResultSet = jedis.sinter("{user1}set2", "{user1}newEmpty");
+    jedis.sadd("{tag1}newEmpty", "born2die");
+    jedis.srem("{tag1}newEmpty", "born2die");
+    Set<String> otherEmptyResultSet = jedis.sinter("{tag1}set2", "{tag1}newEmpty");
     assertThat(otherEmptyResultSet).isEmpty();
   }
 
@@ -87,38 +87,38 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
     String[] secondSet = new String[] {"apple", "microsoft", "linux", "peach"};
     String[] thirdSet = new String[] {"luigi", "bowser", "peach", "mario"};
-    jedis.sadd("{user1}set1", firstSet);
-    jedis.sadd("{user1}set2", secondSet);
-    jedis.sadd("{user1}set3", thirdSet);
+    jedis.sadd("{tag1}set1", firstSet);
+    jedis.sadd("{tag1}set2", secondSet);
+    jedis.sadd("{tag1}set3", thirdSet);
 
     Long resultSize =
-        jedis.sinterstore("{user1}result", "{user1}set1", "{user1}set2", "{user1}set3");
-    Set<String> resultSet = jedis.smembers("{user1}result");
+        jedis.sinterstore("{tag1}result", "{tag1}set1", "{tag1}set2", "{tag1}set3");
+    Set<String> resultSet = jedis.smembers("{tag1}result");
 
     String[] expected = new String[] {"peach"};
     assertThat(resultSize).isEqualTo(expected.length);
     assertThat(resultSet).containsExactlyInAnyOrder(expected);
 
-    Long otherResultSize = jedis.sinterstore("{user1}set1", "{user1}set1", "{user1}set2");
-    Set<String> otherResultSet = jedis.smembers("{user1}set1");
+    Long otherResultSize = jedis.sinterstore("{tag1}set1", "{tag1}set1", "{tag1}set2");
+    Set<String> otherResultSet = jedis.smembers("{tag1}set1");
     String[] otherExpected = new String[] {"apple", "peach"};
     assertThat(otherResultSize).isEqualTo(otherExpected.length);
     assertThat(otherResultSet).containsExactlyInAnyOrder(otherExpected);
 
     Long emptySetSize =
-        jedis.sinterstore("{user1}newEmpty", "{user1}nonexistent", "{user1}set2", "{user1}set3");
-    Set<String> emptyResultSet = jedis.smembers("{user1}newEmpty");
+        jedis.sinterstore("{tag1}newEmpty", "{tag1}nonexistent", "{tag1}set2", "{tag1}set3");
+    Set<String> emptyResultSet = jedis.smembers("{tag1}newEmpty");
     assertThat(emptySetSize).isEqualTo(0L);
     assertThat(emptyResultSet).isEmpty();
 
     emptySetSize =
-        jedis.sinterstore("{user1}set1", "{user1}nonexistent", "{user1}set2", "{user1}set3");
-    emptyResultSet = jedis.smembers("{user1}set1");
+        jedis.sinterstore("{tag1}set1", "{tag1}nonexistent", "{tag1}set2", "{tag1}set3");
+    emptyResultSet = jedis.smembers("{tag1}set1");
     assertThat(emptySetSize).isEqualTo(0L);
     assertThat(emptyResultSet).isEmpty();
 
-    Long copySetSize = jedis.sinterstore("{user1}copySet", "{user1}set2", "{user1}newEmpty");
-    Set<String> copyResultSet = jedis.smembers("{user1}copySet");
+    Long copySetSize = jedis.sinterstore("{tag1}copySet", "{tag1}set2", "{tag1}newEmpty");
+    Set<String> copyResultSet = jedis.smembers("{tag1}copySet");
     assertThat(copySetSize).isEqualTo(0);
     assertThat(copyResultSet).isEmpty();
   }
@@ -126,12 +126,12 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
   @Test
   public void testSInterStore_withNonExistentKeys() {
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
-    jedis.sadd("{user1}set1", firstSet);
+    jedis.sadd("{tag1}set1", firstSet);
 
     Long resultSize =
-        jedis.sinterstore("{user1}set1", "{user1}nonExistent1", "{user1}nonExistent2");
+        jedis.sinterstore("{tag1}set1", "{tag1}nonExistent1", "{tag1}nonExistent2");
     assertThat(resultSize).isEqualTo(0);
-    assertThat(jedis.exists("{user1}set1")).isFalse();
+    assertThat(jedis.exists("{tag1}set1")).isFalse();
   }
 
   @Test
@@ -139,20 +139,20 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.set("string1", "stringValue");
 
     Long resultSize =
-        jedis.sinterstore("{user1}string1", "{user1}nonExistent1", "{user1}nonExistent2");
+        jedis.sinterstore("{tag1}string1", "{tag1}nonExistent1", "{tag1}nonExistent2");
     assertThat(resultSize).isEqualTo(0);
-    assertThat(jedis.exists("{user1}set1")).isFalse();
+    assertThat(jedis.exists("{tag1}set1")).isFalse();
   }
 
   @Test
   public void testSInterStore_withNonSetKey() {
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
-    jedis.sadd("{user1}set1", firstSet);
-    jedis.set("{user1}string1", "value1");
+    jedis.sadd("{tag1}set1", firstSet);
+    jedis.set("{tag1}string1", "value1");
 
-    assertThatThrownBy(() -> jedis.sinterstore("{user1}set1", "{user1}string1"))
+    assertThatThrownBy(() -> jedis.sinterstore("{tag1}set1", "{tag1}string1"))
         .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
-    assertThat(jedis.exists("{user1}set1")).isTrue();
+    assertThat(jedis.exists("{tag1}set1")).isTrue();
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSIsMemberIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSIsMemberIntegrationTest.java
@@ -32,7 +32,7 @@ import org.apache.geode.redis.RedisIntegrationTest;
 
 public abstract class AbstractSIsMemberIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
-  private static final String setKey = "{user1}setkey";
+  private static final String setKey = "{tag1}setkey";
   private static final String[] setMembers = {"one", "two", "three", "four", "five"};
 
   @Before

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSMoveIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSMoveIntegrationTest.java
@@ -59,33 +59,33 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void testSmove_returnsWrongType_whenWrongSourceIsUsed() {
-    jedis.set("{user1}a-string", "value");
-    assertThatThrownBy(() -> jedis.smove("{user1}a-string", "{user1}some-set", "foo"))
+    jedis.set("{tag1}a-string", "value");
+    assertThatThrownBy(() -> jedis.smove("{tag1}a-string", "{tag1}some-set", "foo"))
         .hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
 
-    jedis.hset("{user1}a-hash", "field", "value");
-    assertThatThrownBy(() -> jedis.smove("{user1}a-hash", "{user1}some-set", "foo"))
+    jedis.hset("{tag1}a-hash", "field", "value");
+    assertThatThrownBy(() -> jedis.smove("{tag1}a-hash", "{tag1}some-set", "foo"))
         .hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
   }
 
   @Test
   public void testSmove_returnsWrongType_whenWrongDestinationIsUsed() {
-    jedis.sadd("{user1}a-set", "foobaz");
+    jedis.sadd("{tag1}a-set", "foobaz");
 
-    jedis.set("{user1}a-string", "value");
-    assertThatThrownBy(() -> jedis.smove("{user1}a-set", "{user1}a-string", "foo"))
+    jedis.set("{tag1}a-string", "value");
+    assertThatThrownBy(() -> jedis.smove("{tag1}a-set", "{tag1}a-string", "foo"))
         .hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
 
-    jedis.hset("{user1}a-hash", "field", "value");
-    assertThatThrownBy(() -> jedis.smove("{user1}a-set", "{user1}a-hash", "foo"))
+    jedis.hset("{tag1}a-hash", "field", "value");
+    assertThatThrownBy(() -> jedis.smove("{tag1}a-set", "{tag1}a-hash", "foo"))
         .hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
   }
 
   @Test
   public void testSMove() {
-    String source = "{user1}source";
-    String dest = "{user1}dest";
-    String test = "{user1}test";
+    String source = "{tag1}source";
+    String dest = "{tag1}dest";
+    String test = "{tag1}test";
     int elements = 10;
     String[] strings = generateStrings(elements, "value-");
     jedis.sadd(source, strings);
@@ -107,22 +107,22 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void testSMoveNegativeCases() {
-    String source = "{user1}source";
-    String dest = "{user1}dest";
+    String source = "{tag1}source";
+    String dest = "{tag1}dest";
     jedis.sadd(source, "sourceField");
     jedis.sadd(dest, "destField");
     String nonexistentField = "nonexistentField";
 
     assertThat(jedis.smove(source, dest, nonexistentField)).isEqualTo(0);
     assertThat(jedis.sismember(dest, nonexistentField)).isFalse();
-    assertThat(jedis.smove(source, "{user1}nonexistentDest", nonexistentField)).isEqualTo(0);
-    assertThat(jedis.smove("{user1}nonExistentSource", dest, nonexistentField)).isEqualTo(0);
+    assertThat(jedis.smove(source, "{tag1}nonexistentDest", nonexistentField)).isEqualTo(0);
+    assertThat(jedis.smove("{tag1}nonExistentSource", dest, nonexistentField)).isEqualTo(0);
   }
 
   @Test
   public void testConcurrentSMove() {
-    String source = "{user1}source";
-    String dest = "{user1}dest";
+    String source = "{tag1}source";
+    String dest = "{tag1}dest";
     int elements = 10000;
     String[] strings = generateStrings(elements, "value-");
     jedis.sadd(source, strings);
@@ -139,9 +139,9 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
 
   @Test
   public void testConcurrentSMove_withDifferentDestination() {
-    String source = "{user1}source";
-    String dest1 = "{user1}dest1";
-    String dest2 = "{user1}dest2";
+    String source = "{tag1}source";
+    String dest1 = "{tag1}dest1";
+    String dest2 = "{tag1}dest2";
     int elements = 10000;
     String[] strings = generateStrings(elements, "value-");
     jedis.sadd(source, strings);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionIntegrationTest.java
@@ -65,21 +65,21 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
     String[] secondSet = new String[] {"apple", "microsoft", "linux", "peach"};
     String[] thirdSet = new String[] {"luigi", "bowser", "peach", "mario"};
-    jedis.sadd("{user1}set1", firstSet);
-    jedis.sadd("{user1}set2", secondSet);
-    jedis.sadd("{user1}set3", thirdSet);
+    jedis.sadd("{tag1}set1", firstSet);
+    jedis.sadd("{tag1}set2", secondSet);
+    jedis.sadd("{tag1}set3", thirdSet);
 
-    Set<String> resultSet = jedis.sunion("{user1}set1", "{user1}set2");
+    Set<String> resultSet = jedis.sunion("{tag1}set1", "{tag1}set2");
     String[] expected =
         new String[] {"pear", "apple", "plum", "orange", "peach", "microsoft", "linux"};
     assertThat(resultSet).containsExactlyInAnyOrder(expected);
 
-    Set<String> otherResultSet = jedis.sunion("{user1}nonexistent", "{user1}set1");
+    Set<String> otherResultSet = jedis.sunion("{tag1}nonexistent", "{tag1}set1");
     assertThat(otherResultSet).containsExactlyInAnyOrder(firstSet);
 
-    jedis.sadd("{user1}newEmpty", "born2die");
-    jedis.srem("{user1}newEmpty", "born2die");
-    Set<String> yetAnotherResultSet = jedis.sunion("{user1}set2", "{user1}newEmpty");
+    jedis.sadd("{tag1}newEmpty", "born2die");
+    jedis.srem("{tag1}newEmpty", "born2die");
+    Set<String> yetAnotherResultSet = jedis.sunion("{tag1}set2", "{tag1}newEmpty");
     assertThat(yetAnotherResultSet).containsExactlyInAnyOrder(secondSet);
   }
 
@@ -88,29 +88,29 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
     String[] secondSet = new String[] {"apple", "microsoft", "linux", "peach"};
     String[] thirdSet = new String[] {"luigi", "bowser", "peach", "mario"};
-    jedis.sadd("{user1}set1", firstSet);
-    jedis.sadd("{user1}set2", secondSet);
-    jedis.sadd("{user1}set3", thirdSet);
+    jedis.sadd("{tag1}set1", firstSet);
+    jedis.sadd("{tag1}set2", secondSet);
+    jedis.sadd("{tag1}set3", thirdSet);
 
-    Long resultSize = jedis.sunionstore("{user1}result", "{user1}set1", "{user1}set2");
+    Long resultSize = jedis.sunionstore("{tag1}result", "{tag1}set1", "{tag1}set2");
     assertThat(resultSize).isEqualTo(7);
 
-    Set<String> resultSet = jedis.smembers("{user1}result");
+    Set<String> resultSet = jedis.smembers("{tag1}result");
     String[] expected =
         new String[] {"pear", "apple", "plum", "orange", "peach", "microsoft", "linux"};
     assertThat(resultSet).containsExactlyInAnyOrder(expected);
 
     Long notEmptyResultSize =
-        jedis.sunionstore("{user1}notempty", "{user1}nonexistent", "{user1}set1");
-    Set<String> notEmptyResultSet = jedis.smembers("{user1}notempty");
+        jedis.sunionstore("{tag1}notempty", "{tag1}nonexistent", "{tag1}set1");
+    Set<String> notEmptyResultSet = jedis.smembers("{tag1}notempty");
     assertThat(notEmptyResultSize).isEqualTo(firstSet.length);
     assertThat(notEmptyResultSet).containsExactlyInAnyOrder(firstSet);
 
-    jedis.sadd("{user1}newEmpty", "born2die");
-    jedis.srem("{user1}newEmpty", "born2die");
+    jedis.sadd("{tag1}newEmpty", "born2die");
+    jedis.srem("{tag1}newEmpty", "born2die");
     Long newNotEmptySize =
-        jedis.sunionstore("{user1}newNotEmpty", "{user1}set2", "{user1}newEmpty");
-    Set<String> newNotEmptySet = jedis.smembers("{user1}newNotEmpty");
+        jedis.sunionstore("{tag1}newNotEmpty", "{tag1}set2", "{tag1}newEmpty");
+    Set<String> newNotEmptySet = jedis.smembers("{tag1}newNotEmpty");
     assertThat(newNotEmptySize).isEqualTo(secondSet.length);
     assertThat(newNotEmptySet).containsExactlyInAnyOrder(secondSet);
   }
@@ -118,33 +118,33 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
   @Test
   public void testSUnionStore_withNonExistentKeys() {
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
-    jedis.sadd("{user1}set1", firstSet);
+    jedis.sadd("{tag1}set1", firstSet);
 
     Long resultSize =
-        jedis.sunionstore("{user1}set1", "{user1}nonExistent1", "{user1}nonExistent2");
+        jedis.sunionstore("{tag1}set1", "{tag1}nonExistent1", "{tag1}nonExistent2");
     assertThat(resultSize).isEqualTo(0);
-    assertThat(jedis.exists("{user1}set1")).isFalse();
+    assertThat(jedis.exists("{tag1}set1")).isFalse();
   }
 
   @Test
   public void testSUnionStore_withNonExistentKeys_andNonSetTarget() {
-    jedis.set("{user1}string1", "stringValue");
+    jedis.set("{tag1}string1", "stringValue");
 
     Long resultSize =
-        jedis.sunionstore("{user1}string1", "{user1}nonExistent1", "{user1}nonExistent2");
+        jedis.sunionstore("{tag1}string1", "{tag1}nonExistent1", "{tag1}nonExistent2");
     assertThat(resultSize).isEqualTo(0);
-    assertThat(jedis.exists("{user1}set1")).isFalse();
+    assertThat(jedis.exists("{tag1}set1")).isFalse();
   }
 
   @Test
   public void testSUnionStore_withNonSetKey() {
     String[] firstSet = new String[] {"pear", "apple", "plum", "orange", "peach"};
-    jedis.sadd("{user1}set1", firstSet);
-    jedis.set("{user1}string1", "value1");
+    jedis.sadd("{tag1}set1", firstSet);
+    jedis.set("{tag1}string1", "value1");
 
-    assertThatThrownBy(() -> jedis.sunionstore("{user1}set1", "{user1}string1"))
+    assertThatThrownBy(() -> jedis.sunionstore("{tag1}set1", "{tag1}string1"))
         .hasMessage("WRONGTYPE Operation against a key holding the wrong kind of value");
-    assertThat(jedis.exists("{user1}set1")).isTrue();
+    assertThat(jedis.exists("{tag1}set1")).isTrue();
   }
 
   @Test
@@ -166,22 +166,22 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
       otherSets.add(oneSet);
     }
 
-    jedis.sadd("{user1}master", masterSet.toArray(new String[] {}));
+    jedis.sadd("{tag1}master", masterSet.toArray(new String[] {}));
 
     for (int i = 0; i < ENTRIES; i++) {
-      jedis.sadd("{user1}set-" + i, otherSets.get(i).toArray(new String[] {}));
+      jedis.sadd("{tag1}set-" + i, otherSets.get(i).toArray(new String[] {}));
     }
 
     Runnable runnable1 = () -> {
       for (int i = 0; i < ENTRIES; i++) {
-        jedis.sunionstore("{user1}master", "{user1}master", "{user1}set-" + i);
+        jedis.sunionstore("{tag1}master", "{tag1}master", "{tag1}set-" + i);
         Thread.yield();
       }
     };
 
     Runnable runnable2 = () -> {
       for (int i = 0; i < ENTRIES; i++) {
-        jedis.sunionstore("{user1}master", "{user1}master", "{user1}set-" + i);
+        jedis.sunionstore("{tag1}master", "{tag1}master", "{tag1}set-" + i);
         Thread.yield();
       }
     };
@@ -196,7 +196,7 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
 
     otherSets.forEach(masterSet::addAll);
 
-    assertThat(jedis.smembers("{user1}master").toArray())
+    assertThat(jedis.smembers("{tag1}master").toArray())
         .containsExactlyInAnyOrder(masterSet.toArray());
   }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -47,10 +47,10 @@ import org.apache.geode.redis.internal.RedisConstants;
 
 public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegrationTest {
 
-  private static final String NEW_SET = "{user1}new";
-  private static final String KEY1 = "{user1}sset1";
-  private static final String KEY2 = "{user1}sset2";
-  private static final String KEY3 = "{user1}sset3";
+  private static final String NEW_SET = "{tag1}new";
+  private static final String KEY1 = "{tag1}sset1";
+  private static final String KEY2 = "{tag1}sset2";
+  private static final String KEY3 = "{tag1}sset3";
 
   private JedisCluster jedis;
 
@@ -72,7 +72,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
   @Test
   public void shouldError_givenWrongKeyType() {
-    final String STRING_KEY = "{user1}stringKey";
+    final String STRING_KEY = "{tag1}stringKey";
     jedis.set(STRING_KEY, "value");
     assertThatThrownBy(() -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2",
         STRING_KEY, KEY1)).hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
@@ -80,7 +80,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
   @Test
   public void shouldError_givenSetsCrossSlots() {
-    final String WRONG_KEY = "{user2}another";
+    final String WRONG_KEY = "{tag2}another";
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2", WRONG_KEY,
             KEY1)).hasMessage("CROSSSLOT " + RedisConstants.ERROR_WRONG_SLOT);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
@@ -42,10 +42,10 @@ import org.apache.geode.redis.internal.RedisConstants;
 
 public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegrationTest {
 
-  private static final String NEW_SET = "{user1}new";
-  private static final String KEY1 = "{user1}sset1";
-  private static final String KEY2 = "{user1}sset2";
-  private static final String SORTED_SET_KEY3 = "{user1}sset3";
+  private static final String NEW_SET = "{tag1}new";
+  private static final String KEY1 = "{tag1}sset1";
+  private static final String KEY2 = "{tag1}sset2";
+  private static final String SORTED_SET_KEY3 = "{tag1}sset3";
 
   private JedisCluster jedis;
 
@@ -62,7 +62,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
   @Test
   public void shouldError_givenWrongKeyType() {
-    final String STRING_KEY = "{user1}stringKey";
+    final String STRING_KEY = "{tag1}stringKey";
     jedis.set(STRING_KEY, "value");
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2", STRING_KEY,
@@ -72,7 +72,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
   @Test
   public void shouldError_givenSetsCrossSlots() {
-    final String WRONG_KEY = "{user2}another";
+    final String WRONG_KEY = "{tag2}another";
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2", WRONG_KEY,
             KEY1))

--- a/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/KeyHashUtilTest.java
+++ b/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/KeyHashUtilTest.java
@@ -42,16 +42,16 @@ public class KeyHashUtilTest {
     compareHashes("empty{}hash");
     compareHashes("nested{some{hash}or}hash");
 
-    compareHashes("name{user1000}");
-    compareHashes("{user1000");
-    compareHashes("}user1000{");
-    compareHashes("user{}1000");
-    compareHashes("user}{1000");
-    compareHashes("{user1000}}bar");
-    compareHashes("foo{user1000}{bar}");
-    compareHashes("foo{}{user1000}");
-    compareHashes("{}{user1000}");
-    compareHashes("foo{{user1000}}bar");
+    compareHashes("name{tag1000}");
+    compareHashes("{tag1000");
+    compareHashes("}tag1000{");
+    compareHashes("tag{}1000");
+    compareHashes("tag}{1000");
+    compareHashes("{tag1000}}bar");
+    compareHashes("foo{tag1000}{bar}");
+    compareHashes("foo{}{tag1000}");
+    compareHashes("{}{tag1000}");
+    compareHashes("foo{{tag1000}}bar");
     compareHashes("");
   }
 


### PR DESCRIPTION
 - Instead of {user1} or variants thereof, use {tag1} to prevent
 confusion

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
