### PR TITLE
GEODE-9787: Cascading deprecations for Statistics int methods.

### DIFF
--- a/buildSrc/src/main/resources/japicmp_exceptions.json
+++ b/buildSrc/src/main/resources/japicmp_exceptions.json
@@ -2,5 +2,8 @@
   "Class org.apache.geode.management.builder.GeodeClusterManagementServiceBuilder": "Moved internal class to fix split packages between geode-core and geode-management",
   "Class org.apache.geode.management.api.ClusterManagementOperation": "Fixed missing @Experimental annotation",
   "Method org.apache.geode.management.api.ClusterManagementOperation.getEndpoint()": "Fixed missing @Experimental annotation",
-  "Method org.apache.geode.management.api.ClusterManagementOperation.getOperator()": "Fixed missing @Experimental annotation"
+  "Method org.apache.geode.management.api.ClusterManagementOperation.getOperator()": "Fixed missing @Experimental annotation",
+  "Class org.apache.geode.cache.query.IndexStatistics": "Added new methods.",
+  "Method org.apache.geode.cache.query.IndexStatistics.getNumberOfBucketIndexesLong()": "Added new methods.",
+  "Method org.apache.geode.cache.query.IndexStatistics.getReadLockCountLong()": "Added new methods."
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/internal/index/IndexStatisticsJUnitTest.java
@@ -116,6 +116,7 @@ public class IndexStatisticsJUnitTest {
 
     assertEquals(50, keyIndex1Stats.getTotalUses());
     assertEquals(0, keyIndex1Stats.getReadLockCount());
+    assertEquals(0, keyIndex1Stats.getReadLockCountLong());
 
     // NumOfValues should be reduced.
     for (int i = 0; i < 50; i++) {
@@ -240,6 +241,7 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(0, keyIndex1Stats.getReadLockCount());
+    assertEquals(0, keyIndex1Stats.getReadLockCountLong());
     assertEquals(50, keyIndex1Stats.getTotalUses());
 
     // NumOfValues should be reduced.
@@ -368,6 +370,7 @@ public class IndexStatisticsJUnitTest {
     }
 
     assertEquals(0, keyIndexStats.getReadLockCount());
+    assertEquals(0, keyIndexStats.getReadLockCountLong());
 
     assertEquals(100, keyIndexStats.getTotalUses());
 
@@ -447,6 +450,7 @@ public class IndexStatisticsJUnitTest {
 
 
     assertEquals(0, mapIndexStats.getReadLockCount());
+    assertEquals(0, mapIndexStats.getReadLockCountLong());
 
     assertEquals(100, mapIndexStats.getTotalUses());
 
@@ -819,6 +823,8 @@ public class IndexStatisticsJUnitTest {
     assertEquals("Read locks should have been taken by the query ", 1, observer.readLockCount);
     assertEquals("Read lock count should have been released by the query ", 0,
         statusIndex.getStatistics().getReadLockCount());
+    assertEquals("Read lock count should have been released by the query ", 0,
+        statusIndex.getStatistics().getReadLockCountLong());
 
     QueryObserverHolder.setInstance(old);
     qs.removeIndexes();
@@ -851,17 +857,19 @@ public class IndexStatisticsJUnitTest {
     assertEquals("Read locks should have been taken by the query ", 1, observer.readLockCount);
     assertEquals("Read lock count should have been released by the query ", 0,
         secIdIndex.getStatistics().getReadLockCount());
+    assertEquals("Read lock count should have been released by the query ", 0,
+        secIdIndex.getStatistics().getReadLockCountLong());
 
     QueryObserverHolder.setInstance(old);
     qs.removeIndexes();
   }
 
   public static class QueryObserverImpl extends QueryObserverAdapter {
-    int readLockCount = 0;
+    long readLockCount = 0L;
 
     @Override
     public void beforeIndexLookup(Index index, int oper, Object key) {
-      readLockCount = index.getStatistics().getReadLockCount();
+      readLockCount = index.getStatistics().getReadLockCountLong();
     }
   }
 }

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/query/partitioned/PRIndexStatisticsJUnitTest.java
@@ -108,6 +108,7 @@ public class PRIndexStatisticsJUnitTest {
 
     IndexStatistics keyIndex1Stats = keyIndex1.getStatistics();
     assertEquals(89, keyIndex1Stats.getNumberOfBucketIndexes());
+    assertEquals(89, keyIndex1Stats.getNumberOfBucketIndexesLong());
 
     // Initial stats test (keys, values & updates)
     assertEquals(2 * 100/* Num of values in region */, keyIndex1Stats.getNumberOfKeys());
@@ -179,6 +180,7 @@ public class PRIndexStatisticsJUnitTest {
 
     IndexStatistics keyIndex1Stats = keyIndex2.getStatistics();
     assertEquals(89, keyIndex1Stats.getNumberOfBucketIndexes());
+    assertEquals(89, keyIndex1Stats.getNumberOfBucketIndexesLong());
 
     // Initial stats test (keys, values & updates)
     assertEquals(100, keyIndex1Stats.getNumberOfKeys());
@@ -249,6 +251,7 @@ public class PRIndexStatisticsJUnitTest {
     IndexStatistics keyIndexStats = keyIndex3.getStatistics();
     assertTrue(keyIndexStats instanceof IndexStatistics);
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
+    assertEquals(89, keyIndexStats.getNumberOfBucketIndexesLong());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
@@ -322,8 +325,8 @@ public class PRIndexStatisticsJUnitTest {
     IndexStatistics keyIndexStats = keyIndex3.getStatistics();
     assertTrue(keyIndexStats instanceof IndexStatistics);
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
+    assertEquals(89, keyIndexStats.getNumberOfBucketIndexesLong());
 
-    assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
     assertEquals(200, keyIndexStats.getNumberOfValues());
@@ -404,6 +407,7 @@ public class PRIndexStatisticsJUnitTest {
 
     IndexStatistics keyIndex1Stats = keyIndex1.getStatistics();
     assertEquals(89, keyIndex1Stats.getNumberOfBucketIndexes());
+    assertEquals(89, keyIndex1Stats.getNumberOfBucketIndexesLong());
 
     // Initial stats test (keys, values & updates)
     assertEquals(2 * 100/* Num of values in region */, keyIndex1Stats.getNumberOfKeys());
@@ -483,6 +487,7 @@ public class PRIndexStatisticsJUnitTest {
 
     IndexStatistics keyIndex1Stats = keyIndex2.getStatistics();
     assertEquals(89, keyIndex1Stats.getNumberOfBucketIndexes());
+    assertEquals(89, keyIndex1Stats.getNumberOfBucketIndexesLong());
 
     // Initial stats test (keys, values & updates)
     assertEquals(100, keyIndex1Stats.getNumberOfKeys());
@@ -560,6 +565,7 @@ public class PRIndexStatisticsJUnitTest {
     IndexStatistics keyIndexStats = keyIndex3.getStatistics();
     assertTrue(keyIndexStats instanceof IndexStatistics);
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
+    assertEquals(89, keyIndexStats.getNumberOfBucketIndexesLong());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());
@@ -642,6 +648,7 @@ public class PRIndexStatisticsJUnitTest {
     IndexStatistics keyIndexStats = keyIndex3.getStatistics();
     assertTrue(keyIndexStats instanceof IndexStatistics);
     assertEquals(89, keyIndexStats.getNumberOfBucketIndexes());
+    assertEquals(89, keyIndexStats.getNumberOfBucketIndexesLong());
 
     assertEquals(2, keyIndexStats.getNumberOfMapIndexKeys());
     assertEquals(100, keyIndexStats.getNumberOfKeys());

--- a/geode-core/src/main/java/org/apache/geode/cache/query/IndexStatistics.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/IndexStatistics.java
@@ -56,8 +56,17 @@ public interface IndexStatistics {
 
   /**
    * Return number of read locks taken on this index
+   *
+   * @deprecated Use {@link #getReadLockCountLong()}
    */
+  @Deprecated
   int getReadLockCount();
+
+  /**
+   * Return number of read locks taken on this index
+   */
+  long getReadLockCountLong();
+
 
   /**
    * Returns the number of keys in this index at the highest level
@@ -66,6 +75,14 @@ public interface IndexStatistics {
 
   /**
    * Returns the number of bucket indexes created in the Partitioned Region
+   *
+   * @deprecated Use {@link #getNumberOfBucketIndexesLong()}
    */
+  @Deprecated
   int getNumberOfBucketIndexes();
+
+  /**
+   * Returns the number of bucket indexes created in the Partitioned Region
+   */
+  long getNumberOfBucketIndexesLong();
 }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractIndex.java
@@ -887,19 +887,31 @@ public abstract class AbstractIndex implements IndexProtocol {
       return 0L;
     }
 
+    @Deprecated
     @Override
     public int getReadLockCount() {
-      return 0;
+      return (int) getReadLockCountLong();
+    }
+
+    @Override
+    public long getReadLockCountLong() {
+      return 0L;
     }
 
     @Override
     public long getNumberOfMapIndexKeys() {
-      return 0;
+      return 0L;
+    }
+
+    @Deprecated
+    @Override
+    public int getNumberOfBucketIndexes() {
+      return (int) getNumberOfBucketIndexesLong();
     }
 
     @Override
-    public int getNumberOfBucketIndexes() {
-      return 0;
+    public long getNumberOfBucketIndexesLong() {
+      return 0L;
     }
 
     public void close() {}

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractMapIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/AbstractMapIndex.java
@@ -164,49 +164,31 @@ public abstract class AbstractMapIndex extends AbstractIndex {
       vsdStats.incReadLockCount(delta);
     }
 
-    /**
-     * Returns the total amount of time (in nanoseconds) spent updating this index.
-     */
     @Override
     public long getTotalUpdateTime() {
       return vsdStats.getTotalUpdateTime();
     }
 
-    /**
-     * Returns the total number of times this index has been accessed by a query.
-     */
     @Override
     public long getTotalUses() {
       return vsdStats.getTotalUses();
     }
 
-    /**
-     * Returns the number of keys in this index at the highest level
-     */
     @Override
     public long getNumberOfMapIndexKeys() {
       return vsdStats.getNumberOfMapIndexKeys();
     }
 
-    /**
-     * Returns the number of keys in this index.
-     */
     @Override
     public long getNumberOfKeys() {
       return vsdStats.getNumberOfKeys();
     }
 
-    /**
-     * Returns the number of values in this index.
-     */
     @Override
     public long getNumberOfValues() {
       return vsdStats.getNumberOfValues();
     }
 
-    /**
-     * Return the number of values for the specified key in this index.
-     */
     @Override
     public long getNumberOfValues(Object key) {
       long numValues = 0;
@@ -216,11 +198,8 @@ public abstract class AbstractMapIndex extends AbstractIndex {
       return numValues;
     }
 
-    /**
-     * Return the number of read locks taken on this index
-     */
     @Override
-    public int getReadLockCount() {
+    public long getReadLockCountLong() {
       return vsdStats.getReadLockCount();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
@@ -1049,51 +1049,33 @@ public class CompactRangeIndex extends AbstractIndex {
       vsdStats.incReadLockCount(delta);
     }
 
-    /**
-     * Returns the total amount of time (in nanoseconds) spent updating this index.
-     */
     @Override
     public long getTotalUpdateTime() {
       return vsdStats.getTotalUpdateTime();
     }
 
-    /**
-     * Returns the total number of times this index has been accessed by a query.
-     */
     @Override
     public long getTotalUses() {
       return vsdStats.getTotalUses();
     }
 
-    /**
-     * Returns the number of keys in this index.
-     */
     @Override
     public long getNumberOfKeys() {
       return vsdStats.getNumberOfKeys();
     }
 
-    /**
-     * Returns the number of values in this index.
-     */
     @Override
     public long getNumberOfValues() {
       return vsdStats.getNumberOfValues();
     }
 
-    /**
-     * Return the number of values for the specified key in this index.
-     */
     @Override
     public long getNumberOfValues(Object key) {
       return indexStore.size(key);
     }
 
-    /**
-     * Return the number of read locks taken on this index
-     */
     @Override
-    public int getReadLockCount() {
+    public long getReadLockCountLong() {
       return vsdStats.getReadLockCount();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/HashIndex.java
@@ -915,41 +915,26 @@ public class HashIndex extends AbstractIndex {
       vsdStats.incReadLockCount(delta);
     }
 
-    /**
-     * Returns the total amount of time (in nanoseconds) spent updating this index.
-     */
     @Override
     public long getTotalUpdateTime() {
       return vsdStats.getTotalUpdateTime();
     }
 
-    /**
-     * Returns the total number of times this index has been accessed by a query.
-     */
     @Override
     public long getTotalUses() {
       return vsdStats.getTotalUses();
     }
 
-    /**
-     * Returns the number of keys in this index.
-     */
     @Override
     public long getNumberOfKeys() {
       return vsdStats.getNumberOfKeys();
     }
 
-    /**
-     * Returns the number of values in this index.
-     */
     @Override
     public long getNumberOfValues() {
       return vsdStats.getNumberOfValues();
     }
 
-    /**
-     * Return the number of values for the specified key in this index.
-     */
     @Override
     public long getNumberOfValues(Object key) {
       Object rgnEntries = entriesSet.get(key);
@@ -963,11 +948,8 @@ public class HashIndex extends AbstractIndex {
       }
     }
 
-    /**
-     * Return the number of read locks taken on this index
-     */
     @Override
-    public int getReadLockCount() {
+    public long getReadLockCountLong() {
       return vsdStats.getReadLockCount();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexStats.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexStats.java
@@ -65,12 +65,12 @@ public class IndexStats {
             f.createLongCounter("numUses", numUsesDesc, "operations"),
             f.createLongCounter("updateTime", updateTimeDesc, "nanoseconds"),
             f.createLongCounter("useTime", "Total time spent using this index", "nanoseconds"),
-            f.createIntGauge("updatesInProgress", "Current number of updates in progress.",
+            f.createLongGauge("updatesInProgress", "Current number of updates in progress.",
                 "updates"),
-            f.createIntGauge("usesInProgress", "Current number of uses in progress.", "uses"),
-            f.createIntGauge("readLockCount", "Current number of read locks taken.", "uses"),
+            f.createLongGauge("usesInProgress", "Current number of uses in progress.", "uses"),
+            f.createLongGauge("readLockCount", "Current number of read locks taken.", "uses"),
             f.createLongGauge("numMapIndexKeys", "Number of keys in this Map index", "keys"),
-            f.createIntGauge("numBucketIndexes",
+            f.createLongGauge("numBucketIndexes",
                 "Number of bucket indexes in the partitioned region", "indexes"),});
 
     // Initialize id fields
@@ -124,16 +124,16 @@ public class IndexStats {
     return clock.isEnabled() ? stats.getLong(useTimeId) : 0;
   }
 
-  public int getReadLockCount() {
-    return stats.getInt(readLockCountId);
+  public long getReadLockCount() {
+    return stats.getLong(readLockCountId);
   }
 
   public long getNumberOfMapIndexKeys() {
     return stats.getLong(numMapIndexKeysId);
   }
 
-  public int getNumberOfBucketIndexes() {
-    return stats.getInt(numBucketIndexesId);
+  public long getNumberOfBucketIndexes() {
+    return stats.getLong(numBucketIndexesId);
   }
 
   public void incNumUpdates() {
@@ -167,11 +167,11 @@ public class IndexStats {
   }
 
   public void incUpdatesInProgress(int delta) {
-    stats.incInt(updatesInProgressId, delta);
+    stats.incLong(updatesInProgressId, delta);
   }
 
   public void incUsesInProgress(int delta) {
-    stats.incInt(usesInProgressId, delta);
+    stats.incLong(usesInProgressId, delta);
   }
 
   public void incUseTime(long delta) {
@@ -181,7 +181,7 @@ public class IndexStats {
   }
 
   public void incReadLockCount(int delta) {
-    stats.incInt(readLockCountId, delta);
+    stats.incLong(readLockCountId, delta);
   }
 
   public void incNumMapIndexKeys(long delta) {
@@ -189,7 +189,7 @@ public class IndexStats {
   }
 
   public void incNumBucketIndexes(int delta) {
-    stats.incInt(numBucketIndexesId, delta);
+    stats.incLong(numBucketIndexesId, delta);
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/PartitionedIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/PartitionedIndex.java
@@ -520,56 +520,38 @@ public class PartitionedIndex extends AbstractIndex {
       vsdStats.incNumBucketIndexes(delta);
     }
 
-    /**
-     * Returns the number of keys in this index at the highest level
-     */
     @Override
     public long getNumberOfMapIndexKeys() {
       return vsdStats.getNumberOfMapIndexKeys();
     }
 
-    /**
-     * Returns the total amount of time (in nanoseconds) spent updating this index.
-     */
     @Override
     public long getTotalUpdateTime() {
       return vsdStats.getTotalUpdateTime();
     }
 
-    /**
-     * Returns the total number of times this index has been accessed by a query.
-     */
     @Override
     public long getTotalUses() {
       return vsdStats.getTotalUses();
     }
 
-    /**
-     * Returns the number of keys in this index.
-     */
     @Override
     public long getNumberOfKeys() {
       return vsdStats.getNumberOfKeys();
     }
 
-    /**
-     * Returns the number of values in this index.
-     */
     @Override
     public long getNumberOfValues() {
       return vsdStats.getNumberOfValues();
     }
 
-    /**
-     * Return the number of read locks taken on this index
-     */
     @Override
-    public int getReadLockCount() {
+    public long getReadLockCountLong() {
       return vsdStats.getReadLockCount();
     }
 
     @Override
-    public int getNumberOfBucketIndexes() {
+    public long getNumberOfBucketIndexesLong() {
       return vsdStats.getNumberOfBucketIndexes();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/RangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/RangeIndex.java
@@ -1519,41 +1519,26 @@ public class RangeIndex extends AbstractIndex {
       vsdStats.incReadLockCount(delta);
     }
 
-    /**
-     * Returns the total amount of time (in nanoseconds) spent updating this index.
-     */
     @Override
     public long getTotalUpdateTime() {
       return vsdStats.getTotalUpdateTime();
     }
 
-    /**
-     * Returns the total number of times this index has been accessed by a query.
-     */
     @Override
     public long getTotalUses() {
       return vsdStats.getTotalUses();
     }
 
-    /**
-     * Returns the number of keys in this index.
-     */
     @Override
     public long getNumberOfKeys() {
       return vsdStats.getNumberOfKeys();
     }
 
-    /**
-     * Returns the number of values in this index.
-     */
     @Override
     public long getNumberOfValues() {
       return vsdStats.getNumberOfValues();
     }
 
-    /**
-     * Return the number of values for the specified key in this index.
-     */
     @Override
     public long getNumberOfValues(Object key) {
       if (key == null) {
@@ -1570,11 +1555,8 @@ public class RangeIndex extends AbstractIndex {
       return rvMap.getNumValues();
     }
 
-    /**
-     * Return the number of read locks taken on this index
-     */
     @Override
-    public int getReadLockCount() {
+    public long getReadLockCountLong() {
       return vsdStats.getReadLockCount();
     }
 


### PR DESCRIPTION
Replace IndexStatistics int statistic methods.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
