### PR TITLE
GEODE-10008: Avoid possible EntryDestroyed exception in wan copy-region command

### DIFF
--- a/geode-wan/src/main/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionDelegate.java
+++ b/geode-wan/src/main/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionDelegate.java
@@ -26,8 +26,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.Logger;
 
@@ -186,13 +184,11 @@ public class WanCopyRegionFunctionDelegate implements Serializable {
     return batch;
   }
 
-  private Set<?> getEntries(Region<?, ?> region, GatewaySender sender) {
+  private List<?> getEntries(Region<?, ?> region, GatewaySender sender) {
     if (region instanceof PartitionedRegion && sender.isParallel()) {
-      return ((PartitionedRegion) region).getDataStore().getAllLocalBucketRegions()
-          .stream()
-          .flatMap(br -> ((Set<?>) br.entrySet()).stream()).collect(Collectors.toSet());
+      return ((PartitionedRegion) region).getDataStore().getEntries();
     }
-    return region.entrySet();
+    return new ArrayList<>(region.entrySet());
   }
 
   /**


### PR DESCRIPTION
The `wan-copy region` command, when run on a partitioned region using a parallel gateway sender, retrieves the entries from the region and puts them in a Set for further processing. In order to add them to the Set, the `hashCode` method of the entry (`NonTXEntry`) in invoked. If any of those entries was destroyed, then the EntryDestroyedException will be thrown.

In order to avoid this exception, the `wan-copy region` command will not put the entries in a Set for further processing as it is not needed.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
