### PR TITLE
GEODE-9998: upgrade Jedis client to 4.1.1

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -460,7 +460,7 @@
       <dependency>
         <groupId>redis.clients</groupId>
         <artifactId>jedis</artifactId>
-        <version>3.6.3</version>
+        <version>4.1.1</version>
       </dependency>
       <dependency>
         <groupId>xerces</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -172,7 +172,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.springframework.shell', name: 'spring-shell', version: get('springshell.version'))
         api(group: 'org.testcontainers', name: 'testcontainers', version: '1.15.3')
         api(group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.0')
-        api(group: 'redis.clients', name: 'jedis', version: '3.6.3')
+        api(group: 'redis.clients', name: 'jedis', version: '4.1.1')
         api(group: 'xerces', name: 'xercesImpl', version: '2.12.0')
         api(group: 'xml-apis', name: 'xml-apis', version: '1.4.01')
         api(group: 'org.junit-pioneer', name: 'junit-pioneer', version: '1.5.0')

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -17,8 +17,6 @@ package org.apache.geode.redis.mocks;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.lang.reflect.Field;
-import java.net.Socket;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -26,7 +24,6 @@ import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
-import redis.clients.jedis.Connection;
 import redis.clients.jedis.JedisPubSub;
 
 
@@ -46,7 +43,9 @@ public class MockSubscriber extends JedisPubSub {
       Collections.synchronizedList(new ArrayList<>());
   private CountDownLatch messageReceivedLatch = new CountDownLatch(0);
   private CountDownLatch pMessageReceivedLatch = new CountDownLatch(0);
+/*
   private String localSocketAddress;
+*/
 
   public MockSubscriber() {
     this(new CountDownLatch(1));
@@ -65,20 +64,24 @@ public class MockSubscriber extends JedisPubSub {
     this.pUnsubscriptionLatch = pUnsubscriptionLatch;
   }
 
+/*
   @Override
   public void proceed(final Connection connection, final String... channels) {
     try {
       // Kludge due to socket becoming private in jedis 4.1.1
       // TODO is there a safe public way of getting local socket address
+      // This doesn't work (or no longer works in Jedis 4.1.1), results in null socket
       final Field privateSocketField = Connection.class.getDeclaredField("socket");
       privateSocketField.setAccessible(true);
       final Socket socket = (Socket) privateSocketField.get(connection);
+
       localSocketAddress = socket.getLocalSocketAddress().toString();
     } catch (final NoSuchFieldException | IllegalAccessException ex) {
       throw new RuntimeException("Error in accessing private field 'socket' via reflection", ex);
     }
     super.proceed(connection, channels);
   }
+*/
 
   private void switchThreadName(String suffix) {
     String threadName = Thread.currentThread().getName();
@@ -87,7 +90,7 @@ public class MockSubscriber extends JedisPubSub {
       threadName = threadName.substring(0, suffixIndex);
     }
 
-    threadName += " -- " + suffix + " [" + localSocketAddress + "]";
+    threadName += " -- " + suffix;
     Thread.currentThread().setName(threadName);
   }
 

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -43,9 +43,6 @@ public class MockSubscriber extends JedisPubSub {
       Collections.synchronizedList(new ArrayList<>());
   private CountDownLatch messageReceivedLatch = new CountDownLatch(0);
   private CountDownLatch pMessageReceivedLatch = new CountDownLatch(0);
-  /*
-   * private String localSocketAddress;
-   */
 
   public MockSubscriber() {
     this(new CountDownLatch(1));
@@ -63,25 +60,6 @@ public class MockSubscriber extends JedisPubSub {
     this.unsubscriptionLatch = unsubscriptionLatch;
     this.pUnsubscriptionLatch = pUnsubscriptionLatch;
   }
-
-  /*
-   * @Override
-   * public void proceed(final Connection connection, final String... channels) {
-   * try {
-   * // Kludge due to socket becoming private in jedis 4.1.1
-   * // TODO is there a safe public way of getting local socket address
-   * // This doesn't work (or no longer works in Jedis 4.1.1), results in null socket
-   * final Field privateSocketField = Connection.class.getDeclaredField("socket");
-   * privateSocketField.setAccessible(true);
-   * final Socket socket = (Socket) privateSocketField.get(connection);
-   *
-   * localSocketAddress = socket.getLocalSocketAddress().toString();
-   * } catch (final NoSuchFieldException | IllegalAccessException ex) {
-   * throw new RuntimeException("Error in accessing private field 'socket' via reflection", ex);
-   * }
-   * super.proceed(connection, channels);
-   * }
-   */
 
   private void switchThreadName(String suffix) {
     String threadName = Thread.currentThread().getName();

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -70,7 +70,7 @@ public class MockSubscriber extends JedisPubSub {
       // Kludge due to socket becoming private in jedis 4.1.1
       // TODO find a safe public way of getting local socket address
       // Would client.getHostAndPort().getHost() be sufficient?
-      final Socket socket = (Socket)client.getClass().getField("socket").get(client);
+      final Socket socket = (Socket) client.getClass().getField("socket").get(client);
       localSocketAddress = socket.getLocalSocketAddress().toString();
     } catch (final NoSuchFieldException | IllegalAccessException ex) {
       throw new RuntimeException("Error in accessing private field 'socket' via reflection", ex);

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -43,9 +43,9 @@ public class MockSubscriber extends JedisPubSub {
       Collections.synchronizedList(new ArrayList<>());
   private CountDownLatch messageReceivedLatch = new CountDownLatch(0);
   private CountDownLatch pMessageReceivedLatch = new CountDownLatch(0);
-/*
-  private String localSocketAddress;
-*/
+  /*
+   * private String localSocketAddress;
+   */
 
   public MockSubscriber() {
     this(new CountDownLatch(1));
@@ -64,24 +64,24 @@ public class MockSubscriber extends JedisPubSub {
     this.pUnsubscriptionLatch = pUnsubscriptionLatch;
   }
 
-/*
-  @Override
-  public void proceed(final Connection connection, final String... channels) {
-    try {
-      // Kludge due to socket becoming private in jedis 4.1.1
-      // TODO is there a safe public way of getting local socket address
-      // This doesn't work (or no longer works in Jedis 4.1.1), results in null socket
-      final Field privateSocketField = Connection.class.getDeclaredField("socket");
-      privateSocketField.setAccessible(true);
-      final Socket socket = (Socket) privateSocketField.get(connection);
-
-      localSocketAddress = socket.getLocalSocketAddress().toString();
-    } catch (final NoSuchFieldException | IllegalAccessException ex) {
-      throw new RuntimeException("Error in accessing private field 'socket' via reflection", ex);
-    }
-    super.proceed(connection, channels);
-  }
-*/
+  /*
+   * @Override
+   * public void proceed(final Connection connection, final String... channels) {
+   * try {
+   * // Kludge due to socket becoming private in jedis 4.1.1
+   * // TODO is there a safe public way of getting local socket address
+   * // This doesn't work (or no longer works in Jedis 4.1.1), results in null socket
+   * final Field privateSocketField = Connection.class.getDeclaredField("socket");
+   * privateSocketField.setAccessible(true);
+   * final Socket socket = (Socket) privateSocketField.get(connection);
+   *
+   * localSocketAddress = socket.getLocalSocketAddress().toString();
+   * } catch (final NoSuchFieldException | IllegalAccessException ex) {
+   * throw new RuntimeException("Error in accessing private field 'socket' via reflection", ex);
+   * }
+   * super.proceed(connection, channels);
+   * }
+   */
 
   private void switchThreadName(String suffix) {
     String threadName = Thread.currentThread().getName();

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/mocks/MockSubscriber.java
@@ -69,7 +69,7 @@ public class MockSubscriber extends JedisPubSub {
   public void proceed(final Connection connection, final String... channels) {
     try {
       // Kludge due to socket becoming private in jedis 4.1.1
-      // TODO find a safe public way of getting local socket address
+      // TODO is there a safe public way of getting local socket address
       final Field privateSocketField = Connection.class.getDeclaredField("socket");
       privateSocketField.setAccessible(true);
       final Socket socket = (Socket) privateSocketField.get(connection);

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/UserExpirationDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/UserExpirationDUnitTest.java
@@ -26,7 +26,6 @@ import org.junit.After;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
-import redis.clients.jedis.BinaryJedisCluster;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 
@@ -64,7 +63,7 @@ public class UserExpirationDUnitTest {
     jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, redisPort),
         REDIS_CLIENT_TIMEOUT,
         REDIS_CLIENT_TIMEOUT,
-        BinaryJedisCluster.DEFAULT_MAX_ATTEMPTS,
+        JedisCluster.DEFAULT_MAX_ATTEMPTS,
         USER, USER, "test-client",
         new GenericObjectPoolConfig<>());
   }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameRedirectionsDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameRedirectionsDUnitTest.java
@@ -19,7 +19,6 @@ import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADD
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static redis.clients.jedis.Protocol.Command.CLUSTER;
 
 import java.util.List;
 
@@ -27,8 +26,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Connection;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.JedisClusterCRC16;
@@ -70,10 +69,8 @@ public abstract class AbstractRenameRedirectionsDUnitTest implements RedisIntegr
 
   private String getKeyOnDifferentServerAs(String antiKey, String prefix) {
     ClusterNodes clusterNodes;
-    try (final Connection cxn = jedis.getConnectionFromSlot(0)) {
-      cxn.sendCommand(CLUSTER, Protocol.ClusterKeyword.NODES);
-      final String reply = cxn.getBulkReply();
-      clusterNodes = ClusterNodes.parseClusterNodes(reply);
+    try (final Jedis j = new Jedis(jedis.getConnectionFromSlot(0))) {
+      clusterNodes = ClusterNodes.parseClusterNodes(j.clusterNodes());
     }
     int antiSlot = JedisClusterCRC16.getCRC16(antiKey) % RegionProvider.REDIS_SLOTS;
 

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameRedirectionsDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameRedirectionsDUnitTest.java
@@ -29,7 +29,6 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.JedisClusterCRC16;

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/RenameDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/RenameDUnitTest.java
@@ -89,7 +89,7 @@ public class RenameDUnitTest {
 
     int redisServerPort1 = clusterStartUp.getRedisPort(1);
     jedisCluster =
-        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), REDIS_CLIENT_TIMEOUT);
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), REDIS_CLIENT_TIMEOUT, 20);
   }
 
   @Before

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZAddIncrOptionDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZAddIncrOptionDUnitTest.java
@@ -18,7 +18,7 @@ package org.apache.geode.redis.internal.commands.executor.sortedset;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static redis.clients.jedis.BinaryJedisCluster.DEFAULT_MAX_ATTEMPTS;
+import static redis.clients.jedis.JedisCluster.DEFAULT_MAX_ATTEMPTS;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,7 +33,7 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
 
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.Region;
@@ -156,7 +156,7 @@ public class ZAddIncrOptionDUnitTest {
     long memberSize;
     try {
       memberSize = jedis.zcard(sortedSetKey);
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       if (retries < maxRetries) {
         return false;
       }
@@ -188,7 +188,7 @@ public class ZAddIncrOptionDUnitTest {
     for (int i = 0; i < setSize; i++) {
       try {
         doCrashZAddIncr(i);
-      } catch (JedisClusterMaxAttemptsException ignore) {
+      } catch (JedisClusterOperationException ignore) {
         hitJedisClusterIssue2347.set(true);
       }
     }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemDUnitTest.java
@@ -31,7 +31,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
 
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.Region;
@@ -164,7 +164,7 @@ public class ZRemDUnitTest {
     long removed;
     try {
       removed = jedis.zrem(sortedSetKey, map.keySet().toArray(new String[] {}));
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       if (retries < maxRetries) {
         return false;
       }
@@ -223,7 +223,7 @@ public class ZRemDUnitTest {
         Double score = jedis.zscore(sortedSetKey, member);
         assertThat(score).isNull();
       }
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       return false;
     }
     return true;

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemRangeByLexDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemRangeByLexDUnitTest.java
@@ -34,7 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
 
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.Region;
@@ -225,7 +225,7 @@ public class ZRemRangeByLexDUnitTest {
     long removed;
     try {
       removed = jedis.zremrangeByLex(KEY, "[v", "[w");
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       if (retries < maxRetries) {
         return false;
       }
@@ -269,7 +269,7 @@ public class ZRemRangeByLexDUnitTest {
         Double score = jedis.zscore(KEY, member);
         assertThat(score).isNull();
       }
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       return false;
     }
     return true;

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemRangeByRankDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemRangeByRankDUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.redis.internal.commands.executor.sortedset;
 
+import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_PORT;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
@@ -36,6 +37,7 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.exceptions.JedisClusterOperationException;
 
 import org.apache.geode.cache.Operation;
+import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.PartitionedRegionHelper;
 import org.apache.geode.redis.ConcurrentLoopingThreads;
@@ -64,9 +66,19 @@ public class ZRemRangeByRankDUnitTest {
   public void setup() {
     MemberVM locator = clusterStartUp.startLocatorVM(0);
     int locatorPort = locator.getPort();
-    MemberVM server1 = clusterStartUp.startRedisVM(1, locatorPort);
-    MemberVM server2 = clusterStartUp.startRedisVM(2, locatorPort);
-    MemberVM server3 = clusterStartUp.startRedisVM(3, locatorPort);
+
+    int[] serverPorts = AvailablePortHelper.getRandomAvailableTCPPorts(3);
+
+    MemberVM server1 = clusterStartUp.startRedisVM(1, x -> x
+        .withProperty(GEODE_FOR_REDIS_PORT, Integer.toString(serverPorts[0]))
+        .withConnectionToLocator(locatorPort));
+    MemberVM server2 = clusterStartUp.startRedisVM(2, x -> x
+        .withProperty(GEODE_FOR_REDIS_PORT, Integer.toString(serverPorts[1]))
+        .withConnectionToLocator(locatorPort));
+    MemberVM server3 = clusterStartUp.startRedisVM(3, x -> x
+        .withProperty(GEODE_FOR_REDIS_PORT, Integer.toString(serverPorts[2]))
+        .withConnectionToLocator(locatorPort));
+
     servers = new ArrayList<>();
     servers.add(server1);
     servers.add(server2);

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemRangeByRankDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemRangeByRankDUnitTest.java
@@ -33,7 +33,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
 
 import org.apache.geode.cache.Operation;
 import org.apache.geode.internal.cache.PartitionedRegion;
@@ -162,7 +162,7 @@ public class ZRemRangeByRankDUnitTest {
         Double score = jedis.zscore(KEY, member);
         assertThat(score).isNull();
       }
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       return false;
     }
     return true;
@@ -191,7 +191,7 @@ public class ZRemRangeByRankDUnitTest {
     long removed;
     try {
       removed = jedis.zremrangeByRank(KEY, 0, -1);
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       if (retries < maxRetries) {
         return false;
       }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemRangeByScoreDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZRemRangeByScoreDUnitTest.java
@@ -36,7 +36,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.exceptions.JedisClusterMaxAttemptsException;
+import redis.clients.jedis.exceptions.JedisClusterOperationException;
 
 import org.apache.geode.cache.Operation;
 import org.apache.geode.internal.AvailablePortHelper;
@@ -197,7 +197,7 @@ public class ZRemRangeByScoreDUnitTest {
         Double score = jedis.zscore(KEY, member);
         assertThat(score).isNull();
       }
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       return false;
     }
     return true;
@@ -244,7 +244,7 @@ public class ZRemRangeByScoreDUnitTest {
     long removed;
     try {
       removed = jedis.zremrangeByScore(KEY, "-inf", "+inf");
-    } catch (JedisClusterMaxAttemptsException e) {
+    } catch (JedisClusterOperationException e) {
       if (retries < maxRetries) {
         return false;
       }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
@@ -51,7 +51,6 @@ public class AuthWhileServersRestartDUnitTest {
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
   private static int redisServerPort;
-  private static int locatorPort;
   private static SerializableFunction<ServerStarterRule> operatorForVM3;
   private static final String KEY = "key";
   private static final int SO_TIMEOUT = 10_000;
@@ -60,7 +59,7 @@ public class AuthWhileServersRestartDUnitTest {
   public static void classSetup() {
     MemberVM locator = clusterStartUp.startLocatorVM(0,
         x -> x.withSecurityManager(SimpleSecurityManager.class));
-    locatorPort = locator.getPort();
+    final int locatorPort = locator.getPort();
 
     SerializableFunction<ServerStarterRule> serverOperator = s -> s
         .withCredential("cluster", "cluster")

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
@@ -51,6 +51,7 @@ public class AuthWhileServersRestartDUnitTest {
   public static ExecutorServiceRule executor = new ExecutorServiceRule();
 
   private static int redisServerPort;
+  private static int locatorPort;
   private static SerializableFunction<ServerStarterRule> operatorForVM3;
   private static final String KEY = "key";
   private static final int SO_TIMEOUT = 10_000;
@@ -59,7 +60,7 @@ public class AuthWhileServersRestartDUnitTest {
   public static void classSetup() {
     MemberVM locator = clusterStartUp.startLocatorVM(0,
         x -> x.withSecurityManager(SimpleSecurityManager.class));
-    int locatorPort = locator.getPort();
+    locatorPort = locator.getPort();
 
     SerializableFunction<ServerStarterRule> serverOperator = s -> s
         .withCredential("cluster", "cluster")
@@ -72,7 +73,8 @@ public class AuthWhileServersRestartDUnitTest {
     String finalRedisPort = Integer.toString(server3Port);
 
     operatorForVM3 = serverOperator.compose(o -> o
-        .withProperty(GEODE_FOR_REDIS_PORT, finalRedisPort));
+        .withProperty(GEODE_FOR_REDIS_PORT, finalRedisPort)
+        .withConnectionToLocator(locatorPort));
 
     clusterStartUp.startRedisVM(3, operatorForVM3);
 

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/auth/AuthWhileServersRestartDUnitTest.java
@@ -18,7 +18,7 @@ package org.apache.geode.redis.internal.executor.auth;
 import static org.apache.geode.distributed.ConfigurationProperties.GEODE_FOR_REDIS_PORT;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
-import static redis.clients.jedis.BinaryJedisCluster.DEFAULT_MAX_ATTEMPTS;
+import static redis.clients.jedis.JedisCluster.DEFAULT_MAX_ATTEMPTS;
 
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsKillMultipleServersDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsKillMultipleServersDUnitTest.java
@@ -61,11 +61,6 @@ public class StringsKillMultipleServersDUnitTest {
     // This sequence ensures that servers 1, 2 and 3 are hosting all the buckets and server 4
     // has no buckets.
     cluster.startRedisVM(4, locatorPort);
-
-    cluster.enableDebugLogging(1);
-    cluster.enableDebugLogging(2);
-    cluster.enableDebugLogging(3);
-    cluster.enableDebugLogging(4);
   }
 
   @After

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsKillMultipleServersDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/executor/string/StringsKillMultipleServersDUnitTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.executor.string;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 
 import java.util.Random;
 import java.util.concurrent.Future;
@@ -56,7 +57,7 @@ public class StringsKillMultipleServersDUnitTest {
 
     int redisServerPort1 = cluster.getRedisPort(1);
     jedisCluster =
-        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), 10_000);
+        new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort1), REDIS_CLIENT_TIMEOUT);
 
     // This sequence ensures that servers 1, 2 and 3 are hosting all the buckets and server 4
     // has no buckets.

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/AbstractCommandPipeliningIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/AbstractCommandPipeliningIntegrationTest.java
@@ -91,10 +91,11 @@ public abstract class AbstractCommandPipeliningIntegrationTest implements RedisI
     final int NUMBER_OF_COMMANDS_IN_PIPELINE = 100;
     int numberOfPipeLineRequests = 1000;
 
+    jedis.set("x", "-1");
     do {
       Pipeline p = jedis.pipelined();
       for (int i = 0; i < NUMBER_OF_COMMANDS_IN_PIPELINE; i++) {
-        p.echo(String.valueOf(i));
+        p.incr("x");
       }
 
       List<Object> results = p.syncAndReturnAll();

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/AbstractCommandPipeliningIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/AbstractCommandPipeliningIntegrationTest.java
@@ -110,8 +110,8 @@ public abstract class AbstractCommandPipeliningIntegrationTest implements RedisI
 
   private void verifyResultOrder(final int numberOfCommandInPipeline, List<Object> results) {
     for (int i = 0; i < numberOfCommandInPipeline; i++) {
-      String expected = String.valueOf(i);
-      String currentVal = (String) results.get(i);
+      final Long expected = (long) i;
+      final long currentVal = (long) results.get(i);
 
       assertThat(currentVal).isEqualTo(expected);
     }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/RedisTestHelper.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/RedisTestHelper.java
@@ -14,21 +14,28 @@
  */
 package org.apache.geode.redis;
 
+import static redis.clients.jedis.Protocol.Command.INFO;
+
 import java.util.HashMap;
 import java.util.Map;
 
+import redis.clients.jedis.Connection;
 import redis.clients.jedis.Jedis;
 
 public class RedisTestHelper {
   /**
    * Convert the values returned by the INFO command into a basic param:value map.
    */
-  public static Map<String, String> getInfo(Jedis jedis) {
+  public static Map<String, String> getInfoAsMap(Jedis jedis) {
+    return getInfoAsMap(jedis.getConnection());
+  }
+
+  public static Map<String, String> getInfoAsMap(Connection cxn) {
     // Since this info is often used to get memory numbers in various tests, we want those to be
     // as accurate as possible.
     System.gc();
     Map<String, String> results = new HashMap<>();
-    String rawInfo = jedis.info();
+    final String rawInfo = getInfo(cxn);
 
     for (String line : rawInfo.split("\r\n")) {
       int colonIndex = line.indexOf(":");
@@ -41,4 +48,15 @@ public class RedisTestHelper {
 
     return results;
   }
+
+  public static String getInfo(final Connection cxn) {
+    cxn.sendCommand(INFO);
+    return cxn.getBulkReply();
+  }
+
+  public static String getInfo(final Connection cxn, final String section) {
+    cxn.sendCommand(INFO, section);
+    return cxn.getBulkReply();
+  }
+
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/RedisTestHelper.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/RedisTestHelper.java
@@ -14,28 +14,21 @@
  */
 package org.apache.geode.redis;
 
-import static redis.clients.jedis.Protocol.Command.INFO;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import redis.clients.jedis.Connection;
 import redis.clients.jedis.Jedis;
 
 public class RedisTestHelper {
   /**
    * Convert the values returned by the INFO command into a basic param:value map.
    */
-  public static Map<String, String> getInfoAsMap(Jedis jedis) {
-    return getInfoAsMap(jedis.getConnection());
-  }
-
-  public static Map<String, String> getInfoAsMap(Connection cxn) {
+  public static Map<String, String> getInfo(Jedis jedis) {
     // Since this info is often used to get memory numbers in various tests, we want those to be
     // as accurate as possible.
     System.gc();
     Map<String, String> results = new HashMap<>();
-    final String rawInfo = getInfo(cxn);
+    String rawInfo = jedis.info();
 
     for (String line : rawInfo.split("\r\n")) {
       int colonIndex = line.indexOf(":");
@@ -48,15 +41,4 @@ public class RedisTestHelper {
 
     return results;
   }
-
-  public static String getInfo(final Connection cxn) {
-    cxn.sendCommand(INFO);
-    return cxn.getBulkReply();
-  }
-
-  public static String getInfo(final Connection cxn, final String section) {
-    cxn.sendCommand(INFO, section);
-    return cxn.getBulkReply();
-  }
-
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/AbstractClusterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/AbstractClusterIntegrationTest.java
@@ -18,14 +18,13 @@ package org.apache.geode.redis.internal.commands.executor.cluster;
 import static org.apache.geode.redis.internal.services.RegionProvider.REDIS_SLOTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static redis.clients.jedis.Protocol.Command.CLUSTER;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Connection;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.JedisClusterCRC16;
@@ -50,7 +49,7 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
 
   @Test
   public void testCluster_givenWrongNumberOfArguments() {
-    final Connection connection = jedis.getConnectionFromSlot(0);
+    final Jedis connection = new Jedis(jedis.getConnectionFromSlot(0));
     assertThatThrownBy(() -> connection.sendCommand(Protocol.Command.CLUSTER))
         .hasMessage("ERR wrong number of arguments for 'cluster' command");
     assertThatThrownBy(
@@ -78,30 +77,24 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
 
   @Test
   public void keyslot_ReturnsCorrectSlot() {
-    final Connection cxn = jedis.getConnectionFromSlot(0);
-
-    assertThat(clusterKeySlot(cxn, "nohash")).isEqualTo(9072);
-    assertThat(clusterKeySlot(cxn, "with{hash}")).isEqualTo(238);
-    assertThat(clusterKeySlot(cxn, "with{two}{hashes}")).isEqualTo(2127);
-    assertThat(clusterKeySlot(cxn, "with{borked{hashes}")).isEqualTo(1058);
-    assertThat(clusterKeySlot(cxn, "with{unmatched")).isEqualTo(10479);
-    assertThat(clusterKeySlot(cxn, "aaa}bbb{tag}ccc")).isEqualTo(8338);
-    assertThat(clusterKeySlot(cxn, "withunmatchedright}")).isEqualTo(10331);
-    assertThat(clusterKeySlot(cxn, "somekey")).isEqualTo(11058L);
-    assertThat(clusterKeySlot(cxn, "foo{hash_tag}")).isEqualTo(2515L);
-    assertThat(clusterKeySlot(cxn, "bar{hash_tag}")).isEqualTo(2515L);
-    assertThat(clusterKeySlot(cxn, "hash_tag")).isEqualTo(2515L);
+    final Jedis connection = new Jedis(jedis.getConnectionFromSlot(0));
+    assertThat(connection.clusterKeySlot("nohash")).isEqualTo(9072);
+    assertThat(connection.clusterKeySlot("with{hash}")).isEqualTo(238);
+    assertThat(connection.clusterKeySlot("with{two}{hashes}")).isEqualTo(2127);
+    assertThat(connection.clusterKeySlot("with{borked{hashes}")).isEqualTo(1058);
+    assertThat(connection.clusterKeySlot("with{unmatched")).isEqualTo(10479);
+    assertThat(connection.clusterKeySlot("aaa}bbb{tag}ccc")).isEqualTo(8338);
+    assertThat(connection.clusterKeySlot("withunmatchedright}")).isEqualTo(10331);
+    assertThat(connection.clusterKeySlot("somekey")).isEqualTo(11058L);
+    assertThat(connection.clusterKeySlot("foo{hash_tag}")).isEqualTo(2515L);
+    assertThat(connection.clusterKeySlot("bar{hash_tag}")).isEqualTo(2515L);
+    assertThat(connection.clusterKeySlot("hash_tag")).isEqualTo(2515L);
 
     for (int i = 0; i < NUM_KEYS_TO_TEST; i++) {
       String key = RandomStringUtils.random(i % MAX_KEY_LENGTH + 1);
-      assertThat(clusterKeySlot(cxn, key))
+      assertThat(connection.clusterKeySlot(key))
           .withFailMessage("Failure for key %s", key)
           .isEqualTo(JedisClusterCRC16.getCRC16(key) % (long) REDIS_SLOTS);
     }
-  }
-
-  private Long clusterKeySlot(final Connection cxn, final String arg) {
-    cxn.sendCommand(CLUSTER, Protocol.ClusterKeyword.KEYSLOT.toString(), arg);
-    return cxn.getIntegerReply();
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/AbstractClusterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/AbstractClusterIntegrationTest.java
@@ -26,7 +26,6 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.util.JedisClusterCRC16;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/ClusterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/ClusterIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.ClassRule;
 import org.junit.Test;
 import redis.clients.jedis.Connection;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
@@ -36,7 +37,7 @@ public class ClusterIntegrationTest extends AbstractClusterIntegrationTest {
 
   @Test
   public void errorMessageContainsListOfSupportedSubcommands() {
-    final Connection connection = jedis.getConnectionFromSlot(0);
+    final Jedis connection = new Jedis(jedis.getConnectionFromSlot(0));
 
     String invalidSubcommand = "subcommand";
     assertThatThrownBy(() -> connection.sendCommand(Protocol.Command.CLUSTER, invalidSubcommand))

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/ClusterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/ClusterIntegrationTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.Connection;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
@@ -36,7 +36,7 @@ public class ClusterIntegrationTest extends AbstractClusterIntegrationTest {
 
   @Test
   public void errorMessageContainsListOfSupportedSubcommands() {
-    final Jedis connection = jedis.getConnectionFromSlot(0);
+    final Connection connection = jedis.getConnectionFromSlot(0);
 
     String invalidSubcommand = "subcommand";
     assertThatThrownBy(() -> connection.sendCommand(Protocol.Command.CLUSTER, invalidSubcommand))

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/ClusterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/ClusterIntegrationTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import redis.clients.jedis.Connection;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractEchoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractEchoIntegrationTest.java
@@ -20,21 +20,22 @@ import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExact
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static redis.clients.jedis.Protocol.Command.ECHO;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Protocol;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 
 public abstract class AbstractEchoIntegrationTest implements RedisIntegrationTest {
-  private Jedis jedis;
+  private JedisCluster jedis;
 
   @Before
   public void setUp() {
-    jedis = new Jedis(BIND_ADDRESS, getPort(), REDIS_CLIENT_TIMEOUT);
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
   }
 
   @After
@@ -44,12 +45,12 @@ public abstract class AbstractEchoIntegrationTest implements RedisIntegrationTes
 
   @Test
   public void errors_GivenWrongNumberOfArguments() {
-    assertExactNumberOfArgs(jedis, Protocol.Command.ECHO, 1);
+    assertExactNumberOfArgs(jedis, ECHO, 1);
   }
 
   @Test
   public void returnsString_givenString() {
-    String string = "test";
-    assertThat(jedis.echo(string)).isEqualTo(string);
+    final byte[] bytes = "test".getBytes();
+    assertThat((byte[]) jedis.sendCommand(ECHO, bytes)).isEqualTo(bytes);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractEchoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractEchoIntegrationTest.java
@@ -20,25 +20,21 @@ import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExact
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
-import static redis.clients.jedis.Protocol.Command.ECHO;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.CommandObjects;
-import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.JedisCluster;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 
 public abstract class AbstractEchoIntegrationTest implements RedisIntegrationTest {
-  private JedisCluster jedis;
-  private CommandObjects commandObjects = new CommandObjects();
+  private Jedis jedis;
 
   @Before
   public void setUp() {
-    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+    jedis = new Jedis(BIND_ADDRESS, getPort(), REDIS_CLIENT_TIMEOUT);
   }
 
   @After
@@ -54,6 +50,6 @@ public abstract class AbstractEchoIntegrationTest implements RedisIntegrationTes
   @Test
   public void returnsString_givenString() {
     String string = "test";
-    assertThat((String) jedis.sendCommand(ECHO, string)).isEqualTo(string);
+    assertThat(jedis.echo(string)).isEqualTo(string);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractEchoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractEchoIntegrationTest.java
@@ -54,6 +54,6 @@ public abstract class AbstractEchoIntegrationTest implements RedisIntegrationTes
   @Test
   public void returnsString_givenString() {
     String string = "test";
-    assertThat((String)jedis.sendCommand(ECHO, string)).isEqualTo(string);
+    assertThat((String) jedis.sendCommand(ECHO, string)).isEqualTo(string);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractEchoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractEchoIntegrationTest.java
@@ -20,10 +20,12 @@ import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExact
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static redis.clients.jedis.Protocol.Command.ECHO;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import redis.clients.jedis.CommandObjects;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
@@ -32,6 +34,7 @@ import org.apache.geode.redis.RedisIntegrationTest;
 
 public abstract class AbstractEchoIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
+  private CommandObjects commandObjects = new CommandObjects();
 
   @Before
   public void setUp() {
@@ -51,6 +54,6 @@ public abstract class AbstractEchoIntegrationTest implements RedisIntegrationTes
   @Test
   public void returnsString_givenString() {
     String string = "test";
-    assertThat(jedis.echo(string)).isEqualTo(string);
+    assertThat((String)jedis.sendCommand(ECHO, string)).isEqualTo(string);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHScanIntegrationTest.java
@@ -42,7 +42,6 @@ import org.junit.Test;
 import redis.clients.jedis.CommandObjects;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.params.ScanParams;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHashesIntegrationTest.java
@@ -38,8 +38,8 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.ScanResult;
 import redis.clients.jedis.exceptions.JedisDataException;
+import redis.clients.jedis.resps.ScanResult;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExistsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExistsIntegrationTest.java
@@ -125,9 +125,8 @@ public abstract class AbstractExistsIntegrationTest implements RedisIntegrationT
   public void shouldReturn1_givenBitMapExists() {
     String bitMapKey = "bitMapKey";
     long offset = 1L;
-    String bitMapValue = "0";
 
-    jedis.setbit(bitMapKey, offset, bitMapValue);
+    jedis.setbit(bitMapKey, offset, false);
 
     assertThat(jedis.exists(toArray(bitMapKey))).isEqualTo(1L);
   }
@@ -136,9 +135,8 @@ public abstract class AbstractExistsIntegrationTest implements RedisIntegrationT
   public void shouldReturn0_givenBitMapDoesNotExist() {
     String bitMapKey = "bitMapKey";
     long offset = 1L;
-    String bitMapValue = "0";
 
-    jedis.setbit(bitMapKey, offset, bitMapValue);
+    jedis.setbit(bitMapKey, offset, false);
     jedis.del(bitMapKey);
 
     assertThat(jedis.exists(toArray(bitMapKey))).isEqualTo(0L);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireIntegrationTest.java
@@ -113,9 +113,8 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
 
     String key = "key";
     long offset = 1L;
-    String value = "0";
 
-    jedis.setbit(key, offset, value);
+    jedis.setbit(key, offset, false);
 
     Long timeToLive = jedis.ttl(key);
     assertThat(timeToLive).isEqualTo(-1);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPersistIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPersistIntegrationTest.java
@@ -96,9 +96,8 @@ public abstract class AbstractPersistIntegrationTest implements RedisIntegration
   public void shouldPersistKey_givenKeyWith_bitMapValue() {
     String bitMapKey = "bitMapKey";
     long offset = 1L;
-    String bitMapValue = "0";
 
-    jedis.setbit(bitMapKey, offset, bitMapValue);
+    jedis.setbit(bitMapKey, offset, false);
     jedis.expire(bitMapKey, 20L);
 
     assertThat(jedis.persist(bitMapKey)).isEqualTo(1L);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
@@ -31,8 +31,8 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.ScanParams;
-import redis.clients.jedis.ScanResult;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/ScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/ScanIntegrationTest.java
@@ -22,8 +22,8 @@ import java.util.List;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import redis.clients.jedis.ScanParams;
-import redis.clients.jedis.ScanResult;
+import redis.clients.jedis.params.ScanParams;
+import redis.clients.jedis.resps.ScanResult;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubCommandsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubCommandsIntegrationTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static redis.clients.jedis.Protocol.Command.PUBSUB;
 import static redis.clients.jedis.Protocol.Keyword.CHANNELS;
+import static redis.clients.jedis.Protocol.Keyword.NUMPAT;
 import static redis.clients.jedis.Protocol.Keyword.NUMSUB;
 
 import java.net.SocketException;
@@ -39,7 +40,6 @@ import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.mocks.MockSubscriber;
@@ -81,7 +81,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   public void channels_shouldError_givenTooManyArguments() {
     assertAtMostNArgsForSubCommand(introspector,
         PUBSUB,
-        CHANNELS.toString().getBytes(),
+        CHANNELS.getRaw(),
         1);
   }
 
@@ -294,7 +294,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   public void numpat_shouldError_givenTooManyArguments() {
     assertAtMostNArgsForSubCommand(introspector,
         PUBSUB,
-        Protocol.Keyword.NUMPAT.toString().getBytes(),
+        NUMPAT.getRaw(),
         0);
   }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
@@ -74,9 +74,6 @@ public abstract class AbstractSubscriptionsIntegrationTest implements RedisInteg
     executor.submit(() -> client.subscribe(mockSubscriber, "same"));
     mockSubscriber.awaitSubscribe("same");
     mockSubscriber.ping("potato");
-    // JedisPubSub PING with message is not currently possible, will submit a PR
-    // (https://github.com/xetorthio/jedis/issues/2049)
-    // until then, we have to call this second ping to flush the client
     mockSubscriber.ping();
     GeodeAwaitility.await()
         .untilAsserted(() -> assertThat(mockSubscriber.getReceivedPings().size()).isEqualTo(2));

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
@@ -74,9 +74,8 @@ public abstract class AbstractSubscriptionsIntegrationTest implements RedisInteg
     executor.submit(() -> client.subscribe(mockSubscriber, "same"));
     mockSubscriber.awaitSubscribe("same");
     mockSubscriber.ping("potato");
-    mockSubscriber.ping();
     GeodeAwaitility.await()
-        .untilAsserted(() -> assertThat(mockSubscriber.getReceivedPings().size()).isEqualTo(2));
+        .untilAsserted(() -> assertThat(mockSubscriber.getReceivedPings().size()).isOne());
     assertThat(mockSubscriber.getReceivedPings().get(0)).isEqualTo("potato");
     mockSubscriber.unsubscribe();
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.BitOP;
+import redis.clients.jedis.args.BitOP;
 import redis.clients.jedis.Jedis;
 
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -567,35 +567,35 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   @Test
   public void testSetbit() {
-    runCommandAndAssertNoStatUpdates(STRING_INT_KEY, k -> jedis.setbit(k, 0L, "1"));
+    runCommandAndAssertNoStatUpdates(STRING_INT_KEY, k -> jedis.setbit(k, 0L, true));
   }
 
   /************* Helper Methods *************/
   private void runCommandAndAssertHitsAndMisses(String key, Consumer<String> command) {
-    Map<String, String> info = RedisTestHelper.getInfo(jedis);
+    Map<String, String> info = RedisTestHelper.getInfoAsMap(jedis);
     long currentHits = Long.parseLong(info.get(HITS));
     long currentMisses = Long.parseLong(info.get(MISSES));
 
     command.accept(key);
-    info = RedisTestHelper.getInfo(jedis);
+    info = RedisTestHelper.getInfoAsMap(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses));
 
     command.accept("missed");
-    info = RedisTestHelper.getInfo(jedis);
+    info = RedisTestHelper.getInfoAsMap(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses + 1));
   }
 
   private void runCommandAndAssertNoStatUpdates(String key, Consumer<String> command) {
-    Map<String, String> info = RedisTestHelper.getInfo(jedis);
+    Map<String, String> info = RedisTestHelper.getInfoAsMap(jedis);
     String currentHits = info.get(HITS);
     String currentMisses = info.get(MISSES);
 
     command.accept(key);
-    info = RedisTestHelper.getInfo(jedis);
+    info = RedisTestHelper.getInfoAsMap(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(currentHits);
     assertThat(info.get(MISSES)).isEqualTo(currentMisses);
@@ -603,18 +603,18 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   private void runMultiKeyCommandAndAssertHitsAndMisses(String key,
       BiConsumer<String, String> command) {
-    Map<String, String> info = RedisTestHelper.getInfo(jedis);
+    Map<String, String> info = RedisTestHelper.getInfoAsMap(jedis);
     long currentHits = Long.parseLong(info.get(HITS));
     long currentMisses = Long.parseLong(info.get(MISSES));
 
     command.accept(key, key);
-    info = RedisTestHelper.getInfo(jedis);
+    info = RedisTestHelper.getInfoAsMap(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 2));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses));
 
     command.accept(key, HASHTAG + "missed");
-    info = RedisTestHelper.getInfo(jedis);
+    info = RedisTestHelper.getInfoAsMap(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 3));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses + 1));
@@ -622,18 +622,18 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   private void runMultiKeyCommandAndAssertNoStatUpdates(String key,
       BiConsumer<String, String> command) {
-    Map<String, String> info = RedisTestHelper.getInfo(jedis);
+    Map<String, String> info = RedisTestHelper.getInfoAsMap(jedis);
     String currentHits = info.get(HITS);
     String currentMisses = info.get(MISSES);
 
     command.accept(key, key);
-    info = RedisTestHelper.getInfo(jedis);
+    info = RedisTestHelper.getInfoAsMap(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(currentHits);
     assertThat(info.get(MISSES)).isEqualTo(currentMisses);
 
     command.accept(key, HASHTAG + "missed");
-    info = RedisTestHelper.getInfo(jedis);
+    info = RedisTestHelper.getInfoAsMap(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(currentHits);
     assertThat(info.get(MISSES)).isEqualTo(currentMisses);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -572,30 +572,30 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   /************* Helper Methods *************/
   private void runCommandAndAssertHitsAndMisses(String key, Consumer<String> command) {
-    Map<String, String> info = RedisTestHelper.getInfoAsMap(jedis);
+    Map<String, String> info = RedisTestHelper.getInfo(jedis);
     long currentHits = Long.parseLong(info.get(HITS));
     long currentMisses = Long.parseLong(info.get(MISSES));
 
     command.accept(key);
-    info = RedisTestHelper.getInfoAsMap(jedis);
+    info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses));
 
     command.accept("missed");
-    info = RedisTestHelper.getInfoAsMap(jedis);
+    info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 1));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses + 1));
   }
 
   private void runCommandAndAssertNoStatUpdates(String key, Consumer<String> command) {
-    Map<String, String> info = RedisTestHelper.getInfoAsMap(jedis);
+    Map<String, String> info = RedisTestHelper.getInfo(jedis);
     String currentHits = info.get(HITS);
     String currentMisses = info.get(MISSES);
 
     command.accept(key);
-    info = RedisTestHelper.getInfoAsMap(jedis);
+    info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(currentHits);
     assertThat(info.get(MISSES)).isEqualTo(currentMisses);
@@ -603,18 +603,18 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   private void runMultiKeyCommandAndAssertHitsAndMisses(String key,
       BiConsumer<String, String> command) {
-    Map<String, String> info = RedisTestHelper.getInfoAsMap(jedis);
+    Map<String, String> info = RedisTestHelper.getInfo(jedis);
     long currentHits = Long.parseLong(info.get(HITS));
     long currentMisses = Long.parseLong(info.get(MISSES));
 
     command.accept(key, key);
-    info = RedisTestHelper.getInfoAsMap(jedis);
+    info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 2));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses));
 
     command.accept(key, HASHTAG + "missed");
-    info = RedisTestHelper.getInfoAsMap(jedis);
+    info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(String.valueOf(currentHits + 3));
     assertThat(info.get(MISSES)).isEqualTo(String.valueOf(currentMisses + 1));
@@ -622,18 +622,18 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
 
   private void runMultiKeyCommandAndAssertNoStatUpdates(String key,
       BiConsumer<String, String> command) {
-    Map<String, String> info = RedisTestHelper.getInfoAsMap(jedis);
+    Map<String, String> info = RedisTestHelper.getInfo(jedis);
     String currentHits = info.get(HITS);
     String currentMisses = info.get(MISSES);
 
     command.accept(key, key);
-    info = RedisTestHelper.getInfoAsMap(jedis);
+    info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(currentHits);
     assertThat(info.get(MISSES)).isEqualTo(currentMisses);
 
     command.accept(key, HASHTAG + "missed");
-    info = RedisTestHelper.getInfoAsMap(jedis);
+    info = RedisTestHelper.getInfo(jedis);
 
     assertThat(info.get(HITS)).isEqualTo(currentHits);
     assertThat(info.get(MISSES)).isEqualTo(currentMisses);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -26,8 +26,8 @@ import java.util.function.Consumer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.args.BitOP;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.args.BitOP;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.RedisTestHelper;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisInfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisInfoStatsIntegrationTest.java
@@ -289,7 +289,7 @@ public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisInte
   static synchronized Map<String, String> getInfo(Jedis jedis) {
     numInfoCalled.incrementAndGet();
 
-    return RedisTestHelper.getInfo(jedis);
+    return RedisTestHelper.getInfoAsMap(jedis);
   }
 
   private void validateNetworkBytesRead(Jedis jedis, long initialNetworkBytesRead,

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisInfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisInfoStatsIntegrationTest.java
@@ -289,7 +289,7 @@ public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisInte
   static synchronized Map<String, String> getInfo(Jedis jedis) {
     numInfoCalled.incrementAndGet();
 
-    return RedisTestHelper.getInfoAsMap(jedis);
+    return RedisTestHelper.getInfo(jedis);
   }
 
   private void validateNetworkBytesRead(Jedis jedis, long initialNetworkBytesRead,

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
@@ -55,20 +55,20 @@ public abstract class AbstractRedisMemoryStatsIntegrationTest implements RedisIn
 
   @Test
   public void maxMemory_shouldBeASensibleValue() {
-    long maxMemory = Long.parseLong(RedisTestHelper.getInfoAsMap(jedis).get(MAX_MEMORY));
+    long maxMemory = Long.parseLong(RedisTestHelper.getInfo(jedis).get(MAX_MEMORY));
     assertThat(maxMemory).isGreaterThan(0L);
   }
 
   @Test
   public void memoryFragmentationRatio_shouldBeGreaterThanZero() {
     double memoryFragmentationRatio =
-        Double.parseDouble(RedisTestHelper.getInfoAsMap(jedis).get(MEM_FRAGMENTATION_RATIO));
+        Double.parseDouble(RedisTestHelper.getInfo(jedis).get(MEM_FRAGMENTATION_RATIO));
     assertThat(memoryFragmentationRatio).isGreaterThan(0.0);
   }
 
   @Test
   public void usedMemory_shouldIncrease_givenAdditionalValuesAdded() {
-    long initialUsedMemory = Long.parseLong(RedisTestHelper.getInfoAsMap(jedis).get(USED_MEMORY));
+    long initialUsedMemory = Long.parseLong(RedisTestHelper.getInfo(jedis).get(USED_MEMORY));
     long finalUsedMemory = 0;
 
     for (int i = 0; i < 1_000_000; i++) {
@@ -76,7 +76,7 @@ public abstract class AbstractRedisMemoryStatsIntegrationTest implements RedisIn
 
       // Check every 50,000 entries to see if we've increased in memory.
       if (i % 50_000 == 0) {
-        finalUsedMemory = Long.parseLong(RedisTestHelper.getInfoAsMap(jedis).get(USED_MEMORY));
+        finalUsedMemory = Long.parseLong(RedisTestHelper.getInfo(jedis).get(USED_MEMORY));
         if (finalUsedMemory > initialUsedMemory) {
           return;
         }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractRedisMemoryStatsIntegrationTest.java
@@ -55,20 +55,20 @@ public abstract class AbstractRedisMemoryStatsIntegrationTest implements RedisIn
 
   @Test
   public void maxMemory_shouldBeASensibleValue() {
-    long maxMemory = Long.parseLong(RedisTestHelper.getInfo(jedis).get(MAX_MEMORY));
+    long maxMemory = Long.parseLong(RedisTestHelper.getInfoAsMap(jedis).get(MAX_MEMORY));
     assertThat(maxMemory).isGreaterThan(0L);
   }
 
   @Test
   public void memoryFragmentationRatio_shouldBeGreaterThanZero() {
     double memoryFragmentationRatio =
-        Double.parseDouble(RedisTestHelper.getInfo(jedis).get(MEM_FRAGMENTATION_RATIO));
+        Double.parseDouble(RedisTestHelper.getInfoAsMap(jedis).get(MEM_FRAGMENTATION_RATIO));
     assertThat(memoryFragmentationRatio).isGreaterThan(0.0);
   }
 
   @Test
   public void usedMemory_shouldIncrease_givenAdditionalValuesAdded() {
-    long initialUsedMemory = Long.parseLong(RedisTestHelper.getInfo(jedis).get(USED_MEMORY));
+    long initialUsedMemory = Long.parseLong(RedisTestHelper.getInfoAsMap(jedis).get(USED_MEMORY));
     long finalUsedMemory = 0;
 
     for (int i = 0; i < 1_000_000; i++) {
@@ -76,7 +76,7 @@ public abstract class AbstractRedisMemoryStatsIntegrationTest implements RedisIn
 
       // Check every 50,000 entries to see if we've increased in memory.
       if (i % 50_000 == 0) {
-        finalUsedMemory = Long.parseLong(RedisTestHelper.getInfo(jedis).get(USED_MEMORY));
+        finalUsedMemory = Long.parseLong(RedisTestHelper.getInfoAsMap(jedis).get(USED_MEMORY));
         if (finalUsedMemory > initialUsedMemory) {
           return;
         }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractSlowlogIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractSlowlogIntegrationTest.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.util.Slowlog;
+import redis.clients.jedis.resps.Slowlog;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.ClassRule;
 import org.junit.Test;
+import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 
@@ -38,7 +39,8 @@ public class InfoIntegrationTest extends AbstractInfoIntegrationTest {
   public void shouldReturnRedisVersion() {
     String expectedResult = "redis_version:5.0";
 
-    String actualResult = jedis.info();
+    connection.sendCommand(Protocol.Command.INFO);
+    final String actualResult = connection.getBulkReply();
 
     assertThat(actualResult).contains(expectedResult);
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.ClassRule;
 import org.junit.Test;
-import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 
@@ -39,8 +38,7 @@ public class InfoIntegrationTest extends AbstractInfoIntegrationTest {
   public void shouldReturnRedisVersion() {
     String expectedResult = "redis_version:5.0";
 
-    connection.sendCommand(Protocol.Command.INFO);
-    final String actualResult = connection.getBulkReply();
+    String actualResult = jedis.info();
 
     assertThat(actualResult).contains(expectedResult);
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
@@ -57,7 +57,7 @@ public class ShutdownIntegrationTest implements RedisIntegrationTest {
   @Test
   public void shutdownIsDisabled_whenOnlySupportedCommandsAreAllowed() {
     final String EXPECTED_ERROR_MSG =
-        String.format(ERROR_UNKNOWN_COMMAND, "SHUTDOWN", "");
+        String.format("ERR " + ERROR_UNKNOWN_COMMAND, "SHUTDOWN", "");
 
     assertThatThrownBy(
         () -> jedis.shutdown())

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
@@ -62,7 +62,7 @@ public class ShutdownIntegrationTest implements RedisIntegrationTest {
     assertThatThrownBy(
         () -> jedis.shutdown())
             .isInstanceOf(JedisDataException.class)
-                .hasMessageContaining(EXPECTED_ERROR_MSG);
+            .hasMessageContaining(EXPECTED_ERROR_MSG);
     assertThat(jedis.keys("*")).isEmpty();
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
@@ -16,13 +16,16 @@
 
 package org.apache.geode.redis.internal.commands.executor.server;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
+import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -53,10 +56,13 @@ public class ShutdownIntegrationTest implements RedisIntegrationTest {
 
   @Test
   public void shutdownIsDisabled_whenOnlySupportedCommandsAreAllowed() {
-    // Unfortunately Jedis' shutdown() doesn't seem to throw a JedisDataException when the command
-    // returns an error.
-    jedis.shutdown();
+    final String EXPECTED_ERROR_MSG =
+        String.format(ERROR_UNKNOWN_COMMAND, "SHUTDOWN", "");
 
+    assertThatThrownBy(
+        () -> jedis.shutdown())
+            .isInstanceOf(JedisDataException.class)
+                .hasMessageContaining(EXPECTED_ERROR_MSG);
     assertThat(jedis.keys("*")).isEmpty();
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
@@ -62,7 +62,7 @@ public class ShutdownIntegrationTest implements RedisIntegrationTest {
     assertThatThrownBy(
         () -> jedis.shutdown())
             .isInstanceOf(JedisDataException.class)
-            .hasMessageContaining(EXPECTED_ERROR_MSG);
+            .hasMessage(EXPECTED_ERROR_MSG);
     assertThat(jedis.keys("*")).isEmpty();
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSScanIntegrationTest.java
@@ -32,9 +32,8 @@ import java.util.Set;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.CommandObjects;
-import redis.clients.jedis.Connection;
 import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.params.ScanParams;
@@ -48,8 +47,6 @@ import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
 
 public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTest {
   protected JedisCluster jedis;
-  private final CommandObjects commandObjects = new CommandObjects();
-
   public static final String KEY = "key";
   public static final byte[] KEY_BYTES = KEY.getBytes();
   public static final int SLOT_FOR_KEY = KeyHashUtil.slotForKey(KEY_BYTES);
@@ -384,20 +381,20 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
   public void should_returnAllConsistentlyPresentMembers_givenConcurrentThreadsAddingAndRemovingMembers() {
     final Set<String> initialMemberData = initializeThousandMemberSet();
     final int iterationCount = 500;
-    final Connection cxn1 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
-    final Connection cxn2 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+    final Jedis jedis1 = new Jedis(jedis.getConnectionFromSlot(SLOT_FOR_KEY));
+    final Jedis jedis2 = new Jedis(jedis.getConnectionFromSlot(SLOT_FOR_KEY));
 
     new ConcurrentLoopingThreads(iterationCount,
-        (i) -> multipleSScanAndAssertOnContentOfResultSet(i, cxn1, initialMemberData),
-        (i) -> multipleSScanAndAssertOnContentOfResultSet(i, cxn2, initialMemberData),
+        (i) -> multipleSScanAndAssertOnContentOfResultSet(i, jedis1, initialMemberData),
+        (i) -> multipleSScanAndAssertOnContentOfResultSet(i, jedis2, initialMemberData),
         (i) -> {
           String member = "new_" + BASE_MEMBER_NAME + i;
           jedis.sadd(KEY, member);
           jedis.srem(KEY, member);
         }).run();
 
-    cxn1.close();
-    cxn2.close();
+    jedis1.close();
+    jedis2.close();
   }
 
   @Test
@@ -405,27 +402,27 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     final Set<String> initialMemberData = initializeThousandMemberSet();
     jedis.sadd(KEY, initialMemberData.toArray(new String[0]));
     final int iterationCount = 500;
-    final Connection cxn1 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
-    final Connection cxn2 = jedis.getConnectionFromSlot(SLOT_FOR_KEY);
+    Jedis jedis1 = new Jedis(jedis.getConnectionFromSlot(SLOT_FOR_KEY));
+    Jedis jedis2 = new Jedis(jedis.getConnectionFromSlot(SLOT_FOR_KEY));
 
     new ConcurrentLoopingThreads(iterationCount,
-        (i) -> multipleSScanAndAssertOnContentOfResultSet(i, cxn1, initialMemberData),
-        (i) -> multipleSScanAndAssertOnContentOfResultSet(i, cxn2, initialMemberData))
+        (i) -> multipleSScanAndAssertOnContentOfResultSet(i, jedis1, initialMemberData),
+        (i) -> multipleSScanAndAssertOnContentOfResultSet(i, jedis2, initialMemberData))
             .run();
     assertThat(jedis.smembers(KEY)).containsExactlyInAnyOrderElementsOf(initialMemberData);
 
-    cxn1.close();
-    cxn2.close();
+    jedis1.close();
+    jedis2.close();
   }
 
-  private void multipleSScanAndAssertOnContentOfResultSet(final int iteration, final Connection cxn,
+  private void multipleSScanAndAssertOnContentOfResultSet(int iteration, Jedis jedis,
       final Set<String> initialMemberData) {
     List<String> allEntries = new ArrayList<>();
     String cursor = ZERO_CURSOR;
     ScanResult<String> result;
 
     do {
-      result = cxn.executeCommand(commandObjects.sscan(KEY, cursor, new ScanParams()));
+      result = jedis.sscan(KEY, cursor);
       cursor = result.getCursor();
       List<String> resultEntries = result.getResult();
       allEntries.addAll(resultEntries);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSScanIntegrationTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import redis.clients.jedis.CommandObjects;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.params.ScanParams;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -375,7 +375,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1, 2), KEY1, KEY2))
         .isEqualTo(expectedResults.size());
 
-    final List <Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -260,6 +261,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
   public void shouldStoreIntersection_givenWeightOfOne_andOneRedisSortedSet() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
     final List<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> value);
+    expectedResults.sort(Comparator.naturalOrder());
     jedis.zadd(KEY1, scores);
 
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1), KEY1))
@@ -302,11 +304,11 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.zadd(KEY1, scores);
 
     final List<Tuple> expectedResults = new ArrayList<>();
-    expectedResults.add(new Tuple("player1", Double.POSITIVE_INFINITY));
-    expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player4", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player5", Double.NEGATIVE_INFINITY));
+    expectedResults.add(new Tuple("player2", 0D));
+    expectedResults.add(new Tuple("player1", Double.POSITIVE_INFINITY));
 
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(Double.NEGATIVE_INFINITY),
         KEY1)).isEqualTo(scores.size());
@@ -326,8 +328,8 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", multiplier));
-    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
     expectedResults.add(new Tuple("player5", 3.2D * multiplier));
+    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
 
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(multiplier), KEY1))
         .isEqualTo(scores.size());
@@ -343,8 +345,8 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", 2D));
-    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
     expectedResults.add(new Tuple("player5", 3.2D * 2));
+    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
 
     jedis.zadd(KEY1, scores);
     jedis.zadd(KEY2, scores);
@@ -363,8 +365,8 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", 3D));
-    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
     expectedResults.add(new Tuple("player5", 3.2D * 3));
+    expectedResults.add(new Tuple("player4", Double.POSITIVE_INFINITY));
 
     jedis.zadd(KEY1, scores);
     jedis.zadd(KEY2, scores);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -23,14 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
-import java.util.Set;
 import java.util.function.BiFunction;
 
 import org.assertj.core.data.Offset;
@@ -247,7 +244,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
   @Test
   public void shouldOverwriteDestinationKey_givenDestinationExists() {
-    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    final List<Tuple> expectedResults = new ArrayList<>();
     expectedResults.add(new Tuple("key1Member", 1.0));
 
     jedis.zadd(NEW_SET, 1.0, "newSetMember1");
@@ -256,39 +253,39 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
     assertThat(jedis.zinterstore(NEW_SET, KEY1)).isEqualTo(1L);
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0L, 1L);
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldStoreIntersection_givenWeightOfOne_andOneRedisSortedSet() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
-    Set<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> value);
+    final List<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> value);
     jedis.zadd(KEY1, scores);
 
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1), KEY1))
         .isEqualTo(expectedResults.size());
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldStoreIntersection_givenWeightOfZero_andOneRedisSortedSet() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
-    Set<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> 0D);
+    final List<Tuple> expectedResults = convertToTuples(scores, (ignore, value) -> 0D);
     jedis.zadd(KEY1, scores);
 
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(0), KEY1))
         .isEqualTo(scores.size());
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldStoreIntersection_givenWeightOfPositiveInfinity_andOneRedisSortedSet() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
-    Set<Tuple> expectedResults =
+    final List<Tuple> expectedResults =
         convertToTuples(scores, (ignore, value) -> value > 0 ? Double.POSITIVE_INFINITY : value);
     jedis.zadd(KEY1, scores);
 
@@ -296,7 +293,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
         KEY1)).isEqualTo(scores.size());
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -304,7 +301,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores = buildMapOfMembersAndScores();
     jedis.zadd(KEY1, scores);
 
-    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    final List<Tuple> expectedResults = new ArrayList<>();
     expectedResults.add(new Tuple("player1", Double.POSITIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", Double.NEGATIVE_INFINITY));
@@ -315,7 +312,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
         KEY1)).isEqualTo(scores.size());
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -325,7 +322,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
     double multiplier = 2.71D;
 
-    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    final List<Tuple> expectedResults = new ArrayList<>();
     expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", multiplier));
@@ -336,13 +333,13 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
         .isEqualTo(scores.size());
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldStoreIntersection_givenMultipleRedisSortedSets() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
-    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    final List<Tuple> expectedResults = new ArrayList<>();
     expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", 2D));
@@ -356,13 +353,13 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
         .isEqualTo(expectedResults.size());
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldStoreIntersection_givenTwoRedisSortedSets_withDifferentWeights() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
-    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    final List<Tuple> expectedResults = new ArrayList<>();
     expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", 3D));
@@ -376,13 +373,13 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
         .isEqualTo(expectedResults.size());
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldStoreIntersection_givenMultipleIdenticalRedisSortedSets_withDifferentPositiveWeights() {
     Map<String, Double> scores = buildMapOfMembersAndScores();
-    Set<Tuple> expectedResults = new LinkedHashSet<>();
+    final List<Tuple> expectedResults = new ArrayList<>();
     expectedResults.add(new Tuple("player1", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player3", 4.5D));
@@ -435,7 +432,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.SUM),
         KEY1, KEY2, KEY3)).isEqualTo(5);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 6; i <= 10; i++) {
       expected.add(tupleSumOfScores("player" + i, scores1, scores2, scores3));
     }
@@ -467,7 +464,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MAX),
         KEY1, KEY2, KEY3)).isEqualTo(5);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 6; i <= 10; i++) {
       expected.add(tupleMaxOfScores("player" + i, scores1, scores2, scores3));
     }
@@ -490,7 +487,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MIN),
         KEY1, KEY2, KEY3)).isEqualTo(5);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 6; i <= 10; i++) {
       expected.add(tupleMinOfScores("player" + i, scores1, scores2, scores3));
     }
@@ -519,7 +516,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
     assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 6; i <= 10; i++) {
       expected.add(tupleSumOfScoresWithWeights("player" + i, scores1, scores2, scores3, weight1,
           weight2, weight3));
@@ -549,7 +546,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
     assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 6; i <= 10; i++) {
       expected.add(tupleMaxOfScoresWithWeights("player" + i, scores1, scores2, scores3, weight1,
           weight2, weight3));
@@ -579,7 +576,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
     assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 6; i <= 10; i++) {
       expected.add(tupleMinOfScoresWithWeights("player" + i, scores1, scores2, scores3, weight1,
           weight2, weight3));
@@ -605,7 +602,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
     assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 6; i <= 10; i++) {
       expected.add(new Tuple("player" + i, score));
     }
@@ -630,7 +627,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
     assertThat(jedis.zinterstore(NEW_SET, zParams, KEY1, KEY2, KEY3)).isEqualTo(5);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 6; i <= 10; i++) {
       expected.add(new Tuple("player" + i, score));
     }
@@ -650,7 +647,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.zadd(KEY2, scores2);
     jedis.zadd(KEY3, scores3);
 
-    Set<Tuple> expected = new HashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 12; i <= 13; i++) {
       expected.add(tupleMaxOfScores("player" + i, scores1, scores2, scores3));
     }
@@ -669,7 +666,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.zadd(KEY1, scores);
     jedis.zadd(KEY2, scores);
 
-    Set<Tuple> expectedResults = convertToTuples(scores, (ignore, score) -> score * 2);
+    final List<Tuple> expectedResults = convertToTuples(scores, (ignore, score) -> score * 2);
 
     // destination key is a key that exists
     assertThat(jedis.zinterstore(KEY1, KEY1, KEY2)).isEqualTo(scores.size());
@@ -786,9 +783,9 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
         scores2.get(memberName) * weight2), scores3.get(memberName) * weight3));
   }
 
-  private Set<Tuple> convertToTuples(Map<String, Double> map,
+  private List<Tuple> convertToTuples(Map<String, Double> map,
       BiFunction<Integer, Double, Double> function) {
-    Set<Tuple> tuples = new LinkedHashSet<>();
+    final List<Tuple> tuples = new ArrayList<>();
     int x = 0;
     for (Map.Entry<String, Double> e : map.entrySet()) {
       tuples.add(new Tuple(e.getKey().getBytes(), function.apply(x++, e.getValue())));
@@ -799,8 +796,8 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
   @Test
   public void test_assertThatActualScoresAreVeryCloseToExpectedScores() {
-    List<Tuple> actualResult = new ArrayList<>(3);
-    Set<Tuple> expectedResult = new HashSet<>(2);
+    final List<Tuple> actualResult = new ArrayList<>(3);
+    final List<Tuple> expectedResult = new ArrayList<>(2);
 
     actualResult.add(new Tuple("element1", 1.0));
     expectedResult.add(new Tuple("element1", 1.0));
@@ -825,7 +822,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
   }
 
   private void assertThatActualScoresAreVeryCloseToExpectedScores(
-      final Set<Tuple> expectedResults, final List<Tuple> results) {
+      final List<Tuple> expectedResults, final List<Tuple> results) {
     assertThat(expectedResults.size()).isEqualTo(results.size());
 
     for (Tuple expectedResult : expectedResults) {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -22,9 +22,11 @@ import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CL
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Random;
@@ -38,8 +40,8 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Tuple;
-import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.ZParams;
+import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -253,7 +255,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.zadd(KEY1, 1.0, "key1Member");
 
     assertThat(jedis.zinterstore(NEW_SET, KEY1)).isEqualTo(1L);
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0L, 1L);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0L, 1L);
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
@@ -266,7 +268,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1), KEY1))
         .isEqualTo(expectedResults.size());
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
@@ -279,7 +281,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(0), KEY1))
         .isEqualTo(scores.size());
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
@@ -293,7 +295,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(Double.POSITIVE_INFINITY),
         KEY1)).isEqualTo(scores.size());
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
@@ -312,7 +314,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(Double.NEGATIVE_INFINITY),
         KEY1)).isEqualTo(scores.size());
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
@@ -333,7 +335,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(multiplier), KEY1))
         .isEqualTo(scores.size());
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
@@ -353,7 +355,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams(), KEY1, KEY2))
         .isEqualTo(expectedResults.size());
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
@@ -373,7 +375,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1, 2), KEY1, KEY2))
         .isEqualTo(expectedResults.size());
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List <Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
@@ -394,7 +396,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThat(jedis.zinterstore(NEW_SET, new ZParams().weights(1D, 2D, 1.5D), KEY1, KEY2, KEY3))
         .isEqualTo(expectedResults.size());
 
-    Set<Tuple> actualResults = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    final List<Tuple> actualResults = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
     assertThatActualScoresAreVeryCloseToExpectedScores(expectedResults, actualResults);
   }
 
@@ -438,7 +440,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
       expected.add(tupleSumOfScores("player" + i, scores1, scores2, scores3));
     }
 
-    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
   }
@@ -470,7 +472,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
       expected.add(tupleMaxOfScores("player" + i, scores1, scores2, scores3));
     }
 
-    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
   }
@@ -493,7 +495,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
       expected.add(tupleMinOfScores("player" + i, scores1, scores2, scores3));
     }
 
-    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
   }
@@ -523,7 +525,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
           weight2, weight3));
     }
 
-    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
   }
@@ -553,7 +555,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
           weight2, weight3));
     }
 
-    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
   }
@@ -583,7 +585,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
           weight2, weight3));
     }
 
-    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
   }
@@ -608,7 +610,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
       expected.add(new Tuple("player" + i, score));
     }
 
-    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
   }
@@ -633,7 +635,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
       expected.add(new Tuple("player" + i, score));
     }
 
-    Set<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> actual = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, actual);
   }
@@ -656,7 +658,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "3",
         KEY1, KEY2, KEY3, "AGGREGATE", "MIN", "AGGREGATE", "MAX");
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expected, results);
   }
@@ -672,7 +674,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     // destination key is a key that exists
     assertThat(jedis.zinterstore(KEY1, KEY1, KEY2)).isEqualTo(scores.size());
 
-    Set<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
 
     assertThatActualScoresAreVeryCloseToExpectedScores(expectedResults, results);
   }
@@ -797,7 +799,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
 
   @Test
   public void test_assertThatActualScoresAreVeryCloseToExpectedScores() {
-    Set<Tuple> actualResult = new HashSet<>(3);
+    List<Tuple> actualResult = new ArrayList<>(3);
     Set<Tuple> expectedResult = new HashSet<>(2);
 
     actualResult.add(new Tuple("element1", 1.0));
@@ -823,7 +825,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
   }
 
   private void assertThatActualScoresAreVeryCloseToExpectedScores(
-      Set<Tuple> expectedResults, Set<Tuple> results) {
+      final Set<Tuple> expectedResults, final List<Tuple> results) {
     assertThat(expectedResults.size()).isEqualTo(results.size());
 
     for (Tuple expectedResult : expectedResults) {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMaxIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMaxIntegrationTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMinIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMinIntegrationTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
@@ -37,7 +37,7 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
@@ -139,7 +139,7 @@ public abstract class AbstractZRangeIntegrationTest implements RedisIntegrationT
 
   @Test
   public void shouldAlsoReturnScores_whenWithScoresSpecified() {
-    Set<Tuple> expected = new LinkedHashSet<>();
+    final List<Tuple> expected = new ArrayList<>();
     for (int i = 0; i < members.size(); i++) {
       expected.add(new Tuple(members.get(i), scores.get(i)));
     }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
@@ -24,10 +24,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.junit.After;
 import org.junit.Before;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
@@ -35,7 +35,7 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.internal.RedisConstants;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
@@ -216,16 +216,17 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
   public void shouldReturnRange_boundedByLimit() {
     createZSetRangeTestMap();
 
-/* Fails in Jedis 4.1.1 for both Geode and Native Redis, so must be a Jedis bug
-   TODO submit GitHub issue for this
-
-    assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 0, 2))  --> returns empty list
-        .containsExactly("f", "e");
-    assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 2, 3))
-        .containsExactly("d", "c", "b");
-    assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 2, 10))
-        .containsExactly("d", "c", "b");
-*/
+    /*
+     * Fails in Jedis 4.1.1 for both Geode and Native Redis, so must be a Jedis bug
+     * TODO submit GitHub issue for this
+     *
+     * assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 0, 2)) --> returns empty list
+     * .containsExactly("f", "e");
+     * assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 2, 3))
+     * .containsExactly("d", "c", "b");
+     * assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 2, 10))
+     * .containsExactly("d", "c", "b");
+     */
     assertThat(jedis.zrevrangeByScore(KEY, 10d, 0d, 0, 2))
         .containsExactly("f", "e");
     assertThat(jedis.zrevrangeByScore(KEY, 10d, 0d, 2, 3))

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
@@ -40,7 +40,7 @@ import org.junit.runner.RunWith;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.junit.runners.GeodeParamsRunner;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
@@ -216,17 +216,6 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
   public void shouldReturnRange_boundedByLimit() {
     createZSetRangeTestMap();
 
-    /*
-     * Fails in Jedis 4.1.1 for both Geode and Native Redis, so must be a Jedis bug
-     * TODO submit GitHub issue for this
-     *
-     * assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 0, 2)) --> returns empty list
-     * .containsExactly("f", "e");
-     * assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 2, 3))
-     * .containsExactly("d", "c", "b");
-     * assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 2, 10))
-     * .containsExactly("d", "c", "b");
-     */
     assertThat(jedis.zrevrangeByScore(KEY, 10d, 0d, 0, 2))
         .containsExactly("f", "e");
     assertThat(jedis.zrevrangeByScore(KEY, 10d, 0d, 2, 3))

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
@@ -216,11 +216,21 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
   public void shouldReturnRange_boundedByLimit() {
     createZSetRangeTestMap();
 
-    assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 0, 2))
+/* Fails in Jedis 4.1.1 for both Geode and Native Redis, so must be a Jedis bug
+   TODO submit GitHub issue for this
+
+    assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 0, 2))  --> returns empty list
         .containsExactly("f", "e");
     assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 2, 3))
         .containsExactly("d", "c", "b");
     assertThat(jedis.zrevrangeByScore(KEY, "10", "0", 2, 10))
+        .containsExactly("d", "c", "b");
+*/
+    assertThat(jedis.zrevrangeByScore(KEY, 10d, 0d, 0, 2))
+        .containsExactly("f", "e");
+    assertThat(jedis.zrevrangeByScore(KEY, 10d, 0d, 2, 3))
+        .containsExactly("d", "c", "b");
+    assertThat(jedis.zrevrangeByScore(KEY, 10d, 0d, 2, 10))
         .containsExactly("d", "c", "b");
   }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeIntegrationTest.java
@@ -36,7 +36,7 @@ import org.junit.runner.RunWith;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Tuple;
+import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.junit.runners.GeodeParamsRunner;
@@ -132,7 +132,7 @@ public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrati
     List<Tuple> expectedRevrange = entries.subList(subListStartIndex, subListEndIndex);
     Collections.reverse(expectedRevrange);
 
-    Set<Tuple> revrange = jedis.zrevrangeWithScores(KEY, start, end);
+    final List<Tuple> revrange = jedis.zrevrangeWithScores(KEY, start, end);
 
     assertThat(revrange).containsExactlyElementsOf(expectedRevrange);
   }
@@ -176,7 +176,7 @@ public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrati
     List<String> expectedRevrange = entries.subList(subListStartIndex, subListEndIndex);
     Collections.reverse(expectedRevrange);
 
-    Set<String> revrange = jedis.zrevrange(KEY, start, end);
+    final List<String> revrange = jedis.zrevrange(KEY, start, end);
 
     assertThat(revrange).containsExactlyElementsOf(expectedRevrange);
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeIntegrationTest.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZScanIntegrationTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 import redis.clients.jedis.CommandObjects;
 import redis.clients.jedis.Connection;
 import redis.clients.jedis.HostAndPort;
-import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
 import redis.clients.jedis.params.ScanParams;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
@@ -308,7 +308,8 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(10, x -> (double) (9 - x));
     jedis.zadd(KEY2, scores2);
 
-    final Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (x * 2.0) + ((9 - x) * 1.5));
+    final Set<Tuple> expectedResults =
+        convertToTuples(scores1, (i, x) -> (x * 2.0) + ((9 - x) * 1.5));
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(2.0, 1.5), KEY1, KEY2);
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
@@ -20,11 +20,10 @@ import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CL
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -230,67 +229,67 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     scores.put("player2", 0D);
     scores.put("player3", 1D);
     scores.put("player4", Double.POSITIVE_INFINITY);
-    Set<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x);
+    List<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x);
     jedis.zadd(KEY1, scores);
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(1), KEY1);
 
     List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(0), KEY1);
 
     expectedResults = convertToTuples(scores, (i, x) -> 0D);
     results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(Double.POSITIVE_INFINITY), KEY1);
 
     expectedResults = convertToTuples(scores, (i, x) -> x == 1 ? Double.POSITIVE_INFINITY : x);
     results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(Double.NEGATIVE_INFINITY), KEY1);
 
-    expectedResults = new LinkedHashSet<>();
+    expectedResults = new ArrayList<>();
     expectedResults.add(new Tuple("player3", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player4", Double.NEGATIVE_INFINITY));
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player1", Double.POSITIVE_INFINITY));
     results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldUnionize_givenASingleSet() {
     Map<String, Double> scores = makeScoreMap(10, x -> (double) x);
-    Set<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x);
+    final List<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x);
     jedis.zadd(KEY1, scores);
 
     assertThat(jedis.zunionstore(NEW_SET, KEY1)).isEqualTo(10);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldUnionize_givenOneSetDoesNotExist() {
     Map<String, Double> scores = makeScoreMap(10, x -> (double) x);
-    Set<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x);
+    final List<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x);
     jedis.zadd(KEY1, scores);
 
     jedis.zunionstore(NEW_SET, KEY1, KEY2);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
   public void shouldUnionize_givenWeight() {
     Map<String, Double> scores = makeScoreMap(10, x -> (double) x);
-    Set<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x * 1.5);
+    final List<Tuple> expectedResults = convertToTuples(scores, (i, x) -> x * 1.5);
     jedis.zadd(KEY1, scores);
 
     jedis.zunionstore(KEY1, new ZParams().weights(1.5), KEY1);
@@ -308,14 +307,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(10, x -> (double) (9 - x));
     jedis.zadd(KEY2, scores2);
 
-    final Set<Tuple> expectedResults =
+    final List<Tuple> expectedResults =
         convertToTuples(scores1, (i, x) -> (x * 2.0) + ((9 - x) * 1.5));
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(2.0, 1.5), KEY1, KEY2);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -326,14 +325,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(10, x -> 0D);
     jedis.zadd(KEY2, scores2);
 
-    Set<Tuple> expectedResults = convertToTuples(scores2, (i, x) -> x);
+    final List<Tuple> expectedResults = convertToTuples(scores2, (i, x) -> x);
 
     jedis.zunionstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MIN),
         KEY1, KEY2);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -344,14 +343,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(10, x -> (double) ((x % 2 == 0) ? x : 0));
     jedis.zadd(KEY2, scores2);
 
-    Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (double) i);
+    final List<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (double) i);
 
     jedis.zunionstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MAX),
         KEY1, KEY2);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -362,14 +361,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(10, x -> (double) 1);
     jedis.zadd(KEY2, scores2);
 
-    Set<Tuple> expectedResults = convertToTuples(scores2, (i, x) -> x);
+    final List<Tuple> expectedResults = convertToTuples(scores2, (i, x) -> x);
 
     jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2",
         KEY1, KEY2, "AGGREGATE", "MIN", "AGGREGATE", "MAX");
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -380,14 +379,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(10, x -> (double) ((x % 2 == 0) ? x : 0));
     jedis.zadd(KEY2, scores2);
 
-    Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (double) (i * 2));
+    final List<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (double) (i * 2));
 
     jedis.zunionstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MAX).weights(2, 2),
         KEY1, KEY2);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -401,14 +400,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores3 = makeScoreMap(10, x -> (double) (x * 3));
     jedis.zadd(SORTED_SET_KEY3, scores3);
 
-    Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> x * 6);
+    final List<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> x * 6);
 
     jedis.zunionstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.SUM),
         KEY1, KEY2, SORTED_SET_KEY3);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -419,14 +418,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(1, 2, 10, x -> (double) x);
     jedis.zadd(KEY2, scores2);
 
-    Set<Tuple> expectedResults =
+    final List<Tuple> expectedResults =
         convertToTuples(makeScoreMap(0, 1, 20, x -> (double) x), (i, x) -> x);
 
     jedis.zunionstore(NEW_SET, KEY1, KEY2);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 20);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -437,14 +436,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(5, 1, 10, x -> (double) (x < 10 ? x : x * 2));
     jedis.zadd(KEY2, scores2);
 
-    Set<Tuple> expectedResults = convertToTuples(makeScoreMap(0, 1, 15, x -> (double) x),
+    final List<Tuple> expectedResults = convertToTuples(makeScoreMap(0, 1, 15, x -> (double) x),
         (i, x) -> (double) (i < 5 ? i : i * 2));
 
     jedis.zunionstore(NEW_SET, KEY1, KEY2);
 
     final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 20);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -455,14 +454,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(10, x -> (double) x);
     jedis.zadd(KEY2, scores2);
 
-    Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (double) (i * 10));
+    final List<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (double) (i * 10));
 
     jedis.zunionstore(KEY1,
         new ZParams().weights(1, 10).aggregate(ZParams.Aggregate.MAX), KEY1, KEY2);
 
     final List<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 20);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -470,14 +469,14 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores1 = makeScoreMap(10, x -> (double) x);
     jedis.zadd(KEY1, scores1);
 
-    Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> x * 2);
+    final List<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> x * 2);
 
     // Default aggregation is SUM
     jedis.zunionstore(KEY1, KEY1, KEY1);
 
     final List<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -485,13 +484,13 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores1 = makeScoreMap(10, x -> (double) x);
     jedis.zadd(KEY1, scores1);
 
-    Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> x);
+    final List<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> x);
 
     jedis.zunionstore(KEY1, KEY1);
 
     final List<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
 
-    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
+    assertThat(results).containsExactlyElementsOf(expectedResults);
   }
 
   @Test
@@ -532,9 +531,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     return map;
   }
 
-  private Set<Tuple> convertToTuples(Map<String, Double> map,
+  private List<Tuple> convertToTuples(Map<String, Double> map,
       BiFunction<Integer, Double, Double> function) {
-    Set<Tuple> tuples = new LinkedHashSet<>();
+    List<Tuple> tuples = new ArrayList<>();
     int x = 0;
     for (Map.Entry<String, Double> e : map.entrySet()) {
       tuples.add(new Tuple(e.getKey().getBytes(), function.apply(x++, e.getValue())));

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
@@ -447,7 +447,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
   }
 
   @Test
-  public void ensureWeightsAreAppliedBeforeAxggregation() {
+  public void ensureWeightsAreAppliedBeforeAggregation() {
     Map<String, Double> scores1 = makeScoreMap(10, x -> (double) x * 5);
     jedis.zadd(KEY1, scores1);
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -33,8 +34,8 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.Tuple;
-import redis.clients.jedis.ZParams;
+import redis.clients.jedis.params.ZParams;
+import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -234,20 +235,20 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(1), KEY1);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(0), KEY1);
 
     expectedResults = convertToTuples(scores, (i, x) -> 0D);
     results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(Double.POSITIVE_INFINITY), KEY1);
 
     expectedResults = convertToTuples(scores, (i, x) -> x == 1 ? Double.POSITIVE_INFINITY : x);
     results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(Double.NEGATIVE_INFINITY), KEY1);
 
@@ -257,7 +258,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     expectedResults.add(new Tuple("player2", 0D));
     expectedResults.add(new Tuple("player1", Double.POSITIVE_INFINITY));
     results = jedis.zrangeWithScores(NEW_SET, 0, scores.size());
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -268,9 +269,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
     assertThat(jedis.zunionstore(NEW_SET, KEY1)).isEqualTo(10);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -281,9 +282,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
     jedis.zunionstore(NEW_SET, KEY1, KEY2);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -294,7 +295,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
     jedis.zunionstore(KEY1, new ZParams().weights(1.5), KEY1);
 
-    Set<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
 
     assertThat(results).containsExactlyElementsOf(expectedResults);
   }
@@ -307,13 +308,13 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     Map<String, Double> scores2 = makeScoreMap(10, x -> (double) (9 - x));
     jedis.zadd(KEY2, scores2);
 
-    Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (x * 2.0) + ((9 - x) * 1.5));
+    final Set<Tuple> expectedResults = convertToTuples(scores1, (i, x) -> (x * 2.0) + ((9 - x) * 1.5));
 
     jedis.zunionstore(NEW_SET, new ZParams().weights(2.0, 1.5), KEY1, KEY2);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -329,9 +330,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.zunionstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MIN),
         KEY1, KEY2);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -347,9 +348,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.zunionstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MAX),
         KEY1, KEY2);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -365,9 +366,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2",
         KEY1, KEY2, "AGGREGATE", "MIN", "AGGREGATE", "MAX");
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -383,9 +384,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.zunionstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.MAX).weights(2, 2),
         KEY1, KEY2);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -404,9 +405,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.zunionstore(NEW_SET, new ZParams().aggregate(ZParams.Aggregate.SUM),
         KEY1, KEY2, SORTED_SET_KEY3);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -422,9 +423,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
     jedis.zunionstore(NEW_SET, KEY1, KEY2);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 20);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 20);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -440,13 +441,13 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
     jedis.zunionstore(NEW_SET, KEY1, KEY2);
 
-    Set<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 20);
+    final List<Tuple> results = jedis.zrangeWithScores(NEW_SET, 0, 20);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
-  public void ensureWeightsAreAppliedBeforeAggregation() {
+  public void ensureWeightsAreAppliedBeforeAxggregation() {
     Map<String, Double> scores1 = makeScoreMap(10, x -> (double) x * 5);
     jedis.zadd(KEY1, scores1);
 
@@ -458,9 +459,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.zunionstore(KEY1,
         new ZParams().weights(1, 10).aggregate(ZParams.Aggregate.MAX), KEY1, KEY2);
 
-    Set<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 20);
+    final List<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 20);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -473,9 +474,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     // Default aggregation is SUM
     jedis.zunionstore(KEY1, KEY1, KEY1);
 
-    Set<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test
@@ -487,9 +488,9 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
 
     jedis.zunionstore(KEY1, KEY1);
 
-    Set<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
+    final List<Tuple> results = jedis.zrangeWithScores(KEY1, 0, 10);
 
-    assertThat(results).containsExactlyElementsOf(expectedResults);
+    assertThat(results).containsExactlyInAnyOrderElementsOf(expectedResults);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitOpIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitOpIntegrationTest.java
@@ -24,10 +24,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.BitOP;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.args.BitOP;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitPosIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitPosIntegrationTest.java
@@ -21,9 +21,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import redis.clients.jedis.BitPosParams;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.Protocol;
+import redis.clients.jedis.params.BitPosParams;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;


### PR DESCRIPTION
Upgrade Jedis client to 4.1.1.

The biggest change from Jedis 3.6.3 to 4.1.1 is that you have to specify a `maxAttempts` when you construct a JedisCluster because the default of 5 is not enough for HA. I used 20 or 25 in the tests, which is apparently enough. 

Also, I don't think the changes to the tests ended up being enough to be concerned about for backporting, so I think this can just be merged to develop



<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
