### PR TITLE
GEODE-9704: Ready for events was happening before it should

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import org.junit.After;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -171,7 +170,6 @@ public class AuthExpirationDUnitTest {
   }
 
   @Test
-  @Ignore("unnecessary test case for re-auth, but it manifests GEODE-9704")
   public void registeredInterest_slowReAuth_policyKeys_durableClient() throws Exception {
     int serverPort = server.getPort();
     clientVM = cluster.startClientVM(0,
@@ -187,7 +185,7 @@ public class AuthExpirationDUnitTest {
       Region<Object, Object> region = clientCache
           .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
 
-      region.registerInterestForAllKeys(InterestResultPolicy.KEYS, true);
+      region.registerInterestForAllKeys(InterestResultPolicy.NONE, true);
       clientCache.readyForEvents();
       UpdatableUserAuthInitialize.setUser("user11");
       // wait for time longer than server's max time to wait to re-authenticate

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -80,20 +80,16 @@ public class AuthExpirationDUnitTest {
     startClientWithCQ();
     Region<Object, Object> region = server.getCache().getRegion("/region");
     region.put("1", "value1");
-    clientVM.invoke(() -> {
-      await().untilAsserted(
-          () -> assertThat(CQLISTENER0.getKeys())
-              .asList()
-              .containsExactly("1"));
-    });
+    clientVM.invoke(() -> await().untilAsserted(
+        () -> assertThat(CQLISTENER0.getKeys())
+            .asList()
+            .containsExactly("1")));
 
     // expire the current user
     getSecurityManager().addExpiredUser("user1");
 
     // update the user to be used before we try to send the 2nd event
-    clientVM.invoke(() -> {
-      UpdatableUserAuthInitialize.setUser("user2");
-    });
+    clientVM.invoke(() -> UpdatableUserAuthInitialize.setUser("user2"));
 
     // do a second put, the event should be queued until client re-authenticate
     region.put("2", "value2");

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -165,6 +165,7 @@ public class AuthExpirationDUnitTest {
         .containsExactly("DATA:READ:region:key0");
   }
 
+  // @Ignore("unnecessary test case for re-auth, but it manifests GEODE-9704")
   @Test
   public void registeredInterest_slowReAuth_policyKeys_durableClient() throws Exception {
     int serverPort = server.getPort();
@@ -181,7 +182,7 @@ public class AuthExpirationDUnitTest {
       Region<Object, Object> region = clientCache
           .createClientRegionFactory(ClientRegionShortcut.CACHING_PROXY).create("region");
 
-      region.registerInterestForAllKeys(InterestResultPolicy.NONE, true);
+      region.registerInterestForAllKeys(InterestResultPolicy.KEYS, true);
       clientCache.readyForEvents();
       UpdatableUserAuthInitialize.setUser("user11");
       // wait for time longer than server's max time to wait to re-authenticate

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -914,6 +914,7 @@ public class QueueManagerImpl implements QueueManager {
         // could not find a new primary to create
         break;
       }
+
       if (!addToConnectionList(newPrimary, true)) {
         excludedServers.add(newPrimary.getServer());
         newPrimary = null;

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -802,10 +802,13 @@ public class QueueManagerImpl implements QueueManager {
       excludedServers.addAll(servers);
     }
 
+    return primary;
+  }
+
+  private void markAsQueueAsReadyForEvents(QueueConnectionImpl primary) {
     if (primary != null && sentClientReady && primary.sendClientReady()) {
       readyForEventsAfterFailover(primary);
     }
-    return primary;
   }
 
   private List<ServerLocation> findQueueServers(Set<ServerLocation> excludedServers, int count,
@@ -926,6 +929,9 @@ public class QueueManagerImpl implements QueueManager {
           excludedServers.add(newPrimary.getServer());
           newPrimary = null;
         }
+
+        markAsQueueAsReadyForEvents(newPrimary);
+
         // New primary queue was found from a non backup, alert the affected cqs
         cqsConnected();
       }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -50,6 +50,7 @@ import org.apache.geode.cache.client.internal.RegisterInterestTracker.RegionInte
 import org.apache.geode.cache.client.internal.ServerDenyList.DenyListListener;
 import org.apache.geode.cache.client.internal.ServerDenyList.DenyListListenerAdapter;
 import org.apache.geode.cache.client.internal.ServerDenyList.FailureTracker;
+import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.query.internal.CqStateImpl;
 import org.apache.geode.cache.query.internal.DefaultQueryService;
 import org.apache.geode.cache.query.internal.cq.ClientCQ;
@@ -1110,9 +1111,8 @@ public class QueueManagerImpl implements QueueManager {
   }
 
   private void recoverCqs(Connection recoveredConnection, boolean isDurable) {
-    Map cqs = this.getPool().getRITracker().getCqsMap();
-    for (Object o : cqs.entrySet()) {
-      Map.Entry e = (Map.Entry) o;
+    Map<CqQuery, Boolean> cqs = this.getPool().getRITracker().getCqsMap();
+    for (Map.Entry<CqQuery, Boolean> e : cqs.entrySet()) {
       ClientCQ cqi = (ClientCQ) e.getKey();
       String name = cqi.getName();
       if (this.pool.getMultiuserAuthentication()) {

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -44,7 +44,6 @@ import org.apache.geode.annotations.Immutable;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.InterestResultPolicy;
 import org.apache.geode.cache.NoSubscriptionServersAvailableException;
-import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.client.ServerConnectivityException;
 import org.apache.geode.cache.client.ServerRefusedConnectionException;
 import org.apache.geode.cache.client.internal.PoolImpl.PoolTask;

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -44,6 +44,7 @@ import org.apache.geode.annotations.Immutable;
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.InterestResultPolicy;
 import org.apache.geode.cache.NoSubscriptionServersAvailableException;
+import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.client.ServerConnectivityException;
 import org.apache.geode.cache.client.ServerRefusedConnectionException;
 import org.apache.geode.cache.client.internal.PoolImpl.PoolTask;
@@ -109,6 +110,11 @@ public class QueueManagerImpl implements QueueManager {
 
   private ScheduledExecutorService recoveryThread;
   private volatile boolean sentClientReady;
+
+  public void setQueueConnections(
+      ConnectionList queueConnections) {
+    this.queueConnections = queueConnections;
+  }
 
   // queueConnections in maintained by using copy-on-write
   private volatile ConnectionList queueConnections = new ConnectionList();
@@ -1119,9 +1125,9 @@ public class QueueManagerImpl implements QueueManager {
     for (Map.Entry<CqQuery, Boolean> e : cqs.entrySet()) {
       ClientCQ cqi = (ClientCQ) e.getKey();
       String name = cqi.getName();
-      if (this.pool.getMultiuserAuthentication()) {
+      if (pool.getMultiuserAuthentication()) {
         UserAttributes.userAttributes
-            .set(((DefaultQueryService) this.pool.getQueryService()).getUserAttributes(name));
+            .set(((DefaultQueryService) pool.getQueryService()).getUserAttributes(name));
       }
       try {
         if (((CqStateImpl) cqi.getState()).getState() != CqStateImpl.INIT

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ReadyForEventsOp.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ReadyForEventsOp.java
@@ -40,7 +40,7 @@ public class ReadyForEventsOp {
     // no instances allowed
   }
 
-  private static class ReadyForEventsOpImpl extends AbstractOp {
+  protected static class ReadyForEventsOpImpl extends AbstractOp {
     /**
      * @throws org.apache.geode.SerializationException if serialization fails
      */

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/RegisterInterestTracker.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/RegisterInterestTracker.java
@@ -383,5 +383,13 @@ public class RegisterInterestTracker {
     public ConcurrentMap<Object, InterestResultPolicy> getInterests() {
       return interests;
     }
+
+    @Override
+    public String toString() {
+      return "RegionInterestEntry{" +
+          "region=" + region +
+          ", interests=" + interests +
+          '}';
+    }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ServerRegionProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ServerRegionProxy.java
@@ -89,6 +89,16 @@ public class ServerRegionProxy extends ServerProxy implements ServerRegionDataAc
     this.regionName = regionName;
   }
 
+  /**
+   * Used by tests to create proxies for "fake" regions.
+   */
+  public ServerRegionProxy(String regionName, InternalPool pool) {
+    super(pool);
+    region = null;
+    this.regionName = regionName;
+  }
+
+
   private static InternalPool calcPool(Region<?, ?> r) {
     String poolName = r.getAttributes().getPoolName();
     if (poolName == null || "".equals(poolName)) {


### PR DESCRIPTION
Ready for events was being sent, then subsequently recover interest reregisters and clears the region.
This is a problem because it could clear entries that should be kept. 

Solution: move the ready for events message after the recover interest