### PR TITLE
GEODE-10021: Clean up RemoteTransactionDUnitTest

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionDUnitTest.java
@@ -23,6 +23,7 @@ import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTC
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.LogWriterUtils.getDUnitLogLevel;
 import static org.apache.geode.test.dunit.LogWriterUtils.getLogWriter;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -47,7 +48,6 @@ import javax.transaction.RollbackException;
 import javax.transaction.Synchronization;
 import javax.transaction.UserTransaction;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -118,7 +118,6 @@ import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.SerializableCallable;
 import org.apache.geode.test.dunit.SerializableRunnable;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.dunit.WaitCriterion;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -190,7 +189,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
   private Integer createRegionOnServerWithTimeout(VM vm, final boolean startServer,
       final boolean accessor, final int redundantCopies, final int txTimeoutSecs) {
-    return (Integer) vm.invoke(new SerializableCallable() {
+    return (Integer) vm.invoke(new SerializableCallable<Object>() {
       @Override
       public Object call() throws Exception {
         createRegion(accessor, redundantCopies, null);
@@ -209,7 +208,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
   }
 
   private Integer createRegionOnDisconnectedServer(VM vm, final boolean startServer) {
-    return (Integer) vm.invoke(new SerializableCallable() {
+    return (Integer) vm.invoke(new SerializableCallable<Object>() {
       @Override
       public Object call() throws Exception {
         AttributesFactory af = new AttributesFactory();
@@ -246,9 +245,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
   private void createClientRegionAndPopulateData(VM vm, final int port, final boolean isEmpty) {
     createClientRegion(vm, port, isEmpty);
-    vm.invoke(new SerializableCallable() {
+    vm.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         populateData();
         return null;
       }
@@ -256,9 +255,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
   }
 
   private void createClientRegion2(VM vm, final int port, final boolean isEmpty, final boolean ri) {
-    vm.invoke(new SerializableCallable() {
+    vm.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         ClientCacheFactory ccf = new ClientCacheFactory();
         setCCF(port, ccf);
         // these settings were used to manually check that tx operation stats were being updated
@@ -473,7 +472,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     SerializableCallable verifyExists =
         new SerializableCallable("verify txstate for client exists") {
           @Override
-          public Object call() throws Exception {
+          public Object call() {
             TXManagerImpl txmgr = getGemfireCache().getTxManager();
             Set states = txmgr.getTransactionsForClient((InternalDistributedMember) myId);
             assertEquals(1, states.size()); // only one in-progress transaction
@@ -488,22 +487,14 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     SerializableCallable verifyExpired = new SerializableCallable("verify txstate is expired") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         final TXManagerImpl txmgr = getGemfireCache().getTxManager();
         try {
-          GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
-            @Override
-            public boolean done() {
-              Set states = txmgr.getTransactionsForClient((InternalDistributedMember) myId);
-              getLogWriter()
-                  .info("found " + states.size() + " tx states for " + myId);
-              return states.isEmpty();
-            }
-
-            @Override
-            public String description() {
-              return "Waiting for transaction state to expire";
-            }
+          GeodeAwaitility.await().untilAsserted(() -> {
+            Set states = txmgr.getTransactionsForClient((InternalDistributedMember) myId);
+            getLogWriter()
+                .info("found " + states.size() + " tx states for " + myId);
+            assertThat(states).as("Waiting for transaction state to expire").isEmpty();
           });
           return null;
         } finally {
@@ -553,7 +544,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     SerializableCallable verifyExists =
         new SerializableCallable("verify txstate for client exists") {
           @Override
-          public Object call() throws Exception {
+          public Object call() {
             TXManagerImpl txmgr = getGemfireCache().getTxManager();
             Set states = txmgr.getTransactionsForClient((InternalDistributedMember) myId);
             assertEquals(1, states.size()); // only one in-progress transaction
@@ -569,7 +560,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     SerializableCallable verifyExpired = new SerializableCallable("verify txstate is expired") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         final TXManagerImpl txmgr = getGemfireCache().getTxManager();
         return verifyTXStateExpired(myId, txmgr);
       }
@@ -637,7 +628,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     SerializableCallable verifyExists =
         new SerializableCallable("verify txstate for client exists") {
           @Override
-          public Object call() throws Exception {
+          public Object call() {
             TXManagerImpl txmgr = getGemfireCache().getTxManager();
             Set<TXId> states = txmgr.getTransactionsForClient((InternalDistributedMember) myId);
             assertEquals(1, states.size()); // only one in-progress transaction
@@ -649,7 +640,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     SerializableCallable getProxyServer = new SerializableCallable("get proxy server") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         final TXManagerImpl txmgr = getGemfireCache().getTxManager();
         DistributedMember proxyServer = null;
         TXStateProxyImpl tx = null;
@@ -682,7 +673,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     SerializableCallable verifyProxyServerChanged =
         new SerializableCallable("verify proxy server is updated") {
           @Override
-          public Object call() throws Exception {
+          public Object call() {
             final TXManagerImpl txmgr = getGemfireCache().getTxManager();
             TXStateProxyImpl tx = null;
             Set<TXStateProxy> states =
@@ -754,7 +745,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       createClientRegion(client, port1, false);
     }
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
       public Object call() throws Exception {
         String suffix = prePopulateData ? "Updated" : "";
@@ -841,9 +832,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    server.invoke(new SerializableCallable() {
+    server.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<Integer, String> r = getGemfireCache().getRegion(D_REFERENCE);
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
         int expectedRegionSize = isCommit ? MAX_ENTRIES : 5;
@@ -855,9 +846,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    server.invoke(new SerializableCallable() {
+    server.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         String suffix = prePopulateData ? "Updated" : "";
         Region<Integer, String> r = getGemfireCache().getRegion(D_REFERENCE);
         Region<Integer, String> pr = getGemfireCache().getRegion(CUSTOMER);
@@ -881,17 +872,17 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
   @Override
   @Test
-  public void testTXCreationAndCleanupAtCommit() throws Exception {
+  public void testTXCreationAndCleanupAtCommit() {
     doBasicChecks(true);
   }
 
   @Override
   @Test
-  public void testTXCreationAndCleanupAtRollback() throws Exception {
+  public void testTXCreationAndCleanupAtRollback() {
     doBasicChecks(false);
   }
 
-  private void doBasicChecks(final boolean commit) throws Exception {
+  private void doBasicChecks(final boolean commit) {
     Host host = Host.getHost(0);
     VM server = host.getVM(0);
     VM client = host.getVM(1);
@@ -902,16 +893,16 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     server.invoke(new SerializableCallable("verify tx") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         assertTrue(mgr.isHostedTxInProgress(txId));
         return null;
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         mgr.resume(txId);
         TXStateProxy tx = mgr.pauseTransaction();
@@ -926,38 +917,28 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    server.invoke(new SerializableCallable() {
+    server.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         final TXManagerImpl mgr = getGemfireCache().getTxManager();
-        WaitCriterion w = new WaitCriterion() {
-          @Override
-          public boolean done() {
-            return !mgr.isHostedTxInProgress(txId);
-          }
-
-          @Override
-          public String description() {
-            return "waiting for hosted tx in progress to terminate";
-          }
-        };
-        GeodeAwaitility.await().untilAsserted(w);
+        GeodeAwaitility.await().untilAsserted(() -> assertThat(mgr.isHostedTxInProgress(txId))
+            .as("waiting for hosted tx in progress to terminate").isFalse());
         return null;
       }
     });
     if (commit) {
-      client.invoke(new SerializableCallable() {
+      client.invoke(new SerializableCallable<Object>() {
         @Override
-        public Object call() throws Exception {
+        public Object call() {
           verifyAfterCommit(OP.PUT);
           System.out.println("expected verification to fail for this VM");
           return null;
         }
       });
     } else {
-      client.invoke(new SerializableCallable() {
+      client.invoke(new SerializableCallable<Object>() {
         @Override
-        public Object call() throws Exception {
+        public Object call() {
           verifyAfterRollback(OP.PUT);
           return null;
         }
@@ -1027,7 +1008,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     server.invoke(new SerializableCallable("verify tx") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         mgr.begin();
@@ -1054,7 +1035,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     server.invoke(new SerializableCallable("verify tx") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         mgr.begin();
@@ -1079,7 +1060,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     server.invoke(new SerializableCallable("verify tx") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         mgr.begin();
@@ -1105,7 +1086,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     server.invoke(new SerializableCallable("verify getAll tx") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         orderRegion.getAttributesMutator().setCacheLoader(new CacheLoader() {
@@ -1142,7 +1123,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     server.invoke(new SerializableCallable("add cache loader") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         orderRegion.getAttributesMutator().setCacheLoader(new CacheLoader() {
           @Override
@@ -1159,7 +1140,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     client.invoke(new SerializableCallable("verify getAll uses tx") {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         mgr.begin();
@@ -1190,9 +1171,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ServerListener());
         return null;
@@ -1200,9 +1181,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1217,9 +1198,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1245,9 +1226,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ClientListener());
         return null;
@@ -1255,9 +1236,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1290,9 +1271,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ClientListener());
         return null;
@@ -1300,9 +1281,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1332,9 +1313,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ClientListener());
         return null;
@@ -1342,9 +1323,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1388,9 +1369,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ClientListener());
         return null;
@@ -1398,9 +1379,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1415,9 +1396,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1441,9 +1422,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ClientListener());
         return null;
@@ -1451,9 +1432,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1470,26 +1451,16 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         final Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
         final ClientListener cl =
             (ClientListener) custRegion.getAttributes().getCacheListeners()[0];
-        GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
-
-          @Override
-          public boolean done() {
-            return cl.invoked;
-          }
-
-          @Override
-          public String description() {
-            return "Listener was not invoked in 30 seconds";
-          }
-        });
+        GeodeAwaitility.await().untilAsserted(() -> assertThat(cl.invoked)
+            .as("Listener was not invoked in 30 seconds").isTrue());
 
         assertEquals(1, cl.invokeCount);
         return null;
@@ -1511,9 +1482,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ClientListener());
         return null;
@@ -1521,9 +1492,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1540,9 +1511,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1569,9 +1540,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ClientListener());
         return null;
@@ -1579,9 +1550,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1598,9 +1569,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1626,9 +1597,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
         custRegion.getAttributesMutator().addCacheListener(new ClientListener());
         return null;
@@ -1640,9 +1611,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
      * Test a no-op commit: put/invalidate
      */
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1660,9 +1631,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     /*
      * Validate nothing came through
      */
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1680,9 +1651,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1707,9 +1678,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     client.invoke(doAPutInTx);
     client.invoke(doAnInvalidateInTx);
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1726,9 +1697,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
         // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1748,9 +1719,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
 
 
-  SerializableCallable validateNoEvents = new SerializableCallable() {
+  SerializableCallable validateNoEvents = new SerializableCallable<Object>() {
     @Override
-    public Object call() throws Exception {
+    public Object call() {
       Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
       // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
       // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1763,9 +1734,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
   };
 
 
-  SerializableCallable doAPutInTx = new SerializableCallable() {
+  SerializableCallable doAPutInTx = new SerializableCallable<Object>() {
     @Override
-    public Object call() throws Exception {
+    public Object call() {
       Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
       // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
       // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1779,9 +1750,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
   };
 
 
-  SerializableCallable doAnInvalidateInTx = new SerializableCallable() {
+  SerializableCallable doAnInvalidateInTx = new SerializableCallable<Object>() {
     @Override
-    public Object call() throws Exception {
+    public Object call() {
       Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
       // Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
       // Region<CustId,Customer> refRegion = getCache().getRegion(D_REFERENCE);
@@ -1809,9 +1780,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, false);
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         Region<Integer, String> r = getGemfireCache().getRegion(D_REFERENCE);
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
@@ -1827,9 +1798,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         return null;
       }
     });
-    server1.invoke(new SerializableCallable() {
+    server1.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<Integer, String> r = getGemfireCache().getRegion(D_REFERENCE);
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
         assertEquals(new Customer("name10", "address10"), pr.get(new CustId(10)));
@@ -1860,9 +1831,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     TransactionId txId = client.invoke(() -> doTransactionPut(port1));
 
-    SerializableCallable countActiveTx = new SerializableCallable() {
+    SerializableCallable countActiveTx = new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         return mgr.hostedTransactionsInProgressForTest();
       }
@@ -1896,9 +1867,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     final int port2 = createRegionsAndStartServer(server2, false);
 
 
-    SerializableCallable hostedSize = new SerializableCallable() {
+    SerializableCallable hostedSize = new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         return mgr.hostedTransactionsInProgressForTest();
       }
@@ -1909,9 +1880,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
 
 
-    final TXId txid = (TXId) client.invoke(new SerializableCallable() {
+    final TXId txid = (TXId) client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         ClientCacheFactory ccf = new ClientCacheFactory();
         ccf.addPoolServer("localhost"/* getServerHostName(Host.getHost(0)) */, port1);
         ccf.addPoolServer("localhost", port2);
@@ -1941,9 +1912,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    SerializableCallable activeTx = new SerializableCallable() {
+    SerializableCallable activeTx = new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         TXStateProxy tx = mgr.getHostedTXState(txid);
         mgr.getCache().getLogger().info("SWAP:activeTx:" + tx);
@@ -1964,9 +1935,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     int myCount = (Integer) server1.invoke(activeTx) + (Integer) server2.invoke(activeTx);
     assertTrue("expected count to be 11 or 12 but was " + myCount, myCount >= 11 && myCount <= 12);
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         mgr.resume(txid);
         mgr.commit();
@@ -2034,9 +2005,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     final int port3 = serverOnDatastore ? createRegionsAndStartServer(datastore, false)
         : createRegionOnServer(datastore, false, false);
 
-    final TXId txid = (TXId) client.invoke(new SerializableCallable() {
+    final TXId txid = (TXId) client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
             "true");
         ClientCacheFactory ccf = new ClientCacheFactory();
@@ -2071,9 +2042,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    accessor1.invoke(new SerializableCallable() {
+    accessor1.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         for (CacheServer s : getCache().getCacheServers()) {
           getCache().getLogger().info("SWAP:Stopping " + s);
           s.stop();
@@ -2082,9 +2053,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         mgr.resume(txid);
         Region<Integer, String> r = getGemfireCache().getRegion(D_REFERENCE);
@@ -2100,18 +2071,18 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         assertEquals(1, mgr.hostedTransactionsInProgressForTest());
         return null;
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         mgr.resume(txid);
         Region<Integer, String> r = getGemfireCache().getRegion(D_REFERENCE);
@@ -2140,9 +2111,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     int port = createRegionsAndStartServer(datastore, false);
     createClientRegion(client, port, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
         pr.getAttributesMutator().setCacheLoader(new CacheLoader<CustId, Customer>() {
           @Override
@@ -2159,9 +2130,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         // Region<Integer, String> r = getGemfireCache().getRegion(D_REFERENCE);
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
@@ -2195,17 +2166,17 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     int port = createRegionsAndStartServer(datastore, false);
     createClientRegion(client, port, true);
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
         pr.getAttributesMutator().setCacheWriter(new ServerWriter());
         return null;
       }
     });
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
         /* CacheTransactionManager mgr = */ getCache().getCacheTransactionManager();
         pr.put(new CustId(0), new Customer("name0", "address0"));
@@ -2324,9 +2295,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     }
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         CacheTransactionManager mgr = getCache().getCacheTransactionManager();
         mgr.addListener(new ClientTxListener());
         mgr.setWriter(new ClientTxWriter());
@@ -2337,9 +2308,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         CacheTransactionManager mgr = getCache().getCacheTransactionManager();
         mgr.addListener(new ClientTxListener());
         try {
@@ -2383,10 +2354,10 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     }
     client.invoke(new doOps(false));
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
       @SuppressWarnings("synthetic-access")
-      public Object call() throws Exception {
+      public Object call() {
         CacheTransactionManager mgr = getGemfireCache().getCacheTransactionManager();
         ClientTxListener l = (ClientTxListener) mgr.getListeners()[0];
         assertTrue(l.afterRollbackInvoked);
@@ -2396,9 +2367,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     client.invoke(new doOps(true));
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         CacheTransactionManager mgr = getGemfireCache().getCacheTransactionManager();
         ClientTxListener l = (ClientTxListener) mgr.getListeners()[0];
         assertTrue(l.afterCommitInvoked);
@@ -2408,9 +2379,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         CacheTransactionManager mgr = getGemfireCache().getCacheTransactionManager();
         ClientTxListener l = (ClientTxListener) mgr.getListeners()[0];
         assertFalse(l.afterCommitInvoked);
@@ -2441,9 +2412,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     }
 
-    SerializableCallable registerTxListener = new SerializableCallable() {
+    SerializableCallable registerTxListener = new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         getCache().getCacheTransactionManager().addListener(new RedundantListener());
         return null;
       }
@@ -2452,9 +2423,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     datastore1.invoke(registerTxListener);
     datastore2.invoke(registerTxListener);
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
         getGemfireCache().getCacheTransactionManager().begin();
         pr.put(new CustId(1), new Customer("name1", "address1"));
@@ -2463,9 +2434,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    SerializableCallable listenerInvoked = new SerializableCallable() {
+    SerializableCallable listenerInvoked = new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         RedundantListener l =
             (RedundantListener) getCache().getCacheTransactionManager().getListeners()[0];
         return l.invoked;
@@ -2526,9 +2497,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     }
 
-    SerializableCallable registerFunction = new SerializableCallable() {
+    SerializableCallable registerFunction = new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         FunctionService.registerFunction(new BasicTransactionalFunction());
         return null;
       }
@@ -2539,9 +2510,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       accessor.invoke(registerFunction);
     }
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         FunctionService.registerFunction(new BasicTransactionalFunction());
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
         Region<CustId, Customer> r = getGemfireCache().getRegion(D_REFERENCE);
@@ -2583,9 +2554,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     int port = createRegionsAndStartServer(datastore, false);
     createClientRegion(client, port, false);
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getGemfireCache().getRegion(CUSTOMER);
         getCache().getCacheTransactionManager().begin();
         pr.size();
@@ -2604,7 +2575,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     final int port1 = createRegionsAndStartServer(server1, false);
     final int port2 = createRegionsAndStartServer(server2, false);
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
       public Object call() throws Exception {
         ClientCacheFactory ccf = new ClientCacheFactory();
@@ -2798,7 +2769,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
   @Override
   @Test
-  public void testTXWithRI() throws Exception {}
+  public void testTXWithRI() {}
 
   @Override
   @Test
@@ -2806,7 +2777,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
   @Override
   @Test
-  public void testTXWithRICommitInDatastore() throws Exception {}
+  public void testTXWithRICommitInDatastore() {}
 
   @Override
   @Test
@@ -2835,9 +2806,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     createClientRegion(client, port, false);
     final CustId key = new CustId(1);
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getCache().getRegion(CUSTOMER);
         assertNull(pr.get(key));
         getCache().getCacheTransactionManager().begin();
@@ -2847,17 +2818,17 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    datastore.invoke(new SerializableCallable() {
+    datastore.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         getCache().close();
         return null;
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         try {
           getCache().getCacheTransactionManager().commit();
           fail("expected exception not thrown");
@@ -2880,9 +2851,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     createRegionOnServer(datastore, false, false);
     createClientRegion(client, port, false);
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getCache().getRegion(CUSTOMER);
         pr.put(new CustId(1), new Customer("name1", "address"));
         getCache().getCacheTransactionManager().begin();
@@ -2900,9 +2871,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     VM client = host.getVM(1);
 
     int port = createRegionsAndStartServer(server, false);
-    server.invoke(new SerializableCallable() {
+    server.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getCache().getRegion(CUSTOMER);
         Region<String, String> r = getCache().getRegion(D_REFERENCE);
         pr.getAttributesMutator().addCacheListener(new ServerListener());
@@ -2911,9 +2882,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
     createClientRegion(client, port, false);
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getCache().getRegion(CUSTOMER);
         Region<String, String> r = getCache().getRegion(D_REFERENCE);
         pr.getAttributesMutator().addCacheListener(new ClientListener());
@@ -2921,9 +2892,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         return null;
       }
     });
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getCache().getRegion(CUSTOMER);
         Region<String, String> r = getCache().getRegion(D_REFERENCE);
         pr.put(new CustId(1), new Customer("name1", "address1"));
@@ -2951,9 +2922,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         return null;
       }
     });
-    server.invoke(new SerializableCallable() {
+    server.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region<CustId, Customer> pr = getCache().getRegion(CUSTOMER);
         Region<String, String> r = getCache().getRegion(D_REFERENCE);
         ServerListener prl = (ServerListener) pr.getAttributes().getCacheListeners()[0];
@@ -2998,9 +2969,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     VM client = host.getVM(3);
 
     final int port1 = createRegionsAndStartServer(accessor, true);
-    final int port2 = (Integer) datastore1.invoke(new SerializableCallable() {
+    final int port2 = (Integer) datastore1.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         return getRandomAvailableTCPPort();
       }
     });
@@ -3009,9 +2980,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     accessor.invoke(new CreateReplicateRegion("r2"));
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         disconnectFromDS();
         System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
             "true");
@@ -3034,9 +3005,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     datastore1.invoke(new CreateReplicateRegion("r1"));
     datastore2.invoke(new CreateReplicateRegion("r2"));
 
-    final TransactionId txId = (TransactionId) client.invoke(new SerializableCallable() {
+    final TransactionId txId = (TransactionId) client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         ClientCache cCache = (ClientCache) getCache();
         Region r1 = cCache.getRegion("r1");
         Region r2 = cCache.getRegion("r2");
@@ -3048,7 +3019,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    datastore1.invoke(new SerializableCallable() {
+    datastore1.invoke(new SerializableCallable<Object>() {
       @Override
       public Object call() throws Exception {
         CacheServer s = getCache().addCacheServer();
@@ -3059,9 +3030,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    accessor.invoke(new SerializableCallable() {
+    accessor.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         getCache().getLogger().info("SWAP:accessor");
         final TXManagerImpl mgr = (TXManagerImpl) getCache().getCacheTransactionManager();
         assertTrue(mgr.isHostedTxInProgress((TXId) txId));
@@ -3082,9 +3053,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         getCache().getLogger().info("SWAP:commiting transaction");
         getCache().getCacheTransactionManager().resume(txId);
         getCache().getCacheTransactionManager().commit();
@@ -3202,7 +3173,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     VM client = host.getVM(1);
     int port = createRegionsAndStartServer(server, false);
     createClientRegion(client, port, false);
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
       public Object call() throws Exception {
         final Region r = getCache().getRegion(CUSTOMER);
@@ -3289,9 +3260,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
 
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region cust = getCache().getRegion(CUSTOMER);
         assertNull(cust.get(new CustId(0)));
         assertNull(cust.get(new CustId(1)));
@@ -3360,9 +3331,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     server2.invoke(suspectStrings);
 
     try {
-      client.invoke(new SerializableCallable() {
+      client.invoke(new SerializableCallable<Object>() {
         @Override
-        public Object call() throws Exception {
+        public Object call() {
           System.setProperty(
               GeodeGlossary.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints", "true");
           ClientCacheFactory ccf = new ClientCacheFactory(getDistributedSystemProperties());
@@ -3472,9 +3443,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     createClientRegion(client, port, true);
 
-    final TransactionId txId = (TransactionId) client.invoke(new SerializableCallable() {
+    final TransactionId txId = (TransactionId) client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region cust = getCache().getRegion(CUSTOMER);
         assertNull(cust.get(new CustId(0)));
         assertNull(cust.get(new CustId(1)));
@@ -3506,17 +3477,17 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    server2.invoke(new SerializableCallable() {
+    server2.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         disconnectFromDS();
         return null;
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region cust = getCache().getRegion(CUSTOMER);
         try {
           List list = null;
@@ -3559,9 +3530,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     createRegionOnServer(peer2);
     createRegionOnServer(accessor, false, true);
 
-    final TransactionId txId = (TransactionId) peer1.invoke(new SerializableCallable() {
+    final TransactionId txId = (TransactionId) peer1.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         PartitionedRegion r = (PartitionedRegion) getCache().getRegion(CUSTOMER);
         CustId cust = null;
         DistributedMember myId = getCache().getDistributedSystem().getDistributedMember();
@@ -3585,9 +3556,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     assertNotNull(txId);
 
-    accessor.invoke(new SerializableCallable() {
+    accessor.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Execution exe = FunctionService.onMember(((TXId) txId).getMemberId()).setArguments(txId);
         List list = null;
         if (commit) {
@@ -3612,9 +3583,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     createRegionOnServer(server1);
     createRegionOnServer(server2);
 
-    server1.invoke(new SerializableCallable() {
+    server1.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region r = getCache().getRegion(CUSTOMER);
         CacheTransactionManager mgr = getCache().getCacheTransactionManager();
         mgr.begin();
@@ -3642,9 +3613,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     final int port = createRegionsAndStartServer(server, false);
     createClientRegion(client, port, true);
 
-    final TransactionId txId = (TransactionId) client.invoke(new SerializableCallable() {
+    final TransactionId txId = (TransactionId) client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = (TXManagerImpl) getCache().getCacheTransactionManager();
         mgr.setSuspendedTransactionTimeout(1);
         Region r = getCache().getRegion(CUSTOMER);
@@ -3654,20 +3625,10 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         assertTrue(txState.isInProgress());
         r.put(new CustId(101), new Customer("name101", "address101"));
         TransactionId txId = mgr.suspend(MILLISECONDS);
-        WaitCriterion waitForTxTimeout = new WaitCriterion() {
-          @Override
-          public boolean done() {
-            return !txState.isInProgress();
-          }
-
-          @Override
-          public String description() {
-            return "txState stayed in progress indicating that the suspend did not timeout";
-          }
-        };
         // tx should timeout after 1 ms but to deal with loaded machines and thread
         // scheduling latency wait for 10 seconds before reporting an error.
-        GeodeAwaitility.await().untilAsserted(waitForTxTimeout);
+        GeodeAwaitility.await().untilAsserted(() -> assertThat(txState.isInProgress())
+            .as("txState suspend did not timeout").isFalse());
         try {
           mgr.resume(txId);
           fail("expected exception not thrown");
@@ -3677,9 +3638,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         return txId;
       }
     });
-    server.invoke(new SerializableCallable() {
+    server.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = (TXManagerImpl) getCache().getCacheTransactionManager();
         assertNull(mgr.getHostedTXState((TXId) txId));
         assertEquals(0, mgr.hostedTransactionsInProgressForTest());
@@ -3701,9 +3662,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     final int port1 = createRegionsAndStartServer(delegate, true);
     final int port2 = createRegionsAndStartServer(server, false);
 
-    final TXId txid = (TXId) client.invoke(new SerializableCallable() {
+    final TXId txid = (TXId) client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
             "true");
         ClientCacheFactory ccf = new ClientCacheFactory();
@@ -3731,9 +3692,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         mgr.resume(txid);
         EntryEventImpl event = null;
@@ -3752,9 +3713,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    server.invoke(new SerializableCallable() {
+    server.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         TXStateProxyImpl txProxy = (TXStateProxyImpl) mgr.getHostedTXState(txid);
         assert txProxy.isRealDealLocal();
@@ -3766,9 +3727,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    delegate.invoke(new SerializableCallable() {
+    delegate.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         for (CacheServer s : getCache().getCacheServers()) {
           getCache().getLogger().info("SWAP:Stopping " + s);
           s.stop();
@@ -3777,9 +3738,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    client.invoke(new SerializableCallable() {
+    client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         TXManagerImpl mgr = getGemfireCache().getTxManager();
         mgr.resume(txid);
         mgr.commit();
@@ -3831,9 +3792,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         }
       }
     }
-    server1.invoke(new SerializableCallable() {
+    server1.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region ref = getCache().getRegion(D_REFERENCE);
         getCache().getLogger().info("SWAP:ADDWRITER:server1");
         ref.getAttributesMutator().setCacheWriter(new ExceptionWriter());
@@ -3841,9 +3802,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    /* final TXId txid = (TXId) */client.invoke(new SerializableCallable() {
+    /* final TXId txid = (TXId) */client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
             "true");
         ClientCacheFactory ccf = new ClientCacheFactory();
@@ -3878,9 +3839,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     });
 
     // make sure tx has not failed over to server2
-    server2.invoke(new SerializableCallable() {
+    server2.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         GemFireCacheImpl cache = getGemfireCache();
         assertEquals(0, cache.getTxManager().hostedTransactionsInProgressForTest());
         return null;
@@ -3922,9 +3883,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     }
 
-    server.invoke(new SerializableCallable() {
+    server.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region ref = getCache().getRegion(D_REFERENCE);
         Region r = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
         ref.getAttributesMutator().setCacheWriter(new SecurityWriter());
@@ -3932,9 +3893,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
       }
     });
 
-    /* final TXId txid = (TXId) */client.invoke(new SerializableCallable() {
+    /* final TXId txid = (TXId) */client.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
             "true");
         ClientCacheFactory ccf = new ClientCacheFactory();
@@ -3975,9 +3936,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     final int port1 = createRegionsAndStartServer(server1, false);
     final int port2 = createRegionsAndStartServer(server2, false);
 
-    SerializableCallable createServerRegionWithInterest = new SerializableCallable() {
+    SerializableCallable createServerRegionWithInterest = new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         RegionFactory rf = getCache().createRegionFactory(RegionShortcut.PARTITION);
         rf.setSubscriptionAttributes(new SubscriptionAttributes(InterestPolicy.CACHE_CONTENT));
         rf.create(regionName);
@@ -3988,9 +3949,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     server2.invoke(createServerRegionWithInterest);
 
     // get two colocated keys on server1
-    final List<String> keys = (List<String>) server1.invoke(new SerializableCallable() {
+    final List<String> keys = (List<String>) server1.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region r = getCache().getRegion(regionName);
         PartitionedRegion pr = (PartitionedRegion) r;
         List<String> server1Keys = new ArrayList<>();
@@ -4026,9 +3987,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         keys.add(event.getKey());
       }
     }
-    client2.invoke(new SerializableCallable() {
+    client2.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
             "true");
         ClientCacheFactory ccf = new ClientCacheFactory();
@@ -4045,9 +4006,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         return null;
       }
     });
-    client1.invoke(new SerializableCallable() {
+    client1.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "bridge.disableShufflingOfEndpoints",
             "true");
         ClientCacheFactory ccf = new ClientCacheFactory();
@@ -4066,9 +4027,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
         return null;
       }
     });
-    client2.invoke(new SerializableCallable() {
+    client2.invoke(new SerializableCallable<Object>() {
       @Override
-      public Object call() throws Exception {
+      public Object call() {
         Region r = getCache().getRegion(regionName);
         CacheListener[] listeners = r.getAttributes().getCacheListeners();
         boolean foundListener = false;
@@ -4076,18 +4037,8 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
           if (listener instanceof ClientListener) {
             foundListener = true;
             final ClientListener clientListener = (ClientListener) listener;
-            WaitCriterion wc = new WaitCriterion() {
-              @Override
-              public boolean done() {
-                return clientListener.keys.containsAll(keys);
-              }
-
-              @Override
-              public String description() {
-                return "expected:" + keys + " found:" + clientListener.keys;
-              }
-            };
-            GeodeAwaitility.await().untilAsserted(wc);
+            GeodeAwaitility.await().untilAsserted(
+                () -> assertThat(clientListener.keys).containsExactlyElementsOf(keys));
           }
         }
         assertTrue(foundListener);
@@ -4208,19 +4159,11 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
   Object verifyTXStateExpired(final DistributedMember myId, final TXManagerImpl txmgr) {
     try {
-      GeodeAwaitility.await().untilAsserted(new WaitCriterion() {
-        @Override
-        public boolean done() {
-          Set states = txmgr.getTransactionsForClient((InternalDistributedMember) myId);
-          getLogWriter()
-              .info("found " + states.size() + " tx states for " + myId);
-          return states.isEmpty();
-        }
-
-        @Override
-        public String description() {
-          return "Waiting for transaction state to expire";
-        }
+      GeodeAwaitility.await().untilAsserted(() -> {
+        Set states = txmgr.getTransactionsForClient((InternalDistributedMember) myId);
+        getLogWriter()
+            .info("found " + states.size() + " tx states for " + myId);
+        assertThat(states).isEmpty();
       });
       return null;
     } finally {
@@ -4269,7 +4212,7 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
 
     client1.invoke(() -> verifyClientCacheData(regionName));
 
-    client1.invoke(new SerializableCallable() {
+    client1.invoke(new SerializableCallable<Object>() {
       @Override
       public Object call() throws Exception {
         final CountDownLatch latch1 = new CountDownLatch(1);
@@ -4298,9 +4241,9 @@ public class ClientServerTransactionDUnitTest extends RemoteTransactionDUnitTest
     // There exists a race that TXState is yet to be removed when client JTA tx is finished.
     // Add the wait before checking the TXState.
     await()
-        .untilAsserted(() -> Assertions
-            .assertThat(txmgr.getTransactionsForClient((InternalDistributedMember) clientId).size())
-            .isEqualTo(0));
+        .untilAsserted(() -> assertThat(
+            txmgr.getTransactionsForClient((InternalDistributedMember) clientId).size())
+                .isEqualTo(0));
   }
 
   private SerializableCallable getClientDM() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
@@ -1853,7 +1853,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         getCache().getTxManager().begin();
         Region r = getCache().getRegion(CUSTOMER);
         r.put(new CustId(8), new Customer("name8", "address8"));
-        getCache().getTxManager().commit();
+        assertThatThrownBy(() -> getCache().getTxManager().commit())
+            .isInstanceOf(CommitConflictException.class);
         return null;
       }
     });

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
@@ -513,7 +513,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         getCache().getLogger().info("SWAP:verifyRollback:" + orderRegion);
         getCache().getLogger().info("SWAP:verifyRollback:" + orderRegion.getEntry(orderId2));
         assertThat(getCache().getTXMgr().getTXState()).isNull();
-        assertThat(orderRegion.getEntry(orderId2)).as("" + orderRegion.getEntry(orderId2));
+        assertThat(orderRegion.getEntry(orderId2))
+            .as("" + orderRegion.getEntry(orderId2)).isNull();
         assertThat(orderRegion.getEntry(orderId3)).isNull();
         assertThat(orderRegion.get(orderId2)).isNull();
         assertThat(orderRegion.get(orderId3)).isNull();
@@ -635,7 +636,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
         System.out.println("TXRS:" + tx.getRegions());
-        assertThat(3).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(tx.getRegions().size()).isEqualTo(3);// 2 buckets for the two puts we
         // did in the accessor
         // plus the dist. region
         for (InternalRegion r : tx.getRegions()) {
@@ -825,7 +826,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertThat(3).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(tx.getRegions().size()).isEqualTo(3);// 2 buckets for the two puts we
         // did in the accessor
         // +1 for the dist_region
         for (InternalRegion r : tx.getRegions()) {
@@ -871,7 +872,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertThat(3).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(tx.getRegions().size()).isEqualTo(3);// 2 buckets for the two puts we
         // did in the accessor
         // plus the dist. region
         for (InternalRegion r : tx.getRegions()) {
@@ -915,7 +916,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertThat(3).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(tx.getRegions().size()).isEqualTo(3);// 2 buckets for the two puts we
         // did in the accessor
         // plus the dist. region
         for (InternalRegion r : tx.getRegions()) {
@@ -998,11 +999,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertThat(3 + (hash1 == hash10 ? 0 : 1)).isEqualTo(tx.getRegions().size());// 2 buckets for
-                                                                                    // the two
-        // puts we
-        // did in the accessor one dist. region, and one more bucket if Cust1 and Cust10 resolve to
-        // different buckets
+        assertThat(tx.getRegions().size()).isEqualTo(3 + (hash1 == hash10 ? 0 : 1));// 2 buckets for
+        // the two puts we did in the accessor one dist. region, and one more bucket if Cust1 and
+        // Cust10 resolve to different buckets
         for (InternalRegion r : tx.getRegions()) {
           assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
@@ -1078,7 +1077,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertThat(2).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(tx.getRegions().size()).isEqualTo(2);// 2 buckets for the two puts we
         // did in the accessor one dist. region, and one more bucket if Cust1 and Cust10 resolve to
         // different buckets
         for (InternalRegion r : tx.getRegions()) {
@@ -1154,7 +1153,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertThat(4).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(tx.getRegions().size()).isEqualTo(4);// 2 buckets for the two puts we
         // did in the accessor one dist. region, and one more bucket if Cust1 and Cust10 resolve to
         // different buckets
         for (InternalRegion r : tx.getRegions()) {
@@ -1347,7 +1346,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertThat(2).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(tx.getRegions().size()).isEqualTo(2);// 2 buckets for the two puts we
         // did in the accessor one dist. region, and one more bucket if Cust1 and Cust10 resolve to
         // different buckets
         for (InternalRegion r : tx.getRegions()) {
@@ -1854,8 +1853,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         getCache().getTxManager().begin();
         Region r = getCache().getRegion(CUSTOMER);
         r.put(new CustId(8), new Customer("name8", "address8"));
-        assertThatThrownBy(() -> getCache().getTxManager().commit())
-            .isInstanceOf(CommitConflictException.class);
+        getCache().getTxManager().commit();
         return null;
       }
     });
@@ -1886,7 +1884,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Region custRegion = getCache().getRegion(CUSTOMER);
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.begin();
-        assertThat(5).isEqualTo(custRegion.size());
+        assertThat(custRegion.size()).isEqualTo(5);
         assertThat(mgr.getTXState()).isNotNull();
         return mgr.suspend();
       }
@@ -1920,14 +1918,14 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         getCache().getLogger()
             .info("Putting " + custId + ", keyInfo:" + custPR.getKeyInfo(new CustId(remoteKey)));
         orderRegion.put(orderId, new Order("order" + remoteKey));
-        assertThat(6).isEqualTo(custRegion.size());
+        assertThat(custRegion.size()).isEqualTo(6);
         mgr.suspend();
         return null;
       }
     });
     final Integer txOnDatastore1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertThat(1).isEqualTo(txOnDatastore1 + txOnDatastore2);
+    assertThat(txOnDatastore1 + txOnDatastore2).isOne();
 
     taskVM.invoke(new SerializableCallable<Object>() {
       @Override
@@ -1944,8 +1942,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     final Integer txOnDatastore1_1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2_2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertThat(0).isEqualTo(txOnDatastore1_1.intValue());
-    assertThat(0).isEqualTo(txOnDatastore2_2.intValue());
+    assertThat(txOnDatastore1_1.intValue()).isZero();
+    assertThat(txOnDatastore2_2.intValue()).isZero();
   }
 
   @Test
@@ -2025,12 +2023,12 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           case KEYS:
             originalSet = getCustIdSet(5);
             assertThat(originalSet.containsAll(custRegion.keySet())).isTrue();
-            assertThat(5).isEqualTo(custRegion.keySet().size());
+            assertThat(custRegion.keySet().size()).isEqualTo(5);
             break;
           case VALUES:
             originalSet = getCustomerSet(5);
             assertThat(originalSet.containsAll(custRegion.values())).isTrue();
-            assertThat(5).isEqualTo(custRegion.values().size());
+            assertThat(custRegion.values().size()).isEqualTo(5);
             break;
           case ENTRIES:
             Set<CustId> originalKeySet = getCustIdSet(5);
@@ -2045,7 +2043,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
               assertThat(originalKeySet.contains(entry.getKey())).isTrue();
               assertThat(originalValueSet.contains(entry.getValue())).isTrue();
             }
-            assertThat(5).isEqualTo(custRegion.entrySet().size());
+            assertThat(custRegion.entrySet().size()).isEqualTo(5);
             break;
           default:
             throw new IllegalArgumentException();
@@ -2119,7 +2117,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     });
     final Integer txOnDatastore1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertThat(1).isEqualTo(txOnDatastore1 + txOnDatastore2);
+    assertThat(txOnDatastore1 + txOnDatastore2).isOne();
 
     accessor.invoke(new SerializableCallable<Object>() {
       @Override
@@ -2132,7 +2130,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     });
     final Integer txOnDatastore1_1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2_2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertThat(0).isEqualTo(txOnDatastore1_1 + txOnDatastore2_2);
+    assertThat(txOnDatastore1_1 + txOnDatastore2_2).isZero();
 
     datastore1.invoke(new SerializableCallable<Object>() {
       CustId custId;
@@ -2274,9 +2272,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertThat(5).isEqualTo(i);
+        assertThat(i).isEqualTo(5);
         assertThat(getCustIdSet(5)).isEqualTo(set);
-        assertThat(5).isEqualTo(rr.keySet().size());
+        assertThat(rr.keySet().size()).isEqualTo(5);
         rr.put(custId, customer);
         set = rr.keySet();
         assertThat(getCustIdSet(6)).isEqualTo(set);
@@ -2286,12 +2284,12 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertThat(6).isEqualTo(i);
-        assertThat(6).isEqualTo(rr.keySet().size());
+        assertThat(i).isEqualTo(6);
+        assertThat(rr.keySet().size()).isEqualTo(6);
         assertThat(rr.get(custId)).isNotNull();
         TXStateProxy tx = mgr.pauseTransaction();
         assertThat(getCustIdSet(5)).isEqualTo(rr.keySet());
-        assertThat(5).isEqualTo(rr.keySet().size());
+        assertThat(rr.keySet().size()).isEqualTo(5);
         assertThat(rr.get(custId)).isNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
@@ -2325,9 +2323,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertThat(5).isEqualTo(i);
+        assertThat(i).isEqualTo(5);
         assertThat(getCustomerSet(5)).isEqualTo(set);
-        assertThat(5).isEqualTo(rr.values().size());
+        assertThat(rr.values().size()).isEqualTo(5);
         rr.put(custId, customer);
         set = (Set) rr.values();
         assertThat(getCustomerSet(6)).isEqualTo(set);
@@ -2337,12 +2335,12 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertThat(6).isEqualTo(i);
-        assertThat(6).isEqualTo(rr.values().size());
+        assertThat(i).isEqualTo(6);
+        assertThat(rr.values().size()).isEqualTo(6);
         assertThat(rr.get(custId)).isNotNull();
         TXStateProxy tx = mgr.pauseTransaction();
         assertThat(getCustomerSet(5)).isEqualTo(rr.values());
-        assertThat(5).isEqualTo(rr.values().size());
+        assertThat(rr.values().size()).isEqualTo(5);
         assertThat(rr.get(custId)).isNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
@@ -2376,9 +2374,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertThat(5).isEqualTo(i);
+        assertThat(i).isEqualTo(5);
         // assertThat(getCustIdSet(5).equals(set)).isTrue();
-        assertThat(5).isEqualTo(rr.entrySet().size());
+        assertThat(rr.entrySet().size()).isEqualTo(5);
         rr.put(custId, customer);
         set = rr.entrySet();
         // assertThat(getCustIdSet(6).equals(set)).isTrue();
@@ -2388,12 +2386,12 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertThat(6).isEqualTo(i);
-        assertThat(6).isEqualTo(rr.entrySet().size());
+        assertThat(i).isEqualTo(6);
+        assertThat(rr.entrySet().size()).isEqualTo(6);
         assertThat(rr.get(custId)).isNotNull();
         TXStateProxy tx = mgr.pauseTransaction();
         // assertIndexDetailsEquals(getCustIdSet(5), rr.entrySet());
-        assertThat(5).isEqualTo(rr.entrySet().size());
+        assertThat(rr.entrySet().size()).isEqualTo(5);
         assertThat(rr.get(custId)).isNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
@@ -2565,7 +2563,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     final Integer txOnDatastore1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertThat(1).isEqualTo(txOnDatastore1 + txOnDatastore2);
+    assertThat(txOnDatastore1 + txOnDatastore2).isOne();
 
     accessor.invoke(new SerializableCallable<Object>() {
       @Override
@@ -2830,7 +2828,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     final Integer txOnDatastore1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertThat(1).isEqualTo(txOnDatastore1 + txOnDatastore2);
+    assertThat(txOnDatastore1 + txOnDatastore2).isOne();
 
     accessor.invoke(new SerializableCallable<Object>() {
       @Override
@@ -2883,7 +2881,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     });
     final Integer txOnDatastore1_1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2_1 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertThat(1).isEqualTo(txOnDatastore1_1 + txOnDatastore2_1);
+    assertThat(txOnDatastore1_1 + txOnDatastore2_1).isOne();
 
     accessor.invoke(new SerializableCallable<Object>() {
       @Override
@@ -2931,9 +2929,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
       final Integer txOnDatastore1_2 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
       final Integer txOnDatastore2_2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-      assertThat(0).isEqualTo(txOnDatastore1_2 + txOnDatastore2_2);// ds1 has a local transaction,
-                                                                   // not
-      // remote
+      assertThat(txOnDatastore1_2 + txOnDatastore2_2).isZero();// ds1 has a local transaction,
+                                                               // not remote
       CloseFnOnDsTx closeFnOnDsTx = new CloseFnOnDsTx(dsTxId);
       datastore1.invoke(closeFnOnDsTx);
     } else {
@@ -2941,9 +2938,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
       final Integer txOnDatastore1_2 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
       final Integer txOnDatastore2_2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-      assertThat(0).isEqualTo(txOnDatastore1_2 + txOnDatastore2_2);// ds1 has a local transaction,
-                                                                   // not
-      // remote
+      assertThat(txOnDatastore1_2 + txOnDatastore2_2).isZero();// ds1 has a local transaction,
+                                                               // not remote
       CloseFnOnDsTx closeFnOnDsTx = new CloseFnOnDsTx(dsTxId);
       datastore2.invoke(closeFnOnDsTx);
     }
@@ -3199,9 +3195,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       public Object call() {
         Region refRegion = getCache().getRegion(D_REFERENCE);
         OriginRemoteRRWriter w = (OriginRemoteRRWriter) refRegion.getAttributes().getCacheWriter();
-        assertThat(1).isEqualTo(w.fireC);
-        assertThat(1).isEqualTo(w.fireD);
-        assertThat(1).isEqualTo(w.fireU);
+        assertThat(w.fireC).isOne();
+        assertThat(w.fireD).isOne();
+        assertThat(w.fireU).isOne();
         return null;
       }
     });
@@ -3245,7 +3241,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region refRegion = getCache().getRegion(D_REFERENCE);
-        assertThat("dawg").isEqualTo(refRegion.get("sup"));
+        assertThat(refRegion.get("sup")).isEqualTo("dawg");
         return null;
       }
     });
@@ -3279,9 +3275,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertThat(1).isEqualTo(mgr.hostedTransactionsInProgressForTest());
+        assertThat(mgr.hostedTransactionsInProgressForTest()).isOne();
         mgr.memberDeparted(getCache().getDistributionManager(), member, true);
-        assertThat(0).isEqualTo(mgr.hostedTransactionsInProgressForTest());
+        assertThat(mgr.hostedTransactionsInProgressForTest()).isZero();
         return null;
       }
     });
@@ -3538,7 +3534,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Region cust = getCache().getRegion(D_REFERENCE);
         OneUpdateCacheListener rat =
             (OneUpdateCacheListener) cust.getAttributes().getCacheListener();
-        assertThat(rat.getSuccess()).isTrue();
+        assertThat(rat.getSuccess())
+            .as("The OneUpdateCacheListener didnt get an update").isTrue();
         return null;
       }
     });
@@ -3592,7 +3589,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     private boolean oneCreate;
 
     public void checkSuccess() {
-      assertThat(oneDestroy && oneCreate).isTrue();
+      assertThat(oneDestroy && oneCreate)
+          .as("Didn't get both events. oneDestroy=" + oneDestroy + " oneCreate=" + oneCreate)
+          .isTrue();
     }
 
     @Override
@@ -3890,7 +3889,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         getCache().getLogger().info("SWAP:callingCommit");
         getCache().getCacheTransactionManager().commit();
         assertThat(ref.containsKey("one")).isTrue();
-        assertThat("value1").isEqualTo(ref.get("one"));
+        assertThat(ref.get("one")).isEqualTo("value1");
         assertThat(empty.containsKey("eone")).isFalse();
         assertThat(empty.get("eone")).isNull();
         return null;
@@ -4000,7 +3999,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     int totalInvocation = (Integer) datastore1.invoke(getListenerCount)
         + (Integer) datastore2.invoke(getListenerCount);
-    assertThat(1).isEqualTo(totalInvocation);
+    assertThat(totalInvocation).isOne();
   }
 
   private class ListenerInvocationCounter extends CacheListenerAdapter {
@@ -4192,13 +4191,13 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         assertThat(rgn.get("txkey")).isNull();
         TXManagerImpl txMgr = getCache().getTxManager();
         TXStateProxy tx = txMgr.getHostedTXState((TXId) txid);
-        assertThat(1).isEqualTo(tx.getRegions().size());
+        assertThat(tx.getRegions().size()).isOne();
         for (InternalRegion r : tx.getRegions()) {
           assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertThat("txkey").isEqualTo(key);
+            assertThat(key).isEqualTo("txkey");
             assertThat(es.getValue(key, r, false)).isNotNull();
             if (key.equals("txkey")) {
               assertThat(es.isDirty()).isTrue();
@@ -4217,8 +4216,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.resume(txid);
         mgr.commit();
         CountingListener cl = (CountingListener) rgn.getAttributes().getCacheListeners()[0];
-        assertThat(0).isEqualTo(cl.count);
-        assertThat("txvalue").isEqualTo(rgn.get("txkey"));
+        assertThat(cl.count).isZero();
+        assertThat(rgn.get("txkey")).isEqualTo("txvalue");
         return null;
       }
     });
@@ -4227,7 +4226,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       public Object call() {
         Region rgn = getCache().getRegion(name);
         CountingListener cl = (CountingListener) rgn.getAttributes().getCacheListeners()[0];
-        assertThat(2).isEqualTo(cl.count);
+        assertThat(cl.count).isEqualTo(2);
         return null;
       }
     });

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
@@ -21,11 +21,6 @@ import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTC
 import static org.apache.geode.internal.cache.ExpiryTask.permitExpiration;
 import static org.apache.geode.internal.cache.ExpiryTask.suspendExpiration;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -312,9 +307,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           expectedCust = custRegion.get(custId);
           expectedOrder = orderRegion.get(orderId);
           expectedRefCust = refRegion.get(custId);
-          assertNotNull(expectedCust);
-          assertNotNull(expectedOrder);
-          assertNotNull(expectedRefCust);
+          assertThat(expectedCust).isNotNull();
+          assertThat(expectedOrder).isNotNull();
+          assertThat(expectedRefCust).isNotNull();
           validateContains(custId, Collections.singleton(orderId), true, true);
           break;
         case DESTROY:
@@ -370,21 +365,21 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     }
     boolean rContainsVR = refRegion.containsValueForKey(custId);
 
-    assertEquals(containsKey, rContainsKC);
-    assertEquals(containsKey, rContainsKO);
-    assertEquals(containsKey, rContainsKR);
-    assertEquals(containsValue, rContainsVR);
-    assertEquals(containsValue, rContainsVC);
-    assertEquals(containsValue, rContainsVO);
+    assertThat(containsKey).isEqualTo(rContainsKC);
+    assertThat(containsKey).isEqualTo(rContainsKO);
+    assertThat(containsKey).isEqualTo(rContainsKR);
+    assertThat(containsValue).isEqualTo(rContainsVR);
+    assertThat(containsValue).isEqualTo(rContainsVC);
+    assertThat(containsValue).isEqualTo(rContainsVO);
 
     if (containsKey) {
       Region.Entry eC = custRegion.getEntry(custId);
       for (OrderId o : ordersSet) {
-        assertNotNull(orderRegion.getEntry(o));
+        assertThat(orderRegion.getEntry(o)).isNotNull();
       }
       Region.Entry eR = refRegion.getEntry(custId);
-      assertNotNull(eC);
-      assertNotNull(eR);
+      assertThat(eC).isNotNull();
+      assertThat(eR).isNotNull();
       // assertIndexDetailsEquals(1,custRegion.size());
       // assertIndexDetailsEquals(1,orderRegion.size());
       // assertIndexDetailsEquals(1,refRegion.size());
@@ -395,23 +390,23 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       // assertIndexDetailsEquals(0,refRegion.size());
       try {
         Region.Entry eC = custRegion.getEntry(custId);
-        assertNull("should have had an EntryNotFoundException:" + eC, eC);
+        assertThat(eC).as("should have had an EntryNotFoundException:" + eC).isNull();
 
       } catch (EntryNotFoundException enfe) {
         // this is what we expect
       }
       try {
         for (OrderId o : ordersSet) {
-          assertNull("should have had an EntryNotFoundException:" + orderRegion.getEntry(o),
-              orderRegion.getEntry(o));
+          assertThat(orderRegion.getEntry(o))
+              .as("should have had an EntryNotFoundException:" + orderRegion.getEntry(o))
+              .isNull();
         }
-
       } catch (EntryNotFoundException enfe) {
         // this is what we expect
       }
       try {
         Region.Entry eR = refRegion.getEntry(custId);
-        assertNull("should have had an EntryNotFoundException:" + eR, eR);
+        assertThat(eR).as("should have had an EntryNotFoundException:" + eR).isNull();
       } catch (EntryNotFoundException enfe) {
         // this is what we expect
       }
@@ -441,20 +436,20 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         expectedOrder2 = new Order("fooOrder2");
         expectedOrder3 = new Order("fooOrder3");
         expectedRef = expectedCust;
-        assertNotNull(custRegion.getEntry(custId));
-        assertEquals(expectedCust, custRegion.getEntry(custId).getValue());
+        assertThat(custRegion.getEntry(custId)).isNotNull();
+        assertThat(expectedCust).isEqualTo(custRegion.getEntry(custId).getValue());
         /*
-         * assertNotNull(orderRegion.getEntry(orderId)); assertIndexDetailsEquals(expectedOrder,
+         * assertThat(orderRegion.getEntry(orderId)).isNotNull(); assertIndexDetailsEquals(expectedOrder,
          * orderRegion.getEntry(orderId).getValue());
          *
-         * assertNotNull(orderRegion.getEntry(orderId2)); assertIndexDetailsEquals(expectedOrder2,
+         * assertThat(orderRegion.getEntry(orderId2)).isNotNull(); assertIndexDetailsEquals(expectedOrder2,
          * orderRegion.getEntry(orderId2).getValue());
          *
-         * assertNotNull(orderRegion.getEntry(orderId3)); assertIndexDetailsEquals(expectedOrder3,
+         * assertThat(orderRegion.getEntry(orderId3)).isNotNull(); assertIndexDetailsEquals(expectedOrder3,
          * orderRegion.getEntry(orderId3).getValue());
          */
-        assertNotNull(refRegion.getEntry(custId));
-        assertEquals(expectedRef, refRegion.getEntry(custId).getValue());
+        assertThat(refRegion.getEntry(custId)).isNotNull();
+        assertThat(expectedRef).isEqualTo(refRegion.getEntry(custId).getValue());
 
         // Set<OrderId> ordersSet = new HashSet<>();
         // ordersSet.add(orderId);ordersSet.add(orderId2);ordersSet.add(orderId3);
@@ -467,21 +462,21 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         validateContains(custId, Collections.singleton(orderId), true);
         break;
       case DESTROY:
-        assertTrue(!custRegion.containsKey(custId));
-        assertTrue(!orderRegion.containsKey(orderId));
-        assertTrue(!refRegion.containsKey(custId));
+        assertThat(!custRegion.containsKey(custId)).isTrue();
+        assertThat(!orderRegion.containsKey(orderId)).isTrue();
+        assertThat(!refRegion.containsKey(custId)).isTrue();
         validateContains(custId, Collections.singleton(orderId), false);
         break;
       case INVALIDATE:
         boolean validateContainsKey = true;
         if (!((GemFireCacheImpl) custRegion.getCache()).isClient()) {
-          assertTrue(custRegion.containsKey(custId));
-          assertTrue(orderRegion.containsKey(orderId));
-          assertTrue(refRegion.containsKey(custId));
+          assertThat(custRegion.containsKey(custId)).isTrue();
+          assertThat(orderRegion.containsKey(orderId)).isTrue();
+          assertThat(refRegion.containsKey(custId)).isTrue();
         }
-        assertNull(custRegion.get(custId));
-        assertNull(orderRegion.get(orderId));
-        assertNull(refRegion.get(custId));
+        assertThat(custRegion.get(custId)).isNull();
+        assertThat(orderRegion.get(orderId)).isNull();
+        assertThat(refRegion.get(custId)).isNull();
         validateContains(custId, Collections.singleton(orderId), validateContainsKey, false);
         break;
       default:
@@ -494,9 +489,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
     Region<OrderId, Order> orderRegion = getCache().getRegion(ORDER);
     Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-    assertNotNull(custRegion);
-    assertNotNull(orderRegion);
-    assertNotNull(refRegion);
+    assertThat(custRegion).isNotNull();
+    assertThat(orderRegion).isNotNull();
+    assertThat(refRegion).isNotNull();
 
     CustId custId = new CustId(1);
     OrderId orderId = new OrderId(1, custId);
@@ -510,16 +505,16 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         expectedCust = new Customer("customer1", "address1");
         expectedOrder = new Order("order1");
         expectedRef = new Customer("customer1", "address1");
-        assertEquals(expectedCust, custRegion.getEntry(custId).getValue());
-        assertEquals(expectedOrder, orderRegion.getEntry(orderId).getValue());
+        assertThat(expectedCust).isEqualTo(custRegion.getEntry(custId).getValue());
+        assertThat(expectedOrder).isEqualTo(orderRegion.getEntry(orderId).getValue());
         getCache().getLogger().info("SWAP:verifyRollback:" + orderRegion);
         getCache().getLogger().info("SWAP:verifyRollback:" + orderRegion.getEntry(orderId2));
-        assertNull(getCache().getTXMgr().getTXState());
-        assertNull("" + orderRegion.getEntry(orderId2), orderRegion.getEntry(orderId2));
-        assertNull(orderRegion.getEntry(orderId3));
-        assertNull(orderRegion.get(orderId2));
-        assertNull(orderRegion.get(orderId3));
-        assertEquals(expectedRef, refRegion.getEntry(custId).getValue());
+        assertThat(getCache().getTXMgr().getTXState()).isNull();
+        assertThat(orderRegion.getEntry(orderId2)).as("" + orderRegion.getEntry(orderId2));
+        assertThat(orderRegion.getEntry(orderId3)).isNull();
+        assertThat(orderRegion.get(orderId2)).isNull();
+        assertThat(orderRegion.get(orderId3)).isNull();
+        assertThat(expectedRef).isEqualTo(refRegion.getEntry(custId).getValue());
         validateContains(custId, Collections.singleton(orderId), true);
         break;
       case GET:
@@ -529,18 +524,18 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         validateContains(custId, Collections.singleton(orderId), true);
         break;
       case DESTROY:
-        assertFalse(custRegion.containsKey(custId));
-        assertFalse(orderRegion.containsKey(orderId));
-        assertFalse(refRegion.containsKey(custId));
+        assertThat(custRegion.containsKey(custId)).isFalse();
+        assertThat(orderRegion.containsKey(orderId)).isFalse();
+        assertThat(refRegion.containsKey(custId)).isFalse();
         validateContains(custId, Collections.singleton(orderId), true);
         break;
       case INVALIDATE:
-        assertTrue(custRegion.containsKey(custId));
-        assertTrue(orderRegion.containsKey(orderId));
-        assertTrue(refRegion.containsKey(custId));
-        assertNull(custRegion.get(custId));
-        assertNull(orderRegion.get(orderId));
-        assertNull(refRegion.get(custId));
+        assertThat(custRegion.containsKey(custId)).isTrue();
+        assertThat(orderRegion.containsKey(orderId)).isTrue();
+        assertThat(refRegion.containsKey(custId)).isTrue();
+        assertThat(custRegion.get(custId)).isNull();
+        assertThat(orderRegion.get(orderId)).isNull();
+        assertThat(refRegion.get(custId)).isNull();
         validateContains(custId, Collections.singleton(orderId), true, true);
         break;
       default:
@@ -571,7 +566,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr).isNotNull();
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         return null;
       }
     });
@@ -582,7 +578,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.resume(txId);
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNotNull(tx);
+        assertThat(tx).isNotNull();
         mgr.unpauseTransaction(tx);
         if (commit) {
           mgr.commit();
@@ -597,7 +593,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertFalse(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isFalse();
         return null;
       }
     });
@@ -633,19 +629,19 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
         System.out.println("TXRS:" + tx.getRegions());
-        assertEquals(3, tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(3).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
         // did in the accessor
         // plus the dist. region
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertNotNull(es.getValue(key, r, false));
-            assertFalse(es.isDirty());
+            assertThat(es.getValue(key, r, false)).isNotNull();
+            assertThat(es.isDirty()).isFalse();
           }
         }
         return null;
@@ -696,16 +692,16 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.begin();
         Region<Object, Object> cust = getCache().getRegion(CUSTOMER);
         Customer s = (Customer) cust.get(new CustId(8));
-        assertEquals(new Customer("sup dawg", "add"), s);
-        assertTrue(cust.containsKey(new CustId(8)));
+        assertThat(new Customer("sup dawg", "add")).isEqualTo(s);
+        assertThat(cust.containsKey(new CustId(8))).isTrue();
         TXStateProxy tx = mgr.pauseTransaction();
-        assertFalse(cust.containsKey(new CustId(8)));
+        assertThat(cust.containsKey(new CustId(8))).isFalse();
         mgr.unpauseTransaction(tx);
         mgr.commit();
         Customer s2 = (Customer) cust.get(new CustId(8));
         Customer ex = new Customer("sup dawg", "add");
-        assertEquals(ex, s);
-        assertEquals(ex, s2);
+        assertThat(ex).isEqualTo(s);
+        assertThat(ex).isEqualTo(s2);
         return null;
       }
     });
@@ -734,32 +730,32 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Region<Object, Object> cust = getCache().getRegion(CUSTOMER);
         CustId sup = new CustId(7);
         Region.Entry e = cust.getEntry(sup);
-        assertNull(e);
+        assertThat(e).isNull();
         CustId custId = new CustId(5);
         cust.put(custId, new Customer("customer5", "address5"));
 
         Region.Entry ee = cust.getEntry(custId);
-        assertNotNull(ee);
+        assertThat(ee).isNotNull();
 
         CacheTransactionManager mgr = getCache().getTxManager();
         mgr.begin();
         Region.Entry e2 = cust.getEntry(sup);
-        assertNull(e2);
+        assertThat(e2).isNull();
         mgr.commit();
         Region.Entry e3 = cust.getEntry(sup);
-        assertNull(e3);
+        assertThat(e3).isNull();
 
         mgr.begin();
         Customer dawg = new Customer("dawg", "dawgaddr");
         cust.put(sup, dawg);
         Region.Entry e4 = cust.getEntry(sup);
-        assertNotNull(e4);
-        assertEquals(dawg, e4.getValue());
+        assertThat(e4).isNotNull();
+        assertThat(dawg).isEqualTo(e4.getValue());
         mgr.commit();
 
         Region.Entry e5 = cust.getEntry(sup);
-        assertNotNull(e5);
-        assertEquals(dawg, e5.getValue());
+        assertThat(e5).isNotNull();
+        assertThat(dawg).isEqualTo(e5.getValue());
         return null;
       }
     });
@@ -795,8 +791,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.commit();
         Customer s2 = (Customer) cust.get(custId);
         Customer expectedCust = new Customer("sup dawg", "addr");
-        assertEquals(s, expectedCust);
-        assertEquals(s2, expectedCust);
+        assertThat(s).isEqualTo(expectedCust);
+        assertThat(s2).isEqualTo(expectedCust);
         return null;
       }
     });
@@ -824,18 +820,18 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertEquals(3, tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(3).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
         // did in the accessor
         // +1 for the dist_region
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertNotNull(es.getValue(key, r, false));
-            assertTrue(es.isDirty());
+            assertThat(es.getValue(key, r, false)).isNotNull();
+            assertThat(es.isDirty()).isTrue();
           }
         }
         return null;
@@ -846,11 +842,11 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.resume(txId);
-        assertNotNull(mgr.getTXState());
+        assertThat(mgr.getTXState()).isNotNull();
         getCache().getLogger().fine("SWAP:accessorTXState:" + mgr.getTXState());
         mgr.commit();
         verifyAfterCommit(OP.PUT);
-        assertNull(mgr.getTXState());
+        assertThat(mgr.getTXState()).isNull();
         return null;
       }
     });
@@ -870,18 +866,18 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertEquals(3, tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(3).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
         // did in the accessor
         // plus the dist. region
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertNotNull(es.getValue(key, r, false));
-            assertTrue(es.isDirty());
+            assertThat(es.getValue(key, r, false)).isNotNull();
+            assertThat(es.isDirty()).isTrue();
           }
         }
         return null;
@@ -914,18 +910,18 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertEquals(3, tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(3).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
         // did in the accessor
         // plus the dist. region
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion);
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertNull(es.getValue(key, r, false));
-            assertTrue(es.isDirty());
+            assertThat(es.getValue(key, r, false)).isNull();
+            assertThat(es.isDirty()).isTrue();
           }
         }
         return null;
@@ -964,24 +960,25 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         getCache().getLogger().fine("SWAP:doingPutIfAbsent");
         CustId oldCustId = new CustId(1);
         Customer old = cust.putIfAbsent(oldCustId, updateCust);
-        assertEquals("expected:" + expectedCust + " but was " + old, expectedCust, old);
+        assertThat(expectedCust).as("expected:" + expectedCust + " but was " + old)
+            .isEqualTo(old);
         // transaction should be bootstrapped
         old = rr.putIfAbsent(oldCustId, updateCust);
-        assertEquals("expected:" + expectedCust + " but was " + old, expectedCust, old);
+        assertThat(expectedCust).as("expected:" + expectedCust + " but was " + old).isEqualTo(old);
         // now a key that does not exist
         old = cust.putIfAbsent(newCustId, updateCust);
-        assertNull(old);
+        assertThat(old).isNull();
         old = rr.putIfAbsent(newCustId, updateCust);
-        assertNull(old);
+        assertThat(old).isNull();
         Region<OrderId, Order> order = getCache().getRegion(ORDER);
         Order oldOrder = order.putIfAbsent(new OrderId(10, newCustId), new Order("order10"));
-        assertNull(old);
-        assertNull(oldOrder);
-        assertNotNull(cust.get(newCustId));
-        assertNotNull(rr.get(newCustId));
+        assertThat(old).isNull();
+        assertThat(oldOrder).isNull();
+        assertThat(cust.get(newCustId)).isNotNull();
+        assertThat(rr.get(newCustId)).isNotNull();
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNull(cust.get(newCustId));
-        assertNull(rr.get(newCustId));
+        assertThat(cust.get(newCustId)).isNull();
+        assertThat(rr.get(newCustId)).isNull();
         mgr.unpauseTransaction(tx);
         cust.put(oldCustId, new Customer("foo", "bar"));
         rr.put(oldCustId, new Customer("foo", "bar"));
@@ -996,19 +993,19 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         int hash1 = PartitionedRegionHelper.getHashKey((PartitionedRegion) cust, new CustId(1));
         int hash10 = PartitionedRegionHelper.getHashKey((PartitionedRegion) cust, new CustId(10));
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertEquals(3 + (hash1 == hash10 ? 0 : 1), tx.getRegions().size());// 2 buckets for the two
+        assertThat(3 + (hash1 == hash10 ? 0 : 1)).isEqualTo(tx.getRegions().size());// 2 buckets for the two
         // puts we
         // did in the accessor one dist. region, and one more bucket if Cust1 and Cust10 resolve to
         // different buckets
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertNotNull(es.getValue(key, r, false));
-            assertTrue("key:" + key + " r:" + r.getFullPath(), es.isDirty());
+            assertThat(es.getValue(key, r, false)).isNotNull();
+            assertThat(es.isDirty()).as("key:" + key + " r:" + r.getFullPath()).isTrue();
           }
         }
         return null;
@@ -1022,8 +1019,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.commit();
         Region<CustId, Customer> cust = getCache().getRegion(CUSTOMER);
         Region<CustId, Customer> rr = getCache().getRegion(D_REFERENCE);
-        assertEquals(updateCust, cust.get(newCustId));
-        assertEquals(updateCust, rr.get(newCustId));
+        assertThat(updateCust).isEqualTo(cust.get(newCustId));
+        assertThat(updateCust).isEqualTo(rr.get(newCustId));
         // test conflict
         mgr.begin();
         CustId conflictCust = new CustId(11);
@@ -1033,7 +1030,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.unpauseTransaction(tx);
         try {
           mgr.commit();
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (CommitConflictException ignored) {
         }
         return null;
@@ -1064,13 +1061,13 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.begin();
         Customer customer = new Customer("customer1", "address1");
         Customer fakeCust = new Customer("foo", "bar");
-        assertFalse(cust.remove(custId, fakeCust));
-        assertTrue(cust.remove(custId, customer));
-        assertFalse(ref.remove(custId, fakeCust));
-        assertTrue(ref.remove(custId, customer));
+        assertThat(cust.remove(custId, fakeCust)).isFalse();
+        assertThat(cust.remove(custId, customer)).isTrue();
+        assertThat(ref.remove(custId, fakeCust)).isFalse();
+        assertThat(ref.remove(custId, customer)).isTrue();
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNotNull(cust.get(custId));
-        assertNotNull(ref.get(custId));
+        assertThat(cust.get(custId)).isNotNull();
+        assertThat(ref.get(custId)).isNotNull();
         mgr.unpauseTransaction(tx);
         return mgr.suspend();
       }
@@ -1079,18 +1076,18 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertEquals(2, tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(2).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
         // did in the accessor one dist. region, and one more bucket if Cust1 and Cust10 resolve to
         // different buckets
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertNull(es.getValue(key, r, false));
-            assertTrue("key:" + key + " r:" + r.getFullPath(), es.isDirty());
+            assertThat(es.getValue(key, r, false)).isNull();
+            assertThat(es.isDirty()).as("key:" + key + " r:" + r.getFullPath()).isTrue();
           }
         }
         return null;
@@ -1104,20 +1101,20 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.commit();
         Region<CustId, Customer> cust = getCache().getRegion(CUSTOMER);
         Region<CustId, Customer> rr = getCache().getRegion(D_REFERENCE);
-        assertNull(cust.get(custId));
-        assertNull(rr.get(custId));
+        assertThat(cust.get(custId)).isNull();
+        assertThat(rr.get(custId)).isNull();
         // check conflict
         mgr.begin();
         CustId conflictCust = new CustId(2);
         Customer customer = new Customer("customer2", "address2");
         getCache().getLogger().fine("SWAP:removeConflict");
-        assertTrue(cust.remove(conflictCust, customer));
+        assertThat(cust.remove(conflictCust, customer)).isTrue();
         TXStateProxy tx = mgr.pauseTransaction();
         cust.put(conflictCust, new Customer("foo", "bar"));
         mgr.unpauseTransaction(tx);
         try {
           mgr.commit();
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (CommitConflictException ignored) {
         }
         return null;
@@ -1149,8 +1146,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         cust.removeAll(Arrays.asList(custId1, custId2, custId20));
         ref.removeAll(Arrays.asList(custId1, custId2, custId20));
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNotNull(cust.get(custId1));
-        assertNotNull(ref.get(custId2));
+        assertThat(cust.get(custId1)).isNotNull();
+        assertThat(ref.get(custId2)).isNotNull();
         mgr.unpauseTransaction(tx);
         return mgr.suspend();
       }
@@ -1159,20 +1156,20 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertEquals(4, tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(4).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
         // did in the accessor one dist. region, and one more bucket if Cust1 and Cust10 resolve to
         // different buckets
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertNull(es.getValue(key, r, false));
+            assertThat(es.getValue(key, r, false)).isNull();
             // custId20 won't be dirty because it doesn't exist.
-            assertTrue("key:" + key + " r:" + r.getFullPath(),
-                key.equals(custId20) || es.isDirty());
+            assertThat(key.equals(custId20) || es.isDirty())
+                .as("key:" + key + " r:" + r.getFullPath()).isTrue();
           }
         }
         return null;
@@ -1186,8 +1183,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.commit();
         Region<CustId, Customer> cust = getCache().getRegion(CUSTOMER);
         Region<CustId, Customer> rr = getCache().getRegion(D_REFERENCE);
-        assertNull(cust.get(custId1));
-        assertNull(rr.get(custId2));
+        assertThat(cust.get(custId1)).isNull();
+        assertThat(rr.get(custId2)).isNull();
         // check conflict
         mgr.begin();
         CustId custId3 = new CustId(3);
@@ -1197,17 +1194,17 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXStateProxy tx = mgr.pauseTransaction();
         // cust.put(custId3, new Customer("foo", "bar"));
         cust.put(custId20, new Customer("foo", "bar"));
-        assertNotNull(cust.get(custId20));
+        assertThat(cust.get(custId20)).isNotNull();
         cust.put(custId4, new Customer("foo", "bar"));
         mgr.unpauseTransaction(tx);
         try {
           mgr.commit();
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (CommitConflictException ignored) {
         }
-        assertNotNull(cust.get(custId3));
-        assertNotNull(cust.get(custId4));
-        assertNotNull(cust.get(custId20));
+        assertThat(cust.get(custId3)).isNotNull();
+        assertThat(cust.get(custId4)).isNotNull();
+        assertThat(cust.get(custId20)).isNotNull();
 
         // Test a removeall an already missing key.
         // custId2 has already been removed
@@ -1218,8 +1215,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         cust.put(custId2, new Customer("foo", "bar"));
         mgr.unpauseTransaction(tx);
         mgr.commit();
-        assertNotNull(cust.get(custId2));
-        assertNull(cust.get(custId3));
+        assertThat(cust.get(custId2)).isNotNull();
+        assertThat(cust.get(custId3)).isNull();
         return null;
       }
     });
@@ -1259,15 +1256,15 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Customer fakeCust = new Customer("foo2", "bar2");
         try {
           cust.removeAll(Arrays.asList(custId0, custId4, custId1, custId2, custId3, custId20));
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (TransactionDataNotColocatedException e) {
           mgr.rollback();
         }
-        assertNotNull(cust.get(custId0));
-        assertNotNull(cust.get(custId1));
-        assertNotNull(cust.get(custId2));
-        assertNotNull(cust.get(custId3));
-        assertNotNull(cust.get(custId4));
+        assertThat(cust.get(custId0)).isNotNull();
+        assertThat(cust.get(custId1)).isNotNull();
+        assertThat(cust.get(custId2)).isNotNull();
+        assertThat(cust.get(custId3)).isNotNull();
+        assertThat(cust.get(custId4)).isNotNull();
         return mgr.getTransactionId();
       }
     });
@@ -1305,8 +1302,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.begin();
         cust.removeAll(Arrays.asList(custId0, custId4));
         mgr.commit();
-        assertNull(cust.get(custId0));
-        assertNull(cust.get(custId4));
+        assertThat(cust.get(custId0)).isNull();
+        assertThat(cust.get(custId4)).isNull();
         return mgr.getTransactionId();
       }
     });
@@ -1315,8 +1312,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         PartitionedRegion cust = (PartitionedRegion) getCache().getRegion(CUSTOMER);
-        assertNull(cust.get(custId0));
-        assertNull(cust.get(custId4));
+        assertThat(cust.get(custId0)).isNull();
+        assertThat(cust.get(custId4)).isNull();
         return null;
       }
     };
@@ -1343,13 +1340,13 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.begin();
         Customer customer = new Customer("customer1", "address1");
         Customer fakeCust = new Customer("foo", "bar");
-        assertFalse(cust.replace(custId, fakeCust, updatedCust));
-        assertTrue(cust.replace(custId, customer, updatedCust));
-        assertFalse(ref.replace(custId, fakeCust, updatedCust));
-        assertTrue(ref.replace(custId, customer, updatedCust));
+        assertThat(cust.replace(custId, fakeCust, updatedCust)).isFalse();
+        assertThat(cust.replace(custId, customer, updatedCust)).isTrue();
+        assertThat(ref.replace(custId, fakeCust, updatedCust)).isFalse();
+        assertThat(ref.replace(custId, customer, updatedCust)).isTrue();
         TXStateProxy tx = mgr.pauseTransaction();
-        assertEquals(cust.get(custId), customer);
-        assertEquals(ref.get(custId), customer);
+        assertThat(cust.get(custId)).isEqualTo(customer);
+        assertThat(ref.get(custId)).isEqualTo(customer);
         mgr.unpauseTransaction(tx);
         return mgr.suspend();
       }
@@ -1358,18 +1355,18 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertTrue(mgr.isHostedTxInProgress(txId));
+        assertThat(mgr.isHostedTxInProgress(txId)).isTrue();
         TXStateProxy tx = mgr.getHostedTXState(txId);
-        assertEquals(2, tx.getRegions().size());// 2 buckets for the two puts we
+        assertThat(2).isEqualTo(tx.getRegions().size());// 2 buckets for the two puts we
         // did in the accessor one dist. region, and one more bucket if Cust1 and Cust10 resolve to
         // different buckets
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertNotNull(es.getValue(key, r, false));
-            assertTrue("key:" + key + " r:" + r.getFullPath(), es.isDirty());
+            assertThat(es.getValue(key, r, false)).isNotNull();
+            assertThat(es.isDirty()).as("key:" + key + " r:" + r.getFullPath()).isTrue();
           }
         }
         return null;
@@ -1383,20 +1380,20 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.commit();
         Region<CustId, Customer> cust = getCache().getRegion(CUSTOMER);
         Region<CustId, Customer> rr = getCache().getRegion(D_REFERENCE);
-        assertEquals(updatedCust, cust.get(custId));
-        assertEquals(updatedCust, rr.get(custId));
+        assertThat(updatedCust).isEqualTo(cust.get(custId));
+        assertThat(updatedCust).isEqualTo(rr.get(custId));
         // check conflict
         mgr.begin();
         CustId conflictCust = new CustId(2);
         Customer customer = new Customer("customer2", "address2");
         getCache().getLogger().fine("SWAP:removeConflict");
-        assertTrue(cust.replace(conflictCust, customer, new Customer("conflict", "conflict")));
+        assertThat(cust.replace(conflictCust, customer, new Customer("conflict", "conflict"))).isTrue();
         TXStateProxy tx = mgr.pauseTransaction();
         cust.put(conflictCust, new Customer("foo", "bar"));
         mgr.unpauseTransaction(tx);
         try {
           mgr.commit();
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (CommitConflictException ignored) {
         }
         return null;
@@ -1541,11 +1538,11 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         @Override
         public Object call() {
           Region cust = getCache().getRegion(CUSTOMER);
-          assertFalse(((TestCacheWriter) cust.getAttributes().getCacheWriter()).wasFired);
+          assertThat(((TestCacheWriter) cust.getAttributes().getCacheWriter()).wasFired).isFalse();
           Region order = getCache().getRegion(ORDER);
-          assertFalse(((TestCacheWriter) order.getAttributes().getCacheWriter()).wasFired);
+          assertThat(((TestCacheWriter) order.getAttributes().getCacheWriter()).wasFired).isFalse();
           Region ref = getCache().getRegion(D_REFERENCE);
-          assertFalse(((TestCacheWriter) ref.getAttributes().getCacheWriter()).wasFired);
+          assertThat(((TestCacheWriter) ref.getAttributes().getCacheWriter()).wasFired).isFalse();
           return null;
         }
       });
@@ -1555,11 +1552,11 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         @Override
         public Object call() {
           Region cust = getCache().getRegion(CUSTOMER);
-          assertTrue(((TestCacheWriter) cust.getAttributes().getCacheWriter()).wasFired);
+          assertThat(((TestCacheWriter) cust.getAttributes().getCacheWriter()).wasFired).isTrue();
           Region order = getCache().getRegion(ORDER);
-          assertTrue(((TestCacheWriter) order.getAttributes().getCacheWriter()).wasFired);
+          assertThat(((TestCacheWriter) order.getAttributes().getCacheWriter()).wasFired).isTrue();
           Region ref = getCache().getRegion(D_REFERENCE);
-          assertTrue(((TestCacheWriter) ref.getAttributes().getCacheWriter()).wasFired);
+          assertThat(((TestCacheWriter) ref.getAttributes().getCacheWriter()).wasFired).isTrue();
           return null;
         }
       });
@@ -1579,7 +1576,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TestTxListener l = (TestTxListener) getCache().getTxManager().getListener();
-        assertTrue(l.isListenerInvoked());
+        assertThat(l.isListenerInvoked()).isTrue();
         return null;
       }
     });
@@ -1645,7 +1642,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     protected void verifyOrigin(EntryEvent event) {
       try {
-        assertEquals(!isAccessor, event.isOriginRemote());
+        assertThat(!isAccessor).isEqualTo(event.isOriginRemote());
       } catch (Exception e) {
         ex = e;
       }
@@ -1656,8 +1653,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       OrderId knownOrderId = new OrderId(2, knownCustId);
       if (event.getKey().equals(knownOrderId)) {
         try {
-          assertTrue(event.getOperation().isPutAll());
-          assertNotNull(event.getTransactionId());
+          assertThat(event.getOperation().isPutAll()).isTrue();
+          assertThat(event.getTransactionId()).isNotNull();
         } catch (Exception e) {
           ex = e;
         }
@@ -1775,7 +1772,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     private void verifyOrigin(CacheEvent event) {
       try {
-        assertTrue(event.isOriginRemote()); // change to !isAccessor after fixing #41498
+        assertThat(event.isOriginRemote()).isTrue(); // change to !isAccessor after fixing #41498
       } catch (Exception e) {
         ex = e;
       }
@@ -1790,8 +1787,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       OrderId knownOrderId = new OrderId(2, knownCustId);
       if (event.getKey().equals(knownOrderId)) {
         try {
-          assertTrue(event.getOperation().isPutAll());
-          assertNotNull(event.getTransactionId());
+          assertThat(event.getOperation().isPutAll()).isTrue();
+          assertThat(event.getTransactionId()).isNotNull();
         } catch (Exception e) {
           ex = e;
         }
@@ -1877,9 +1874,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         r.put(new CustId(8), new Customer("name8", "address8"));
         try {
           getCache().getTxManager().commit();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (Exception e) {
-          assertEquals("AssertionError", e.getCause().getMessage());
+          assertThat("AssertionError").isEqualTo(e.getCause().getMessage());
         }
         return null;
       }
@@ -1911,8 +1908,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Region custRegion = getCache().getRegion(CUSTOMER);
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.begin();
-        assertEquals(5, custRegion.size());
-        assertNotNull(mgr.getTXState());
+        assertThat(5).isEqualTo(custRegion.size());
+        assertThat(mgr.getTXState()).isNotNull();
         return mgr.suspend();
       }
     });
@@ -1938,21 +1935,21 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           throw new IllegalStateException("expected non-negative key");
         }
         mgr.resume(txId);
-        assertNotNull(mgr.getTXState());
+        assertThat(mgr.getTXState()).isNotNull();
         CustId custId = new CustId(remoteKey);
         OrderId orderId = new OrderId(remoteKey, custId);
         custRegion.put(custId, new Customer("customer" + remoteKey, "address" + remoteKey));
         getCache().getLogger()
             .info("Putting " + custId + ", keyInfo:" + custPR.getKeyInfo(new CustId(remoteKey)));
         orderRegion.put(orderId, new Order("order" + remoteKey));
-        assertEquals(6, custRegion.size());
+        assertThat(6).isEqualTo(custRegion.size());
         mgr.suspend();
         return null;
       }
     });
     final Integer txOnDatastore1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertEquals(1, txOnDatastore1 + txOnDatastore2);
+    assertThat(1).isEqualTo(txOnDatastore1 + txOnDatastore2);
 
     taskVM.invoke(new SerializableCallable<Object>() {
       @Override
@@ -1969,8 +1966,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     final Integer txOnDatastore1_1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2_2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertEquals(0, txOnDatastore1_1.intValue());
-    assertEquals(0, txOnDatastore2_2.intValue());
+    assertThat(0).isEqualTo(txOnDatastore1_1.intValue());
+    assertThat(0).isEqualTo(txOnDatastore2_2.intValue());
   }
 
   @Test
@@ -2049,13 +2046,13 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         switch (iteratorType) {
           case KEYS:
             originalSet = getCustIdSet(5);
-            assertTrue(originalSet.containsAll(custRegion.keySet()));
-            assertEquals(5, custRegion.keySet().size());
+            assertThat(originalSet.containsAll(custRegion.keySet())).isTrue();
+            assertThat(5).isEqualTo(custRegion.keySet().size());
             break;
           case VALUES:
             originalSet = getCustomerSet(5);
-            assertTrue(originalSet.containsAll(custRegion.values()));
-            assertEquals(5, custRegion.values().size());
+            assertThat(originalSet.containsAll(custRegion.values())).isTrue();
+            assertThat(5).isEqualTo(custRegion.values().size());
             break;
           case ENTRIES:
             Set<CustId> originalKeySet = getCustIdSet(5);
@@ -2067,15 +2064,15 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
             }
             for (final Object o : entrySet) {
               entry = (Entry) o;
-              assertTrue(originalKeySet.contains(entry.getKey()));
-              assertTrue(originalValueSet.contains(entry.getValue()));
+              assertThat(originalKeySet.contains(entry.getKey())).isTrue();
+              assertThat(originalValueSet.contains(entry.getValue())).isTrue();
             }
-            assertEquals(5, custRegion.entrySet().size());
+            assertThat(5).isEqualTo(custRegion.entrySet().size());
             break;
           default:
             throw new IllegalArgumentException();
         }
-        assertNotNull(mgr.getTXState());
+        assertThat(mgr.getTXState()).isNotNull();
         return mgr.suspend();
       }
     });
@@ -2090,7 +2087,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.resume(txId);
-        assertNotNull(mgr.getTXState());
+        assertThat(mgr.getTXState()).isNotNull();
         int expectedSetSize = 0;
         switch (op) {
           case PUT:
@@ -2113,12 +2110,12 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
         switch (iteratorType) {
           case KEYS:
-            assertTrue(getCustIdSet(expectedSetSize).containsAll(custRegion.keySet()));
-            assertEquals(expectedSetSize, custRegion.keySet().size());
+            assertThat(getCustIdSet(expectedSetSize).containsAll(custRegion.keySet())).isTrue();
+            assertThat(expectedSetSize).isEqualTo(custRegion.keySet().size());
             break;
           case VALUES:
-            assertTrue(getCustomerSet(expectedSetSize).containsAll(custRegion.values()));
-            assertEquals(expectedSetSize, custRegion.values().size());
+            assertThat(getCustomerSet(expectedSetSize).containsAll(custRegion.values())).isTrue();
+            assertThat(expectedSetSize).isEqualTo(custRegion.values().size());
             break;
           case ENTRIES:
             Set originalKeySet = getCustIdSet(expectedSetSize);
@@ -2130,10 +2127,10 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
             }
             for (final Object o : entrySet) {
               entry = (Entry) o;
-              assertTrue(originalKeySet.contains(entry.getKey()));
-              assertTrue(originalValueSet.contains(entry.getValue()));
+              assertThat(originalKeySet.contains(entry.getKey())).isTrue();
+              assertThat(originalValueSet.contains(entry.getValue())).isTrue();
             }
-            assertEquals(expectedSetSize, custRegion.entrySet().size());
+            assertThat(expectedSetSize).isEqualTo(custRegion.entrySet().size());
             break;
           default:
             throw new IllegalArgumentException();
@@ -2144,7 +2141,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     });
     final Integer txOnDatastore1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertEquals(1, txOnDatastore1 + txOnDatastore2);
+    assertThat(1).isEqualTo(txOnDatastore1 + txOnDatastore2);
 
     accessor.invoke(new SerializableCallable<Object>() {
       @Override
@@ -2157,7 +2154,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     });
     final Integer txOnDatastore1_1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2_2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertEquals(0, txOnDatastore1_1 + txOnDatastore2_2);
+    assertThat(0).isEqualTo(txOnDatastore1_1 + txOnDatastore2_2);
 
     datastore1.invoke(new SerializableCallable<Object>() {
       CustId custId;
@@ -2176,13 +2173,13 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         switch (iteratorType) {
           case KEYS:
             expectedSet = getExpectedCustIdSet();
-            assertEquals(expectedSet, custRegion.keySet());
-            assertEquals(expectedSetSize, custRegion.keySet().size());
+            assertThat(expectedSet).isEqualTo(custRegion.keySet());
+            assertThat(expectedSetSize).isEqualTo(custRegion.keySet().size());
             break;
           case VALUES:
             expectedSet = getExpectedCustomerSet();
-            assertEquals(expectedSet, custRegion.values());
-            assertEquals(expectedSetSize, custRegion.values().size());
+            assertThat(expectedSet).isEqualTo(custRegion.values());
+            assertThat(expectedSetSize).isEqualTo(custRegion.values().size());
             break;
           case ENTRIES:
             Set originalKeySet = getExpectedCustIdSet();
@@ -2194,10 +2191,10 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
             }
             for (final Object o : entrySet) {
               entry = (Entry) o;
-              assertTrue(originalKeySet.contains(entry.getKey()));
-              assertTrue(originalValueSet.contains(entry.getValue()));
+              assertThat(originalKeySet.contains(entry.getKey())).isTrue();
+              assertThat(originalValueSet.contains(entry.getValue())).isTrue();
             }
-            assertEquals(expectedSetSize, custRegion.entrySet().size());
+            assertThat(expectedSetSize).isEqualTo(custRegion.entrySet().size());
             break;
           default:
             throw new IllegalArgumentException();
@@ -2299,25 +2296,25 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertEquals(5, i);
-        assertEquals(getCustIdSet(5), set);
-        assertEquals(5, rr.keySet().size());
+        assertThat(5).isEqualTo(i);
+        assertThat(getCustIdSet(5)).isEqualTo(set);
+        assertThat(5).isEqualTo(rr.keySet().size());
         rr.put(custId, customer);
         set = rr.keySet();
-        assertEquals(getCustIdSet(6), set);
+        assertThat(getCustIdSet(6)).isEqualTo(set);
         it = set.iterator();
         i = 0;
         while (it.hasNext()) {
           i++;
           it.next();
         }
-        assertEquals(6, i);
-        assertEquals(6, rr.keySet().size());
-        assertNotNull(rr.get(custId));
+        assertThat(6).isEqualTo(i);
+        assertThat(6).isEqualTo(rr.keySet().size());
+        assertThat(rr.get(custId)).isNotNull();
         TXStateProxy tx = mgr.pauseTransaction();
-        assertEquals(getCustIdSet(5), rr.keySet());
-        assertEquals(5, rr.keySet().size());
-        assertNull(rr.get(custId));
+        assertThat(getCustIdSet(5)).isEqualTo(rr.keySet());
+        assertThat(5).isEqualTo(rr.keySet().size());
+        assertThat(rr.get(custId)).isNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
         return null;
@@ -2350,25 +2347,25 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertEquals(5, i);
-        assertEquals(getCustomerSet(5), set);
-        assertEquals(5, rr.values().size());
+        assertThat(5).isEqualTo(i);
+        assertThat(getCustomerSet(5)).isEqualTo(set);
+        assertThat(5).isEqualTo(rr.values().size());
         rr.put(custId, customer);
         set = (Set) rr.values();
-        assertEquals(getCustomerSet(6), set);
+        assertThat(getCustomerSet(6)).isEqualTo(set);
         it = set.iterator();
         i = 0;
         while (it.hasNext()) {
           i++;
           it.next();
         }
-        assertEquals(6, i);
-        assertEquals(6, rr.values().size());
-        assertNotNull(rr.get(custId));
+        assertThat(6).isEqualTo(i);
+        assertThat(6).isEqualTo(rr.values().size());
+        assertThat(rr.get(custId)).isNotNull();
         TXStateProxy tx = mgr.pauseTransaction();
-        assertEquals(getCustomerSet(5), rr.values());
-        assertEquals(5, rr.values().size());
-        assertNull(rr.get(custId));
+        assertThat(getCustomerSet(5)).isEqualTo(rr.values());
+        assertThat(5).isEqualTo(rr.values().size());
+        assertThat(rr.get(custId)).isNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
         return null;
@@ -2401,25 +2398,25 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           i++;
           it.next();
         }
-        assertEquals(5, i);
-        // assertTrue(getCustIdSet(5).equals(set));
-        assertEquals(5, rr.entrySet().size());
+        assertThat(5).isEqualTo(i);
+        // assertThat(getCustIdSet(5).equals(set)).isTrue();
+        assertThat(5).isEqualTo(rr.entrySet().size());
         rr.put(custId, customer);
         set = rr.entrySet();
-        // assertTrue(getCustIdSet(6).equals(set));
+        // assertThat(getCustIdSet(6).equals(set)).isTrue();
         it = set.iterator();
         i = 0;
         while (it.hasNext()) {
           i++;
           it.next();
         }
-        assertEquals(6, i);
-        assertEquals(6, rr.entrySet().size());
-        assertNotNull(rr.get(custId));
+        assertThat(6).isEqualTo(i);
+        assertThat(6).isEqualTo(rr.entrySet().size());
+        assertThat(rr.get(custId)).isNotNull();
         TXStateProxy tx = mgr.pauseTransaction();
         // assertIndexDetailsEquals(getCustIdSet(5), rr.entrySet());
-        assertEquals(5, rr.entrySet().size());
-        assertNull(rr.get(custId));
+        assertThat(5).isEqualTo(rr.entrySet().size());
+        assertThat(rr.get(custId)).isNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
         return null;
@@ -2447,37 +2444,37 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         // now we allow for using non-TX iterators in TX context
         try {
           keySet.size();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           entrySet.size();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           valueSet.size();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           keySet.iterator();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           entrySet.iterator();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           valueSet.iterator();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
@@ -2490,37 +2487,37 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         // don't allow for TX iterator after TX has committed
         try {
           keySet.size();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           entrySet.size();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           valueSet.size();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           keySet.iterator();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           entrySet.iterator();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
         try {
           valueSet.iterator();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (IllegalStateException expected) {
           // ignore
         }
@@ -2619,12 +2616,12 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
               FunctionService.onMembers().execute(TXFunction.id).getResult();
               break;
           }
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (TransactionException ignored) {
         }
         try {
           InternalFunctionService.onRegions(regions).execute(TXFunction.id).getResult();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (TransactionException ignored) {
         }
         Set filter = new HashSet();
@@ -2642,7 +2639,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         }
         TXStateProxy tx = mgr.pauseTransaction();
         GemFireCacheImpl.getInstance().getLogger().warning("TX SUSPENDO:" + tx);
-        assertNull(custRegion.get(expectedCustId));
+        assertThat(custRegion.get(expectedCustId)).isNull();
         mgr.unpauseTransaction(tx);
         return mgr.suspend();
       }
@@ -2650,7 +2647,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     final Integer txOnDatastore1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertEquals(1, txOnDatastore1 + txOnDatastore2);
+    assertThat(1).isEqualTo(txOnDatastore1 + txOnDatastore2);
 
     accessor.invoke(new SerializableCallable<Object>() {
       @Override
@@ -2666,7 +2663,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
-        assertEquals(expectedCustomer, custRegion.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(custRegion.get(expectedCustId));
         return null;
       }
     });
@@ -2717,7 +2714,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public void execute(FunctionContext context) {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertNotNull(mgr.getTXState());
+        assertThat(mgr.getTXState()).isNotNull();
         try {
           mgr.commit();
           fail("expected exceptio not thrown");
@@ -2742,7 +2739,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         } else {
           r = getCache().getRegion(CUSTOMER);
         }
-        assertNotNull(getCache().getTxManager().getTXState());
+        assertThat(getCache().getTxManager().getTXState()).isNotNull();
         PartitionedRegion pr = (PartitionedRegion) getCache().getRegion(CUSTOMER);
         Set filter = new HashSet();
         filter.add(expectedCustId);
@@ -2750,7 +2747,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         r.put(expectedCustId, expectedCustomer);
         FunctionService.onRegion(pr).withFilter(filter).execute(new NestedTxFunction2())
             .getResult();
-        assertNotNull(getCache().getTxManager().getTXState());
+        assertThat(getCache().getTxManager().getTXState()).isNotNull();
         context.getResultSender().lastResult(Boolean.TRUE);
       }
 
@@ -2774,9 +2771,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Set filter = new HashSet();
         filter.add(expectedCustId);
         FunctionService.onRegion(pr).withFilter(filter).execute(new NestedTxFunction()).getResult();
-        assertNotNull(getCache().getTxManager().getTXState());
+        assertThat(getCache().getTxManager().getTXState()).isNotNull();
         mgr.commit();
-        assertEquals(expectedCustomer, pr.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(pr.get(expectedCustId));
         return null;
       }
     });
@@ -2838,15 +2835,15 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTXMgr();
         mgr.begin();
         FunctionService.onRegion(custRegion).execute(TXFunction.id).getResult();
-        assertNotNull(mgr.getTXState());
+        assertThat(mgr.getTXState()).isNotNull();
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNull(mgr.getTXState());
+        assertThat(mgr.getTXState()).isNull();
         getCache().getLogger().fine("SWAP:callingget");
-        assertNull("expected null but was:" + custRegion.get(expectedCustId),
-            custRegion.get(expectedCustId));
+        assertThat(custRegion.get(expectedCustId))
+            .as("expected null but was:" + custRegion.get(expectedCustId)).isNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
-        assertEquals(expectedCustomer, custRegion.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(custRegion.get(expectedCustId));
         return null;
       }
     });
@@ -2865,16 +2862,16 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
           @Override
           public void execute(FunctionContext context) {
-            assertNotNull(getCache().getTxManager().getTXState());
+            assertThat(getCache().getTxManager().getTXState()).isNotNull();
             custRegion.destroy(expectedCustId);
             context.getResultSender().lastResult(Boolean.TRUE);
           }
         }).getResult();
         TXStateProxy tx = mgr.pauseTransaction();
-        assertEquals(custRegion.get(expectedCustId), expectedCustomer);
+        assertThat(custRegion.get(expectedCustId)).isEqualTo(expectedCustomer);
         mgr.unpauseTransaction(tx);
         mgr.commit();
-        assertNull(custRegion.get(expectedCustId));
+        assertThat(custRegion.get(expectedCustId)).isNull();
         return null;
       }
     });
@@ -2908,15 +2905,15 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         mgr.begin();
         try {
           FunctionService.onRegion(custRegion).execute(TXFunction.id).getResult();
-          fail("Expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (TransactionException ignored) {
         }
         Set filter = new HashSet();
         filter.add(expectedCustId);
         FunctionService.onRegion(custRegion).withFilter(filter).execute(TXFunction.id).getResult();
-        assertEquals(expectedCustomer, custRegion.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(custRegion.get(expectedCustId));
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNull(custRegion.get(expectedCustId));
+        assertThat(custRegion.get(expectedCustId)).isNull();
         mgr.unpauseTransaction(tx);
         return mgr.suspend();
       }
@@ -2924,7 +2921,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     final Integer txOnDatastore1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertEquals(1, txOnDatastore1 + txOnDatastore2);
+    assertThat(1).isEqualTo(txOnDatastore1 + txOnDatastore2);
 
     accessor.invoke(new SerializableCallable<Object>() {
       @Override
@@ -2933,7 +2930,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         CacheTransactionManager mgr = getCache().getTXMgr();
         mgr.resume(txId);
         mgr.commit();
-        assertEquals(expectedCustomer, custRegion.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(custRegion.get(expectedCustId));
         custRegion.destroy(expectedCustId);
         return null;
       }
@@ -2966,20 +2963,20 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         members.add(ds2);
         try {
           FunctionService.onMembers(members).execute(TXFunction.id).getResult();
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (TransactionException ignored) {
         }
         FunctionService.onMember(owner).execute(TXFunction.id).getResult();
-        assertEquals(expectedCustomer, pr.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(pr.get(expectedCustId));
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNull(pr.get(expectedCustId));
+        assertThat(pr.get(expectedCustId)).isNull();
         mgr.unpauseTransaction(tx);
         return mgr.suspend();
       }
     });
     final Integer txOnDatastore1_1 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
     final Integer txOnDatastore2_1 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-    assertEquals(1, txOnDatastore1_1 + txOnDatastore2_1);
+    assertThat(1).isEqualTo(txOnDatastore1_1 + txOnDatastore2_1);
 
     accessor.invoke(new SerializableCallable<Object>() {
       @Override
@@ -2988,7 +2985,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         CacheTransactionManager mgr = getCache().getTXMgr();
         mgr.resume(txId2);
         mgr.commit();
-        assertEquals(expectedCustomer, custRegion.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(custRegion.get(expectedCustId));
         custRegion.destroy(expectedCustId);
         return null;
       }
@@ -3014,9 +3011,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Set filter = new HashSet();
         filter.add(keyOnDs);
         FunctionService.onRegion(pr).withFilter(filter).execute(TXFunction.id).getResult();
-        assertEquals(expectedCustomer, pr.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(pr.get(expectedCustId));
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNull(pr.get(expectedCustId));
+        assertThat(pr.get(expectedCustId)).isNull();
         mgr.unpauseTransaction(tx);
         return mgr.suspend();
       }
@@ -3027,7 +3024,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
       final Integer txOnDatastore1_2 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
       final Integer txOnDatastore2_2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-      assertEquals(0, txOnDatastore1_2 + txOnDatastore2_2);// ds1 has a local transaction, not
+      assertThat(0).isEqualTo(txOnDatastore1_2 + txOnDatastore2_2);// ds1 has a local transaction, not
       // remote
       CloseFnOnDsTx closeFnOnDsTx = new CloseFnOnDsTx(dsTxId);
       datastore1.invoke(closeFnOnDsTx);
@@ -3036,7 +3033,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
       final Integer txOnDatastore1_2 = (Integer) datastore1.invoke(getNumberOfTXInProgress);
       final Integer txOnDatastore2_2 = (Integer) datastore2.invoke(getNumberOfTXInProgress);
-      assertEquals(0, txOnDatastore1_2 + txOnDatastore2_2);// ds1 has a local transaction, not
+      assertThat(0).isEqualTo(txOnDatastore1_2 + txOnDatastore2_2);// ds1 has a local transaction, not
       // remote
       CloseFnOnDsTx closeFnOnDsTx = new CloseFnOnDsTx(dsTxId);
       datastore2.invoke(closeFnOnDsTx);
@@ -3056,12 +3053,12 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         filter.add(keyOnDs2);
         try {
           FunctionService.onRegion(pr).withFilter(filter).execute(TXFunction.id).getResult();
-          fail("expected Exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (TransactionDataRebalancedException ignored) {
         }
         try {
           FunctionService.onMember(ds2).execute(TXFunction.id).getResult();
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (TransactionDataNotColocatedException ignored) {
         }
         mgr.commit();
@@ -3084,7 +3081,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       CacheTransactionManager mgr = getCache().getTXMgr();
       mgr.resume(txId);
       mgr.commit();
-      assertEquals(expectedCustomer, custRegion.get(expectedCustId));
+      assertThat(expectedCustomer).isEqualTo(custRegion.get(expectedCustId));
       custRegion.destroy(expectedCustId);
       return null;
     }
@@ -3155,11 +3152,11 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Region<CustId, Customer> custRegion = getCache().getRegion(CUSTOMER);
         Context ctx = getCache().getJNDIContext();
         UserTransaction tx = (UserTransaction) ctx.lookup("java:/UserTransaction");
-        assertEquals(Status.STATUS_NO_TRANSACTION, tx.getStatus());
+        assertThat(Status.STATUS_NO_TRANSACTION).isEqualTo(tx.getStatus());
         tx.begin();
-        assertEquals(Status.STATUS_ACTIVE, tx.getStatus());
+        assertThat(Status.STATUS_ACTIVE).isEqualTo(tx.getStatus());
         custRegion.put(expectedCustId, expectedCustomer);
-        assertEquals(expectedCustomer, custRegion.get(expectedCustId));
+        assertThat(expectedCustomer).isEqualTo(custRegion.get(expectedCustId));
         return null;
       }
     });
@@ -3167,7 +3164,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region custRegion = getCache().getRegion(CUSTOMER);
-        assertNull(custRegion.get(expectedCustId));
+        assertThat(custRegion.get(expectedCustId)).isNull();
         return null;
       }
     });
@@ -3179,10 +3176,10 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         UserTransaction tx = (UserTransaction) ctx.lookup("java:/UserTransaction");
         if (isCommit) {
           tx.commit();
-          assertEquals(expectedCustomer, custRegion.get(expectedCustId));
+          assertThat(expectedCustomer).isEqualTo(custRegion.get(expectedCustId));
         } else {
           tx.rollback();
-          assertNull(custRegion.get(expectedCustId));
+          assertThat(custRegion.get(expectedCustId)).isNull();
         }
         return null;
       }
@@ -3191,7 +3188,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TestTxListener l = (TestTxListener) getCache().getTXMgr().getListener();
-        assertTrue(l.isListenerInvoked());
+        assertThat(l.isListenerInvoked()).isTrue();
         return null;
       }
     });
@@ -3255,7 +3252,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.resume(putTxId);
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNotNull(tx);
+        assertThat(tx).isNotNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
         return null;
@@ -3270,7 +3267,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.resume(destroyTxId);
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNotNull(tx);
+        assertThat(tx).isNotNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
         return null;
@@ -3285,7 +3282,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.resume(putTxId2);
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNotNull(tx);
+        assertThat(tx).isNotNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
         return null;
@@ -3298,9 +3295,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       public Object call() {
         Region refRegion = getCache().getRegion(D_REFERENCE);
         OriginRemoteRRWriter w = (OriginRemoteRRWriter) refRegion.getAttributes().getCacheWriter();
-        assertEquals(1, w.fireC);
-        assertEquals(1, w.fireD);
-        assertEquals(1, w.fireU);
+        assertThat(1).isEqualTo(w.fireC);
+        assertThat(1).isEqualTo(w.fireD);
+        assertThat(1).isEqualTo(w.fireU);
         return null;
       }
     });
@@ -3332,7 +3329,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.resume(txId);
         TXStateProxy tx = mgr.pauseTransaction();
-        assertNotNull(tx);
+        assertThat(tx).isNotNull();
         mgr.unpauseTransaction(tx);
         mgr.commit();
         return null;
@@ -3344,7 +3341,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region refRegion = getCache().getRegion(D_REFERENCE);
-        assertEquals("dawg", refRegion.get("sup"));
+        assertThat("dawg").isEqualTo(refRegion.get("sup"));
         return null;
       }
     });
@@ -3378,9 +3375,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         TXManagerImpl mgr = getCache().getTxManager();
-        assertEquals(1, mgr.hostedTransactionsInProgressForTest());
+        assertThat(1).isEqualTo(mgr.hostedTransactionsInProgressForTest());
         mgr.memberDeparted(getCache().getDistributionManager(), member, true);
-        assertEquals(0, mgr.hostedTransactionsInProgressForTest());
+        assertThat(0).isEqualTo(mgr.hostedTransactionsInProgressForTest());
         return null;
       }
     });
@@ -3432,7 +3429,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
             default:
               break;
           }
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (TransactionDataNotColocatedException ignored) {
         }
         cache.getCacheTransactionManager().rollback();
@@ -3498,7 +3495,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           custRegion.removeAll(custMap.keySet());
         }
         getCache().getCacheTransactionManager().rollback();
-        assertEquals(regionSize, custRegion.size());
+        assertThat(regionSize).isEqualTo(custRegion.size());
         // now commit
         getCache().getCacheTransactionManager().begin();
         if (op.equals(OP.PUTALL)) {
@@ -3507,7 +3504,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           custRegion.removeAll(custMap.keySet());
         }
         getCache().getCacheTransactionManager().commit();
-        assertEquals(getExpectedSize(custMap, regionSize), custRegion.size());
+        assertThat(getExpectedSize(custMap, regionSize)).isEqualTo(custRegion.size());
 
         // bulk op on other member
         custMap.clear();
@@ -3527,7 +3524,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           custRegion.removeAll(custMap.keySet());
         }
         getCache().getCacheTransactionManager().rollback();
-        assertEquals(regionSize, custRegion.size());
+        assertThat(regionSize).isEqualTo(custRegion.size());
         // now commit
         getCache().getCacheTransactionManager().begin();
         if (op.equals(OP.PUTALL)) {
@@ -3536,7 +3533,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           custRegion.removeAll(custMap.keySet());
         }
         getCache().getCacheTransactionManager().commit();
-        assertEquals(getExpectedSize(custMap, regionSize), custRegion.size());
+        assertThat(getExpectedSize(custMap, regionSize)).isEqualTo(custRegion.size());
         return localBuckets;
       }
 
@@ -3570,7 +3567,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           custRegion.removeAll(custMap.keySet());
         }
         getCache().getCacheTransactionManager().rollback();
-        assertEquals(regionSize, custRegion.size());
+        assertThat(regionSize).isEqualTo(custRegion.size());
         // now commit
         getCache().getCacheTransactionManager().begin();
         if (op.equals(OP.PUTALL)) {
@@ -3579,7 +3576,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
           custRegion.removeAll(custMap.keySet());
         }
         getCache().getCacheTransactionManager().commit();
-        assertEquals(getExpectedSize(custMap, regionSize), custRegion.size());
+        assertThat(getExpectedSize(custMap, regionSize)).isEqualTo(custRegion.size());
         return null;
       }
 
@@ -3895,21 +3892,21 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     public void beforeCreate(EntryEvent event) throws CacheWriterException {
       invoked = true;
       event.getRegion().getCache().getLogger().info("SWAP:writer:" + event);
-      assertTrue(event.isOriginRemote());
+      assertThat(event.isOriginRemote()).isTrue();
     }
 
     @Override
     public void beforeUpdate(EntryEvent event) throws CacheWriterException {
       invoked = true;
       event.getRegion().getCache().getLogger().info("SWAP:writer:" + event);
-      assertTrue(event.isOriginRemote());
+      assertThat(event.isOriginRemote()).isTrue();
     }
 
     @Override
     public void beforeDestroy(EntryEvent event) throws CacheWriterException {
       invoked = true;
       event.getRegion().getCache().getLogger().info("SWAP:writer:" + event);
-      assertTrue(event.isOriginRemote());
+      assertThat(event.isOriginRemote()).isTrue();
     }
   }
 
@@ -4011,10 +4008,10 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         empty.put("eone", "valueOne");
         getCache().getLogger().info("SWAP:callingCommit");
         getCache().getCacheTransactionManager().commit();
-        assertTrue(ref.containsKey("one"));
-        assertEquals("value1", ref.get("one"));
-        assertFalse(empty.containsKey("eone"));
-        assertNull(empty.get("eone"));
+        assertThat(ref.containsKey("one")).isTrue();
+        assertThat("value1").isEqualTo(ref.get("one"));
+        assertThat(empty.containsKey("eone")).isFalse();
+        assertThat(empty.get("eone")).isNull();
         return null;
       }
     });
@@ -4122,7 +4119,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     int totalInvocation = (Integer) datastore1.invoke(getListenerCount)
         + (Integer) datastore2.invoke(getListenerCount);
-    assertEquals(1, totalInvocation);
+    assertThat(1).isEqualTo(totalInvocation);
   }
 
   private class ListenerInvocationCounter extends CacheListenerAdapter {
@@ -4148,7 +4145,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-        assertNull(refRegion.get(custId));
+        assertThat(refRegion.get(custId)).isNull();
         getCache().getCacheTransactionManager().begin();
         refRegion.put(custId, new Customer("name1", "address1"));
         return getCache().getCacheTransactionManager().suspend();
@@ -4158,7 +4155,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region<CustId, Customer> refRegion = getCache().getRegion(D_REFERENCE);
-        assertNull(refRegion.get(custId));
+        assertThat(refRegion.get(custId)).isNull();
         refRegion.put(custId, new Customer("nameNew", "addressNew"));
         return null;
       }
@@ -4182,7 +4179,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
     createRegion(false, 0, null);
     Context ctx = getCache().getJNDIContext();
     UserTransaction tx = (UserTransaction) ctx.lookup("java:/UserTransaction");
-    assertEquals(Status.STATUS_NO_TRANSACTION, tx.getStatus());
+    assertThat(Status.STATUS_NO_TRANSACTION).isEqualTo(tx.getStatus());
     Region pr = getCache().getRegion(CUSTOMER);
     Region rr = getCache().getRegion(D_REFERENCE);
     // test all ops
@@ -4234,7 +4231,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       // Putting a string key causes this, the partition resolver
       // doesn't handle it.
       IgnoredException.addIgnoredException("IllegalStateException");
-      assertEquals(Status.STATUS_ACTIVE, tx.getStatus());
+      assertThat(Status.STATUS_ACTIVE).isEqualTo(tx.getStatus());
       final CountDownLatch latch = new CountDownLatch(1);
       Thread t = new Thread(() -> {
         Context ctx1 = getCache().getJNDIContext();
@@ -4254,7 +4251,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       try {
         pr.put(new CustId(1), new Customer("name11", "address11"));
         tx.commit();
-        fail("expected exception not thrown");
+        fail("expected exception that was not thrown");
       } catch (RollbackException ignored) {
       }
     }
@@ -4315,19 +4312,19 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region rgn = getCache().getRegion(name);
-        assertNull(rgn.get("txkey"));
+        assertThat(rgn.get("txkey")).isNull();
         TXManagerImpl txMgr = getCache().getTxManager();
         TXStateProxy tx = txMgr.getHostedTXState((TXId) txid);
-        assertEquals(1, tx.getRegions().size());
+        assertThat(1).isEqualTo(tx.getRegions().size());
         for (InternalRegion r : tx.getRegions()) {
-          assertTrue(r instanceof DistributedRegion);
+          assertThat(r instanceof DistributedRegion).isTrue();
           TXRegionState rs = tx.readRegion(r);
           for (Object key : rs.getEntryKeys()) {
             TXEntryState es = rs.readEntry(key);
-            assertEquals("txkey", key);
-            assertNotNull(es.getValue(key, r, false));
+            assertThat("txkey").isEqualTo(key);
+            assertThat(es.getValue(key, r, false)).isNotNull();
             if (key.equals("txkey")) {
-              assertTrue(es.isDirty());
+              assertThat(es.isDirty()).isTrue();
             }
           }
         }
@@ -4338,13 +4335,13 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region rgn = getCache().getRegion(name);
-        assertNull(rgn.get("txkey"));
+        assertThat(rgn.get("txkey")).isNull();
         CacheTransactionManager mgr = getCache().getCacheTransactionManager();
         mgr.resume(txid);
         mgr.commit();
         CountingListener cl = (CountingListener) rgn.getAttributes().getCacheListeners()[0];
-        assertEquals(0, cl.count);
-        assertEquals("txvalue", rgn.get("txkey"));
+        assertThat(0).isEqualTo(cl.count);
+        assertThat("txvalue").isEqualTo(rgn.get("txkey"));
         return null;
       }
     });
@@ -4353,7 +4350,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       public Object call() {
         Region rgn = getCache().getRegion(name);
         CountingListener cl = (CountingListener) rgn.getAttributes().getCacheListeners()[0];
-        assertEquals(2, cl.count);
+        assertThat(2).isEqualTo(cl.count);
         return null;
       }
     });
@@ -4421,7 +4418,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         // tx is hosted in vm2 so expiration can happen in vm1.
         GeodeAwaitility.await().untilAsserted(runnable);
         getCache().getCacheTransactionManager().resume(tx);
-        assertTrue(r.containsKey("key"));
+        assertThat(r.containsKey("key")).isTrue();
         getCache().getCacheTransactionManager().commit();
         GeodeAwaitility.await().untilAsserted(runnable);
 
@@ -4460,10 +4457,10 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         r.cache.getLogger().info("SWAP:remoteTag:" + remote);
         try {
           remote = r.fetchRemoteVersionTag("nonExistentKey");
-          fail("expected exception not thrown");
+          fail("expected exception that was not thrown");
         } catch (EntryNotFoundException ignored) {
         }
-        assertEquals(tag, remote);
+        assertThat(tag).isEqualTo(remote);
         return null;
       }
     });
@@ -4501,7 +4498,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         TXManagerImpl mgr = getCache().getTxManager();
         mgr.begin();
         r.put("key", "value");
-        assertTrue(mgr.getTXState().isRealDealLocal());
+        assertThat(mgr.getTXState().isRealDealLocal()).isTrue();
         getCache().getLogger().fine("SWAP:doingPutInNormalRegion");
         n.put("key", "value");
         getCache().getLogger().fine("SWAP:commiting");
@@ -4516,8 +4513,8 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Region n = getCache().getRegion(regionNameNormal);
         VersionTag localTag =
             ((LocalRegion) n).getRegionEntry("key").getVersionStamp().asVersionTag();
-        assertEquals(tag.getEntryVersion(), localTag.getEntryVersion());
-        assertEquals(tag.getRegionVersion(), localTag.getRegionVersion());
+        assertThat(tag.getEntryVersion()).isEqualTo(localTag.getEntryVersion());
+        assertThat(tag.getRegionVersion()).isEqualTo(localTag.getRegionVersion());
         return null;
       }
     });
@@ -4562,7 +4559,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       @Override
       public Object call() {
         Region lr = getCache().getRegion(lrName);
-        assertNull(lr.get("key"));
+        assertThat(lr.get("key")).isNull();
         return null;
       }
     });
@@ -4633,7 +4630,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         for (CacheListener listener : listeners) {
           if (listener instanceof NonInlineListener) {
             NonInlineListener l = (NonInlineListener) listener;
-            assertFalse(l.assertException);
+            assertThat(l.assertException).isFalse();
           }
         }
         return null;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoteTransactionDUnitTest.java
@@ -141,9 +141,9 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
       } catch (CacheClosedException e) {
         return null;
       }
-      // TXManagerImpl mgr = getGemfireCache().getTxManager();
+      // TXManagerImpl mgr = getCache().getTxManager();
       // assertIndexDetailsEquals(0, mgr.hostedTransactionsInProgressForTest());
-      final TXManagerImpl mgr = getGemfireCache().getTxManager();
+      final TXManagerImpl mgr = getCache().getTxManager();
       GeodeAwaitility.await().atMost(Duration.ofMillis(30000)).untilAsserted(
           () -> assertThat(mgr.hostedTransactionsInProgressForTest()).isZero());
       return null;
@@ -1246,14 +1246,10 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
         Customer customer = new Customer("customer1", "address1");
         Customer customer2 = new Customer("customer2", "address2");
         Customer fakeCust = new Customer("foo2", "bar2");
-        try {
-          assertThatThrownBy(() -> cust
-              .removeAll(Arrays.asList(custId0, custId4, custId1, custId2, custId3, custId20)))
-                  .isInstanceOf(TransactionDataNotColocatedException.class);
-        } catch (Throwable e) {
-          mgr.rollback();
-          throw e;
-        }
+        assertThatThrownBy(() -> cust
+            .removeAll(Arrays.asList(custId0, custId4, custId1, custId2, custId3, custId20)))
+                .isInstanceOf(TransactionDataNotColocatedException.class);
+        mgr.rollback();
         assertThat(cust.get(custId0)).isNotNull();
         assertThat(cust.get(custId1)).isNotNull();
         assertThat(cust.get(custId2)).isNotNull();
@@ -3575,7 +3571,7 @@ public class RemoteTransactionDUnitTest extends JUnit4CacheTestCase {
 
     @Override
     public void afterUpdate(EntryEvent event) {
-      assertThat(success).as("Should have only had one update").isTrue();
+      assertThat(success).as("Should have only had one update").isFalse();
       System.out.println("WE WIN!");
       success = true;
     }


### PR DESCRIPTION
Clean up RemoteTransactionDUnitTest for the next time this failure
occurs.

While trying to reproduce the failure described by GEODE-9929 I did some
clean up so I would be able to get more useful information out of the
failures. I cleaned up a lot of warnings, mostly using IntelliJ's tools.

I have determined the test failure to not be a 1.15 release blocker so I
will not be pursuing the issue further, but I hope this cleanup will
help the next person to work on this ticket.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
