### PR TITLE
GEODE-9977: Remove defunct RedisCommandSupportLevel.INTERNAL type

### DIFF
--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandSupportLevel.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandSupportLevel.java
@@ -19,6 +19,5 @@ package org.apache.geode.redis.internal.commands;
 public enum RedisCommandSupportLevel {
   SUPPORTED,
   UNSUPPORTED,
-  UNKNOWN,
-  INTERNAL
+  UNKNOWN
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.commands;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.commands.RedisCommandSupportLevel.INTERNAL;
 import static org.apache.geode.redis.internal.commands.RedisCommandSupportLevel.SUPPORTED;
 import static org.apache.geode.redis.internal.commands.RedisCommandSupportLevel.UNSUPPORTED;
 import static org.apache.geode.redis.internal.commands.RedisCommandType.Flag.ADMIN;
@@ -445,11 +444,6 @@ public enum RedisCommandType {
 
   public boolean isUnsupported() {
     return supportLevel == UNSUPPORTED;
-  }
-
-
-  public boolean isInternal() {
-    return supportLevel == INTERNAL;
   }
 
   public boolean isUnknown() {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/COMMANDCommandExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/COMMANDCommandExecutor.java
@@ -62,8 +62,7 @@ public class COMMANDCommandExecutor implements CommandExecutor {
     List<Object> response = new ArrayList<>();
 
     for (RedisCommandType type : RedisCommandType.values()) {
-      if (type.isInternal()
-          || type.isUnknown()
+      if (type.isUnknown()
           || (type.isUnsupported() && !context.allowUnsupportedCommands())
           || type == RedisCommandType.QUIT) {
         continue;


### PR DESCRIPTION
Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [N/A] Have you written or updated unit tests to verify your changes?

- [N/A] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
