### PR TITLE
GEODE-9942: Include JUnit 5 tests in stress tests

### DIFF
--- a/geode-junit/src/main/java/org/apache/geode/test/util/StressNewTestHelper.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/util/StressNewTestHelper.java
@@ -78,6 +78,7 @@ public class StressNewTestHelper {
     this.packageToScan = packageToScan;
     scanResult = new ClassGraph().whitelistPackages(packageToScan)
         .enableClassInfo()
+        .ignoreClassVisibility() // Because JUnit 5 tests can have default (non-public) visibility
         .enableAnnotationInfo().scan();
   }
 


### PR DESCRIPTION
PROBLEM

JUnit 5 test classes need not be public. Indeed, IntelliJ's default
inspections discourage making JUnit 5 classes public.

`StressTestHelper` uses a `ClassGraph` to gather information about test
classes. By default, the `ClassGraph` scans only public classes. So by
default, the `ClassGraph` does not gather information about JUnit 5
classes with non-public visibility.

As a result, our stress test scripts do not run JUnit 5 tests.

SOLUTION

Call `ignoreClassVisibility()` to configure the `ClassGraph` to scan all
classes, not just public ones.

A few poorly-controlled, unsophisticated experiments (on a 2016 MacBook)
show that this increases the scan duration from 3 seconds to 3.4
seconds.
