### PR TITLE
GEODE-10042: do not make ClientUserAuths null when we are not unregister client yet.

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxyTest.java
@@ -26,8 +26,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.util.Scanner;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -52,7 +55,7 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 public class CacheClientProxyTest {
 
   @Rule
-  public ServerStarterRule serverRule = new ServerStarterRule().withAutoStart();
+  public ServerStarterRule serverRule = new ServerStarterRule().withLogFile().withAutoStart();
 
   @Rule
   public ExecutorServiceRule executorServiceRule = new ExecutorServiceRule();
@@ -96,10 +99,19 @@ public class CacheClientProxyTest {
   }
 
   @Test
-  public void closeSocket1000Times() {
+  public void closeSocket1000Times() throws FileNotFoundException {
     // run it for 1000 times to introduce conflicts between threads
     for (int i = 0; i < 1000; i++) {
       closeSocketShouldBeAtomic();
+    }
+
+    // make sure there is no NPE warning in the log file
+    File logFile = new File(serverRule.getWorkingDir(), "server.log");
+    Scanner scanner = new Scanner(logFile);
+    while (scanner.hasNextLine()) {
+      String line = scanner.nextLine();
+      assertThat(line).describedAs("File: %s, Line: %s", logFile.getAbsolutePath(), line)
+          .doesNotContain("NullPointerException");
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -785,24 +785,7 @@ public class CacheClientProxy implements ClientSession {
     // Close the Authorization callback or subject if we are not keeping the proxy
     try {
       if (!pauseDurable) {
-        // single user case -- old security
-        if (postAuthzCallback != null) {
-          postAuthzCallback.close();
-          postAuthzCallback = null;
-        }
-        // single user case -- integrated security
-        // connection is closed, so we can log out this subject
-        else if (subject != null) {
-          secureLogger.debug("CacheClientProxy.close, logging out {}. ", subject.getPrincipal());
-          subject.logout();
-          subject = null;
-        }
-        // for multiUser case, in non-durable case, we are closing the connection
-        else if (clientUserAuths != null) {
-          secureLogger.debug("CacheClientProxy.close, cleanup all client subjects. ");
-          clientUserAuths.cleanup(true);
-          clientUserAuths = null;
-        }
+        cleanClientAuths();
       }
     } catch (Exception ex) {
       logger.warn("{}", this, ex);
@@ -810,6 +793,28 @@ public class CacheClientProxy implements ClientSession {
     // Notify the caller whether to keep this proxy. If the proxy is durable
     // and should be paused, then return true; otherwise return false.
     return keepProxy;
+  }
+
+  // this needs to synchronized to avoid NPE between null check and operations
+  private synchronized void cleanClientAuths() {
+    // single user case -- old security
+    if (postAuthzCallback != null) {
+      postAuthzCallback.close();
+      postAuthzCallback = null;
+    }
+    // single user case -- integrated security
+    // connection is closed, so we can log out this subject
+    else if (subject != null) {
+      secureLogger.debug("CacheClientProxy.close, logging out {}. ", subject.getPrincipal());
+      subject.logout();
+      subject = null;
+    }
+    // for multiUser case, in non-durable case, we are closing the connection
+    else if (clientUserAuths != null) {
+      secureLogger.debug("CacheClientProxy.close, cleanup all client subjects. ");
+      clientUserAuths.cleanup(true);
+      clientUserAuths = null;
+    }
   }
 
   protected void pauseDispatching() {

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -796,24 +796,26 @@ public class CacheClientProxy implements ClientSession {
   }
 
   // this needs to synchronized to avoid NPE between null check and operations
-  private synchronized void cleanClientAuths() {
-    // single user case -- old security
-    if (postAuthzCallback != null) {
-      postAuthzCallback.close();
-      postAuthzCallback = null;
-    }
-    // single user case -- integrated security
-    // connection is closed, so we can log out this subject
-    else if (subject != null) {
-      secureLogger.debug("CacheClientProxy.close, logging out {}. ", subject.getPrincipal());
-      subject.logout();
-      subject = null;
-    }
-    // for multiUser case, in non-durable case, we are closing the connection
-    else if (clientUserAuths != null) {
-      secureLogger.debug("CacheClientProxy.close, cleanup all client subjects. ");
-      clientUserAuths.cleanup(true);
-      clientUserAuths = null;
+  private void cleanClientAuths() {
+    synchronized (clientUserAuthsLock) {
+      // single user case -- old security
+      if (postAuthzCallback != null) {
+        postAuthzCallback.close();
+        postAuthzCallback = null;
+      }
+      // single user case -- integrated security
+      // connection is closed, so we can log out this subject
+      else if (subject != null) {
+        secureLogger.debug("CacheClientProxy.close, logging out {}. ", subject.getPrincipal());
+        subject.logout();
+        subject = null;
+      }
+      // for multiUser case, in non-durable case, we are closing the connection
+      else if (clientUserAuths != null) {
+        secureLogger.debug("CacheClientProxy.close, cleanup all client subjects. ");
+        clientUserAuths.cleanup(true);
+        clientUserAuths = null;
+      }
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -795,7 +795,9 @@ public class ServerConnection implements Runnable {
     if (verifyClientConnection()) {
       initializeCommands();
       if (!getCommunicationMode().isWAN()) {
-        initializeClientUserAuths();
+        synchronized (clientUserAuthsLock) {
+          initializeClientUserAuths();
+        }
       }
     }
     if (TEST_VERSION_AFTER_HANDSHAKE_FLAG) {
@@ -1240,7 +1242,9 @@ public class ServerConnection implements Runnable {
 
   @TestOnly
   protected void setClientUserAuths(ClientUserAuths clientUserAuths) {
-    this.clientUserAuths = clientUserAuths;
+    synchronized (clientUserAuthsLock) {
+      this.clientUserAuths = clientUserAuths;
+    }
   }
 
   private void setSecurityPart() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/ServerConnectionTest.java
@@ -284,6 +284,7 @@ public class ServerConnectionTest {
   @Test
   public void handleTerminationWithoutUnrgisterClientShouldNotNullClientAuths() {
     when(acceptor.getClientHealthMonitor()).thenReturn(clientHealthMonitor);
+    when(acceptor.getCacheClientNotifier()).thenReturn(notifier);
     ClientUserAuths clientUserAuths = mock(ClientUserAuths.class);
     ServerConnection spy = spy(serverConnection);
     doReturn(new HashMap<>()).when(clientHealthMonitor).getCleanupTable();
@@ -292,6 +293,10 @@ public class ServerConnectionTest {
 
     spy.handleTermination(false);
     assertThat(spy.getClientUserAuths()).isNotNull();
+
+    // subsequent putSubject call will be successful
+    Subject subject = mock(Subject.class);
+    spy.putSubject(subject, -1);
   }
 
   @Test


### PR DESCRIPTION
handleTermination method is setting the clientUserAuth null even when we are not unregister client.

* make cleanUserAuths synchronized to avoid NPE
* This also pass down client termination reason when we clean up client threads