### PR TITLE
GEODE-9924: Avoid merging repeat test logs

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/testing/repeat/RepeatTest.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/testing/repeat/RepeatTest.groovy
@@ -46,7 +46,7 @@ class RepeatTest extends Test {
      */
     @Override
     protected TestExecuter<JvmTestExecutionSpec> createTestExecuter() {
-        return new RepeatableTestExecuter(
+        return new RepeatTestExecuter(
                 super.createTestExecuter().workerFactory,
                 getActorFactory(),
                 getModuleRegistry(),
@@ -54,6 +54,7 @@ class RepeatTest extends Test {
                 getServices().get(StartParameter.class).getMaxWorkerCount(),
                 getServices().get(Clock.class),
                 getServices().get(DocumentationRegistry.class),
-                (DefaultTestFilter) getFilter())
+                (DefaultTestFilter) getFilter(),
+                times)
     }
 }

--- a/buildSrc/src/main/java/org/apache/geode/gradle/testing/repeat/ExecutionTrackingTestClassProcessor.java
+++ b/buildSrc/src/main/java/org/apache/geode/gradle/testing/repeat/ExecutionTrackingTestClassProcessor.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.gradle.testing.repeat;
+
+import org.gradle.api.internal.tasks.testing.TestClassProcessor;
+import org.gradle.api.internal.tasks.testing.TestClassRunInfo;
+import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+
+/**
+ * A test class processor that decorates its result processor to associate each test event with
+ * the test class execution that reported it.
+ */
+public class ExecutionTrackingTestClassProcessor implements TestClassProcessor {
+  private final TestClassProcessor processor;
+  private final int iterationCount;
+
+  public ExecutionTrackingTestClassProcessor(TestClassProcessor processor,
+      int iterationCount) {
+    this.processor = processor;
+    this.iterationCount = iterationCount;
+  }
+
+  @Override
+  public void startProcessing(TestResultProcessor resultProcessor) {
+    processor.startProcessing(
+        new ExecutionTrackingTestResultProcessor(resultProcessor, iterationCount));
+  }
+
+  @Override
+  public void processTestClass(TestClassRunInfo testClass) {
+    processor.processTestClass(testClass);
+  }
+
+  @Override
+  public void stop() {
+    processor.stop();
+  }
+
+  @Override
+  public void stopNow() {
+    processor.stopNow();
+  }
+}

--- a/buildSrc/src/main/java/org/apache/geode/gradle/testing/repeat/ExecutionTrackingTestResultProcessor.java
+++ b/buildSrc/src/main/java/org/apache/geode/gradle/testing/repeat/ExecutionTrackingTestResultProcessor.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.gradle.testing.repeat;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.gradle.api.internal.tasks.testing.DefaultTestClassDescriptor;
+import org.gradle.api.internal.tasks.testing.DefaultTestDescriptor;
+import org.gradle.api.internal.tasks.testing.TestCompleteEvent;
+import org.gradle.api.internal.tasks.testing.TestDescriptorInternal;
+import org.gradle.api.internal.tasks.testing.TestResultProcessor;
+import org.gradle.api.internal.tasks.testing.TestStartEvent;
+import org.gradle.api.internal.tasks.testing.worker.WorkerTestClassProcessor;
+import org.gradle.api.tasks.testing.TestOutputEvent;
+
+/**
+ * A test result processor that associates each test event with the test class execution that
+ * reported it.
+ */
+public class ExecutionTrackingTestResultProcessor implements TestResultProcessor {
+  private static final Map<String, AtomicInteger> EXECUTION_COUNTERS = new ConcurrentHashMap<>();
+  private final TestResultProcessor processor;
+  private final String executionNameFormat;
+  // The ID of the test class execution reported by this processor. The ID is generated when the
+  // first class starts. The first class is the top-level class being executed in this execution.
+  // Subsequent classes (if any) are all nested classes, and will get the same execution ID as their
+  // top-level class, making it possible to identify the classes that were executed together.
+  private int executionId;
+  private String workerName;
+
+  public ExecutionTrackingTestResultProcessor(TestResultProcessor processor, int repetitions) {
+    this.processor = processor;
+    int idWidth = String.valueOf(repetitions).length();
+    executionNameFormat = "%s-%0" + idWidth + 'd';
+  }
+
+  /**
+   * Reports a test start event, appending an execution ID to the test class name. The execution ID
+   * is a simple counter that distinguishes one execution of a given test class from another.
+   */
+  @Override
+  public void started(TestDescriptorInternal test, TestStartEvent event) {
+    processor.started(executionTrackingDescriptor(test), event);
+  }
+
+  @Override
+  public void completed(Object testId, TestCompleteEvent event) {
+    processor.completed(testId, event);
+  }
+
+  @Override
+  public void output(Object testId, TestOutputEvent event) {
+    processor.output(testId, event);
+  }
+
+  @Override
+  public void failure(Object testId, Throwable result) {
+    processor.failure(testId, result);
+  }
+
+  private TestDescriptorInternal executionTrackingDescriptor(TestDescriptorInternal original) {
+    if (original instanceof DefaultTestDescriptor) {
+      return executionTrackingTestDescriptor(original);
+    }
+    if (original instanceof DefaultTestClassDescriptor) {
+      if (executionId == 0) {
+        executionId = nextExecutionIdFor(original.getClassName());
+      }
+      return executionTrackingClassDescriptor(original);
+    }
+    if (!(original instanceof WorkerTestClassProcessor.WorkerTestSuiteDescriptor)) {
+      warnUnrecognized(original);
+    } else {
+      workerName = original.getName();
+    }
+    return original;
+  }
+
+  private TestDescriptorInternal executionTrackingClassDescriptor(TestDescriptorInternal original) {
+    String executionTrackingClassName = executionTrackingClassNameFor(original);
+    return new DefaultTestClassDescriptor(original.getId(), executionTrackingClassName,
+        original.getClassDisplayName());
+  }
+
+  private TestDescriptorInternal executionTrackingTestDescriptor(TestDescriptorInternal original) {
+    String executionTrackingClassName = executionTrackingClassNameFor(original);
+    return new DefaultTestDescriptor(original.getId(), executionTrackingClassName,
+        original.getName(), original.getClassDisplayName(), original.getDisplayName());
+  }
+
+  private String executionTrackingClassNameFor(TestDescriptorInternal original) {
+    return String.format(executionNameFormat, original.getClassName(), executionId);
+  }
+
+  private static int nextExecutionIdFor(String className) {
+    AtomicInteger executionCounter =
+        EXECUTION_COUNTERS.computeIfAbsent(className, name -> new AtomicInteger());
+    return executionCounter.incrementAndGet();
+  }
+
+  private void warnUnrecognized(TestDescriptorInternal original) {
+    System.out.printf(
+        "WARNING: %s does not recognize test descriptor type %s (className=%s, name=%s)%n",
+        getClass().getName(), original.getClass().getSimpleName(), original.getClassName(),
+        original.getName());
+  }
+}

--- a/buildSrc/src/main/java/org/apache/geode/gradle/testing/repeat/RepeatTestExecuter.java
+++ b/buildSrc/src/main/java/org/apache/geode/gradle/testing/repeat/RepeatTestExecuter.java
@@ -57,11 +57,16 @@ import org.gradle.process.internal.worker.WorkerProcessFactory;
  *   classes, preventing the {@code RepeatTest} from repeating the tests.</li>
  * </ul>
  * <p>
- * This class omits the {@code RunPreviousFailedFirstTestClassProcessor}, and so each test class
+ * This executer omits the {@code RunPreviousFailedFirstTestClassProcessor}, and so each test class
  * is processed as many times as {@code RepeatTest} submits it. See the comment in {@link #execute}.
+ * <p>
+ * This executer also assigns an ID to each execution of a test class, and appends that ID onto the
+ * class name for that test instance. Gradle writes each test's output to a log associated with
+ * the class name. Appending an execution ID onto the class name causes Gradle to write the output
+ * from each instance to its own log.
  */
-public class RepeatableTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
-  private static final Logger LOGGER = Logging.getLogger(RepeatableTestExecuter.class);
+public class RepeatTestExecuter implements TestExecuter<JvmTestExecutionSpec> {
+  private static final Logger LOGGER = Logging.getLogger(RepeatTestExecuter.class);
 
   private final WorkerProcessFactory workerFactory;
   private final ActorFactory actorFactory;
@@ -71,11 +76,13 @@ public class RepeatableTestExecuter implements TestExecuter<JvmTestExecutionSpec
   private final Clock clock;
   private final DocumentationRegistry documentationRegistry;
   private final DefaultTestFilter testFilter;
+  private final int iterationCount;
   private TestClassProcessor processor;
 
-  public RepeatableTestExecuter(WorkerProcessFactory workerFactory, ActorFactory actorFactory,
+  public RepeatTestExecuter(WorkerProcessFactory workerFactory, ActorFactory actorFactory,
       ModuleRegistry moduleRegistry, WorkerLeaseRegistry workerLeaseRegistry, int maxWorkerCount,
-      Clock clock, DocumentationRegistry documentationRegistry, DefaultTestFilter testFilter) {
+      Clock clock, DocumentationRegistry documentationRegistry, DefaultTestFilter testFilter,
+      int iterationCount) {
     this.workerFactory = workerFactory;
     this.actorFactory = actorFactory;
     this.moduleRegistry = moduleRegistry;
@@ -84,6 +91,7 @@ public class RepeatableTestExecuter implements TestExecuter<JvmTestExecutionSpec
     this.clock = clock;
     this.documentationRegistry = documentationRegistry;
     this.testFilter = testFilter;
+    this.iterationCount = iterationCount;
   }
 
   @Override
@@ -102,10 +110,13 @@ public class RepeatableTestExecuter implements TestExecuter<JvmTestExecutionSpec
     final Factory<TestClassProcessor> forkingProcessorFactory = new Factory<TestClassProcessor>() {
       @Override
       public TestClassProcessor create() {
-        return new ForkingTestClassProcessor(currentWorkerLease, workerFactory, testInstanceFactory,
-            testExecutionSpec.getJavaForkOptions(),
-            classpath, modulePath, testWorkerImplementationModules,
-            testFramework.getWorkerConfigurationAction(), moduleRegistry, documentationRegistry);
+        TestClassProcessor forkingTestClassProcessor =
+            new ForkingTestClassProcessor(currentWorkerLease, workerFactory, testInstanceFactory,
+                testExecutionSpec.getJavaForkOptions(), classpath, modulePath,
+                testWorkerImplementationModules, testFramework.getWorkerConfigurationAction(),
+                moduleRegistry, documentationRegistry);
+        // Wrap the forking processor to make it distinguish different executions of a test class
+        return new ExecutionTrackingTestClassProcessor(forkingTestClassProcessor, iterationCount);
       }
     };
     final Factory<TestClassProcessor>

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
@@ -39,7 +39,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.jar.Attributes;
 import java.util.jar.JarOutputStream;
 import java.util.jar.Manifest;
@@ -55,7 +54,7 @@ import org.apache.geode.internal.membership.utils.AvailablePort;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.version.VersionManager;
 
-public class ProcessManager implements ChildVMLauncher {
+class ProcessManager implements ChildVMLauncher {
   private int namingPort;
   private Map<Integer, ProcessHolder> processes = new HashMap<>();
   private File log4jConfig;
@@ -64,7 +63,6 @@ public class ProcessManager implements ChildVMLauncher {
   private int debugPort = Integer.getInteger("dunit.debug.basePort", 0);
   private int suspendVM = Integer.getInteger("dunit.debug.suspendVM", -100);
   private VersionManager versionManager;
-  public static final String ID = UUID.randomUUID().toString().substring(0, 4);
 
   public ProcessManager(int namingPort, Registry registry) {
     this.versionManager = VersionManager.getInstance();
@@ -156,7 +154,7 @@ public class ProcessManager implements ChildVMLauncher {
 
   private void linkStreams(final String version, final int vmNum, final ProcessHolder holder,
       final InputStream in, final PrintStream out) {
-    final String vmName = "[" + VM.getVMName(version, vmNum) + "-" + ID + "] ";
+    final String vmName = "[" + VM.getVMName(version, vmNum) + "] ";
     Thread ioTransport = new Thread() {
       @Override
       public void run() {


### PR DESCRIPTION
PROBLEM

Our repeat test tasks merge the output from all executions of a given
test class, making it very difficult to diagnose failures in repeat
tests.

CAUSE

In order to run tests repeatedly, our repeat test tasks override Gradle
code to allow a test class to execute more than once. Gradle's test
reporting code does not expect this. It directs the output from each
test to a log associated with the test class name, not with the specific
execution of the test class. This results in merging the outputs from
different executions of the same class.

SOLUTION

Change Gradle to distinguish separate executions of a test class, and to
log the output from each execution separately.

Components:
- New `ExecutionTrackingTestResultProcessor` class: Wraps a given test
  result processor to append an execution identifier (a simple counter)
  to the name of the test class when reporting results. Gradle
  associates the output with this execution-specific name instead of
  with the class name.
- New `ExecutionTrackingTestClassProcessor` class: Wraps a given test
  class processor to report via an
  `ExecutionTrackingTestResultProcessor`.
- Change `RepeatTestExecuter` to use an
  `ExecutionTrackingTestClassProcessor`.

This commit also reverts GEODE-9912, which partially addressed the same
problem by adding an execution ID to each log line from a DUnit ChildVM.
The execution ID made it possible to identify the source of each merged
log line. GEODE-9924 (this commit) makes the changes from GEODE-9912
unnecessary.

NOTES
- Gradle now creates distinct XML and HTML report files for each
  execution of a given test class.
- The test summary HTML page created by Gradle lists each test class
  execution separately. If a class named `FooTest` executes 50 times (as
  in a stress test run), the summary will list `FooTest-01`,
  `FooTest-02`, ..., `FooTest-50` as if they were separate test classes.
