### PR TITLE
GEODE-9962: Update redis INFO command for cluster mode responses

### DIFF
--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoNativeRedisAcceptanceTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoNativeRedisAcceptanceTest.java
@@ -17,15 +17,15 @@ package org.apache.geode.redis.internal.commands.executor.server;
 
 import org.junit.ClassRule;
 
-import org.apache.geode.NativeRedisTestRule;
+import org.apache.geode.redis.NativeRedisClusterTestRule;
 
 public class InfoNativeRedisAcceptanceTest extends AbstractInfoIntegrationTest {
 
   @ClassRule
-  public static NativeRedisTestRule redis = new NativeRedisTestRule();
+  public static NativeRedisClusterTestRule redis = new NativeRedisClusterTestRule();
 
   @Override
   public int getPort() {
-    return redis.getPort();
+    return redis.getExposedPorts().get(0);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoIntegrationTest.java
@@ -36,7 +36,7 @@ public class InfoIntegrationTest extends AbstractInfoIntegrationTest {
 
   @Test
   public void shouldReturnRedisVersion() {
-    String expectedResult = "redis_version:5.0.6";
+    String expectedResult = "redis_version:5.0";
 
     String actualResult = jedis.info();
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/InfoExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/InfoExecutor.java
@@ -107,13 +107,13 @@ public class InfoExecutor implements CommandExecutor {
   }
 
   private String getServerSection(ExecutionHandlerContext context) {
-    final String CURRENT_REDIS_VERSION = "5.0.6";
+    final String CURRENT_REDIS_VERSION = "5.0";
     // @todo test in info command integration test?
     final int TCP_PORT = context.getServerPort();
     final RedisStats redisStats = context.getRedisStats();
     return "# Server\r\n" +
         "redis_version:" + CURRENT_REDIS_VERSION + "\r\n" +
-        "redis_mode:standalone\r\n" +
+        "redis_mode:cluster\r\n" +
         "tcp_port:" + TCP_PORT + "\r\n" +
         "uptime_in_seconds:" + redisStats.getUptimeInSeconds() + "\r\n" +
         "uptime_in_days:" + redisStats.getUptimeInDays() + "\r\n";
@@ -180,7 +180,7 @@ public class InfoExecutor implements CommandExecutor {
   }
 
   private String getClusterSection() {
-    return "# Cluster\r\ncluster_enabled:0\r\n";
+    return "# Cluster\r\ncluster_enabled:1\r\n";
   }
 
   private String getReplicationSection() {


### PR DESCRIPTION
- Redis version is set to `5.0`
- InfoNativeRedisAcceptanceTest changed to use an actual Redis cluster
- Responses in cluster mode match native Redis

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
