### PR TITLE
Revert "GEODE-9586: modify 1.15.0's client server protocol version"

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CommandInitializer.java
@@ -205,7 +205,6 @@ public class CommandInitializer implements CommandRegistry {
     allCommands.put(KnownVersion.GEODE_1_13_0, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_13_2, geode18Commands);
     allCommands.put(KnownVersion.GEODE_1_14_0, geode18Commands);
-    allCommands.put(KnownVersion.GEODE_1_15_0, geode18Commands);
 
     // as of GEODE_1_15_0 we only create new command sets when the
     // client/server protocol changes

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
@@ -207,7 +207,7 @@ public class KnownVersion extends AbstractVersion {
   @Immutable
   public static final KnownVersion GEODE_1_15_0 =
       new KnownVersion("GEODE", "1.15.0", (byte) 1, (byte) 15, (byte) 0, (byte) 0,
-          GEODE_1_15_0_ORDINAL, true);
+          GEODE_1_15_0_ORDINAL);
 
   /* NOTE: when adding a new version bump the ordinal by 10. Ordinals can be short ints */
 

--- a/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
+++ b/geode-serialization/src/test/java/org/apache/geode/internal/serialization/KnownVersionJUnitTest.java
@@ -68,7 +68,7 @@ public class KnownVersionJUnitTest {
     assertThat(KnownVersion.GEODE_1_14_0.getClientServerProtocolVersion())
         .isEqualTo(KnownVersion.GEODE_1_14_0);
     assertThat(KnownVersion.GEODE_1_15_0.getClientServerProtocolVersion())
-        .isEqualTo(KnownVersion.GEODE_1_15_0);
+        .isEqualTo(KnownVersion.GEODE_1_14_0);
   }
 
   private void compare(KnownVersion later, KnownVersion earlier) {


### PR DESCRIPTION
since this commit was made without any corresponding test or code changes, I'm curious to confirm whether we have tests that will fail without it