### PR TITLE
GEODE-10010: Sample Redis ops per second during operations in test

### DIFF
--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsNativeRedisAcceptanceTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsNativeRedisAcceptanceTest.java
@@ -20,7 +20,7 @@ import redis.clients.jedis.Jedis;
 
 import org.apache.geode.NativeRedisTestRule;
 
-public class InfoStatsNativeRedisAcceptanceTest extends AbstractRedisInfoStatsIntegrationTest {
+public class InfoStatsNativeRedisAcceptanceTest extends AbstractInfoStatsIntegrationTest {
   @ClassRule
   public static NativeRedisTestRule redis = new NativeRedisTestRule();
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoStatsIntegrationTest.java
@@ -15,17 +15,25 @@
 package org.apache.geode.redis.internal.commands.executor.server;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+import static org.assertj.core.api.Assertions.withinPercentage;
 
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.assertj.core.data.Offset;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
 
@@ -34,17 +42,19 @@ import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.redis.RedisTestHelper;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
 
-public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisIntegrationTest {
+public abstract class AbstractInfoStatsIntegrationTest implements RedisIntegrationTest {
+  @Rule
+  public ExecutorServiceRule executor = new ExecutorServiceRule();
 
-  private static final int TIMEOUT = (int) GeodeAwaitility.getTimeout().toMillis();
   private static final String EXISTING_HASH_KEY = "Existing_Hash";
   private static final String EXISTING_STRING_KEY = "Existing_String";
   private static final String EXISTING_SET_KEY_1 = "Existing_Set_1";
   private static final String EXISTING_SET_KEY_2 = "Existing_Set_2";
 
   private Jedis jedis;
-  private static long START_TIME;
+  private static long startTime;
   private static StatisticsClock statisticsClock;
 
   private long preTestConnectionsReceived = 0;
@@ -73,12 +83,12 @@ public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisInte
   @BeforeClass
   public static void beforeClass() {
     statisticsClock = new EnabledStatisticsClock();
-    START_TIME = statisticsClock.getTime();
+    startTime = statisticsClock.getTime();
   }
 
   @Before
   public void before() {
-    jedis = new Jedis("localhost", getPort(), TIMEOUT);
+    jedis = new Jedis(BIND_ADDRESS, getPort(), REDIS_CLIENT_TIMEOUT);
     numInfoCalled.set(0);
 
     long preSetupCommandsProcessed = Long.parseLong(getInfo(jedis).get(COMMANDS_PROCESSED));
@@ -157,27 +167,56 @@ public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisInte
   }
 
   @Test
-  public void opsPerformedOverLastSecond_ShouldUpdate_givenOperationsOccurring() {
-    int NUMBER_SECONDS_TO_RUN = 10;
-    AtomicInteger numberOfCommandsExecuted = new AtomicInteger();
+  public void opsPerformedOverLastSecond_ShouldUpdate_givenOperationsOccurring()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    long numberSecondsToRun = 4;
+    AtomicInteger totalOpsPerformed = new AtomicInteger();
 
-    await().during(Duration.ofSeconds(NUMBER_SECONDS_TO_RUN)).until(() -> {
-      jedis.set("key", "value");
-      numberOfCommandsExecuted.getAndIncrement();
-      return true;
+    long startTime = System.currentTimeMillis();
+    long endTime = startTime + Duration.ofSeconds(numberSecondsToRun).toMillis();
+
+    // Take a sample in the middle of performing operations to help eliminate warmup as a factor
+    long timeToSampleAt = startTime + Duration.ofSeconds(numberSecondsToRun / 2).toMillis();
+    long timeToGetBaselineOpsPerformed = timeToSampleAt - Duration.ofSeconds(1).toMillis();
+
+    // Execute commands in the background
+    Future<Void> executeCommands = executor.submit(() -> {
+      Jedis jedis2 = new Jedis(BIND_ADDRESS, getPort(), REDIS_CLIENT_TIMEOUT);
+      while (System.currentTimeMillis() < endTime) {
+        jedis2.set("key", "value");
+        totalOpsPerformed.getAndIncrement();
+      }
+      jedis2.close();
     });
+
+    // Record the total number of operations performed a second before we plan to sample. A poll
+    // interval less than the default of 100ms is used to increase the accuracy of the expected
+    // value, as the stats update the value of instantaneous per second values every 62.5ms
+    await().pollInterval(Duration.ofMillis(50))
+        .until(() -> System.currentTimeMillis() >= timeToGetBaselineOpsPerformed);
+    int opsPerformedUntilASecondBeforeSampling = totalOpsPerformed.get();
+
+    // Calculate how many operations were performed in the last second. A poll interval less than
+    // the default of 100ms is used to increase the accuracy of the expected value, as the stats
+    // update the value of instantaneous per second values every 62.5ms
+    await().pollInterval(Duration.ofMillis(50))
+        .until(() -> System.currentTimeMillis() >= timeToSampleAt);
+    int expected = totalOpsPerformed.get() - opsPerformedUntilASecondBeforeSampling;
+
     double reportedCommandsPerLastSecond =
         Double.parseDouble(getInfo(jedis).get(OPS_PERFORMED_OVER_LAST_SECOND));
 
-    long expected = numberOfCommandsExecuted.get() / NUMBER_SECONDS_TO_RUN;
+    assertThat(reportedCommandsPerLastSecond).isCloseTo(expected, withinPercentage(10));
 
-    assertThat(reportedCommandsPerLastSecond).isCloseTo(expected, Offset.offset(4.0));
+    executeCommands.get(GeodeAwaitility.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
 
-    // if time passes w/o operations
-    await().during(NUMBER_SECONDS_TO_RUN, TimeUnit.SECONDS).until(() -> true);
+    // Wait two seconds with no operations
+    Thread.sleep(2000);
 
-    assertThat(Double.valueOf(getInfo(jedis).get(OPS_PERFORMED_OVER_LAST_SECOND)))
-        .isCloseTo(0.0, Offset.offset(1.0));
+    // Confirm that instantaneous operations per second returns to zero when no operations are being
+    // performed, with a small offset to account for the info command being executed
+    assertThat(Double.parseDouble(getInfo(jedis).get(OPS_PERFORMED_OVER_LAST_SECOND))).isCloseTo(0,
+        offset(1.0));
   }
 
   @Test
@@ -193,39 +232,71 @@ public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisInte
   }
 
   @Test
-  public void networkKiloBytesReadOverLastSecond_shouldBeCloseToBytesReadOverLastSecond() {
-
-    double REASONABLE_SOUNDING_OFFSET = .8;
-    int NUMBER_SECONDS_TO_RUN = 5;
-    String RESP_COMMAND_STRING = "*3\r\n$3\r\nset\r\n$3\r\nkey\r\n$5\r\nvalue\r\n";
-    int BYTES_SENT_PER_COMMAND = RESP_COMMAND_STRING.length();
+  public void networkKiloBytesReadOverLastSecond_shouldBeCloseToBytesReadOverLastSecond()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    int numberSecondsToRun = 4;
+    String command = "set";
+    String key = "key";
+    String value = "value";
+    int bytesSentPerCommand =
+        ("*3\r\n$" + command.length() + "\r\n" + command +
+            "\r\n$" + key.length() + "\r\n" + key +
+            "\r\n$" + value.length() + "\r\n" + value +
+            "\r\n").length();
     AtomicInteger totalBytesSent = new AtomicInteger();
 
-    await().during(Duration.ofSeconds(NUMBER_SECONDS_TO_RUN)).until(() -> {
-      jedis.set("key", "value");
-      totalBytesSent.addAndGet(BYTES_SENT_PER_COMMAND);
-      return true;
+    long startTime = System.currentTimeMillis();
+    long endTime = startTime + Duration.ofSeconds(numberSecondsToRun).toMillis();
+
+    // Take a sample in the middle of performing operations to help eliminate warmup as a factor
+    long timeToSampleAt = startTime + Duration.ofSeconds(numberSecondsToRun / 2).toMillis();
+    long timeToGetBaselineBytesSent = timeToSampleAt - Duration.ofSeconds(1).toMillis();
+
+    // Execute commands in the background
+    Future<Void> executeCommands = executor.submit(() -> {
+      Jedis jedis2 = new Jedis(BIND_ADDRESS, getPort(), REDIS_CLIENT_TIMEOUT);
+      while (System.currentTimeMillis() < endTime) {
+        jedis2.set(key, value);
+        totalBytesSent.addAndGet(bytesSentPerCommand);
+      }
+      jedis2.close();
     });
-    double actual_kbs = Double.parseDouble(getInfo(jedis).get(NETWORK_KB_READ_OVER_LAST_SECOND));
-    double expected_kbs = ((double) totalBytesSent.get() / NUMBER_SECONDS_TO_RUN) / 1000;
 
-    assertThat(actual_kbs).isCloseTo(expected_kbs, Offset.offset(REASONABLE_SOUNDING_OFFSET));
+    // Record the total number of KB sent a second before we plan to sample. A poll interval less
+    // than the default of 100ms is used to increase the accuracy of the expected value, as the
+    // stats update the value of instantaneous per second values every 62.5ms
+    await().pollInterval(Duration.ofMillis(50))
+        .until(() -> System.currentTimeMillis() >= timeToGetBaselineBytesSent);
+    int bytesSentUntilASecondBeforeSampling = totalBytesSent.get();
 
-    // if time passes w/o operations
-    await().during(NUMBER_SECONDS_TO_RUN, TimeUnit.SECONDS)
-        .until(() -> true);
+    // Calculate how many KB were sent in the last second. A poll interval less than the default of
+    // 100ms is used to increase the accuracy of the expected value, as the stats update the value
+    // of instantaneous per second values every 62.5ms
+    await().pollInterval(Duration.ofMillis(50))
+        .until(() -> System.currentTimeMillis() >= timeToSampleAt);
+    double expected = (totalBytesSent.get() - bytesSentUntilASecondBeforeSampling) / 1024.0;
 
-    // Kb/s should eventually drop to 0 or at least very close since just executing the info
-    // command may result in the value increasing.
-    assertThat(Double.valueOf(getInfo(jedis).get(NETWORK_KB_READ_OVER_LAST_SECOND)))
-        .isCloseTo(0.0, Offset.offset(0.1));
+    double reportedKBReadPerLastSecond =
+        Double.parseDouble(getInfo(jedis).get(NETWORK_KB_READ_OVER_LAST_SECOND));
+
+    assertThat(reportedKBReadPerLastSecond).isCloseTo(expected, withinPercentage(10));
+
+    executeCommands.get(GeodeAwaitility.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
+
+    // Wait two seconds with no operations
+    Thread.sleep(2000);
+
+    // Confirm that instantaneous KB read per second returns to zero when no operations are being
+    // performed, with a small offset to account for the info command being executed
+    assertThat(Double.parseDouble(getInfo(jedis).get(NETWORK_KB_READ_OVER_LAST_SECOND)))
+        .isCloseTo(0, offset(0.02));
   }
 
   // ------------------- Clients Section -------------------------- //
 
   @Test
   public void connectedClients_incrAndDecrWhenClientConnectsAndDisconnects() {
-    Jedis jedis2 = new Jedis("localhost", getPort(), TIMEOUT);
+    Jedis jedis2 = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
     jedis2.ping();
 
     validateConnectedClients(jedis, preTestConnectedClients, 1);
@@ -237,7 +308,7 @@ public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisInte
 
   @Test
   public void totalConnectionsReceivedStat_shouldIncrement_whenNewConnectionOccurs() {
-    Jedis jedis2 = new Jedis("localhost", getPort(), TIMEOUT);
+    Jedis jedis2 = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT);
     jedis2.ping();
 
     validateConnectionsReceived(jedis, preTestConnectionsReceived, 1);
@@ -276,7 +347,7 @@ public abstract class AbstractRedisInfoStatsIntegrationTest implements RedisInte
 
   // ------------------- Helper Methods ----------------------------- //
   public long getStartTime() {
-    return START_TIME;
+    return startTime;
   }
 
   public long getCurrentTime() {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoStatsIntegrationTest.java
@@ -169,15 +169,15 @@ public abstract class AbstractInfoStatsIntegrationTest implements RedisIntegrati
   @Test
   public void opsPerformedOverLastSecond_ShouldUpdate_givenOperationsOccurring()
       throws InterruptedException, ExecutionException, TimeoutException {
-    long numberSecondsToRun = 4;
+    final long numberSecondsToRun = 4;
     AtomicInteger totalOpsPerformed = new AtomicInteger();
 
-    long startTime = System.currentTimeMillis();
-    long endTime = startTime + Duration.ofSeconds(numberSecondsToRun).toMillis();
+    final long startTime = System.currentTimeMillis();
+    final long endTime = startTime + Duration.ofSeconds(numberSecondsToRun).toMillis();
 
     // Take a sample in the middle of performing operations to help eliminate warmup as a factor
-    long timeToSampleAt = startTime + Duration.ofSeconds(numberSecondsToRun / 2).toMillis();
-    long timeToGetBaselineOpsPerformed = timeToSampleAt - Duration.ofSeconds(1).toMillis();
+    final long timeToSampleAt = startTime + Duration.ofSeconds(numberSecondsToRun / 2).toMillis();
+    final long timeToGetBaselineOpsPerformed = timeToSampleAt - Duration.ofSeconds(1).toMillis();
 
     // Execute commands in the background
     Future<Void> executeCommands = executor.submit(() -> {
@@ -192,19 +192,20 @@ public abstract class AbstractInfoStatsIntegrationTest implements RedisIntegrati
     // Record the total number of operations performed a second before we plan to sample. A poll
     // interval less than the default of 100ms is used to increase the accuracy of the expected
     // value, as the stats update the value of instantaneous per second values every 62.5ms
-    await().pollInterval(Duration.ofMillis(50))
+    await().pollInterval(Duration.ofMillis(10))
         .until(() -> System.currentTimeMillis() >= timeToGetBaselineOpsPerformed);
-    int opsPerformedUntilASecondBeforeSampling = totalOpsPerformed.get();
+    final int opsPerformedUntilASecondBeforeSampling = totalOpsPerformed.get();
 
     // Calculate how many operations were performed in the last second. A poll interval less than
     // the default of 100ms is used to increase the accuracy of the expected value, as the stats
     // update the value of instantaneous per second values every 62.5ms
-    await().pollInterval(Duration.ofMillis(50))
+    await().pollInterval(Duration.ofMillis(10))
         .until(() -> System.currentTimeMillis() >= timeToSampleAt);
-    int expected = totalOpsPerformed.get() - opsPerformedUntilASecondBeforeSampling;
 
-    double reportedCommandsPerLastSecond =
+    final double reportedCommandsPerLastSecond =
         Double.parseDouble(getInfo(jedis).get(OPS_PERFORMED_OVER_LAST_SECOND));
+
+    final int expected = totalOpsPerformed.get() - opsPerformedUntilASecondBeforeSampling;
 
     assertThat(reportedCommandsPerLastSecond).isCloseTo(expected, withinPercentage(12.5));
 
@@ -234,23 +235,23 @@ public abstract class AbstractInfoStatsIntegrationTest implements RedisIntegrati
   @Test
   public void networkKiloBytesReadOverLastSecond_shouldBeCloseToBytesReadOverLastSecond()
       throws InterruptedException, ExecutionException, TimeoutException {
-    int numberSecondsToRun = 4;
-    String command = "set";
-    String key = "key";
-    String value = "value";
-    int bytesSentPerCommand =
+    final int numberSecondsToRun = 4;
+    final String command = "set";
+    final String key = "key";
+    final String value = "value";
+    final int bytesSentPerCommand =
         ("*3\r\n$" + command.length() + "\r\n" + command +
             "\r\n$" + key.length() + "\r\n" + key +
             "\r\n$" + value.length() + "\r\n" + value +
             "\r\n").length();
     AtomicInteger totalBytesSent = new AtomicInteger();
 
-    long startTime = System.currentTimeMillis();
-    long endTime = startTime + Duration.ofSeconds(numberSecondsToRun).toMillis();
+    final long startTime = System.currentTimeMillis();
+    final long endTime = startTime + Duration.ofSeconds(numberSecondsToRun).toMillis();
 
     // Take a sample in the middle of performing operations to help eliminate warmup as a factor
-    long timeToSampleAt = startTime + Duration.ofSeconds(numberSecondsToRun / 2).toMillis();
-    long timeToGetBaselineBytesSent = timeToSampleAt - Duration.ofSeconds(1).toMillis();
+    final long timeToSampleAt = startTime + Duration.ofSeconds(numberSecondsToRun / 2).toMillis();
+    final long timeToGetBaselineBytesSent = timeToSampleAt - Duration.ofSeconds(1).toMillis();
 
     // Execute commands in the background
     Future<Void> executeCommands = executor.submit(() -> {
@@ -265,19 +266,20 @@ public abstract class AbstractInfoStatsIntegrationTest implements RedisIntegrati
     // Record the total number of KB sent a second before we plan to sample. A poll interval less
     // than the default of 100ms is used to increase the accuracy of the expected value, as the
     // stats update the value of instantaneous per second values every 62.5ms
-    await().pollInterval(Duration.ofMillis(50))
+    await().pollInterval(Duration.ofMillis(10))
         .until(() -> System.currentTimeMillis() >= timeToGetBaselineBytesSent);
-    int bytesSentUntilASecondBeforeSampling = totalBytesSent.get();
+    final int bytesSentUntilASecondBeforeSampling = totalBytesSent.get();
 
     // Calculate how many KB were sent in the last second. A poll interval less than the default of
     // 100ms is used to increase the accuracy of the expected value, as the stats update the value
     // of instantaneous per second values every 62.5ms
-    await().pollInterval(Duration.ofMillis(50))
+    await().pollInterval(Duration.ofMillis(10))
         .until(() -> System.currentTimeMillis() >= timeToSampleAt);
-    double expected = (totalBytesSent.get() - bytesSentUntilASecondBeforeSampling) / 1024.0;
 
-    double reportedKBReadPerLastSecond =
+    final double reportedKBReadPerLastSecond =
         Double.parseDouble(getInfo(jedis).get(NETWORK_KB_READ_OVER_LAST_SECOND));
+
+    final double expected = (totalBytesSent.get() - bytesSentUntilASecondBeforeSampling) / 1024.0;
 
     assertThat(reportedKBReadPerLastSecond).isCloseTo(expected, withinPercentage(12.5));
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoStatsIntegrationTest.java
@@ -206,7 +206,7 @@ public abstract class AbstractInfoStatsIntegrationTest implements RedisIntegrati
     double reportedCommandsPerLastSecond =
         Double.parseDouble(getInfo(jedis).get(OPS_PERFORMED_OVER_LAST_SECOND));
 
-    assertThat(reportedCommandsPerLastSecond).isCloseTo(expected, withinPercentage(10));
+    assertThat(reportedCommandsPerLastSecond).isCloseTo(expected, withinPercentage(12.5));
 
     executeCommands.get(GeodeAwaitility.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
 
@@ -279,7 +279,7 @@ public abstract class AbstractInfoStatsIntegrationTest implements RedisIntegrati
     double reportedKBReadPerLastSecond =
         Double.parseDouble(getInfo(jedis).get(NETWORK_KB_READ_OVER_LAST_SECOND));
 
-    assertThat(reportedKBReadPerLastSecond).isCloseTo(expected, withinPercentage(10));
+    assertThat(reportedKBReadPerLastSecond).isCloseTo(expected, withinPercentage(12.5));
 
     executeCommands.get(GeodeAwaitility.getTimeout().toMillis(), TimeUnit.MILLISECONDS);
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsIntegrationTest.java
@@ -20,7 +20,7 @@ import redis.clients.jedis.Jedis;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 
-public class InfoStatsIntegrationTest extends AbstractRedisInfoStatsIntegrationTest {
+public class InfoStatsIntegrationTest extends AbstractInfoStatsIntegrationTest {
   @ClassRule
   public static GeodeRedisServerRule server = new GeodeRedisServerRule();
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsIntegrationTest.java
@@ -35,7 +35,5 @@ public class InfoStatsIntegrationTest extends AbstractInfoStatsIntegrationTest {
   }
 
   @Override
-  public void configureMaxMemory(Jedis jedis) {
-    return;
-  }
+  public void configureMaxMemory(Jedis jedis) {}
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/statistics/RedisStats.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/statistics/RedisStats.java
@@ -42,10 +42,9 @@ public class RedisStats {
   private static final int ROLLING_AVERAGE_SAMPLES_PER_SECOND = 16;
   private final ScheduledExecutorService rollingAverageExecutor;
   private int rollingAverageTick = 0;
-  private final RollingUpgradeStat networkKiloBytesReadRollingAverageStat =
-      new RollingUpgradeStat();
+  private final RollingAverageStat networkBytesReadRollingAverageStat = new RollingAverageStat();
   private volatile double networkKiloBytesReadOverLastSecond;
-  private final RollingUpgradeStat opsPerformedRollingAverageStat = new RollingUpgradeStat();
+  private final RollingAverageStat opsPerformedRollingAverageStat = new RollingAverageStat();
   private volatile double opsPerformedOverLastSecond;
 
   private final StatisticsClock clock;
@@ -221,7 +220,7 @@ public class RedisStats {
   }
 
   private void doRollingAverageUpdates() {
-    networkKiloBytesReadOverLastSecond = networkKiloBytesReadRollingAverageStat
+    networkKiloBytesReadOverLastSecond = networkBytesReadRollingAverageStat
         .calculate(getTotalNetworkBytesRead(), rollingAverageTick) / 1024.0;
     opsPerformedOverLastSecond =
         opsPerformedRollingAverageStat.calculate(getCommandsProcessed(), rollingAverageTick);
@@ -231,7 +230,7 @@ public class RedisStats {
     }
   }
 
-  private static class RollingUpgradeStat {
+  private static class RollingAverageStat {
     private long valueReadLastTick;
     private final long[] valuesReadOverLastNSamples = new long[ROLLING_AVERAGE_SAMPLES_PER_SECOND];
 


### PR DESCRIPTION
 - Rather than a value that updates once per second, instantaneous
 operations per second and instantaneous kilobytes read per second now
 return a rolling average of those stats updated 16 times per second
 - Rename AbstractRedisInfoStatsIntegrationTest to match child classes
 - Rather than measuring instantaneous per second stats after
 operations have finished, sample them while operations are ongoing and
 calculate the expected value based on the number of operations
 performed in the one second prior to sampling.

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
