### PR TITLE
GEODE-10032: Add Category to RadishCommandType

### DIFF
--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/CommandIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/CommandIntegrationTest.java
@@ -126,6 +126,13 @@ public class CommandIntegrationTest {
     softly.assertThat(actual.lastKey).as(expected.name + ".lastKey").isEqualTo(expected.lastKey);
     softly.assertThat(actual.stepCount).as(expected.name + ".stepCount")
         .isEqualTo(expected.stepCount);
+    if (!actual.categories.get(0).equals("@ignored")) {
+      softly.assertThat(actual.categories.get(0)).as(expected.name + ".category")
+          .isIn(expected.categories);
+    } else {
+      softly.assertThat(actual.name).as("command " + actual.name + " is categorized as IGNORED")
+          .isIn("info", "lolwut", "time");
+    }
     softly.assertAll();
   }
 
@@ -143,7 +150,8 @@ public class CommandIntegrationTest {
           (List<String>) entry.get(2),
           (long) entry.get(3),
           (long) entry.get(4),
-          (long) entry.get(5));
+          (long) entry.get(5),
+          (List<String>) entry.get(6));
 
       commands.put(key, cmd);
     }
@@ -158,15 +166,17 @@ public class CommandIntegrationTest {
     final List<String> flags;
     final long lastKey;
     final long stepCount;
+    final List<String> categories;
 
     public CommandStructure(String name, long arity, List<String> flags, long firstKey,
-        long lastKey, long stepCount) {
+        long lastKey, long stepCount, List<String> categories) {
       this.name = name;
       this.arity = arity;
       this.flags = flags;
       this.firstKey = firstKey;
       this.lastKey = lastKey;
       this.stepCount = stepCount;
+      this.categories = categories;
     }
   }
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -17,7 +17,7 @@ package org.apache.geode.redis.internal;
 
 import org.apache.geode.redis.internal.commands.executor.cluster.ClusterExecutor;
 import org.apache.geode.redis.internal.commands.executor.connection.ClientExecutor;
-import org.apache.geode.redis.internal.commands.executor.server.COMMANDCommandExecutor;
+import org.apache.geode.redis.internal.commands.executor.server.CommandCommandExecutor;
 
 public class RedisConstants {
 
@@ -64,7 +64,7 @@ public class RedisConstants {
           + ClusterExecutor.getSupportedSubcommands();
   public static final String ERROR_UNKNOWN_COMMAND_COMMAND_SUBCOMMAND =
       "Unknown subcommand or wrong number of arguments for '%s'. Supported subcommands are: "
-          + COMMANDCommandExecutor.getSupportedSubcommands();
+          + CommandCommandExecutor.getSupportedSubcommands();
   public static final String ERROR_INVALID_ZADD_OPTION_NX_XX =
       "XX and NX options at the same time are not compatible";
   public static final String ERROR_UNKNOWN_PUBSUB_SUBCOMMAND =

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/CommandCommandExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/server/CommandCommandExecutor.java
@@ -39,7 +39,7 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
  * COMMAND refers to the redis command being implemented.
  * CommandExecutor refers to the interface being implemented.
  */
-public class COMMANDCommandExecutor implements CommandExecutor {
+public class CommandCommandExecutor implements CommandExecutor {
   @Immutable
   private static final List<String> supportedSubcommands =
       Collections.unmodifiableList(Arrays.asList("(no subcommand)"));
@@ -76,6 +76,10 @@ public class COMMANDCommandExecutor implements CommandExecutor {
       oneCommand.add(type.firstKey());
       oneCommand.add(type.lastKey());
       oneCommand.add(type.step());
+
+      List<String> categories = new ArrayList<>();
+      categories.add("@" + type.category().name().toLowerCase());
+      oneCommand.add(categories);
 
       response.add(oneCommand);
     }


### PR DESCRIPTION
- This adds a single category (or type) to each command in order to
  identify the type of data structure it applies too. This is initially
  being done in order to allow Geode statistics to be finer grained in
  how the Radish-specific stats are grouped.
- The category is derived from Redis' ACL Categories. In Redis these
  categories also include the command's flags (and possibly additional
  values). This implementation only specifies the category as it relates
  to the command's data type.  For example, in Redis the `GET` command
  has categories `@read`, `@fast` and `@string`. In Geode, the category
  would only be `@string`. This may well change in the future if ACLs
  are implemented.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
