### PR TITLE
GEODE-10013: Remove unused code in Geode for Redis tests

### DIFF
--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HExistsDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HExistsDUnitTest.java
@@ -68,9 +68,6 @@ public class HExistsDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HGetDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HGetDUnitTest.java
@@ -66,9 +66,6 @@ public class HGetDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HKeysDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HKeysDUnitTest.java
@@ -72,10 +72,6 @@ public class HKeysDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
-    locator.stop();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HMgetDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HMgetDUnitTest.java
@@ -66,9 +66,6 @@ public class HMgetDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HMsetDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HMsetDUnitTest.java
@@ -69,10 +69,6 @@ public class HMsetDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
-    server3.stop();
   }
 
 

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HsetDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HsetDUnitTest.java
@@ -69,10 +69,6 @@ public class HsetDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
-    server3.stop();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/ExpireDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/ExpireDUnitTest.java
@@ -63,10 +63,6 @@ public class ExpireDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
-    server3.stop();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/PubSubConcurrentDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/PubSubConcurrentDUnitTest.java
@@ -122,8 +122,6 @@ public class PubSubConcurrentDUnitTest {
 
   @After
   public void tearDown() {
-    server1.stop();
-    server2.stop();
     subscriberVM.invoke(() -> {
       subscribers.clear();
       mockSubscribers.clear();

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/PubSubDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/PubSubDUnitTest.java
@@ -131,12 +131,6 @@ public class PubSubDUnitTest {
     subscriber2.disconnect();
     publisher1.disconnect();
     publisher2.disconnect();
-
-    server1.stop();
-    server2.stop();
-    server3.stop();
-    server4.stop();
-    server5.stop();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/set/SaddDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/set/SaddDUnitTest.java
@@ -69,10 +69,6 @@ public class SaddDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
-    server3.stop();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/set/SremDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/set/SremDUnitTest.java
@@ -69,10 +69,6 @@ public class SremDUnitTest {
   @AfterClass
   public static void tearDown() {
     jedis.close();
-
-    server1.stop();
-    server2.stop();
-    server3.stop();
   }
 
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHashesIntegrationTest.java
@@ -880,20 +880,6 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   }
 
   @Test
-  public void testHset_canStoreBinaryData() {
-    byte[] blob = new byte[256];
-    for (int i = 0; i < 256; i++) {
-      blob[i] = (byte) i;
-    }
-
-    jedis.hset("key".getBytes(), blob, blob);
-    Map<byte[], byte[]> result = jedis.hgetAll("key".getBytes());
-
-    assertThat(result.keySet()).containsExactly(blob);
-    assertThat(result.values()).containsExactly(blob);
-  }
-
-  @Test
   public void testHstrlen_withBinaryData() {
     byte[] zero = new byte[] {0};
     jedis.hset(zero, zero, zero);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSetsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSetsIntegrationTest.java
@@ -85,19 +85,6 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
   }
 
   @Test
-  public void testSAdd_canStoreBinaryData() {
-    byte[] blob = new byte[256];
-    for (int i = 0; i < 256; i++) {
-      blob[i] = (byte) i;
-    }
-
-    jedis.sadd("key".getBytes(), blob, blob);
-    Set<byte[]> result = jedis.smembers("key".getBytes());
-
-    assertThat(result).containsExactly(blob);
-  }
-
-  @Test
   public void smembers_givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SMEMBERS))
         .hasMessageContaining("ERR wrong number of arguments for 'smembers' command");


### PR DESCRIPTION
Remove redundant server.stop() calls and unnecessary "canStoreBinaryData" tests from Geode for Redis tests.