### PR TITLE
GEODE-10018: Remove redundant TX flag from SetOptions

### DIFF
--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetExecutor.java
@@ -15,13 +15,10 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
-import static org.apache.geode.redis.internal.commands.executor.BaseSetOptions.Exists.NONE;
-import static org.apache.geode.redis.internal.commands.executor.BaseSetOptions.Exists.NX;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.geode.annotations.Immutable;
 import org.apache.geode.redis.internal.commands.Command;
 import org.apache.geode.redis.internal.commands.executor.CommandExecutor;
 import org.apache.geode.redis.internal.commands.executor.RedisResponse;
@@ -65,23 +62,16 @@ public abstract class AbstractMSetExecutor implements CommandExecutor {
   }
 
   protected void mset(ExecutionHandlerContext context, List<RedisKey> keys, List<byte[]> values,
-      boolean nx) {
+      SetOptions options) {
     List<RedisKey> keysToLock = new ArrayList<>(keys);
     RegionProvider regionProvider = context.getRegionProvider();
 
     context.lockedExecuteInTransaction(keysToLock.get(0), keysToLock,
-        () -> mset0(regionProvider, keys, values, nx));
+        () -> mset0(regionProvider, keys, values, options));
   }
 
-  @Immutable
-  private static final SetOptions msetnxOptions = new SetOptions(NX, 0L, false, true);
-
-  @Immutable
-  private static final SetOptions msetOptions = new SetOptions(NONE, 0L, false, true);
-
   private Void mset0(RegionProvider regionProvider, List<RedisKey> keys, List<byte[]> values,
-      boolean nx) {
-    SetOptions options = nx ? msetnxOptions : msetOptions;
+      SetOptions options) {
     for (int i = 0; i < keys.size(); i++) {
       if (!SetExecutor.set(regionProvider, keys.get(i), values.get(i), options)) {
         // rolls back transaction

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/MSetExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/MSetExecutor.java
@@ -15,18 +15,24 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 
+import static org.apache.geode.redis.internal.commands.executor.BaseSetOptions.Exists.NONE;
+
 import java.util.List;
 
+import org.apache.geode.annotations.Immutable;
 import org.apache.geode.redis.internal.commands.executor.RedisResponse;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class MSetExecutor extends AbstractMSetExecutor {
 
+  @Immutable
+  private static final SetOptions msetOptions = new SetOptions(NONE, 0L, false);
+
   @Override
   protected void executeMSet(ExecutionHandlerContext context, List<RedisKey> keys,
       List<byte[]> values) {
-    mset(context, keys, values, false);
+    mset(context, keys, values, msetOptions);
   }
 
   @Override

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/MSetNXExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/MSetNXExecutor.java
@@ -15,8 +15,11 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 
+import static org.apache.geode.redis.internal.commands.executor.BaseSetOptions.Exists.NX;
+
 import java.util.List;
 
+import org.apache.geode.annotations.Immutable;
 import org.apache.geode.redis.internal.commands.executor.RedisResponse;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
@@ -27,10 +30,13 @@ public class MSetNXExecutor extends AbstractMSetExecutor {
 
   private static final int NO_KEY_SET = 0;
 
+  @Immutable
+  private static final SetOptions msetnxOptions = new SetOptions(NX, 0L, false);
+
   @Override
   protected void executeMSet(ExecutionHandlerContext context, List<RedisKey> keys,
       List<byte[]> values) {
-    mset(context, keys, values, true);
+    mset(context, keys, values, msetnxOptions);
   }
 
   @Override

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/SetOptions.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/SetOptions.java
@@ -26,17 +26,11 @@ public class SetOptions extends BaseSetOptions {
 
   private final long expirationMillis;
   private final boolean keepTTL;
-  private final boolean inTransaction;
 
   public SetOptions(Exists exists, long expiration, boolean keepTTL) {
-    this(exists, expiration, keepTTL, false);
-  }
-
-  public SetOptions(Exists exists, long expiration, boolean keepTTL, boolean inTransaction) {
     super(exists);
     expirationMillis = expiration;
     this.keepTTL = keepTTL;
-    this.inTransaction = inTransaction;
   }
 
   public long getExpiration() {
@@ -45,9 +39,5 @@ public class SetOptions extends BaseSetOptions {
 
   public boolean isKeepTTL() {
     return keepTTL;
-  }
-
-  public boolean inTransaction() {
-    return inTransaction;
   }
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -68,14 +68,7 @@ public class RedisString extends AbstractRedisData {
       SetOptions options) {
     value = newValue;
     handleSetExpiration(options);
-    if (options != null && options.inTransaction()) {
-      // In a tx, delta requires cloning-enabled which is very expensive.
-      // So just do a put instead of storeChanges which uses delta.
-      region.put(key, this);
-    } else {
-      storeChanges(region, key,
-          new SetByteArrayAndTimestamp(newValue, getExpirationTimestamp()));
-    }
+    storeChanges(region, key, new SetByteArrayAndTimestamp(newValue, getExpirationTimestamp()));
   }
 
   public int append(Region<RedisKey, RedisData> region, RedisKey key, byte[] appendValue) {


### PR DESCRIPTION
Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
