### PR TITLE
GEODE-10011: Do not perform second scan if first scanned entire map

### DIFF
--- a/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/collections/SizeableBytes2ObjectOpenCustomHashMapWithCursorQuickCheckTest.java
+++ b/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/collections/SizeableBytes2ObjectOpenCustomHashMapWithCursorQuickCheckTest.java
@@ -78,7 +78,11 @@ public class SizeableBytes2ObjectOpenCustomHashMapWithCursorQuickCheckTest {
     int cursor =
         map.scan(0, initialData.size() / 2, (data, key, value) -> data.add(value), scanned);
 
-    cursor = map.scan(cursor, 100000, (data, key, value) -> data.add(value), scanned);
+    // It's possible to scan the entire map in the first scan if the map is small and there are hash
+    // collisions, so only do a second scan if the first one was not a complete scan
+    if (cursor != 0) {
+      cursor = map.scan(cursor, 100000, (data, key, value) -> data.add(value), scanned);
+    }
     assertThat(cursor).isEqualTo(0);
 
     // Test that no duplicate entries were added and no entries were missed.


### PR DESCRIPTION
 - The test scanWithNoModificationsDoesNotReturnDuplicates in
 SizeableBytes2ObjectOpenCustomHashMapWithCursorQuickCheckTest should
 only perform a second scan if the first one was not a complete scan of
 the map

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
