### PR TITLE
GEODE-9845: Refactor OutOfMemoryDUnitTest

### DIFF
--- a/geode-for-redis/build.gradle
+++ b/geode-for-redis/build.gradle
@@ -116,6 +116,16 @@ acceptanceTest {
   dependsOn(':geode-assembly:installDist')
 }
 
+distributedTest {
+  environment 'GEODE_HOME', "$buildDir/../../geode-assembly/build/install/apache-geode"
+  dependsOn(':geode-assembly:installDist')
+}
+
+repeatDistributedTest {
+  environment 'GEODE_HOME', "$buildDir/../../geode-assembly/build/install/apache-geode"
+  dependsOn(':geode-assembly:installDist')
+}
+
 tasks.register("redisAPITest") {
   dependsOn ':geode-assembly:installDist'
   doLast {

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/ClusterNode.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/ClusterNode.java
@@ -64,4 +64,13 @@ public class ClusterNode {
         ", slots=" + slots +
         '}';
   }
+
+  public boolean isSlotOnNode(int slot) {
+    for (Pair<Long, Long> slotRange : slots) {
+      if (slotRange.getLeft() <= slot && slotRange.getRight() >= slot) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -15,252 +15,366 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_LOCATOR;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_LOCATOR__DIR;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_LOCATOR__J;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_LOCATOR__PORT;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__CRITICAL__HEAP__PERCENTAGE;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__DIR;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__INITIAL_HEAP;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__J;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__LOCATORS;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__MAXHEAP;
+import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__SERVER_PORT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 
-import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.exceptions.JedisException;
+import redis.clients.jedis.util.JedisClusterCRC16;
 
+import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.redis.mocks.MockSubscriber;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.rules.MemberVM;
-import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.RequiresGeodeHome;
 
 public class OutOfMemoryDUnitTest {
 
   @ClassRule
-  public static RedisClusterStartupRule clusterStartUp = new RedisClusterStartupRule(4);
+  public static RequiresGeodeHome requiresGeodeHome = new RequiresGeodeHome();
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
+
+  @ClassRule
+  public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Rule
   public ExecutorServiceRule executor = new ExecutorServiceRule();
 
-  private static final String expectedEx = "Member: .*? above .*? critical threshold";
-  private static final String FILLER_KEY = "{key}filler-";
-  private static final String PRESSURE_KEY = "{key}pressure-";
   private static final long KEY_TTL_SECONDS = 10;
   private static final int MAX_ITERATION_COUNT = 4000;
   private static final int LARGE_VALUE_SIZE = 128 * 1024;
-  private static final int PRESSURE_VALUE_SIZE = 4 * 1024;
+  private static final String KEY = "key";
+
+  private static String locatorPort;
   private static JedisCluster jedis;
+  private static String server1Tag;
+  private static String server2Tag;
+  private static int[] redisServerPorts;
 
-  private static MemberVM server1;
-  private static MemberVM server2;
-
-  private static Thread memoryPressureThread;
+  private final AtomicInteger numberOfKeys = new AtomicInteger(0);
 
   @BeforeClass
-  public static void classSetup() {
-    IgnoredException.addIgnoredException(expectedEx);
+  public static void setUpClass() throws Exception {
+    IgnoredException.addIgnoredException("Member: .*? above .*? critical threshold");
+    IgnoredException.addIgnoredException("LowMemoryException");
 
-    MemberVM locator = clusterStartUp.startLocatorVM(0);
+    int[] locatorPorts = getRandomAvailableTCPPorts(3);
 
-    server1 = clusterStartUp.startRedisVM(1, locator.getPort());
-    server2 = clusterStartUp.startRedisVM(2, locator.getPort());
+    locatorPort = String.valueOf(locatorPorts[0]);
+    int httpPort = locatorPorts[1];
+    int rmiPort = locatorPorts[2];
 
-    server1.getVM().invoke(() -> RedisClusterStartupRule.getCache().getResourceManager()
-        .setCriticalHeapPercentage(5.0F));
-    server2.getVM().invoke(() -> RedisClusterStartupRule.getCache().getResourceManager()
-        .setCriticalHeapPercentage(5.0F));
+    CommandStringBuilder startLocatorCommand = new CommandStringBuilder(START_LOCATOR)
+        .addOption(START_LOCATOR__DIR, temporaryFolder.newFolder().getAbsolutePath())
+        .addOption(START_LOCATOR__PORT, locatorPort)
+        .addOption(START_LOCATOR__J, "-Dgemfire.jmx-manager=true")
+        .addOption(START_LOCATOR__J, "-Dgemfire.jmx-manager-start=true")
+        .addOption(START_LOCATOR__J, "-Dgemfire.jmx-manager-http-port=" + httpPort)
+        .addOption(START_LOCATOR__J, "-Dgemfire.jmx-manager-port=" + rmiPort);
 
-    int redisServerPort1 = clusterStartUp.getRedisPort(1);
-    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), REDIS_CLIENT_TIMEOUT);
+    gfsh.executeAndAssertThat(startLocatorCommand.getCommandString()).statusIsSuccess();
+    redisServerPorts = getRandomAvailableTCPPorts(2);
+
+    startServer(redisServerPorts[0]);
+    startServer(redisServerPorts[1]);
+
+    List<ClusterNode> nodes;
+    try (Jedis singleNodeJedis =
+        new Jedis(BIND_ADDRESS, redisServerPorts[0], REDIS_CLIENT_TIMEOUT)) {
+      nodes = ClusterNodes.parseClusterNodes(singleNodeJedis.clusterNodes()).getNodes();
+    }
+
+    server1Tag = getHashtagForServerWithRedisPort(nodes, redisServerPorts[0]);
+    server2Tag = getHashtagForServerWithRedisPort(nodes, redisServerPorts[1]);
+
+    jedis =
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPorts[0]), REDIS_CLIENT_TIMEOUT);
   }
 
-  @Before
-  public void testSetup() {
-    clusterStartUp.flushAll();
+  private static void startServer(int redisPort) throws Exception {
+    CommandStringBuilder startServerCommand = new CommandStringBuilder(START_SERVER)
+        .addOption(START_SERVER__DIR, temporaryFolder.newFolder().getAbsolutePath())
+        .addOption(START_SERVER__SERVER_PORT, "0")
+        .addOption(START_SERVER__LOCATORS, "localhost[" + locatorPort + "]")
+        .addOption(START_SERVER__J, "-Dgemfire.geode-for-redis-enabled=true")
+        .addOption(START_SERVER__J, "-Dgemfire.geode-for-redis-bind-address=" + BIND_ADDRESS)
+        .addOption(START_SERVER__J, "-Dgemfire.geode-for-redis-port=" + redisPort)
+        .addOption(START_SERVER__INITIAL_HEAP, "125m")
+        .addOption(START_SERVER__MAXHEAP, "125m")
+        .addOption(START_SERVER__CRITICAL__HEAP__PERCENTAGE, "50")
+        .addOption(START_SERVER__J, "-XX:CMSInitiatingOccupancyFraction=45");
+    gfsh.executeAndAssertThat(startServerCommand.getCommandString()).statusIsSuccess();
+  }
+
+  private static String getHashtagForServerWithRedisPort(List<ClusterNode> nodes, int redisPort) {
+    // Find the node with the port that we're interested in
+    ClusterNode serverNode = nodes
+        .stream()
+        .filter(node -> node.port == redisPort)
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            "Could not find a server with the provided redis port"));
+
+    // Find a key that maps to a slot on that node
+    String key = "";
+    for (int i = 0; i < 1000; ++i) {
+      key = "tag" + i;
+      int slot = JedisClusterCRC16.getSlot(key);
+      if (serverNode.isSlotOnNode(slot)) {
+        break;
+      }
+    }
+    return "{" + key + "}";
   }
 
   @AfterClass
-  public static void tearDown() {
+  public static void tearDownClass() throws Exception {
     jedis.close();
+    gfsh.connectAndVerify(Integer.parseInt(locatorPort), GfshCommandRule.PortType.locator);
+    gfsh.executeAndAssertThat("shutdown --include-locators").statusIsSuccess();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    removeAllKeysAndForceGC();
   }
 
   @Test
-  public void shouldReturnOOMError_forWriteOperations_whenThresholdReached()
-      throws InterruptedException {
-    IgnoredException.addIgnoredException(expectedEx);
-    IgnoredException.addIgnoredException("LowMemoryException");
+  public void shouldReturnOOMError_forWriteOperations_whenThresholdReached() {
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
 
-    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
-    memoryPressureThread.start();
+    await()
+        .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server1Tag + "oneMoreKey", "value"))
+            .hasMessageContaining("OOM"));
 
-    fillMemory(jedis, false);
-
-    assertThatThrownBy(
-        () -> jedis.set("{key}oneMoreKey", "value"))
-            .hasMessageContaining("OOM");
-
-    memoryPressureThread.interrupt();
-    memoryPressureThread.join();
+    memoryPressure.cancel(true);
   }
 
   @Test
-  public void shouldReturnOOMError_forSubscribe_whenThresholdReached()
-      throws InterruptedException {
-    IgnoredException.addIgnoredException(expectedEx);
-    IgnoredException.addIgnoredException("LowMemoryException");
+  public void shouldReturnOOMError_forSubscribe_whenThresholdReached() {
     MockSubscriber mockSubscriber = new MockSubscriber();
-    int redisServerPort1 = clusterStartUp.getRedisPort(1);
     JedisCluster subJedis =
-        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), REDIS_CLIENT_TIMEOUT);
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPorts[0]), REDIS_CLIENT_TIMEOUT);
 
-    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
-    memoryPressureThread.start();
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
 
-    fillMemory(jedis, false);
-
-    assertThatThrownBy(
-        () -> subJedis.subscribe(mockSubscriber, "channel"))
-            .hasMessageContaining("OOM");
+    await()
+        .untilAsserted(() -> assertThatThrownBy(() -> subJedis.subscribe(mockSubscriber, "channel"))
+            .hasMessageContaining("OOM"));
 
     subJedis.close();
 
-    memoryPressureThread.interrupt();
-    memoryPressureThread.join();
+    memoryPressure.cancel(true);
   }
 
   @Test
-  public void shouldReturnOOMError_forPublish_whenThresholdReached()
-      throws InterruptedException {
-    IgnoredException.addIgnoredException(expectedEx);
-    IgnoredException.addIgnoredException("LowMemoryException");
+  public void shouldReturnOOMError_forPublish_whenThresholdReached() {
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
 
-    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
-    memoryPressureThread.start();
+    await().untilAsserted(() -> assertThatThrownBy(() -> jedis.publish("channel", "message"))
+        .hasMessageContaining("OOM"));
 
-    fillMemory(jedis, false);
-
-    assertThatThrownBy(
-        () -> jedis.publish("channel", "message"))
-            .hasMessageContaining("OOM");
-
-    memoryPressureThread.interrupt();
-    memoryPressureThread.join();
+    memoryPressure.cancel(true);
   }
 
   @Test
-  public void shouldAllowDeleteOperations_afterThresholdReached() throws InterruptedException {
-    IgnoredException.addIgnoredException(expectedEx);
-    IgnoredException.addIgnoredException("LowMemoryException");
+  public void shouldReturnOOMError_onOtherServer_forWriteOperations_whenThresholdReached() {
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
 
-    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
-    memoryPressureThread.start();
+    await()
+        .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server2Tag + "oneMoreKey", "value"))
+            .hasMessageContaining("OOM"));
 
-    fillMemory(jedis, false);
-
-    assertThatNoException().isThrownBy(() -> jedis.del(FILLER_KEY + 1));
-
-    memoryPressureThread.interrupt();
-    memoryPressureThread.join();
+    memoryPressure.cancel(true);
   }
 
   @Test
-  public void shouldAllowExpiration_afterThresholdReached() throws InterruptedException {
-    IgnoredException.addIgnoredException(expectedEx);
-    IgnoredException.addIgnoredException("LowMemoryException");
+  public void shouldAllowDeleteOperations_afterThresholdReached() {
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
 
-    memoryPressureThread = new Thread(makeMemoryPressureRunnable());
-    memoryPressureThread.start();
+    await().untilAsserted(
+        () -> assertThatNoException().isThrownBy(() -> jedis.del(server1Tag + KEY + 1)));
 
-    fillMemory(jedis, true);
-
-    await().untilAsserted(() -> assertThat(jedis.ttl(FILLER_KEY + 1)).isEqualTo(-2));
-
-    memoryPressureThread.interrupt();
-    memoryPressureThread.join();
+    memoryPressure.cancel(true);
   }
 
-  // TODO: test that write operations become allowed after memory has dropped
-  // below critical levels. Difficult to do right now because of vagaries of the
-  // Java garbage collector.
+  @Test
+  public void shouldAllowExpiration_afterThresholdReached() {
+    fillServer1Memory(jedis, true);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, true));
 
-  private void fillMemory(JedisCluster jedis, boolean withExpiration) {
-    String valueString;
-    int valueSize = LARGE_VALUE_SIZE;
+    await().untilAsserted(() -> assertThat(jedis.ttl(server1Tag + KEY + 1)).isEqualTo(-2));
 
-    while (valueSize > 1) {
-      forceGC(); // Helps ensure we really do fill all available memory
-      valueString = makeLongStringValue(LARGE_VALUE_SIZE);
-      addMultipleKeys(jedis, valueString, withExpiration);
-      valueSize /= 2;
-    }
+    memoryPressure.cancel(true);
   }
 
-  private void addMultipleKeys(JedisCluster jedis, String valueString, boolean withExpiration) {
-    // count is final because it is never reassigned
-    AtomicInteger count = new AtomicInteger();
+  @Test
+  public void shouldAllowWriteOperations_afterDroppingBelowCriticalThreshold() {
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
 
-    Throwable thrown = catchThrowable(() -> {
-      for (count.set(0); count.get() < MAX_ITERATION_COUNT; count.incrementAndGet()) {
-        setRedisKeyAndValue(jedis, withExpiration, valueString, count.get());
-      }
+    await()
+        .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server1Tag + "oneMoreKey", "value"))
+            .hasMessageContaining("OOM"));
+
+    memoryPressure.cancel(true);
+
+    String value = StringUtils.leftPad("a", LARGE_VALUE_SIZE);
+    await().untilAsserted(() -> assertThatNoException().isThrownBy(
+        () -> {
+          removeAllKeysAndForceGC();
+          jedis.set(server1Tag + "newKey", value);
+        }));
+  }
+
+  @Test
+  public void shouldAllowWriteOperations_onOtherServer_afterDroppingBelowCriticalThreshold() {
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
+
+    await()
+        .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server2Tag + "oneMoreKey", "value"))
+            .hasMessageContaining("OOM"));
+
+    memoryPressure.cancel(true);
+
+    String value = StringUtils.leftPad("a", LARGE_VALUE_SIZE);
+    await().untilAsserted(() -> assertThatNoException().isThrownBy(
+        () -> {
+          removeAllKeysAndForceGC();
+          jedis.set(server2Tag + "newKey", value);
+        }));
+  }
+
+  @Test
+  public void shouldAllowSubscribe_afterDroppingBelowCriticalThreshold() {
+    MockSubscriber mockSubscriber = new MockSubscriber();
+    JedisCluster subJedis =
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPorts[0]), REDIS_CLIENT_TIMEOUT);
+
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
+
+    String channel = "channel";
+    await().untilAsserted(() -> assertThatThrownBy(
+        () -> subJedis.subscribe(mockSubscriber, channel)).hasMessageContaining("OOM"));
+
+    memoryPressure.cancel(true);
+
+    await().untilAsserted(() -> {
+      removeAllKeysAndForceGC();
+      executor.submit(() -> subJedis.subscribe(mockSubscriber, channel));
+      assertThat(mockSubscriber.getSubscribedChannels()).isOne();
     });
 
-    assertThat(thrown)
-        .isInstanceOf(Exception.class)
-        .hasMessageContaining("OOM command not allowed");
-
-    assertThat(count.get()).isLessThan(MAX_ITERATION_COUNT);
+    mockSubscriber.unsubscribe();
+    subJedis.close();
   }
 
-  private void setRedisKeyAndValue(JedisCluster jedis, boolean withExpiration, String valueString,
-      int keyNumber) {
-    if (withExpiration) {
-      jedis.setex(FILLER_KEY + keyNumber, KEY_TTL_SECONDS, valueString);
-    } else {
-      jedis.set(FILLER_KEY + keyNumber, valueString);
+  @Test
+  public void shouldAllowPublish_afterDroppingBelowCriticalThreshold() {
+    fillServer1Memory(jedis, false);
+    Future<Void> memoryPressure =
+        executor.submit(() -> maintainMemoryPressure(jedis, false));
+
+    await().untilAsserted(() -> assertThatThrownBy(() -> jedis.publish("channel", "message"))
+        .hasMessageContaining("OOM"));
+
+    memoryPressure.cancel(true);
+
+    await().untilAsserted(
+        () -> assertThatNoException().isThrownBy(() -> {
+          removeAllKeysAndForceGC();
+          jedis.publish("channel", "message");
+        }));
+  }
+
+  private void fillServer1Memory(JedisCluster jedis, boolean withExpiration) {
+    String valueString = StringUtils.leftPad("a", LARGE_VALUE_SIZE);
+
+    while (valueString.length() > 1) {
+      addMultipleKeysToServer1UntilOOMExceptionIsThrown(jedis, valueString, withExpiration);
+      valueString = valueString.substring(valueString.length() / 2);
     }
   }
 
-  private static String makeLongStringValue(int requestedSize) {
-    char[] largeCharData = new char[requestedSize];
-    Arrays.fill(largeCharData, 'a');
-    return new String(largeCharData);
+  private void maintainMemoryPressure(JedisCluster jedis, boolean withExpiration) {
+    while (!Thread.interrupted()) {
+      fillServer1Memory(jedis, withExpiration);
+    }
   }
 
-  private static Runnable makeMemoryPressureRunnable() {
-    return new Runnable() {
-      boolean running = true;
-      final String pressureValue = makeLongStringValue(PRESSURE_VALUE_SIZE);
-
-      @Override
-      public void run() {
-        int i = 0;
-        while (running) {
-          if (Thread.currentThread().isInterrupted()) {
-            running = false;
-            break;
-          }
-          try {
-            jedis.set(PRESSURE_KEY + i, pressureValue);
-          } catch (JedisException je) {
-            // Ignore, keep trying to fill memory
-          }
-          i++;
+  private void addMultipleKeysToServer1UntilOOMExceptionIsThrown(JedisCluster jedis,
+      String valueString, boolean withExpiration) {
+    assertThatThrownBy(() -> {
+      for (int count = 0; count < MAX_ITERATION_COUNT; ++count) {
+        if (withExpiration) {
+          jedis.setex(server1Tag + KEY + numberOfKeys.get(), KEY_TTL_SECONDS, valueString);
+        } else {
+          jedis.set(server1Tag + KEY + numberOfKeys.get(), valueString);
         }
+        numberOfKeys.incrementAndGet();
       }
-    };
+    }).hasMessageContaining("OOM command not allowed");
   }
 
-  private void forceGC() {
-    server1.getVM().invoke(() -> Runtime.getRuntime().gc());
-    server2.getVM().invoke(() -> Runtime.getRuntime().gc());
+  void removeAllKeysAndForceGC() throws Exception {
+    // Remove all the keys to allow memory to drop below critical
+    Set<String> keys = jedis.keys(server1Tag + "*");
+    keys.addAll(jedis.keys(server2Tag + "*"));
+    for (String key : keys) {
+      jedis.del(key);
+    }
+
+    // Force GC
+    gfsh.execute("gc");
   }
 }


### PR DESCRIPTION
 - Start servers using gfsh to allow setting
 XX:CMSInitiatingOccupancyFraction and other VM memory/GC settings
 - Add test coverage for commands being allowed again after recovering
 from critical
 - Add test that non-critical member does not allow write operations if
 there is a critical member in the cluster

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
