### PR TITLE
GEODE-9944: Handle a race when HARegionQueue is not initialized yet.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ha/QueueSynchronizationProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ha/QueueSynchronizationProcessor.java
@@ -157,7 +157,7 @@ public class QueueSynchronizationProcessor extends ReplyProcessor21 {
         return null;
       }
       HARegionQueue haRegionQueue = ((HARegion) region).getOwner();
-      return haRegionQueue.getDispatchedEvents(eventIds);
+      return haRegionQueue == null ? null : haRegionQueue.getDispatchedEvents(eventIds);
     }
 
     @Override

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/QueueSynchronizationProcessorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/QueueSynchronizationProcessorTest.java
@@ -129,11 +129,23 @@ public class QueueSynchronizationProcessorTest {
   }
 
   @Test
-  public void getDispatchedEventsReturnsNullIfQueueIsNull() {
+  public void getDispatchedEventsReturnsNullIfHARegionIsNull() {
     message = spy(new QueueSynchronizationProcessor.QueueSynchronizationMessage());
     String regionName = "queueName";
     message.setRegionName(regionName);
     when(cache.getRegion(regionName)).thenReturn(null);
+
+    assertThat(message.getDispatchedEvents(cache)).isNull();
+  }
+
+  @Test
+  public void getDispatchedEventsReturnsNullIfQueueNotInitialized() {
+    message = spy(new QueueSynchronizationProcessor.QueueSynchronizationMessage());
+    String regionName = "queueName";
+    message.setRegionName(regionName);
+    HARegion region = mock(HARegion.class);
+    when(cache.getRegion(regionName)).thenReturn(uncheckedCast(region));
+    when(region.getOwner()).thenReturn(null);
 
     assertThat(message.getDispatchedEvents(cache)).isNull();
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/ha/QueueSynchronizationProcessorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/ha/QueueSynchronizationProcessorTest.java
@@ -130,7 +130,7 @@ public class QueueSynchronizationProcessorTest {
 
   @Test
   public void getDispatchedEventsReturnsNullIfHARegionIsNull() {
-    message = spy(new QueueSynchronizationProcessor.QueueSynchronizationMessage());
+    message = new QueueSynchronizationProcessor.QueueSynchronizationMessage();
     String regionName = "queueName";
     message.setRegionName(regionName);
     when(cache.getRegion(regionName)).thenReturn(null);
@@ -140,7 +140,7 @@ public class QueueSynchronizationProcessorTest {
 
   @Test
   public void getDispatchedEventsReturnsNullIfQueueNotInitialized() {
-    message = spy(new QueueSynchronizationProcessor.QueueSynchronizationMessage());
+    message = new QueueSynchronizationProcessor.QueueSynchronizationMessage();
     String regionName = "queueName";
     message.setRegionName(regionName);
     HARegion region = mock(HARegion.class);
@@ -152,7 +152,7 @@ public class QueueSynchronizationProcessorTest {
 
   @Test
   public void getDispatchedEventsReturns() {
-    message = spy(new QueueSynchronizationProcessor.QueueSynchronizationMessage());
+    message = new QueueSynchronizationProcessor.QueueSynchronizationMessage();
     String regionName = "queueName";
     message.setRegionName(regionName);
     message.setEventIdList(eventIDs);


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
