### PR TITLE
GEODE-10049: Change Redis test assertions to check full error message

### DIFF
--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -28,6 +28,7 @@ import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER_
 import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__LOCATORS;
 import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__MAXHEAP;
 import static org.apache.geode.management.internal.i18n.CliStrings.START_SERVER__SERVER_PORT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_OOM_COMMAND_NOT_ALLOWED;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
@@ -182,7 +183,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server1Tag + "oneMoreKey", "value"))
-            .hasMessageContaining("OOM"));
+            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
   }
@@ -199,7 +200,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> subJedis.subscribe(mockSubscriber, "channel"))
-            .hasMessageContaining("OOM"));
+            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     subJedis.close();
 
@@ -213,7 +214,7 @@ public class OutOfMemoryDUnitTest {
         executor.submit(() -> maintainMemoryPressure(jedis, false));
 
     await().untilAsserted(() -> assertThatThrownBy(() -> jedis.publish("channel", "message"))
-        .hasMessageContaining("OOM"));
+        .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
   }
@@ -226,7 +227,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server2Tag + "oneMoreKey", "value"))
-            .hasMessageContaining("OOM"));
+            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
   }
@@ -262,7 +263,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server1Tag + "oneMoreKey", "value"))
-            .hasMessageContaining("OOM"));
+            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
 
@@ -281,7 +282,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server2Tag + "oneMoreKey", "value"))
-            .hasMessageContaining("OOM"));
+            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
 
@@ -304,7 +305,8 @@ public class OutOfMemoryDUnitTest {
 
     String channel = "channel";
     await().untilAsserted(() -> assertThatThrownBy(
-        () -> subJedis.subscribe(mockSubscriber, channel)).hasMessageContaining("OOM"));
+        () -> subJedis.subscribe(mockSubscriber, channel))
+            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
 
@@ -325,7 +327,7 @@ public class OutOfMemoryDUnitTest {
         executor.submit(() -> maintainMemoryPressure(jedis, false));
 
     await().untilAsserted(() -> assertThatThrownBy(() -> jedis.publish("channel", "message"))
-        .hasMessageContaining("OOM"));
+        .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
 
@@ -348,7 +350,7 @@ public class OutOfMemoryDUnitTest {
         }
         numberOfKeys.incrementAndGet();
       }
-    }).hasMessageContaining("OOM command not allowed");
+    }).hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED);
   }
 
   private void maintainMemoryPressure(JedisCluster jedis, boolean withExpiration) {

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -183,7 +183,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server1Tag + "oneMoreKey", "value"))
-            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
+            .hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
   }
@@ -200,7 +200,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> subJedis.subscribe(mockSubscriber, "channel"))
-            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
+            .hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     subJedis.close();
 
@@ -214,7 +214,7 @@ public class OutOfMemoryDUnitTest {
         executor.submit(() -> maintainMemoryPressure(jedis, false));
 
     await().untilAsserted(() -> assertThatThrownBy(() -> jedis.publish("channel", "message"))
-        .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
+        .hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
   }
@@ -227,7 +227,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server2Tag + "oneMoreKey", "value"))
-            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
+            .hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
   }
@@ -263,7 +263,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server1Tag + "oneMoreKey", "value"))
-            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
+            .hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
 
@@ -282,7 +282,7 @@ public class OutOfMemoryDUnitTest {
 
     await()
         .untilAsserted(() -> assertThatThrownBy(() -> jedis.set(server2Tag + "oneMoreKey", "value"))
-            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
+            .hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
 
@@ -306,7 +306,7 @@ public class OutOfMemoryDUnitTest {
     String channel = "channel";
     await().untilAsserted(() -> assertThatThrownBy(
         () -> subJedis.subscribe(mockSubscriber, channel))
-            .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
+            .hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
 
@@ -327,7 +327,7 @@ public class OutOfMemoryDUnitTest {
         executor.submit(() -> maintainMemoryPressure(jedis, false));
 
     await().untilAsserted(() -> assertThatThrownBy(() -> jedis.publish("channel", "message"))
-        .hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED));
+        .hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED));
 
     memoryPressure.cancel(true);
 
@@ -350,7 +350,7 @@ public class OutOfMemoryDUnitTest {
         }
         numberOfKeys.incrementAndGet();
       }
-    }).hasMessage("OOM " + ERROR_OOM_COMMAND_NOT_ALLOWED);
+    }).hasMessage(ERROR_OOM_COMMAND_NOT_ALLOWED);
   }
 
   private void maintainMemoryPressure(JedisCluster jedis, boolean withExpiration) {

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameRedirectionsDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameRedirectionsDUnitTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractRenameRedirectionsDUnitTest implements RedisIntegr
 
     jedis.set(oldKey, "value");
     assertThatThrownBy(() -> jedis.sendCommand(oldKey, Protocol.Command.RENAME, oldKey, newKey))
-        .hasMessage("CROSSSLOT " + RedisConstants.ERROR_WRONG_SLOT);
+        .hasMessage(RedisConstants.ERROR_WRONG_SLOT);
   }
 
   private String getKeyOnDifferentServerAs(String antiKey, String prefix) {

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/RenameDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/key/RenameDUnitTest.java
@@ -148,7 +148,7 @@ public class RenameDUnitTest {
     jedis.set(srcKey, "Fancy that");
 
     assertThatThrownBy(() -> jedis.rename(srcKey, dstKey))
-        .hasMessage("CROSSSLOT " + RedisConstants.ERROR_WRONG_SLOT);
+        .hasMessage(RedisConstants.ERROR_WRONG_SLOT);
   }
 
   private Set<String> getKeysOnSameRandomStripe(int numKeysNeeded) {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
@@ -45,7 +45,7 @@ public class RedisCommandArgumentsTestHelper {
       if (i != numArgs) {
         byte[][] args = buildArgs(i);
         assertThatThrownBy(() -> runMe.apply(command, args))
-            .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
+            .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
                 command.toString().toLowerCase()));
       }
     }
@@ -67,7 +67,7 @@ public class RedisCommandArgumentsTestHelper {
     for (int i = 0; i < minNumArgs; i++) {
       byte[][] args = buildArgs(i);
       assertThatThrownBy(() -> runMe.apply(command, args))
-          .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
+          .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
               command.toString().toLowerCase()));
     }
   }
@@ -95,7 +95,7 @@ public class RedisCommandArgumentsTestHelper {
     for (int i = maxNumArgs + 1; i <= 5; i++) {
       byte[][] args = buildArgs(i);
       assertThatThrownBy(() -> runMe.apply(command, args))
-          .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
+          .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
               command.toString().toLowerCase()));
     }
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/RedisCommandArgumentsTestHelper.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.function.BiFunction;
@@ -44,8 +45,8 @@ public class RedisCommandArgumentsTestHelper {
       if (i != numArgs) {
         byte[][] args = buildArgs(i);
         assertThatThrownBy(() -> runMe.apply(command, args))
-            .hasMessageContaining("ERR wrong number of arguments for '"
-                + command.toString().toLowerCase() + "' command");
+            .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
+                command.toString().toLowerCase()));
       }
     }
   }
@@ -66,8 +67,8 @@ public class RedisCommandArgumentsTestHelper {
     for (int i = 0; i < minNumArgs; i++) {
       byte[][] args = buildArgs(i);
       assertThatThrownBy(() -> runMe.apply(command, args))
-          .hasMessageContaining("ERR wrong number of arguments for '"
-              + command.toString().toLowerCase() + "' command");
+          .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
+              command.toString().toLowerCase()));
     }
   }
 
@@ -94,8 +95,8 @@ public class RedisCommandArgumentsTestHelper {
     for (int i = maxNumArgs + 1; i <= 5; i++) {
       byte[][] args = buildArgs(i);
       assertThatThrownBy(() -> runMe.apply(command, args))
-          .hasMessageContaining("ERR wrong number of arguments for '"
-              + command.toString().toLowerCase() + "' command");
+          .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
+              command.toString().toLowerCase()));
     }
   }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/AbstractUnknownIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/AbstractUnknownIntegrationTest.java
@@ -63,29 +63,4 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
                 "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, ``, ");
   }
 
-  @Test
-  public void givenInternalSMembersCommand_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(
-        () -> jedis.sendCommand("INTERNALSMEMBERS"::getBytes, "something",
-            "somethingElse"))
-                .hasMessage(
-                    "ERR unknown command `INTERNALSMEMBERS`, with args beginning with: `something`, `somethingElse`, ");
-  }
-
-  @Test
-  public void givenInternalPTTLCommand_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(
-        () -> jedis.sendCommand("INTERNALPTTL"::getBytes, "something"))
-            .hasMessage(
-                "ERR unknown command `INTERNALPTTL`, with args beginning with: `something`, ");
-  }
-
-  @Test
-  public void givenInternalTypeCommand_returnsUnknownCommandErrorWithArgumentsListed() {
-    assertThatThrownBy(
-        () -> jedis.sendCommand("INTERNALTYPE"::getBytes, "something"))
-            .hasMessage(
-                "ERR unknown command `INTERNALTYPE`, with args beginning with: `something`, ");
-  }
-
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/AbstractUnknownIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/AbstractUnknownIntegrationTest.java
@@ -50,17 +50,15 @@ public abstract class AbstractUnknownIntegrationTest implements RedisIntegration
   @Test
   public void givenUnknownCommand_withArguments_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(() -> jedis.sendCommand("fhqwhgads"::getBytes, "EVERYBODY",
-        "TO THE LIMIT"))
-            .hasMessage(
-                "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, `TO THE LIMIT`, ");
+        "TO THE LIMIT")).hasMessage(
+            "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, `TO THE LIMIT`, ");
   }
 
   @Test
   public void givenUnknownCommand_withEmptyStringArgument_returnsUnknownCommandErrorWithArgumentsListed() {
     assertThatThrownBy(
-        () -> jedis.sendCommand("fhqwhgads"::getBytes, "EVERYBODY", ""))
-            .hasMessage(
-                "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, ``, ");
+        () -> jedis.sendCommand("fhqwhgads"::getBytes, "EVERYBODY", "")).hasMessage(
+            "ERR unknown command `fhqwhgads`, with args beginning with: `EVERYBODY`, ``, ");
   }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/AbstractClusterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/AbstractClusterIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.commands.executor.cluster;
 
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.apache.geode.redis.internal.services.RegionProvider.REDIS_SLOTS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -51,7 +52,7 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
   public void testCluster_givenWrongNumberOfArguments() {
     final Jedis connection = new Jedis(jedis.getConnectionFromSlot(0));
     assertThatThrownBy(() -> connection.sendCommand(Protocol.Command.CLUSTER))
-        .hasMessage("ERR wrong number of arguments for 'cluster' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "cluster"));
     assertThatThrownBy(
         () -> connection.sendCommand(Protocol.Command.CLUSTER, "1", "2"))
             .hasMessageContaining(

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/AbstractClusterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/cluster/AbstractClusterIntegrationTest.java
@@ -52,11 +52,10 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
   public void testCluster_givenWrongNumberOfArguments() {
     final Jedis connection = new Jedis(jedis.getConnectionFromSlot(0));
     assertThatThrownBy(() -> connection.sendCommand(Protocol.Command.CLUSTER))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "cluster"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "cluster"));
     assertThatThrownBy(
         () -> connection.sendCommand(Protocol.Command.CLUSTER, "1", "2"))
-            .hasMessageContaining(
-                "ERR Unknown subcommand or wrong number of arguments for '1'.");
+            .hasMessageContaining("ERR Unknown subcommand or wrong number of arguments for '1'.");
     assertThatThrownBy(
         () -> connection.sendCommand(Protocol.Command.CLUSTER, "SLOTS", "1"))
             .hasMessageContaining(
@@ -70,10 +69,9 @@ public abstract class AbstractClusterIntegrationTest implements RedisIntegration
             .hasMessageContaining(
                 "ERR Unknown subcommand or wrong number of arguments for 'KEYSLOT'.");
     assertThatThrownBy(
-        () -> connection.sendCommand(Protocol.Command.CLUSTER, "KEYSLOT",
-            "blah", "fo"))
-                .hasMessageContaining(
-                    "ERR Unknown subcommand or wrong number of arguments for 'KEYSLOT'.");
+        () -> connection.sendCommand(Protocol.Command.CLUSTER, "KEYSLOT", "blah", "fo"))
+            .hasMessageContaining(
+                "ERR Unknown subcommand or wrong number of arguments for 'KEYSLOT'.");
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/common/UnsupportedCommandsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/common/UnsupportedCommandsIntegrationTest.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.redis.internal.commands.executor.common;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNKNOWN_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -73,14 +72,11 @@ public class UnsupportedCommandsIntegrationTest {
     assertThat(RedisCommandType.UNLINK.isUnsupported()).isTrue();
     server.setEnableUnsupportedCommands(false);
 
-    final String KEY = "key";
-    final String NEW_VALUE = "changed value";
-    final String EXPECTED_ERROR_MSG =
-        String.format(ERROR_UNKNOWN_COMMAND, "UNLINK", "`" + KEY + "`", NEW_VALUE);
-    jedis.set(KEY, "value");
+    final String key = "key";
+    // The trailing comma and space at the end of the message is necessary to match Redis' message
+    final String expectedErrorMsg =
+        "ERR unknown command `UNLINK`, with args beginning with: `" + key + "`, ";
 
-    assertThatThrownBy(
-        () -> jedis.unlink(KEY))
-            .hasMessageContaining(EXPECTED_ERROR_MSG);
+    assertThatThrownBy(() -> jedis.unlink(key)).hasMessage(expectedErrorMsg);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractAuthIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractAuthIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.redis.internal.commands.executor.connection;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_USERNAME_OR_PASSWORD;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_AUTHENTICATED;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNAUTHENTICATED_BULK;
@@ -77,7 +78,7 @@ public abstract class AbstractAuthIntegrationTest {
     setupCacheWithSecurity(false);
 
     assertThatThrownBy(() -> jedis.auth(getUsername(), "wrongpwd"))
-        .hasMessage("WRONGPASS invalid username-password pair or user is disabled.");
+        .hasMessage(ERROR_INVALID_USERNAME_OR_PASSWORD);
 
     assertThat(jedis.auth(getUsername(), getPassword())).isEqualTo("OK");
     assertThat(jedis.ping()).isEqualTo("PONG");
@@ -87,7 +88,7 @@ public abstract class AbstractAuthIntegrationTest {
   public void givenSecurity_authorizedUser_passes() throws Exception {
     setupCacheWithSecurity(true);
 
-    assertThatThrownBy(() -> jedis.set("foo", "bar")).hasMessage("NOAUTH Authentication required.");
+    assertThatThrownBy(() -> jedis.set("foo", "bar")).hasMessage(ERROR_NOT_AUTHENTICATED);
 
     assertThat(jedis.auth(getUsername(), getPassword())).isEqualTo("OK");
 
@@ -107,7 +108,7 @@ public abstract class AbstractAuthIntegrationTest {
     setupCacheWithSecurity(false);
 
     assertThatThrownBy(() -> jedis.auth("wrong-password"))
-        .hasMessage("WRONGPASS invalid username-password pair or user is disabled.");
+        .hasMessage(ERROR_INVALID_USERNAME_OR_PASSWORD);
   }
 
   /**
@@ -127,7 +128,7 @@ public abstract class AbstractAuthIntegrationTest {
     assertThat(authorizedJedis.set("foo", "bar")).isEqualTo("OK");
 
     assertThatThrownBy(() -> nonAuthorizedJedis.set("foo", "bar"))
-        .hasMessage("NOAUTH Authentication required.");
+        .hasMessage(ERROR_NOT_AUTHENTICATED);
 
     authorizedJedis.close();
     nonAuthorizedJedis.close();

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractAuthIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractAuthIntegrationTest.java
@@ -66,10 +66,10 @@ public abstract class AbstractAuthIntegrationTest {
   public void givenSecurity_authWithIncorrectNumberOfArguments_fails() throws Exception {
     setupCacheWithSecurity(false);
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.AUTH))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "auth"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "auth"));
     assertThatThrownBy(
         () -> jedis.sendCommand(Protocol.Command.AUTH, "username", "password", "extraArg"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -87,8 +87,7 @@ public abstract class AbstractAuthIntegrationTest {
   public void givenSecurity_authorizedUser_passes() throws Exception {
     setupCacheWithSecurity(true);
 
-    assertThatThrownBy(() -> jedis.set("foo", "bar"))
-        .hasMessage("NOAUTH Authentication required.");
+    assertThatThrownBy(() -> jedis.set("foo", "bar")).hasMessage("NOAUTH Authentication required.");
 
     assertThat(jedis.auth(getUsername(), getPassword())).isEqualTo("OK");
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractAuthIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractAuthIntegrationTest.java
@@ -15,8 +15,10 @@
 package org.apache.geode.redis.internal.commands.executor.connection;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_AUTHENTICATED;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNAUTHENTICATED_BULK;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_UNAUTHENTICATED_MULTIBULK;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -64,10 +66,10 @@ public abstract class AbstractAuthIntegrationTest {
   public void givenSecurity_authWithIncorrectNumberOfArguments_fails() throws Exception {
     setupCacheWithSecurity(false);
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.AUTH))
-        .hasMessageContaining("ERR wrong number of arguments for 'auth' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "auth"));
     assertThatThrownBy(
         () -> jedis.sendCommand(Protocol.Command.AUTH, "username", "password", "extraArg"))
-            .hasMessageContaining("ERR syntax error");
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -75,7 +77,7 @@ public abstract class AbstractAuthIntegrationTest {
     setupCacheWithSecurity(false);
 
     assertThatThrownBy(() -> jedis.auth(getUsername(), "wrongpwd"))
-        .hasMessageContaining("WRONGPASS invalid username-password pair or user is disabled.");
+        .hasMessage("WRONGPASS invalid username-password pair or user is disabled.");
 
     assertThat(jedis.auth(getUsername(), getPassword())).isEqualTo("OK");
     assertThat(jedis.ping()).isEqualTo("PONG");

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractClientIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractClientIntegrationTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractClientIntegrationTest implements RedisIntegrationT
   @Test
   public void clientWithNoSubcommand_returnError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.CLIENT))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "client"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "client"));
   }
 
   @Test
@@ -76,22 +76,19 @@ public abstract class AbstractClientIntegrationTest implements RedisIntegrationT
   @Test
   public void clientSetName_withSpace_returnError() {
     String clientName = " ";
-    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(
-        "ERR " + ERROR_INVALID_CLIENT_NAME);
+    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(ERROR_INVALID_CLIENT_NAME);
   }
 
   @Test
   public void clientSetName_withNewLine_returnError() {
     String clientName = "\n";
-    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(
-        "ERR " + ERROR_INVALID_CLIENT_NAME);
+    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(ERROR_INVALID_CLIENT_NAME);
   }
 
   @Test
   public void clientSetName_withInvalidCharacter_returnError() {
     byte[] clientName = {0};
-    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(
-        "ERR " + ERROR_INVALID_CLIENT_NAME);
+    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(ERROR_INVALID_CLIENT_NAME);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractClientIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AbstractClientIntegrationTest.java
@@ -14,6 +14,8 @@
  */
 package org.apache.geode.redis.internal.commands.executor.connection;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_CLIENT_NAME;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,7 +53,7 @@ public abstract class AbstractClientIntegrationTest implements RedisIntegrationT
   @Test
   public void clientWithNoSubcommand_returnError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.CLIENT))
-        .hasMessageContaining("ERR wrong number of arguments for 'client' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "client"));
   }
 
   @Test
@@ -74,22 +76,22 @@ public abstract class AbstractClientIntegrationTest implements RedisIntegrationT
   @Test
   public void clientSetName_withSpace_returnError() {
     String clientName = " ";
-    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessageContaining(
-        "ERR Client names cannot contain spaces, newlines or special characters.");
+    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(
+        "ERR " + ERROR_INVALID_CLIENT_NAME);
   }
 
   @Test
   public void clientSetName_withNewLine_returnError() {
     String clientName = "\n";
-    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessageContaining(
-        "ERR Client names cannot contain spaces, newlines or special characters.");
+    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(
+        "ERR " + ERROR_INVALID_CLIENT_NAME);
   }
 
   @Test
   public void clientSetName_withInvalidCharacter_returnError() {
     byte[] clientName = {0};
-    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessageContaining(
-        "ERR Client names cannot contain spaces, newlines or special characters.");
+    assertThatThrownBy(() -> jedis.clientSetname(clientName)).hasMessage(
+        "ERR " + ERROR_INVALID_CLIENT_NAME);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AuthIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AuthIntegrationTest.java
@@ -148,7 +148,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     setupCacheWithoutSecurity();
 
     assertThatThrownBy(() -> jedis.auth("password"))
-        .hasMessage("ERR " + ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
+        .hasMessage(ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
   }
 
   @Test
@@ -156,7 +156,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     setupCacheWithoutSecurity();
 
     assertThatThrownBy(() -> jedis.auth("username", "password"))
-        .hasMessage("ERR " + ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
+        .hasMessage(ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
   }
 
   @Test
@@ -183,8 +183,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
 
     jedis.auth("dataWrite", "dataWrite");
 
-    assertThatThrownBy(() -> jedis.get("foo"))
-        .hasMessage("ERR " + ERROR_NOT_AUTHORIZED);
+    assertThatThrownBy(() -> jedis.get("foo")).hasMessage(ERROR_NOT_AUTHORIZED);
   }
 
   @Test
@@ -193,8 +192,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
 
     jedis.auth("dataRead", "dataRead");
 
-    assertThatThrownBy(() -> jedis.set("foo", "bar"))
-        .hasMessage("ERR " + ERROR_NOT_AUTHORIZED);
+    assertThatThrownBy(() -> jedis.set("foo", "bar")).hasMessage(ERROR_NOT_AUTHORIZED);
   }
 
   @Test
@@ -205,8 +203,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     assertThat(jedis.set("foo", "bar")).isEqualTo("OK");
 
     try (Jedis jedis2 = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT)) {
-      assertThatThrownBy(() -> jedis2.set("foo", "bar"))
-          .hasMessage("NOAUTH " + ERROR_NOT_AUTHENTICATED);
+      assertThatThrownBy(() -> jedis2.set("foo", "bar")).hasMessage(ERROR_NOT_AUTHENTICATED);
     }
   }
 
@@ -218,8 +215,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     jedis.auth("dataWriteOther", "dataWriteOther");
 
     // Permissions are incorrect
-    assertThatThrownBy(() -> jedis.set("foo", "bar"))
-        .hasMessage("ERR " + ERROR_NOT_AUTHORIZED);
+    assertThatThrownBy(() -> jedis.set("foo", "bar")).hasMessage(ERROR_NOT_AUTHORIZED);
   }
 
   @Test
@@ -243,8 +239,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     setupCacheWithSecurity(true);
 
     assertThat(jedis.auth(getUsername(), getPassword())).isEqualTo("OK");
-    assertThatThrownBy(() -> jedis.get("foo"))
-        .hasMessage("ERR " + ERROR_NOT_AUTHORIZED);
+    assertThatThrownBy(() -> jedis.get("foo")).hasMessage(ERROR_NOT_AUTHORIZED);
   }
 
   @Test
@@ -268,8 +263,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     // The first AUTH command will authenticate the user, and the second will cause the authorize()
     // method on the ThrowsOnAuthorizeSecurityManager to be invoked, throwing an exception
     jedis.auth(LOGGED_PASSWORD);
-    assertThatThrownBy(() -> jedis.auth(LOGGED_PASSWORD))
-        .hasMessageContaining(SERVER_ERROR_MESSAGE);
+    assertThatThrownBy(() -> jedis.auth(LOGGED_PASSWORD)).hasMessage(SERVER_ERROR_MESSAGE);
 
     checkLogFileForPassword(logFile, LOGGED_PASSWORD);
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AuthIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/AuthIntegrationTest.java
@@ -20,6 +20,9 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_AUTHENTICATED;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_AUTHORIZED;
 import static org.apache.geode.redis.internal.RedisConstants.SERVER_ERROR_MESSAGE;
 import static org.apache.geode.redis.internal.RedisProperties.REDIS_REGION_NAME_PROPERTY;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
@@ -47,7 +50,6 @@ import org.apache.geode.examples.SimpleSecurityManager;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.redis.internal.GeodeRedisServer;
-import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.security.AuthenticationExpiredException;
 import org.apache.geode.security.AuthenticationFailedException;
 import org.apache.geode.security.ResourcePermission;
@@ -146,7 +148,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     setupCacheWithoutSecurity();
 
     assertThatThrownBy(() -> jedis.auth("password"))
-        .hasMessageContaining(RedisConstants.ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
+        .hasMessage("ERR " + ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
   }
 
   @Test
@@ -154,7 +156,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     setupCacheWithoutSecurity();
 
     assertThatThrownBy(() -> jedis.auth("username", "password"))
-        .hasMessageContaining(RedisConstants.ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
+        .hasMessage("ERR " + ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED);
   }
 
   @Test
@@ -182,7 +184,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     jedis.auth("dataWrite", "dataWrite");
 
     assertThatThrownBy(() -> jedis.get("foo"))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_AUTHORIZED);
+        .hasMessage("ERR " + ERROR_NOT_AUTHORIZED);
   }
 
   @Test
@@ -192,7 +194,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
     jedis.auth("dataRead", "dataRead");
 
     assertThatThrownBy(() -> jedis.set("foo", "bar"))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_AUTHORIZED);
+        .hasMessage("ERR " + ERROR_NOT_AUTHORIZED);
   }
 
   @Test
@@ -204,7 +206,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
 
     try (Jedis jedis2 = new Jedis("localhost", getPort(), REDIS_CLIENT_TIMEOUT)) {
       assertThatThrownBy(() -> jedis2.set("foo", "bar"))
-          .hasMessageContaining(RedisConstants.ERROR_NOT_AUTHENTICATED);
+          .hasMessage("NOAUTH " + ERROR_NOT_AUTHENTICATED);
     }
   }
 
@@ -217,7 +219,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
 
     // Permissions are incorrect
     assertThatThrownBy(() -> jedis.set("foo", "bar"))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_AUTHORIZED);
+        .hasMessage("ERR " + ERROR_NOT_AUTHORIZED);
   }
 
   @Test
@@ -242,7 +244,7 @@ public class AuthIntegrationTest extends AbstractAuthIntegrationTest {
 
     assertThat(jedis.auth(getUsername(), getPassword())).isEqualTo("OK");
     assertThatThrownBy(() -> jedis.get("foo"))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_AUTHORIZED);
+        .hasMessage("ERR " + ERROR_NOT_AUTHORIZED);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/SelectIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/SelectIntegrationTest.java
@@ -39,6 +39,6 @@ public class SelectIntegrationTest extends AbstractSelectIntegrationTest {
   @Test
   public void givenAnyDBIndexOtherThanZero_returnsSelectError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SELECT, "9223372036854775807"))
-        .hasMessageContaining(ERROR_SELECT);
+        .hasMessage("ERR " + ERROR_SELECT);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/SelectIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/connection/SelectIntegrationTest.java
@@ -39,6 +39,6 @@ public class SelectIntegrationTest extends AbstractSelectIntegrationTest {
   @Test
   public void givenAnyDBIndexOtherThanZero_returnsSelectError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.SELECT, "9223372036854775807"))
-        .hasMessage("ERR " + ERROR_SELECT);
+        .hasMessage(ERROR_SELECT);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHScanIntegrationTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "MATCH"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -113,7 +113,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -130,7 +130,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "a*", "1"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -138,8 +138,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
-            "MATCH"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "MATCH")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -148,8 +147,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
             "3",
-            "COUNT", "sjlfs", "COUNT", "1"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "COUNT", "sjlfs", "COUNT", "1")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -158,8 +156,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
-            ZERO_CURSOR))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            ZERO_CURSOR)).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -168,8 +165,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
-            "-37"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "-37")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -180,8 +176,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR,
             "COUNT", "3",
             "COUNT", "0",
-            "COUNT", "1"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "COUNT", "1")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -189,8 +184,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(HASH_KEY, "member");
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY,
-        ZERO_CURSOR))
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        ZERO_CURSOR)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -198,14 +192,14 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(HASH_KEY, "member");
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, "sjfls"))
-        .hasMessage("ERR " + ERROR_CURSOR);
+        .hasMessage(ERROR_CURSOR);
   }
 
   @Test
   public void givenNonexistentKey_andCursorIsNotAnInteger_returnsCursorError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("notReal", Protocol.Command.HSCAN, "notReal", "sjfls"))
-            .hasMessage("ERR " + ERROR_CURSOR);
+            .hasMessage(ERROR_CURSOR);
   }
 
   @Test
@@ -213,7 +207,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, "sjfls"))
-        .hasMessage("ERR " + ERROR_CURSOR);
+        .hasMessage(ERROR_CURSOR);
   }
 
   @Test
@@ -247,8 +241,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY,
-        UNSIGNED_LONG_CAPACITY.add(new BigInteger("10")).toString()))
-            .hasMessage("ERR " + ERROR_CURSOR);
+        UNSIGNED_LONG_CAPACITY.add(new BigInteger("10")).toString())).hasMessage(ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHScanIntegrationTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "MATCH"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -113,7 +113,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -130,7 +130,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "a*", "1"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -139,7 +139,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
             "MATCH"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -149,7 +149,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
             "3",
             "COUNT", "sjlfs", "COUNT", "1"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -159,7 +159,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
             ZERO_CURSOR))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -169,7 +169,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, ZERO_CURSOR, "COUNT",
             "-37"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -181,7 +181,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
             "COUNT", "3",
             "COUNT", "0",
             "COUNT", "1"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -190,7 +190,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY,
         ZERO_CURSOR))
-            .hasMessageContaining(ERROR_WRONG_TYPE);
+            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -198,14 +198,14 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(HASH_KEY, "member");
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, "sjfls"))
-        .hasMessageContaining(ERROR_CURSOR);
+        .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
   public void givenNonexistentKey_andCursorIsNotAnInteger_returnsCursorError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("notReal", Protocol.Command.HSCAN, "notReal", "sjfls"))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
@@ -213,7 +213,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY, "sjfls"))
-        .hasMessageContaining(ERROR_CURSOR);
+        .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
@@ -248,7 +248,7 @@ public abstract class AbstractHScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY,
         UNSIGNED_LONG_CAPACITY.add(new BigInteger("10")).toString()))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHashesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHashesIntegrationTest.java
@@ -41,7 +41,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.resps.ScanResult;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
@@ -72,25 +71,25 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   @Test
   public void testHMSet_givenWrongNumberOfArguments() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.HMSET, "key"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hmset"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hmset"));
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.HMSET, "key", "1"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hmset"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hmset"));
     // The below error message is correct for Redis 6, but for Redis 5 is "ERR wrong number of
     // arguments for HMSET"
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.HMSET, "key", "1", "2", "3"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hmset"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hmset"));
   }
 
   @Test
   public void testHSet_givenWrongNumberOfArguments() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.HSET, "key"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hset"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hset"));
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.HSET, "key", "1"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hset"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hset"));
     // The below error message is correct for Redis 6, but for Redis 5 is "ERR wrong number of
     // arguments for HMSET"
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.HSET, "key", "1", "2", "3"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hset"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "hset"));
   }
 
   @Test
@@ -118,13 +117,11 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
 
     jedis.set("farm", "chicken");
     assertThatThrownBy(() -> jedis.hmset("farm", animalMap))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
 
     jedis.sadd("zoo", "elephant");
     assertThatThrownBy(() -> jedis.hmset("zoo", animalMap))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -222,21 +219,18 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   public void testHMGetErrorMessage_givenIncorrectDataType() {
     jedis.set("farm", "chicken");
     assertThatThrownBy(() -> jedis.hmget("farm", "chicken"))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
 
     jedis.sadd("zoo", "elephant");
     assertThatThrownBy(() -> jedis.hmget("zoo", "chicken"))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
   public void testHDelErrorMessage_givenIncorrectDataType() {
     jedis.set("farm", "chicken");
     assertThatThrownBy(() -> jedis.hdel("farm", "chicken"))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -265,12 +259,10 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   @Test
   public void testHStrLen_failsForNonHashes() {
     jedis.sadd("farm", "chicken");
-    assertThatThrownBy(() -> jedis.hstrlen("farm", "chicken"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hstrlen("farm", "chicken")).hasMessage(ERROR_WRONG_TYPE);
 
     jedis.set("tractor", "John Deere");
-    assertThatThrownBy(() -> jedis.hstrlen("tractor", "chicken"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hstrlen("tractor", "chicken")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -286,12 +278,10 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   @Test
   public void testHKeys_failsGivenWrongType() {
     jedis.sadd("farm", "chicken");
-    assertThatThrownBy(() -> jedis.hkeys("farm"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hkeys("farm")).hasMessage(ERROR_WRONG_TYPE);
 
     jedis.set("tractor", "John Deere");
-    assertThatThrownBy(() -> jedis.hkeys("tractor"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hkeys("tractor")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -325,8 +315,7 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   @Test
   public void testHIncrBy_failsWhenPerformedOnNonIntegerValue() {
     jedis.sadd("key", "member");
-    assertThatThrownBy(() -> jedis.hincrBy("key", "somefield", 1))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hincrBy("key", "somefield", 1)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -408,12 +397,10 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   @Test
   public void testHExists_failsForNonHashes() {
     jedis.sadd("farm", "chicken");
-    assertThatThrownBy(() -> jedis.hexists("farm", "chicken"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hexists("farm", "chicken")).hasMessage(ERROR_WRONG_TYPE);
 
     jedis.set("tractor", "John Deere");
-    assertThatThrownBy(() -> jedis.hexists("tractor", "chicken"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hexists("tractor", "chicken")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -427,7 +414,7 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
 
     assertThatThrownBy(
         () -> jedis.hscan(key, "this cursor is non-numeric and so completely invalid"))
-            .hasMessage("ERR " + ERROR_CURSOR);
+            .hasMessage(ERROR_CURSOR);
 
     Map<String, String> hash = new HashMap<>();
     hash.put(field, value);
@@ -477,11 +464,10 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
 
     assertThatThrownBy(
         () -> jedis.hsetnx(string_key, field, "something else"))
-            .isInstanceOf(JedisDataException.class)
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+            .hasMessage(ERROR_WRONG_TYPE);
     assertThatThrownBy(
-        () -> jedis.hsetnx(set_key, field, "something else")).isInstanceOf(JedisDataException.class)
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        () -> jedis.hsetnx(set_key, field, "something else"))
+            .hasMessage(ERROR_WRONG_TYPE);
 
     jedis.del(string_key);
     jedis.del(set_key);
@@ -520,12 +506,10 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   @Test
   public void hvalsFailsForNonHash() {
     jedis.sadd("farm", "chicken");
-    assertThatThrownBy(() -> jedis.hvals("farm"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hvals("farm")).hasMessage(ERROR_WRONG_TYPE);
 
     jedis.set("tractor", "John Deere");
-    assertThatThrownBy(() -> jedis.hvals("tractor"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hvals("tractor")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -541,12 +525,10 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   @Test
   public void hgetFailsForNonHash() {
     jedis.sadd("farm", "chicken");
-    assertThatThrownBy(() -> jedis.hget("farm", "chicken"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hget("farm", "chicken")).hasMessage(ERROR_WRONG_TYPE);
 
     jedis.set("tractor", "John Deere");
-    assertThatThrownBy(() -> jedis.hget("tractor", "John Deere"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.hget("tractor", "John Deere")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -612,8 +594,7 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
   public void testHLenErrorMessage_givenIncorrectDataType() {
     jedis.set("farm", "chicken");
     assertThatThrownBy(() -> jedis.hlen("farm"))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -829,8 +810,8 @@ public abstract class AbstractHashesIntegrationTest implements RedisIntegrationT
     jedis.set("key", "value");
 
     assertThatThrownBy(
-        () -> jedis.hset("key", "field", "something else")).isInstanceOf(JedisDataException.class)
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        () -> jedis.hset("key", "field", "something else"))
+            .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHincrByFloatIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHincrByFloatIntegrationTest.java
@@ -16,6 +16,8 @@
 package org.apache.geode.redis.internal.commands.executor.hash;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NAN_OR_INFINITY;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
 import static org.apache.geode.redis.internal.RedisConstants.HASH_VALUE_NOT_FLOAT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -64,35 +66,35 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
 
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "+inf"))
-            .hasMessage("ERR increment would produce NaN or Infinity");
+            .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "-inf"))
-            .hasMessage("ERR increment would produce NaN or Infinity");
+            .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "inf"))
-            .hasMessage("ERR increment would produce NaN or Infinity");
+            .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "+infinity"))
-            .hasMessage("ERR increment would produce NaN or Infinity");
+            .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "-infinity"))
-            .hasMessage("ERR increment would produce NaN or Infinity");
+            .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "infinity"))
-            .hasMessage("ERR increment would produce NaN or Infinity");
+            .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "nan"))
-            .hasMessage("ERR value is not a valid float");
+            .hasMessage(ERROR_NOT_A_VALID_FLOAT);
 
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.HINCRBYFLOAT, "key", "number", "infant"))
-            .hasMessage("ERR value is not a valid float");
+            .hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHincrByFloatIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHincrByFloatIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.commands.executor.hash;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.HASH_VALUE_NOT_FLOAT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.offset;
@@ -161,7 +162,7 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
     jedis.hset(key, field, "foobar");
     assertThatThrownBy(() -> jedis.hincrByFloat(key, field, 1.5))
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("ERR hash value is not a float");
+        .hasMessage("ERR " + HASH_VALUE_NOT_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHincrByFloatIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/AbstractHincrByFloatIntegrationTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -161,8 +160,7 @@ public abstract class AbstractHincrByFloatIntegrationTest implements RedisIntegr
     String field = "field";
     jedis.hset(key, field, "foobar");
     assertThatThrownBy(() -> jedis.hincrByFloat(key, field, 1.5))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + HASH_VALUE_NOT_FLOAT);
+        .hasMessage(HASH_VALUE_NOT_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/HScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/HScanIntegrationTest.java
@@ -45,6 +45,6 @@ public class HScanIntegrationTest extends AbstractHScanIntegrationTest {
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY,
         GREATER_THAN_LONG_MAX))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/HScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/hash/HScanIntegrationTest.java
@@ -44,7 +44,6 @@ public class HScanIntegrationTest extends AbstractHScanIntegrationTest {
     jedis.hset(HASH_KEY, FIELD_ONE, VALUE_ONE);
 
     assertThatThrownBy(() -> jedis.sendCommand(HASH_KEY, Protocol.Command.HSCAN, HASH_KEY,
-        GREATER_THAN_LONG_MAX))
-            .hasMessage("ERR " + ERROR_CURSOR);
+        GREATER_THAN_LONG_MAX)).hasMessage(ERROR_CURSOR);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractDumpRestoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractDumpRestoreIntegrationTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractDumpRestoreIntegrationTest implements RedisIntegra
   public void restoreErrorsWithUnknownOption() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.RESTORE, "key", "0", "", "FOO"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractDumpRestoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractDumpRestoreIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.commands.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -76,7 +77,7 @@ public abstract class AbstractDumpRestoreIntegrationTest implements RedisIntegra
   public void restoreErrorsWithUnknownOption() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.RESTORE, "key", "0", "", "FOO"))
-            .hasMessageContaining("ERR syntax error");
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractDumpRestoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractDumpRestoreIntegrationTest.java
@@ -16,6 +16,10 @@
 package org.apache.geode.redis.internal.commands.executor.key;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_TTL;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_KEY_EXISTS;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_RESTORE_INVALID_PAYLOAD;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
@@ -85,26 +89,26 @@ public abstract class AbstractDumpRestoreIntegrationTest implements RedisIntegra
     lettuce.set("restored", "already exists");
 
     assertThatThrownBy(() -> lettuce.restore("restored", 0, RESTORE_BYTES))
-        .hasMessage("BUSYKEY Target key name already exists.");
+        .hasMessage(ERROR_KEY_EXISTS);
   }
 
   @Test
   public void restoreFails_whenTTLisNegative() {
     assertThatThrownBy(() -> lettuce.restore("restored", -1, RESTORE_BYTES))
-        .hasMessage("ERR Invalid TTL value, must be >= 0");
+        .hasMessage(ERROR_INVALID_TTL);
   }
 
   @Test
   public void restoreFails_whenTTLisNotANumber() {
     assertThatThrownBy(() -> jedis.sendCommand("restored".getBytes(), Protocol.Command.RESTORE,
         "restored".getBytes(), "not-an-integer".getBytes(), RESTORE_BYTES))
-            .hasMessage("ERR value is not an integer or out of range");
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void restoreFails_withInvalidBytes() {
     assertThatThrownBy(() -> lettuce.restore("restored", 0, new byte[] {0, 1, 2, 3}))
-        .hasMessage("ERR DUMP payload version or checksum are wrong");
+        .hasMessage(ERROR_RESTORE_INVALID_PAYLOAD);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireAtIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireAtIntegrationTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractExpireAtIntegrationTest implements RedisIntegratio
   public void givenInvalidTimestamp_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.EXPIREAT, "key", "notInteger"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireAtIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireAtIntegrationTest.java
@@ -61,7 +61,7 @@ public abstract class AbstractExpireAtIntegrationTest implements RedisIntegratio
   public void givenInvalidTimestamp_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.EXPIREAT, "key", "notInteger"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireIntegrationTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
   @Test
   public void givenInvalidTimestamp_returnsNotIntegerError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.EXPIRE, "key", "notInteger"))
-        .hasMessageContaining(ERROR_NOT_INTEGER);
+        .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractExpireIntegrationTest.java
@@ -53,7 +53,7 @@ public abstract class AbstractExpireIntegrationTest implements RedisIntegrationT
   @Test
   public void givenInvalidTimestamp_returnsNotIntegerError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.EXPIRE, "key", "notInteger"))
-        .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPExpireAtIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPExpireAtIntegrationTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractPExpireAtIntegrationTest implements RedisIntegrati
   public void givenInvalidTimestamp_returnsNotIntegerError() {
     assertThatThrownBy(() -> jedis
         .sendCommand("key", Protocol.Command.PEXPIREAT, "key", "notInteger"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPExpireAtIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPExpireAtIntegrationTest.java
@@ -57,7 +57,7 @@ public abstract class AbstractPExpireAtIntegrationTest implements RedisIntegrati
   public void givenInvalidTimestamp_returnsNotIntegerError() {
     assertThatThrownBy(() -> jedis
         .sendCommand("key", Protocol.Command.PEXPIREAT, "key", "notInteger"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPexpireIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPexpireIntegrationTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractPexpireIntegrationTest implements RedisIntegration
   public void givenInvalidTimestamp_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.PEXPIRE, "key", "notInteger"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPexpireIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractPexpireIntegrationTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractPexpireIntegrationTest implements RedisIntegration
   public void givenInvalidTimestamp_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.PEXPIRE, "key", "notInteger"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameIntegrationTest.java
@@ -77,7 +77,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     jedis.set(key1, "value1");
     jedis.set(key2, "value1");
     assertThatThrownBy(() -> jedis.sendCommand(key1, RENAME, key1, key2))
-        .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+        .hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test
@@ -97,7 +97,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   @Test
   public void shouldReturnError_givenNonexistantKey() {
     assertThatThrownBy(() -> jedis.rename("{tag1}foo", "{tag1}newfoo"))
-        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
+        .hasMessage(ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -137,16 +137,14 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     String newKey = "{1}newKey";
     jedis.set(oldKey, "value");
     jedis.rename(oldKey, newKey);
-    assertThatThrownBy(() -> jedis.rename(oldKey, newKey))
-        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
+    assertThatThrownBy(() -> jedis.rename(oldKey, newKey)).hasMessage(ERROR_NO_SUCH_KEY);
   }
 
   @Test
   public void error_whenNeitherKeyExists() {
     String oldKey = "{1}key";
     String newKey = "{1}newKey";
-    assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey))
-        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
+    assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey)).hasMessage(ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -270,7 +268,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
                 jedis.set("{tag1}oldKey", "foo");
               });
     } catch (RuntimeException e) {
-      assertThat(e).getRootCause().hasMessage("ERR " + ERROR_NO_SUCH_KEY);
+      assertThat(e).getRootCause().hasMessage(ERROR_NO_SUCH_KEY);
       return;
     }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameIntegrationTest.java
@@ -45,7 +45,6 @@ import redis.clients.jedis.JedisCluster;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.services.locking.LockingStripedCoordinator;
 import org.apache.geode.redis.internal.services.locking.StripedCoordinator;
@@ -78,7 +77,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     jedis.set(key1, "value1");
     jedis.set(key2, "value1");
     assertThatThrownBy(() -> jedis.sendCommand(key1, RENAME, key1, key2))
-        .hasMessageContaining("CROSSSLOT " + ERROR_WRONG_SLOT);
+        .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
   }
 
   @Test
@@ -98,7 +97,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   @Test
   public void shouldReturnError_givenNonexistantKey() {
     assertThatThrownBy(() -> jedis.rename("{tag1}foo", "{tag1}newfoo"))
-        .hasMessageContaining(RedisConstants.ERROR_NO_SUCH_KEY);
+        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -139,7 +138,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     jedis.set(oldKey, "value");
     jedis.rename(oldKey, newKey);
     assertThatThrownBy(() -> jedis.rename(oldKey, newKey))
-        .hasMessageContaining(ERROR_NO_SUCH_KEY);
+        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -147,7 +146,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
     String oldKey = "{1}key";
     String newKey = "{1}newKey";
     assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey))
-        .hasMessageContaining(ERROR_NO_SUCH_KEY);
+        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -271,7 +270,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
                 jedis.set("{tag1}oldKey", "foo");
               });
     } catch (RuntimeException e) {
-      assertThat(e).hasMessageContaining(ERROR_NO_SUCH_KEY);
+      assertThat(e).getRootCause().hasMessage("ERR " + ERROR_NO_SUCH_KEY);
       return;
     }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameNXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameNXIntegrationTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
     jedis.set(key1, "value1");
     jedis.set(key2, "value1");
     assertThatThrownBy(() -> jedis.sendCommand(key1, RENAMENX, key1, key2))
-        .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+        .hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test
@@ -101,7 +101,7 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
   @Test
   public void shouldReturnError_givenNonexistantKey() {
     assertThatThrownBy(() -> jedis.renamenx("{tag1}foo", "{tag1}newfoo"))
-        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
+        .hasMessage(ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -143,16 +143,14 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
     String newKey = "{1}newKey";
     jedis.set(oldKey, "value");
     jedis.renamenx(oldKey, newKey);
-    assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey))
-        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
+    assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey)).hasMessage(ERROR_NO_SUCH_KEY);
   }
 
   @Test
   public void error_whenNeitherKeyExists() {
     String oldKey = "{1}key";
     String newKey = "{1}newKey";
-    assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey))
-        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
+    assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey)).hasMessage(ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -280,7 +278,7 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
                 jedis.set("{tag1}oldKey", "foo");
               });
     } catch (RuntimeException e) {
-      assertThat(e).getRootCause().hasMessage("ERR " + ERROR_NO_SUCH_KEY);
+      assertThat(e).getRootCause().hasMessage(ERROR_NO_SUCH_KEY);
       return;
     }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameNXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameNXIntegrationTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
     jedis.set(key1, "value1");
     jedis.set(key2, "value1");
     assertThatThrownBy(() -> jedis.sendCommand(key1, RENAMENX, key1, key2))
-        .hasMessageContaining("CROSSSLOT " + ERROR_WRONG_SLOT);
+        .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
   }
 
   @Test
@@ -101,7 +101,7 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
   @Test
   public void shouldReturnError_givenNonexistantKey() {
     assertThatThrownBy(() -> jedis.renamenx("{tag1}foo", "{tag1}newfoo"))
-        .hasMessageContaining(ERROR_NO_SUCH_KEY);
+        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -144,7 +144,7 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
     jedis.set(oldKey, "value");
     jedis.renamenx(oldKey, newKey);
     assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey))
-        .hasMessageContaining(ERROR_NO_SUCH_KEY);
+        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -152,7 +152,7 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
     String oldKey = "{1}key";
     String newKey = "{1}newKey";
     assertThatThrownBy(() -> jedis.renamenx(oldKey, newKey))
-        .hasMessageContaining(ERROR_NO_SUCH_KEY);
+        .hasMessage("ERR " + ERROR_NO_SUCH_KEY);
   }
 
   @Test
@@ -280,7 +280,7 @@ public abstract class AbstractRenameNXIntegrationTest implements RedisIntegratio
                 jedis.set("{tag1}oldKey", "foo");
               });
     } catch (RuntimeException e) {
-      assertThat(e).hasMessageContaining(ERROR_NO_SUCH_KEY);
+      assertThat(e).getRootCause().hasMessage("ERR " + ERROR_NO_SUCH_KEY);
       return;
     }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
@@ -18,6 +18,7 @@ package org.apache.geode.redis.internal.commands.executor.key;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -57,57 +58,57 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenNoCursorArgument_returnsWrongNumberOfArgsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN))
-        .hasMessageContaining("ERR wrong number of arguments for 'scan' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "scan"));
   }
 
   @Test
   public void givenCursorArgumentIsNotAnInteger_returnsCursorError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "sljfs"))
-        .hasMessageContaining(ERROR_CURSOR);
+        .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
   public void givenArgumentsAreNotEven_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "a*"))
-        .hasMessageContaining(ERROR_SYNTAX);
+        .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void givenMatchOrCountKeywordNotSpecified_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "a*", "1"))
-        .hasMessageContaining(ERROR_SYNTAX);
+        .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void givenCount_whenCountParameterIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "MATCH"))
-        .hasMessageContaining(ERROR_NOT_INTEGER);
+        .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenCount_whenCountParameterIsZero_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "0"))
-        .hasMessageContaining(ERROR_SYNTAX);
+        .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void givenCount_whenCountParameterIsNegative_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "-37"))
-        .hasMessageContaining(ERROR_SYNTAX);
+        .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void givenMultipleCounts_whenAnyCountParameterIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "2",
         "COUNT", "sjlfs", "COUNT", "1"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenMultipleCounts_whenAnyCountParameterIsLessThanOne_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "2",
         "COUNT", "0", "COUNT", "1"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -282,13 +283,13 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenCursorGreaterThanUnsignedLongCapacity_returnsCursorError() {
     assertThatThrownBy(() -> jedis.scan("18446744073709551616", new ScanParams().match("{a}*")))
-        .hasMessageContaining(ERROR_CURSOR);
+        .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
   public void givenNegativeCursorGreaterThanUnsignedLongCapacity_returnsCursorError() {
     assertThatThrownBy(() -> jedis.scan("-18446744073709551616", new ScanParams().match("{a}*")))
-        .hasMessageContaining(ERROR_CURSOR);
+        .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanIntegrationTest.java
@@ -58,57 +58,55 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenNoCursorArgument_returnsWrongNumberOfArgsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "scan"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "scan"));
   }
 
   @Test
   public void givenCursorArgumentIsNotAnInteger_returnsCursorError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "sljfs"))
-        .hasMessage("ERR " + ERROR_CURSOR);
+        .hasMessage(ERROR_CURSOR);
   }
 
   @Test
   public void givenArgumentsAreNotEven_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "a*"))
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenMatchOrCountKeywordNotSpecified_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "a*", "1"))
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenCount_whenCountParameterIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "MATCH"))
-        .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenCount_whenCountParameterIsZero_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "0"))
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenCount_whenCountParameterIsNegative_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "-37"))
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenMultipleCounts_whenAnyCountParameterIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "2",
-        "COUNT", "sjlfs", "COUNT", "1"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "COUNT", "sjlfs", "COUNT", "1")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenMultipleCounts_whenAnyCountParameterIsLessThanOne_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SCAN, "0", "COUNT", "2",
-        "COUNT", "0", "COUNT", "1"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "COUNT", "0", "COUNT", "1")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -283,13 +281,13 @@ public abstract class AbstractScanIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenCursorGreaterThanUnsignedLongCapacity_returnsCursorError() {
     assertThatThrownBy(() -> jedis.scan("18446744073709551616", new ScanParams().match("{a}*")))
-        .hasMessage("ERR " + ERROR_CURSOR);
+        .hasMessage(ERROR_CURSOR);
   }
 
   @Test
   public void givenNegativeCursorGreaterThanUnsignedLongCapacity_returnsCursorError() {
     assertThatThrownBy(() -> jedis.scan("-18446744073709551616", new ScanParams().match("{a}*")))
-        .hasMessage("ERR " + ERROR_CURSOR);
+        .hasMessage(ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/DumpRestoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/DumpRestoreIntegrationTest.java
@@ -44,14 +44,14 @@ public class DumpRestoreIntegrationTest extends AbstractDumpRestoreIntegrationTe
   public void restoreWithIdletime_isNotSupported() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.RESTORE, "key", "0", "", "IDLETIME", "1"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void restoreWithFreq_isNotSupported() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.RESTORE, "key", "0", "", "FREQ", "1"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -63,7 +63,7 @@ public class DumpRestoreIntegrationTest extends AbstractDumpRestoreIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.restore("key", 0L, baos.toByteArray()))
-            .hasMessage("ERR " + ERROR_RESTORE_INVALID_PAYLOAD);
+            .hasMessage(ERROR_RESTORE_INVALID_PAYLOAD);
   }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/DumpRestoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/DumpRestoreIntegrationTest.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.redis.internal.commands.executor.key;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_RESTORE_INVALID_PAYLOAD;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.RADISH_DUMP_HEADER;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -42,14 +44,14 @@ public class DumpRestoreIntegrationTest extends AbstractDumpRestoreIntegrationTe
   public void restoreWithIdletime_isNotSupported() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.RESTORE, "key", "0", "", "IDLETIME", "1"))
-            .hasMessageContaining("ERR syntax error");
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void restoreWithFreq_isNotSupported() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.RESTORE, "key", "0", "", "FREQ", "1"))
-            .hasMessageContaining("ERR syntax error");
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -61,7 +63,7 @@ public class DumpRestoreIntegrationTest extends AbstractDumpRestoreIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.restore("key", 0L, baos.toByteArray()))
-            .hasMessageContaining("ERR DUMP payload version or checksum are wrong");
+            .hasMessage("ERR " + ERROR_RESTORE_INVALID_PAYLOAD);
   }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLIndexIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLIndexIntegrationTest.java
@@ -107,14 +107,14 @@ public abstract class AbstractLIndexIntegrationTest implements RedisIntegrationT
   public void lindex_withInvalidIndex_returnsError() {
     jedis.lpush(LIST_KEY, LIST_ELEMENTS);
     assertThatThrownBy(() -> jedis.sendCommand(LIST_KEY, Protocol.Command.LINDEX, LIST_KEY, "b"))
-        .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void lindex_withWrongKeyType_returnsWrongTypeError() {
     String key = "{tag1}ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.lindex(key, 2)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.lindex(key, 2)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -122,7 +122,7 @@ public abstract class AbstractLIndexIntegrationTest implements RedisIntegrationT
     String key = "{tag1}ding";
     jedis.set(key, "dong");
     assertThatThrownBy(() -> jedis.sendCommand(LIST_KEY, Protocol.Command.LINDEX, key, "b"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLLenIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLLenIntegrationTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractLLenIntegrationTest implements RedisIntegrationTes
   @Test
   public void llen_withStringFails() {
     jedis.set("string", PREEXISTING_VALUE);
-    assertThatThrownBy(() -> jedis.llen("string")).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.llen("string")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLPopIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLPopIntegrationTest.java
@@ -59,7 +59,7 @@ public abstract class AbstractLPopIntegrationTest implements RedisIntegrationTes
   @Test
   public void lpop_withNonListKey_Fails() {
     jedis.set("string", PREEXISTING_VALUE);
-    assertThatThrownBy(() -> jedis.lpop("string")).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.lpop("string")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLPushIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLPushIntegrationTest.java
@@ -56,7 +56,7 @@ public abstract class AbstractLPushIntegrationTest implements RedisIntegrationTe
     String elementValue = "list element value that should never get added";
 
     jedis.set(KEY, PREEXISTING_VALUE);
-    
+
     assertThatThrownBy(() -> jedis.lpush(KEY, elementValue)).hasMessage(ERROR_WRONG_TYPE);
 
     String result = jedis.get(KEY);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLPushIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLPushIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.commands.executor.list;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,7 +27,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 
@@ -54,13 +54,10 @@ public abstract class AbstractLPushIntegrationTest implements RedisIntegrationTe
   @Test
   public void lpush_withExistingKey_ofWrongType_returnsWrongTypeError_shouldNotOverWriteExistingKey() {
     String elementValue = "list element value that should never get added";
-    String errorMessage = "WRONGTYPE Operation against a key holding the wrong kind of value";
 
     jedis.set(KEY, PREEXISTING_VALUE);
-
-    assertThatThrownBy(() -> jedis.lpush(KEY, elementValue))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage(errorMessage);
+    
+    assertThatThrownBy(() -> jedis.lpush(KEY, elementValue)).hasMessage(ERROR_WRONG_TYPE);
 
     String result = jedis.get(KEY);
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLPushxIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractLPushxIntegrationTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 
@@ -59,7 +58,6 @@ public abstract class AbstractLPushxIntegrationTest implements RedisIntegrationT
     jedis.set(KEY, PREEXISTING_VALUE);
 
     assertThatThrownBy(() -> jedis.lpushx(KEY, elementValue))
-        .isInstanceOf(JedisDataException.class)
         .hasMessage(errorMessage);
 
     String result = jedis.get(KEY);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubCommandsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubCommandsIntegrationTest.java
@@ -71,7 +71,8 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   public void pubsub_shouldReturnError_givenUnknownSubcommand() {
     String expected = String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, "nonesuch");
 
-    assertThatThrownBy(() -> introspector.sendCommand(PUBSUB, "nonesuch")).hasMessage(expected);
+    assertThatThrownBy(() -> introspector.sendCommand(PUBSUB, "nonesuch"))
+        .hasMessageContaining(expected);
   }
 
   /** -- CHANNELS-- **/

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubCommandsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubCommandsIntegrationTest.java
@@ -71,8 +71,7 @@ public abstract class AbstractSubCommandsIntegrationTest implements RedisIntegra
   public void pubsub_shouldReturnError_givenUnknownSubcommand() {
     String expected = String.format(ERROR_UNKNOWN_PUBSUB_SUBCOMMAND, "nonesuch");
 
-    assertThatThrownBy(() -> introspector.sendCommand(PUBSUB, "nonesuch"))
-        .hasMessageContaining(expected);
+    assertThatThrownBy(() -> introspector.sendCommand(PUBSUB, "nonesuch")).hasMessage(expected);
   }
 
   /** -- CHANNELS-- **/

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
@@ -84,8 +84,8 @@ public abstract class AbstractSubscriptionsIntegrationTest implements RedisInteg
   public void unallowedCommandsWhileSubscribed() {
     client.sendCommand(Protocol.Command.SUBSCRIBE, "hello");
 
-    assertThatThrownBy(() -> client.set("not", "supported")).hasMessage("ERR " +
-        String.format(ERROR_PUBSUB_WRONG_COMMAND, "set"));
+    assertThatThrownBy(() -> client.set("not", "supported"))
+        .hasMessage(String.format(ERROR_PUBSUB_WRONG_COMMAND, "set"));
     client.sendCommand(Protocol.Command.UNSUBSCRIBE);
   }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/pubsub/AbstractSubscriptionsIntegrationTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractSubscriptionsIntegrationTest implements RedisInteg
   public void unallowedCommandsWhileSubscribed() {
     client.sendCommand(Protocol.Command.SUBSCRIBE, "hello");
 
-    assertThatThrownBy(() -> client.set("not", "supported")).hasMessageContaining(
+    assertThatThrownBy(() -> client.set("not", "supported")).hasMessage("ERR " +
         String.format(ERROR_PUBSUB_WRONG_COMMAND, "set"));
     client.sendCommand(Protocol.Command.UNSUBSCRIBE);
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractDBSizeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractDBSizeIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package org.apache.geode.redis.internal.commands.executor.server;
 
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.After;
@@ -46,7 +47,7 @@ public abstract class AbstractDBSizeIntegrationTest implements RedisIntegrationT
   @Test
   public void givenMoreThanOneArgument_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.DBSIZE, "extraArg"))
-        .hasMessageContaining("ERR wrong number of arguments for 'dbsize' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "dbsize"));
   }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractDBSizeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractDBSizeIntegrationTest.java
@@ -47,7 +47,7 @@ public abstract class AbstractDBSizeIntegrationTest implements RedisIntegrationT
   @Test
   public void givenMoreThanOneArgument_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.DBSIZE, "extraArg"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "dbsize"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "dbsize"));
   }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractFlushAllIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractFlushAllIntegrationTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractFlushAllIntegrationTest implements RedisIntegratio
   @Test
   public void givenMoreThanTwoArguments_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.FLUSHALL, "ASYNC", "extraArg"))
-        .hasMessageContaining(ERROR_SYNTAX);
+        .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractFlushAllIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractFlushAllIntegrationTest.java
@@ -48,7 +48,7 @@ public abstract class AbstractFlushAllIntegrationTest implements RedisIntegratio
   @Test
   public void givenMoreThanTwoArguments_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.FLUSHALL, "ASYNC", "extraArg"))
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractFlushDBIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractFlushDBIntegrationTest.java
@@ -47,13 +47,13 @@ public abstract class AbstractFlushDBIntegrationTest implements RedisIntegration
   @Test
   public void givenMoreThanTwoArguments_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.FLUSHDB, "ASYNC", "extraArg"))
-        .hasMessageContaining(ERROR_SYNTAX);
+        .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   // @Test
   // public void givenSecondArgumentIsNotAsyncParameter_returnsSyntaxError() {
   // assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.FLUSHDB, "NOTASYNC"))
-  // .hasMessageContaining(ERROR_SYNTAX);
+  // .hasMessage("ERR " + ERROR_SYNTAX);
   // }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractFlushDBIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractFlushDBIntegrationTest.java
@@ -47,13 +47,13 @@ public abstract class AbstractFlushDBIntegrationTest implements RedisIntegration
   @Test
   public void givenMoreThanTwoArguments_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.FLUSHDB, "ASYNC", "extraArg"))
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
   }
 
   // @Test
   // public void givenSecondArgumentIsNotAsyncParameter_returnsSyntaxError() {
   // assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.FLUSHDB, "NOTASYNC"))
-  // .hasMessage("ERR " + ERROR_SYNTAX);
+  // .hasMessage(ERROR_SYNTAX);
   // }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoIntegrationTest.java
@@ -290,6 +290,6 @@ public abstract class AbstractInfoIntegrationTest implements RedisIntegrationTes
   public void shouldThrowException_ifGivenMoreThanOneParameter() {
     assertThatThrownBy(
         () -> jedis.sendCommand(
-            Protocol.Command.INFO, "Server", "Cluster")).hasMessage("ERR " + ERROR_SYNTAX);
+            Protocol.Command.INFO, "Server", "Cluster")).hasMessage(ERROR_SYNTAX);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractInfoIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.commands.executor.server;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -289,6 +290,6 @@ public abstract class AbstractInfoIntegrationTest implements RedisIntegrationTes
   public void shouldThrowException_ifGivenMoreThanOneParameter() {
     assertThatThrownBy(
         () -> jedis.sendCommand(
-            Protocol.Command.INFO, "Server", "Cluster")).hasMessageContaining("ERR syntax error");
+            Protocol.Command.INFO, "Server", "Cluster")).hasMessage("ERR " + ERROR_SYNTAX);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractSlowlogIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractSlowlogIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.commands.executor.server;
 
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -146,6 +147,7 @@ public abstract class AbstractSlowlogIntegrationTest implements RedisIntegration
     assertThatThrownBy(
         () -> jedis.sendCommand(
             Protocol.Command.SLOWLOG))
-                .hasMessage("ERR wrong number of arguments for 'slowlog' command");
+                .hasMessage(
+                    "ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "slowlog"));
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractSlowlogIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractSlowlogIntegrationTest.java
@@ -93,27 +93,24 @@ public abstract class AbstractSlowlogIntegrationTest implements RedisIntegration
   public void shouldThrowException_givenAnyExtraParameterIsProvidedToReset() {
     assertThatThrownBy(
         () -> jedis.sendCommand(
-            Protocol.Command.SLOWLOG, "RESET", "Superfluous"))
-                .hasMessage(
-                    "ERR Unknown subcommand or wrong number of arguments for 'RESET'. Try SLOWLOG HELP.");
+            Protocol.Command.SLOWLOG, "RESET", "Superfluous")).hasMessage(
+                "ERR Unknown subcommand or wrong number of arguments for 'RESET'. Try SLOWLOG HELP.");
   }
 
   @Test
   public void shouldThrowException_givenAnyExtraParameterIsProvidedToLenAParameter() {
     assertThatThrownBy(
         () -> jedis.sendCommand(
-            Protocol.Command.SLOWLOG, "LEN", "Superfluous"))
-                .hasMessage(
-                    "ERR Unknown subcommand or wrong number of arguments for 'LEN'. Try SLOWLOG HELP.");
+            Protocol.Command.SLOWLOG, "LEN", "Superfluous")).hasMessage(
+                "ERR Unknown subcommand or wrong number of arguments for 'LEN'. Try SLOWLOG HELP.");
   }
 
   @Test
   public void shouldMatchCaseOfSentCommand_whenThrowingException() {
     assertThatThrownBy(
         () -> jedis.sendCommand(
-            Protocol.Command.SLOWLOG, "lEn", "Superfluous"))
-                .hasMessage(
-                    "ERR Unknown subcommand or wrong number of arguments for 'lEn'. Try SLOWLOG HELP.");
+            Protocol.Command.SLOWLOG, "lEn", "Superfluous")).hasMessage(
+                "ERR Unknown subcommand or wrong number of arguments for 'lEn'. Try SLOWLOG HELP.");
   }
 
   @Test
@@ -128,26 +125,23 @@ public abstract class AbstractSlowlogIntegrationTest implements RedisIntegration
   public void shouldThrowException_givenMoreThanThreeArgumentsAfterCommand() {
     assertThatThrownBy(
         () -> jedis.sendCommand(
-            Protocol.Command.SLOWLOG, "secondArg", "thirdArg", "fourthArg"))
-                .hasMessage(
-                    "ERR Unknown subcommand or wrong number of arguments for 'secondArg'. Try SLOWLOG HELP.");
+            Protocol.Command.SLOWLOG, "secondArg", "thirdArg", "fourthArg")).hasMessage(
+                "ERR Unknown subcommand or wrong number of arguments for 'secondArg'. Try SLOWLOG HELP.");
   }
 
   @Test
   public void shouldThrowException_givenUnknownSubcommand() {
     assertThatThrownBy(
         () -> jedis.sendCommand(
-            Protocol.Command.SLOWLOG, "xlerb"))
-                .hasMessage(
-                    "ERR Unknown subcommand or wrong number of arguments for 'xlerb'. Try SLOWLOG HELP.");
+            Protocol.Command.SLOWLOG, "xlerb")).hasMessage(
+                "ERR Unknown subcommand or wrong number of arguments for 'xlerb'. Try SLOWLOG HELP.");
   }
 
   @Test
   public void shouldThrowException_givenNoSubcommand() {
     assertThatThrownBy(
         () -> jedis.sendCommand(
-            Protocol.Command.SLOWLOG))
-                .hasMessage(
-                    "ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "slowlog"));
+            Protocol.Command.SLOWLOG)).hasMessage(
+                String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "slowlog"));
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractSlowlogIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractSlowlogIntegrationTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.commands.executor.server;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -118,7 +119,7 @@ public abstract class AbstractSlowlogIntegrationTest implements RedisIntegration
     assertThatThrownBy(
         () -> jedis.sendCommand(
             Protocol.Command.SLOWLOG, "GET", "I am not a number"))
-                .hasMessage("ERR value is not an integer or out of range");
+                .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/FlushAllIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/FlushAllIntegrationTest.java
@@ -34,6 +34,6 @@ public class FlushAllIntegrationTest extends AbstractFlushAllIntegrationTest {
   // @Test
   // public void givenAsyncParameter_returnsUnimplementedError() {
   // assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.FLUSHALL, "ASYNC", "extraArg"))
-  // .hasMessage("ERR " + ERROR_SYNTAX);
+  // .hasMessage(ERROR_SYNTAX);
   // }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/FlushAllIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/FlushAllIntegrationTest.java
@@ -34,6 +34,6 @@ public class FlushAllIntegrationTest extends AbstractFlushAllIntegrationTest {
   // @Test
   // public void givenAsyncParameter_returnsUnimplementedError() {
   // assertThatThrownBy(() -> jedis.sendCommand(Protocol.Command.FLUSHALL, "ASYNC", "extraArg"))
-  // .hasMessageContaining(ERROR_SYNTAX);
+  // .hasMessage("ERR " + ERROR_SYNTAX);
   // }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/LolWutIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/LolWutIntegrationTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.commands.executor.server;
 
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -133,7 +134,7 @@ public class LolWutIntegrationTest implements RedisIntegrationTest {
   public void shouldError_givenNonNumericArg() {
     assertThatThrownBy(() -> jedis.sendCommand(() -> SafeEncoder.encode("lolwut"),
         SafeEncoder.encode("notEvenCloseToANumber")))
-            .hasMessage("ERR value is not an integer or out of range");
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/ShutdownIntegrationTest.java
@@ -25,7 +25,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import redis.clients.jedis.Jedis;
-import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -57,12 +56,10 @@ public class ShutdownIntegrationTest implements RedisIntegrationTest {
   @Test
   public void shutdownIsDisabled_whenOnlySupportedCommandsAreAllowed() {
     final String EXPECTED_ERROR_MSG =
-        String.format("ERR " + ERROR_UNKNOWN_COMMAND, "SHUTDOWN", "");
+        String.format(ERROR_UNKNOWN_COMMAND, "SHUTDOWN", "");
 
     assertThatThrownBy(
-        () -> jedis.shutdown())
-            .isInstanceOf(JedisDataException.class)
-            .hasMessage(EXPECTED_ERROR_MSG);
+        () -> jedis.shutdown()).hasMessage(EXPECTED_ERROR_MSG);
     assertThat(jedis.keys("*")).isEmpty();
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSCardIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSCardIntegrationTest.java
@@ -100,6 +100,6 @@ public abstract class AbstractSCardIntegrationTest implements RedisIntegrationTe
   @Test
   public void scardWithWrongKeyType_returnsWrongTypeError() {
     jedis.set("ding", "dong");
-    assertThatThrownBy(() -> jedis.scard("ding")).hasMessageContaining(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.scard("ding")).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSCardIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSCardIntegrationTest.java
@@ -100,6 +100,6 @@ public abstract class AbstractSCardIntegrationTest implements RedisIntegrationTe
   @Test
   public void scardWithWrongKeyType_returnsWrongTypeError() {
     jedis.set("ding", "dong");
-    assertThatThrownBy(() -> jedis.scard("ding")).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.scard("ding")).hasMessage(ERROR_WRONG_TYPE);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffIntegrationTest.java
@@ -181,7 +181,7 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
     String secondSetKey = "{tag1}secondKey";
     jedis.sadd(secondSetKey, members);
     assertThatThrownBy(() -> jedis.sdiff(stringKey, SET_KEY, secondSetKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -193,7 +193,7 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
     String secondSetKey = "{tag1}secondKey";
     jedis.sadd(secondSetKey, members);
     assertThatThrownBy(() -> jedis.sdiff(SET_KEY, secondSetKey, stringKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -203,7 +203,7 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
 
     jedis.sadd(SET_KEY, "member");
     assertThatThrownBy(() -> jedis.sdiff(NON_EXISTENT_SET_KEY, SET_KEY, stringKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffIntegrationTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
     jedis.sadd(setKeyDifferentSlot, "member2");
 
     assertThatThrownBy(() -> jedis.sendCommand(SET_KEY, SDIFF, SET_KEY, setKeyDifferentSlot))
-        .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+        .hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test
@@ -181,7 +181,7 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
     String secondSetKey = "{tag1}secondKey";
     jedis.sadd(secondSetKey, members);
     assertThatThrownBy(() -> jedis.sdiff(stringKey, SET_KEY, secondSetKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -193,7 +193,7 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
     String secondSetKey = "{tag1}secondKey";
     jedis.sadd(secondSetKey, members);
     assertThatThrownBy(() -> jedis.sdiff(SET_KEY, secondSetKey, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -203,7 +203,7 @@ public abstract class AbstractSDiffIntegrationTest implements RedisIntegrationTe
 
     jedis.sadd(SET_KEY, "member");
     assertThatThrownBy(() -> jedis.sdiff(NON_EXISTENT_SET_KEY, SET_KEY, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffStoreIntegrationTest.java
@@ -67,7 +67,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
     jedis.sadd(setKeyDifferentSlot, "member2");
 
     assertThatThrownBy(() -> jedis.sendCommand(SET_KEY, SDIFFSTORE, SET_KEY, setKeyDifferentSlot))
-        .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+        .hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test
@@ -79,7 +79,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
     jedis.sadd(SET_KEY, SET_MEMBERS);
     jedis.sadd(secondSetKey, SET_MEMBERS);
     assertThatThrownBy(() -> jedis.sdiffstore(DESTINATION_KEY, stringKey, SET_KEY, secondSetKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -91,7 +91,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
     jedis.sadd(SET_KEY, SET_MEMBERS);
     jedis.sadd(secondSetKey, SET_MEMBERS);
     assertThatThrownBy(() -> jedis.sdiffstore(DESTINATION_KEY, SET_KEY, secondSetKey, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -102,7 +102,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
     jedis.sadd(SET_KEY, SET_MEMBERS);
     assertThatThrownBy(
         () -> jedis.sdiffstore(DESTINATION_KEY, NON_EXISTENT_SET, SET_KEY, stringKey))
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+            .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSDiffStoreIntegrationTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
     jedis.sadd(SET_KEY, SET_MEMBERS);
     jedis.sadd(secondSetKey, SET_MEMBERS);
     assertThatThrownBy(() -> jedis.sdiffstore(DESTINATION_KEY, stringKey, SET_KEY, secondSetKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -91,7 +91,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
     jedis.sadd(SET_KEY, SET_MEMBERS);
     jedis.sadd(secondSetKey, SET_MEMBERS);
     assertThatThrownBy(() -> jedis.sdiffstore(DESTINATION_KEY, SET_KEY, secondSetKey, stringKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -102,7 +102,7 @@ public abstract class AbstractSDiffStoreIntegrationTest implements RedisIntegrat
     jedis.sadd(SET_KEY, SET_MEMBERS);
     assertThatThrownBy(
         () -> jedis.sdiffstore(DESTINATION_KEY, NON_EXISTENT_SET, SET_KEY, stringKey))
-            .hasMessageContaining(ERROR_WRONG_TYPE);
+            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterIntegrationTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.sadd(setKeyDifferentSlot, "member2");
 
     assertThatThrownBy(() -> jedis.sendCommand(SET1, SINTER, SET1, setKeyDifferentSlot))
-        .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+        .hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test
@@ -89,8 +89,7 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.sadd(SET1, firstSet);
     jedis.set("{tag1}nonSet", nonSet);
 
-    assertThatThrownBy(() -> jedis.sinter(SET1, "{tag1}nonSet"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.sinter(SET1, "{tag1}nonSet")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -103,8 +102,7 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     String stringKey = "{tag1}ding";
     jedis.set(stringKey, "dong");
 
-    assertThatThrownBy(() -> jedis.sinter(stringKey, SET1, SET2))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.sinter(stringKey, SET1, SET2)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -117,8 +115,7 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     String stringKey = "{tag1}ding";
     jedis.set(stringKey, "dong");
 
-    assertThatThrownBy(() -> jedis.sinter(SET1, SET2, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.sinter(SET1, SET2, stringKey)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -130,7 +127,7 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.set(stringKey, "dong");
 
     assertThatThrownBy(() -> jedis.sinter("{tag1}nonExistent", SET1, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterIntegrationTest.java
@@ -89,8 +89,8 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.sadd(SET1, firstSet);
     jedis.set("{tag1}nonSet", nonSet);
 
-    assertThatThrownBy(() -> jedis.sinter(SET1, "{tag1}nonSet")).hasMessageContaining(
-        ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.sinter(SET1, "{tag1}nonSet"))
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -104,7 +104,7 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.set(stringKey, "dong");
 
     assertThatThrownBy(() -> jedis.sinter(stringKey, SET1, SET2))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -118,7 +118,7 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.set(stringKey, "dong");
 
     assertThatThrownBy(() -> jedis.sinter(SET1, SET2, stringKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -130,7 +130,7 @@ public abstract class AbstractSInterIntegrationTest implements RedisIntegrationT
     jedis.set(stringKey, "dong");
 
     assertThatThrownBy(() -> jedis.sinter("{tag1}nonExistent", SET1, stringKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterStoreIntegrationTest.java
@@ -171,7 +171,7 @@ public abstract class AbstractSInterStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(() -> jedis.sinterstore(DESTINATION_KEY, stringKey, SET_KEY_1, SET_KEY_2))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -183,7 +183,7 @@ public abstract class AbstractSInterStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(() -> jedis.sinterstore(DESTINATION_KEY, SET_KEY_1, SET_KEY_2, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -195,7 +195,7 @@ public abstract class AbstractSInterStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(
         () -> jedis.sinterstore(DESTINATION_KEY, NON_EXISTENT_SET, SET_KEY_1, stringKey))
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+            .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -206,7 +206,7 @@ public abstract class AbstractSInterStoreIntegrationTest implements RedisIntegra
     jedis.sadd(setKeyDifferentSlot, secondSetMembers);
 
     assertThatThrownBy(() -> jedis.sendCommand(DESTINATION_KEY, SINTERSTORE, DESTINATION_KEY,
-        SET_KEY_1, setKeyDifferentSlot)).hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+        SET_KEY_1, setKeyDifferentSlot)).hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSInterStoreIntegrationTest.java
@@ -171,7 +171,7 @@ public abstract class AbstractSInterStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(() -> jedis.sinterstore(DESTINATION_KEY, stringKey, SET_KEY_1, SET_KEY_2))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -183,7 +183,7 @@ public abstract class AbstractSInterStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(() -> jedis.sinterstore(DESTINATION_KEY, SET_KEY_1, SET_KEY_2, stringKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -195,7 +195,7 @@ public abstract class AbstractSInterStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(
         () -> jedis.sinterstore(DESTINATION_KEY, NON_EXISTENT_SET, SET_KEY_1, stringKey))
-            .hasMessageContaining(ERROR_WRONG_TYPE);
+            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSIsMemberIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSIsMemberIntegrationTest.java
@@ -105,6 +105,6 @@ public abstract class AbstractSIsMemberIntegrationTest implements RedisIntegrati
     String valueString = "alicia";
     jedis.set(keyString, valueString);
     assertThatThrownBy(() -> jedis.sismember(keyString, valueString))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSIsMemberIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSIsMemberIntegrationTest.java
@@ -104,7 +104,6 @@ public abstract class AbstractSIsMemberIntegrationTest implements RedisIntegrati
     String keyString = "keys";
     String valueString = "alicia";
     jedis.set(keyString, valueString);
-    assertThatThrownBy(() -> jedis.sismember(keyString, valueString))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.sismember(keyString, valueString)).hasMessage(ERROR_WRONG_TYPE);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSMoveIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSMoveIntegrationTest.java
@@ -66,7 +66,7 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
     jedis.sadd(DESTINATION_KEY, DESTINATION_MEMBERS);
 
     assertThatThrownBy(() -> jedis.smove(SOURCE_KEY, DESTINATION_KEY, MOVED_MEMBER))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -75,7 +75,7 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
     jedis.set(DESTINATION_KEY, "value");
 
     assertThatThrownBy(() -> jedis.smove(SOURCE_KEY, DESTINATION_KEY, MOVED_MEMBER))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -84,7 +84,7 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
     jedis.set(DESTINATION_KEY, "destMember");
 
     assertThatThrownBy(() -> jedis.smove(SOURCE_KEY, DESTINATION_KEY, MOVED_MEMBER))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -169,7 +169,7 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(SOURCE_KEY, SMOVE, SOURCE_KEY, setKeyDifferentSlot, MOVED_MEMBER))
-            .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+            .hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSMoveIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSMoveIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.commands.executor.set;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +34,6 @@ import redis.clients.jedis.JedisCluster;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 
 public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
@@ -66,7 +66,7 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
     jedis.sadd(DESTINATION_KEY, DESTINATION_MEMBERS);
 
     assertThatThrownBy(() -> jedis.smove(SOURCE_KEY, DESTINATION_KEY, MOVED_MEMBER))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -75,7 +75,7 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
     jedis.set(DESTINATION_KEY, "value");
 
     assertThatThrownBy(() -> jedis.smove(SOURCE_KEY, DESTINATION_KEY, MOVED_MEMBER))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -84,7 +84,7 @@ public abstract class AbstractSMoveIntegrationTest implements RedisIntegrationTe
     jedis.set(DESTINATION_KEY, "destMember");
 
     assertThatThrownBy(() -> jedis.smove(SOURCE_KEY, DESTINATION_KEY, MOVED_MEMBER))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSPopIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSPopIntegrationTest.java
@@ -66,19 +66,19 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
   public void spopTooManyArgs_returnsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(SET_KEY, Protocol.Command.SPOP, SET_KEY, "5", "5"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void spop_withNonNumericCount_returnsError() {
     assertThatThrownBy(() -> jedis.sendCommand(SET_KEY, Protocol.Command.SPOP, SET_KEY, "b"))
-        .hasMessageContaining(ERROR_VALUE_MUST_BE_POSITIVE);
+        .hasMessage("ERR " + ERROR_VALUE_MUST_BE_POSITIVE);
   }
 
   @Test
   public void spop_withNegativeCount_returnsError() {
     assertThatThrownBy(() -> jedis.spop(SET_KEY, -1))
-        .hasMessageContaining(ERROR_VALUE_MUST_BE_POSITIVE);
+        .hasMessage("ERR " + ERROR_VALUE_MUST_BE_POSITIVE);
   }
 
   @Test
@@ -158,7 +158,7 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
   public void spop_withoutCount_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.spop(key)).hasMessageContaining(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.spop(key)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
 
@@ -166,7 +166,7 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
   public void spop_withCountAsZero_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.spop(key, 0)).hasMessageContaining(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.spop(key, 0)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -174,7 +174,7 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
     String key = "ding";
     jedis.set(key, "dong");
     assertThatThrownBy(() -> jedis.spop(key, -1))
-        .hasMessageContaining(ERROR_VALUE_MUST_BE_POSITIVE);
+        .hasMessage("ERR " + ERROR_VALUE_MUST_BE_POSITIVE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSPopIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSPopIntegrationTest.java
@@ -66,19 +66,18 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
   public void spopTooManyArgs_returnsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(SET_KEY, Protocol.Command.SPOP, SET_KEY, "5", "5"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void spop_withNonNumericCount_returnsError() {
     assertThatThrownBy(() -> jedis.sendCommand(SET_KEY, Protocol.Command.SPOP, SET_KEY, "b"))
-        .hasMessage("ERR " + ERROR_VALUE_MUST_BE_POSITIVE);
+        .hasMessage(ERROR_VALUE_MUST_BE_POSITIVE);
   }
 
   @Test
   public void spop_withNegativeCount_returnsError() {
-    assertThatThrownBy(() -> jedis.spop(SET_KEY, -1))
-        .hasMessage("ERR " + ERROR_VALUE_MUST_BE_POSITIVE);
+    assertThatThrownBy(() -> jedis.spop(SET_KEY, -1)).hasMessage(ERROR_VALUE_MUST_BE_POSITIVE);
   }
 
   @Test
@@ -158,7 +157,7 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
   public void spop_withoutCount_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.spop(key)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.spop(key)).hasMessage(ERROR_WRONG_TYPE);
   }
 
 
@@ -166,15 +165,14 @@ public abstract class AbstractSPopIntegrationTest implements RedisIntegrationTes
   public void spop_withCountAsZero_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.spop(key, 0)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.spop(key, 0)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
   public void spop_withCountAsNegative_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.spop(key, -1))
-        .hasMessage("ERR " + ERROR_VALUE_MUST_BE_POSITIVE);
+    assertThatThrownBy(() -> jedis.spop(key, -1)).hasMessage(ERROR_VALUE_MUST_BE_POSITIVE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSRandMemberIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSRandMemberIntegrationTest.java
@@ -62,13 +62,13 @@ public abstract class AbstractSRandMemberIntegrationTest implements RedisIntegra
   public void srandmemberTooManyArgs_returnsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(SET_KEY, Protocol.Command.SRANDMEMBER, SET_KEY, "5", "5"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void srandmember_withInvalidCount_returnsError() {
     assertThatThrownBy(() -> jedis.sendCommand(SET_KEY, Protocol.Command.SRANDMEMBER, SET_KEY, "b"))
-        .hasMessageContaining(ERROR_NOT_INTEGER);
+        .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -146,20 +146,20 @@ public abstract class AbstractSRandMemberIntegrationTest implements RedisIntegra
   public void srandmember_withoutCount_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.srandmember(key)).hasMessageContaining(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.srandmember(key)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
   public void srandmember_withCount_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.srandmember(key, 5)).hasMessageContaining(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.srandmember(key, 5)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
   public void srandmember_withCountAsZero_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.srandmember(key, 0)).hasMessageContaining(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.srandmember(key, 0)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSRandMemberIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSRandMemberIntegrationTest.java
@@ -62,13 +62,13 @@ public abstract class AbstractSRandMemberIntegrationTest implements RedisIntegra
   public void srandmemberTooManyArgs_returnsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(SET_KEY, Protocol.Command.SRANDMEMBER, SET_KEY, "5", "5"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void srandmember_withInvalidCount_returnsError() {
     assertThatThrownBy(() -> jedis.sendCommand(SET_KEY, Protocol.Command.SRANDMEMBER, SET_KEY, "b"))
-        .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -146,20 +146,20 @@ public abstract class AbstractSRandMemberIntegrationTest implements RedisIntegra
   public void srandmember_withoutCount_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.srandmember(key)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.srandmember(key)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
   public void srandmember_withCount_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.srandmember(key, 5)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.srandmember(key, 5)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
   public void srandmember_withCountAsZero_withWrongKeyType_returnsWrongTypeError() {
     String key = "ding";
     jedis.set(key, "dong");
-    assertThatThrownBy(() -> jedis.srandmember(key, 0)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.srandmember(key, 0)).hasMessage(ERROR_WRONG_TYPE);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSRemIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSRemIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.commands.executor.set;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -81,7 +83,8 @@ public abstract class AbstractSRemIntegrationTest implements RedisIntegrationTes
 
   @Test
   public void testSRem_should_ThrowError_givenOnlyKey() {
-    assertThatThrownBy(() -> jedis.srem("key")).hasMessageContaining("wrong number of arguments");
+    assertThatThrownBy(() -> jedis.srem("key"))
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "srem"));
   }
 
   @Test
@@ -117,7 +120,7 @@ public abstract class AbstractSRemIntegrationTest implements RedisIntegrationTes
     jedis.set(key, value);
 
     assertThatThrownBy(() -> jedis.srem(key, value))
-        .hasMessageContaining("WRONGTYPE Operation against a key holding the wrong kind of value");
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSRemIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSRemIntegrationTest.java
@@ -84,7 +84,7 @@ public abstract class AbstractSRemIntegrationTest implements RedisIntegrationTes
   @Test
   public void testSRem_should_ThrowError_givenOnlyKey() {
     assertThatThrownBy(() -> jedis.srem("key"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "srem"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "srem"));
   }
 
   @Test
@@ -119,8 +119,7 @@ public abstract class AbstractSRemIntegrationTest implements RedisIntegrationTes
     String value = "value";
     jedis.set(key, value);
 
-    assertThatThrownBy(() -> jedis.srem(key, value))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.srem(key, value)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSScanIntegrationTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "a*"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -103,7 +103,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "MATCH"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -111,7 +111,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "COUNT"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -119,7 +119,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "a*", "1"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -127,8 +127,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "COUNT",
-            "notAnInteger"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "notAnInteger")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -136,8 +135,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "COUNT", "12",
-            "COUNT", "notAnInteger", "COUNT", "1"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "COUNT", "notAnInteger", "COUNT", "1")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -145,8 +143,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "COUNT", "12",
-            "COUNT", "0", "COUNT", "1"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "COUNT", "0", "COUNT", "1")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -154,7 +151,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sscan(KEY_BYTES, ZERO_CURSOR_BYTES, new ScanParams().count(0)))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -162,15 +159,14 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sscan(KEY_BYTES, ZERO_CURSOR_BYTES, new ScanParams().count(-37)))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenKeyIsNotASet_returnsWrongTypeError() {
     jedis.hset(KEY, "b", MEMBER_ONE);
     assertThatThrownBy(
-        () -> jedis.sscan(KEY, ZERO_CURSOR))
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        () -> jedis.sscan(KEY, ZERO_CURSOR)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -178,30 +174,27 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(KEY, "b", MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sscan(KEY_BYTES, ZERO_CURSOR_BYTES, new ScanParams().count(-37)))
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+            .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
   public void givenKeyIsNotASet_andCursorIsNotAnInteger_returnsInvalidCursorError() {
     jedis.hset(KEY, "b", MEMBER_ONE);
     assertThatThrownBy(
-        () -> jedis.sscan(KEY, "notAnInteger"))
-            .hasMessage("ERR " + ERROR_CURSOR);
+        () -> jedis.sscan(KEY, "notAnInteger")).hasMessage(ERROR_CURSOR);
   }
 
   @Test
   public void givenNonexistentKey_andCursorIsNotInteger_returnsInvalidCursorError() {
     assertThatThrownBy(
-        () -> jedis.sscan("nonexistentKey", "notAnInteger"))
-            .hasMessage("ERR " + ERROR_CURSOR);
+        () -> jedis.sscan("nonexistentKey", "notAnInteger")).hasMessage(ERROR_CURSOR);
   }
 
   @Test
   public void givenExistentSetKey_andCursorIsNotAnInteger_returnsInvalidCursorError() {
     jedis.set(KEY, "b");
     assertThatThrownBy(
-        () -> jedis.sscan(KEY, "notAnInteger"))
-            .hasMessage("ERR " + ERROR_CURSOR);
+        () -> jedis.sscan(KEY, "notAnInteger")).hasMessage(ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSScanIntegrationTest.java
@@ -95,7 +95,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "a*"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -103,7 +103,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "MATCH"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -111,7 +111,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "COUNT"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -119,7 +119,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "a*", "1"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -128,7 +128,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "COUNT",
             "notAnInteger"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -137,7 +137,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "COUNT", "12",
             "COUNT", "notAnInteger", "COUNT", "1"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -146,7 +146,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.SSCAN, KEY, ZERO_CURSOR, "COUNT", "12",
             "COUNT", "0", "COUNT", "1"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -154,7 +154,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sscan(KEY_BYTES, ZERO_CURSOR_BYTES, new ScanParams().count(0)))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -162,7 +162,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sscan(KEY_BYTES, ZERO_CURSOR_BYTES, new ScanParams().count(-37)))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -170,7 +170,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(KEY, "b", MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sscan(KEY, ZERO_CURSOR))
-            .hasMessageContaining(ERROR_WRONG_TYPE);
+            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -178,7 +178,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(KEY, "b", MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sscan(KEY_BYTES, ZERO_CURSOR_BYTES, new ScanParams().count(-37)))
-            .hasMessageContaining(ERROR_WRONG_TYPE);
+            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -186,14 +186,14 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.hset(KEY, "b", MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sscan(KEY, "notAnInteger"))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
   public void givenNonexistentKey_andCursorIsNotInteger_returnsInvalidCursorError() {
     assertThatThrownBy(
         () -> jedis.sscan("nonexistentKey", "notAnInteger"))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
@@ -201,7 +201,7 @@ public abstract class AbstractSScanIntegrationTest implements RedisIntegrationTe
     jedis.set(KEY, "b");
     assertThatThrownBy(
         () -> jedis.sscan(KEY, "notAnInteger"))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionIntegrationTest.java
@@ -127,7 +127,7 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
     jedis.sadd(setKeyDifferentSlot, secondSetMembers);
 
     assertThatThrownBy(() -> jedis.sendCommand(SET_KEY_1, SUNION, SET_KEY_1, setKeyDifferentSlot))
-        .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+        .hasMessage(ERROR_WRONG_SLOT);
   }
 
 
@@ -140,7 +140,7 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
     String diffKey = "{tag1}diffKey";
     jedis.set(diffKey, "dong");
     assertThatThrownBy(() -> jedis.sunion(diffKey, SET_KEY_1, SET_KEY_2))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -152,7 +152,7 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
     String diffKey = "{tag1}diffKey";
     jedis.set(diffKey, "dong");
     assertThatThrownBy(() -> jedis.sunion(SET_KEY_1, SET_KEY_2, diffKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -162,7 +162,7 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
 
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     assertThatThrownBy(() -> jedis.sunion(NON_EXISTENT_SET, SET_KEY_1, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionIntegrationTest.java
@@ -140,7 +140,7 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
     String diffKey = "{tag1}diffKey";
     jedis.set(diffKey, "dong");
     assertThatThrownBy(() -> jedis.sunion(diffKey, SET_KEY_1, SET_KEY_2))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -152,7 +152,7 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
     String diffKey = "{tag1}diffKey";
     jedis.set(diffKey, "dong");
     assertThatThrownBy(() -> jedis.sunion(SET_KEY_1, SET_KEY_2, diffKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -162,7 +162,7 @@ public abstract class AbstractSUnionIntegrationTest implements RedisIntegrationT
 
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     assertThatThrownBy(() -> jedis.sunion(NON_EXISTENT_SET, SET_KEY_1, stringKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionStoreIntegrationTest.java
@@ -173,7 +173,7 @@ public abstract class AbstractSUnionStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(() -> jedis.sunionstore(DESTINATION_KEY, stringKey, SET_KEY_1, SET_KEY_2))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -185,7 +185,7 @@ public abstract class AbstractSUnionStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(() -> jedis.sunionstore(DESTINATION_KEY, SET_KEY_1, SET_KEY_2, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -197,7 +197,7 @@ public abstract class AbstractSUnionStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(
         () -> jedis.sunionstore(DESTINATION_KEY, NON_EXISTENT_SET, SET_KEY_1, stringKey))
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+            .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -208,8 +208,7 @@ public abstract class AbstractSUnionStoreIntegrationTest implements RedisIntegra
     jedis.sadd(setKeyDifferentSlot, secondSetMembers);
 
     assertThatThrownBy(() -> jedis.sendCommand(DESTINATION_KEY, SUNIONSTORE, DESTINATION_KEY,
-        SET_KEY_1, setKeyDifferentSlot))
-            .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+        SET_KEY_1, setKeyDifferentSlot)).hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSUnionStoreIntegrationTest.java
@@ -173,7 +173,7 @@ public abstract class AbstractSUnionStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(() -> jedis.sunionstore(DESTINATION_KEY, stringKey, SET_KEY_1, SET_KEY_2))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -185,7 +185,7 @@ public abstract class AbstractSUnionStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_1, SET_MEMBERS_1);
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(() -> jedis.sunionstore(DESTINATION_KEY, SET_KEY_1, SET_KEY_2, stringKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -197,7 +197,7 @@ public abstract class AbstractSUnionStoreIntegrationTest implements RedisIntegra
     jedis.sadd(SET_KEY_2, "doorbell");
     assertThatThrownBy(
         () -> jedis.sunionstore(DESTINATION_KEY, NON_EXISTENT_SET, SET_KEY_1, stringKey))
-            .hasMessageContaining(ERROR_WRONG_TYPE);
+            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSetsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSetsIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.commands.executor.set;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -64,8 +66,7 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
     setValue[0] = "set value that should never get added";
 
     jedis.set(key, stringValue);
-    assertThatThrownBy(() -> jedis.sadd(key, setValue))
-        .hasMessageContaining("Operation against a key holding the wrong kind of value");
+    assertThatThrownBy(() -> jedis.sadd(key, setValue)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -87,14 +88,14 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
   @Test
   public void smembers_givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SMEMBERS))
-        .hasMessageContaining("ERR wrong number of arguments for 'smembers' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "smembers"));
   }
 
   @Test
   public void smembers_givenMoreThanTwoArguments_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis
         .sendCommand("key", Protocol.Command.SMEMBERS, "key", "extraArg"))
-            .hasMessageContaining("ERR wrong number of arguments for 'smembers' command");
+            .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "smembers"));
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSetsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/AbstractSetsIntegrationTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.management.internal.cli.util.ThreePhraseGenerator;
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -66,7 +65,7 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
     setValue[0] = "set value that should never get added";
 
     jedis.set(key, stringValue);
-    assertThatThrownBy(() -> jedis.sadd(key, setValue)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.sadd(key, setValue)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -78,7 +77,7 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
 
     jedis.set(key, stringValue);
 
-    assertThatThrownBy(() -> jedis.sadd(key, setValue)).isInstanceOf(JedisDataException.class);
+    assertThatThrownBy(() -> jedis.sadd(key, setValue)).hasMessage(ERROR_WRONG_TYPE);
 
     String result = jedis.get(key);
 
@@ -88,14 +87,14 @@ public abstract class AbstractSetsIntegrationTest implements RedisIntegrationTes
   @Test
   public void smembers_givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SMEMBERS))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "smembers"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "smembers"));
   }
 
   @Test
   public void smembers_givenMoreThanTwoArguments_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis
         .sendCommand("key", Protocol.Command.SMEMBERS, "key", "extraArg"))
-            .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "smembers"));
+            .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "smembers"));
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/SScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/SScanIntegrationTest.java
@@ -39,14 +39,14 @@ public class SScanIntegrationTest extends AbstractSScanIntegrationTest {
   public void givenCursorGreaterThanSignedLongMaxValue_returnsCursorError() {
     assertThatThrownBy(
         () -> jedis.sscan(KEY, SIGNED_LONG_MAX.add(BigInteger.ONE).toString()))
-            .hasMessage("ERR " + ERROR_CURSOR);
+            .hasMessage(ERROR_CURSOR);
   }
 
   @Test
   public void givenNegativeCursorLessThanSignedLongMinValue_returnsCursorError() {
     assertThatThrownBy(
         () -> jedis.sscan(KEY, SIGNED_LONG_MIN.subtract(BigInteger.ONE).toString()))
-            .hasMessage("ERR " + ERROR_CURSOR);
+            .hasMessage(ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/SScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/set/SScanIntegrationTest.java
@@ -39,14 +39,14 @@ public class SScanIntegrationTest extends AbstractSScanIntegrationTest {
   public void givenCursorGreaterThanSignedLongMaxValue_returnsCursorError() {
     assertThatThrownBy(
         () -> jedis.sscan(KEY, SIGNED_LONG_MAX.add(BigInteger.ONE).toString()))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
   public void givenNegativeCursorLessThanSignedLongMinValue_returnsCursorError() {
     assertThatThrownBy(
         () -> jedis.sscan(KEY, SIGNED_LONG_MIN.subtract(BigInteger.ONE).toString()))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZAddIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZAddIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLea
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_ZADD_OPTION_NX_XX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -86,7 +87,7 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void shouldError_givenUnevenPairsOfArguments() {
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "1", member, "2"))
-            .hasMessageContaining("ERR syntax error");
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -94,12 +95,12 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "invalidDoubleValue",
             member))
-                .hasMessageContaining(ERROR_NOT_A_VALID_FLOAT);
+                .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
     assertThat(jedis.zscore("fakeKey", member)).isNull();
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "1.0", "member01",
             "invalidDoubleValue", "member02", "3.0", "member03"))
-                .hasMessageContaining(ERROR_NOT_A_VALID_FLOAT);
+                .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
     assertThat(jedis.zscore("fakeKey", "member01")).isNull();
     assertThat(jedis.zscore("fakeKey", "member02")).isNull();
     assertThat(jedis.zscore("fakeKey", "member03")).isNull();
@@ -110,7 +111,7 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "NX", "XX", "1.0",
             "fakeMember"))
-                .hasMessageContaining(ERROR_INVALID_ZADD_OPTION_NX_XX);
+                .hasMessage("ERR " + ERROR_INVALID_ZADD_OPTION_NX_XX);
   }
 
   @Test
@@ -118,23 +119,23 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "NX", "XX", "xlerb",
             member, "2"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "NX", "XX", "xlerb",
             member))
-                .hasMessageContaining(ERROR_INVALID_ZADD_OPTION_NX_XX);
+                .hasMessage("ERR " + ERROR_INVALID_ZADD_OPTION_NX_XX);
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "xlerb", member))
-            .hasMessageContaining(ERROR_NOT_A_VALID_FLOAT);
+            .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "nan", member))
-            .hasMessageContaining(ERROR_NOT_A_VALID_FLOAT);
+            .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
   public void shouldError_givenNaN() {
     assertThatThrownBy(() -> jedis.zadd(SORTED_SET_KEY, Double.NaN, "member"))
-        .hasMessageContaining(ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -346,13 +347,13 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void zaddIncrOptionSupportsOnlyOneIncrementingElementPair() {
     assertThatThrownBy(() -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD,
         SORTED_SET_KEY, incrOption, "1", member, "2", "member_1"))
-            .hasMessageContaining(RedisConstants.ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR);
+            .hasMessage("ERR " + ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR);
   }
 
   @Test
   public void zaddIncrOptionThrowsIfIncorrectScorePair() {
     assertThatThrownBy(() -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD,
-        SORTED_SET_KEY, incrOption, "1", member, "2")).hasMessageContaining(ERROR_SYNTAX);
+        SORTED_SET_KEY, incrOption, "1", member, "2")).hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -396,7 +397,7 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void zaddIncrOptionThrowsErrorIfBothNXAndXXOptionsSpecified() {
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, incrOption, "NX", "XX",
-            "1.0", member)).hasMessageContaining(ERROR_INVALID_ZADD_OPTION_NX_XX);
+            "1.0", member)).hasMessage("ERR " + ERROR_INVALID_ZADD_OPTION_NX_XX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZAddIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZAddIntegrationTest.java
@@ -75,7 +75,7 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
     jedis.set(STRING_KEY, "value");
     assertThatThrownBy(
         () -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZADD, STRING_KEY, "1", member))
-            .hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
+            .hasMessage(RedisConstants.ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -87,20 +87,19 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void shouldError_givenUnevenPairsOfArguments() {
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "1", member, "2"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNonNumericScore() {
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "invalidDoubleValue",
-            member))
-                .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+            member)).hasMessage(ERROR_NOT_A_VALID_FLOAT);
     assertThat(jedis.zscore("fakeKey", member)).isNull();
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "1.0", "member01",
             "invalidDoubleValue", "member02", "3.0", "member03"))
-                .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+                .hasMessage(ERROR_NOT_A_VALID_FLOAT);
     assertThat(jedis.zscore("fakeKey", "member01")).isNull();
     assertThat(jedis.zscore("fakeKey", "member02")).isNull();
     assertThat(jedis.zscore("fakeKey", "member03")).isNull();
@@ -110,32 +109,29 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void shouldError_givenBothNXAndXXOptions() {
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "NX", "XX", "1.0",
-            "fakeMember"))
-                .hasMessage("ERR " + ERROR_INVALID_ZADD_OPTION_NX_XX);
+            "fakeMember")).hasMessage(ERROR_INVALID_ZADD_OPTION_NX_XX);
   }
 
   @Test
   public void shouldPrioritizeErrors_inTheCorrectOrder() {
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "NX", "XX", "xlerb",
-            member, "2"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            member, "2")).hasMessage(ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "NX", "XX", "xlerb",
-            member))
-                .hasMessage("ERR " + ERROR_INVALID_ZADD_OPTION_NX_XX);
+            member)).hasMessage(ERROR_INVALID_ZADD_OPTION_NX_XX);
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "xlerb", member))
-            .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+            .hasMessage(ERROR_NOT_A_VALID_FLOAT);
     assertThatThrownBy(
         () -> jedis.sendCommand("fakeKey", Protocol.Command.ZADD, "fakeKey", "nan", member))
-            .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+            .hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
   public void shouldError_givenNaN() {
     assertThatThrownBy(() -> jedis.zadd(SORTED_SET_KEY, Double.NaN, "member"))
-        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -347,13 +343,13 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void zaddIncrOptionSupportsOnlyOneIncrementingElementPair() {
     assertThatThrownBy(() -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD,
         SORTED_SET_KEY, incrOption, "1", member, "2", "member_1"))
-            .hasMessage("ERR " + ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR);
+            .hasMessage(ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR);
   }
 
   @Test
   public void zaddIncrOptionThrowsIfIncorrectScorePair() {
     assertThatThrownBy(() -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD,
-        SORTED_SET_KEY, incrOption, "1", member, "2")).hasMessage("ERR " + ERROR_SYNTAX);
+        SORTED_SET_KEY, incrOption, "1", member, "2")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -397,7 +393,7 @@ public abstract class AbstractZAddIntegrationTest implements RedisIntegrationTes
   public void zaddIncrOptionThrowsErrorIfBothNXAndXXOptionsSpecified() {
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZADD, incrOption, "NX", "XX",
-            "1.0", member)).hasMessage("ERR " + ERROR_INVALID_ZADD_OPTION_NX_XX);
+            "1.0", member)).hasMessage(ERROR_INVALID_ZADD_OPTION_NX_XX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZCardIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZCardIntegrationTest.java
@@ -74,7 +74,7 @@ public abstract class AbstractZCardIntegrationTest implements RedisIntegrationTe
     jedis.set(key, "value");
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.ZCARD, key))
-            .hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
+            .hasMessage(RedisConstants.ERROR_WRONG_TYPE);
   }
 
   private Map<String, Double> makeMemberScoreMap(String baseString) {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZCountIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZCountIntegrationTest.java
@@ -56,17 +56,17 @@ public abstract class AbstractZCountIntegrationTest implements RedisIntegrationT
   @Test
   public void shouldError_givenInvalidMinOrMax() {
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "notANumber", "1"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "1", "notANumber"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "notANumber", "notANumber"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "((", "1"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "1", "(("))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "(a", "(b"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZCountIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZCountIntegrationTest.java
@@ -56,17 +56,17 @@ public abstract class AbstractZCountIntegrationTest implements RedisIntegrationT
   @Test
   public void shouldError_givenInvalidMinOrMax() {
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "notANumber", "1"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "1", "notANumber"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "notANumber", "notANumber"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "((", "1"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "1", "(("))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zcount("fakeKey", "(a", "(b"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZIncrByIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZIncrByIntegrationTest.java
@@ -18,6 +18,9 @@ package org.apache.geode.redis.internal.commands.executor.sortedset;
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_OPERATION_PRODUCED_NAN;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -35,7 +38,6 @@ import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 
 public abstract class AbstractZIncrByIntegrationTest implements RedisIntegrationTest {
   JedisCluster jedis;
@@ -61,7 +63,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.set(STRING_KEY, "value");
     assertThatThrownBy(
         () -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY, "1", "member"))
-            .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -77,7 +79,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
 
     assertThatThrownBy(() -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY,
         nonFloatIncrement, STRING_MEMBER))
-            .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
+            .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -87,7 +89,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
 
     assertThatThrownBy(() -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY,
         nanIncrement, STRING_MEMBER))
-            .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
+            .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -98,13 +100,13 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
 
     assertThatThrownBy(() -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY,
         increment, STRING_MEMBER))
-            .hasMessageContaining(RedisConstants.ERROR_OPERATION_PRODUCED_NAN);
+            .hasMessage("ERR " + ERROR_OPERATION_PRODUCED_NAN);
   }
 
   @Test
   public void shouldError_whenSettingNewScoreToNaN() {
     assertThatThrownBy(() -> jedis.zincrby(STRING_KEY, Double.NaN, STRING_MEMBER))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
   }
 
   /************* infinity *************/
@@ -207,7 +209,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.zadd(KEY, POSITIVE_INFINITY, MEMBER);
 
     assertThatThrownBy(() -> jedis.zincrby(KEY, NEGATIVE_INFINITY, MEMBER))
-        .hasMessageContaining(RedisConstants.ERROR_OPERATION_PRODUCED_NAN);
+        .hasMessage("ERR " + ERROR_OPERATION_PRODUCED_NAN);
   }
 
   @Test
@@ -215,7 +217,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.zadd(KEY, NEGATIVE_INFINITY, MEMBER);
 
     assertThatThrownBy(() -> jedis.zincrby(KEY, POSITIVE_INFINITY, MEMBER))
-        .hasMessageContaining(RedisConstants.ERROR_OPERATION_PRODUCED_NAN);
+        .hasMessage("ERR " + ERROR_OPERATION_PRODUCED_NAN);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZIncrByIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZIncrByIntegrationTest.java
@@ -63,7 +63,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.set(STRING_KEY, "value");
     assertThatThrownBy(
         () -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY, "1", "member"))
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+            .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -78,8 +78,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.zadd(KEY, 1.0, MEMBER);
 
     assertThatThrownBy(() -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY,
-        nonFloatIncrement, STRING_MEMBER))
-            .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+        nonFloatIncrement, STRING_MEMBER)).hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -88,8 +87,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.zadd(STRING_KEY, 1.0, STRING_MEMBER);
 
     assertThatThrownBy(() -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY,
-        nanIncrement, STRING_MEMBER))
-            .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+        nanIncrement, STRING_MEMBER)).hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -99,14 +97,13 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.zincrby(STRING_KEY, POSITIVE_INFINITY, STRING_MEMBER);
 
     assertThatThrownBy(() -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZINCRBY, STRING_KEY,
-        increment, STRING_MEMBER))
-            .hasMessage("ERR " + ERROR_OPERATION_PRODUCED_NAN);
+        increment, STRING_MEMBER)).hasMessage(ERROR_OPERATION_PRODUCED_NAN);
   }
 
   @Test
   public void shouldError_whenSettingNewScoreToNaN() {
     assertThatThrownBy(() -> jedis.zincrby(STRING_KEY, Double.NaN, STRING_MEMBER))
-        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   /************* infinity *************/
@@ -209,7 +206,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.zadd(KEY, POSITIVE_INFINITY, MEMBER);
 
     assertThatThrownBy(() -> jedis.zincrby(KEY, NEGATIVE_INFINITY, MEMBER))
-        .hasMessage("ERR " + ERROR_OPERATION_PRODUCED_NAN);
+        .hasMessage(ERROR_OPERATION_PRODUCED_NAN);
   }
 
   @Test
@@ -217,7 +214,7 @@ public abstract class AbstractZIncrByIntegrationTest implements RedisIntegration
     jedis.zadd(KEY, NEGATIVE_INFINITY, MEMBER);
 
     assertThatThrownBy(() -> jedis.zincrby(KEY, POSITIVE_INFINITY, MEMBER))
-        .hasMessage("ERR " + ERROR_OPERATION_PRODUCED_NAN);
+        .hasMessage(ERROR_OPERATION_PRODUCED_NAN);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -79,7 +79,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zinterstore(NEW_SET, stringKey, KEY1, KEY2))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -90,7 +90,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zinterstore(NEW_SET, KEY1, KEY2,
-        stringKey)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        stringKey)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -100,7 +100,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zinterstore(NEW_SET, "{tag1}nonExistentKey", KEY1, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -108,87 +108,84 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     final String crossSlotKey = "{tag2}another";
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2", crossSlotKey,
-            KEY1)).hasMessage("CROSSSLOT " + RedisConstants.ERROR_WRONG_SLOT);
+            KEY1)).hasMessage(RedisConstants.ERROR_WRONG_SLOT);
   }
 
   @Test
   public void shouldError_givenNumkeysTooLarge() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2", KEY1))
-            .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            .hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNumkeysTooSmall() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1", KEY1, KEY2))
-            .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            .hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNumKeysOfZero() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "0", KEY1, KEY2))
-            .hasMessage("ERR " + RedisConstants.ERROR_KEY_REQUIRED_ZINTERSTORE);
+            .hasMessage(RedisConstants.ERROR_KEY_REQUIRED_ZINTERSTORE);
   }
 
   @Test
   public void shouldError_givenNegativeNumKeys() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "-2", KEY1, KEY2))
-            .hasMessage("ERR " + RedisConstants.ERROR_KEY_REQUIRED_ZINTERSTORE);
+            .hasMessage(RedisConstants.ERROR_KEY_REQUIRED_ZINTERSTORE);
   }
 
   @Test
   public void shouldError_givenTooManyWeights() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
-            KEY1, "WEIGHTS", "2", "3")).hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "WEIGHTS", "2", "3")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenTooFewWeights() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "2",
-            KEY1, KEY2, "WEIGHTS", "1")).hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, KEY2, "WEIGHTS", "1")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenWeightNotAFloat() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
-            KEY1, "WEIGHTS", "not-a-number"))
-                .hasMessage("ERR " + RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT);
+            KEY1, "WEIGHTS", "not-a-number")).hasMessage(RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT);
   }
 
   @Test
   public void shouldError_givenWeightsWithoutAnyValues() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
-            KEY1, "WEIGHTS")).hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "WEIGHTS")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenMultipleWeightKeywords() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
-            KEY1, "WEIGHT", "1.0", "WEIGHT", "2.0"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "WEIGHT", "1.0", "WEIGHT", "2.0")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenUnknownAggregate() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
-            KEY1, "AGGREGATE", "UNKNOWN", "WEIGHTS", "1"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "AGGREGATE", "UNKNOWN", "WEIGHTS", "1")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenAggregateKeywordWithoutValue() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
-            KEY1, "AGGREGATE")).hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "AGGREGATE")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
@@ -196,7 +193,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "1",
             KEY1, "WEIGHTS", "1", "AGGREGATE", "SUM", "MIN"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+                .hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
@@ -204,14 +201,14 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "3",
             KEY1, KEY2, KEY3, "WEIGHTS", "1", "AGGREGATE", "SUM"))
-                .hasMessage("ERR " + RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT);
+                .hasMessage(RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT);
   }
 
   @Test
   public void shouldError_givenNumKeysNotAnInteger() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZINTERSTORE, NEW_SET, "fish", KEY1, KEY2))
-            .hasMessage("ERR " + RedisConstants.ERROR_NOT_INTEGER);
+            .hasMessage(RedisConstants.ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZInterStoreIntegrationTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.commands.executor.sortedset;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -78,7 +79,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zinterstore(NEW_SET, stringKey, KEY1, KEY2))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -89,7 +90,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zinterstore(NEW_SET, KEY1, KEY2,
-        stringKey)).hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        stringKey)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -99,7 +100,7 @@ public abstract class AbstractZInterStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zinterstore(NEW_SET, "{tag1}nonExistentKey", KEY1, stringKey))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZLexCountIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZLexCountIntegrationTest.java
@@ -65,11 +65,11 @@ public abstract class AbstractZLexCountIntegrationTest implements RedisIntegrati
   @Parameters({"a", "--", "++"})
   public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
     assertThatThrownBy(() -> jedis.zlexcount("fakeKey", invalidArgument, "+"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zlexcount("fakeKey", "-", invalidArgument))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zlexcount("fakeKey", invalidArgument, invalidArgument))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZLexCountIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZLexCountIntegrationTest.java
@@ -65,11 +65,11 @@ public abstract class AbstractZLexCountIntegrationTest implements RedisIntegrati
   @Parameters({"a", "--", "++"})
   public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
     assertThatThrownBy(() -> jedis.zlexcount("fakeKey", invalidArgument, "+"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zlexcount("fakeKey", "-", invalidArgument))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zlexcount("fakeKey", invalidArgument, invalidArgument))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMaxIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMaxIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.commands.executor.sortedset;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +35,6 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 
 public abstract class AbstractZPopMaxIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
@@ -58,14 +59,14 @@ public abstract class AbstractZPopMaxIntegrationTest implements RedisIntegration
   public void shouldError_givenTooManyArguments() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.ZPOPMAX, "key", "1", "2"))
-            .hasMessageContaining(RedisConstants.ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenWrongNumberFormat() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.ZPOPMAX, "key", "wat"))
-            .hasMessageContaining(RedisConstants.ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMaxIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMaxIntegrationTest.java
@@ -59,14 +59,14 @@ public abstract class AbstractZPopMaxIntegrationTest implements RedisIntegration
   public void shouldError_givenTooManyArguments() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.ZPOPMAX, "key", "1", "2"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenWrongNumberFormat() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.ZPOPMAX, "key", "wat"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMinIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMinIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.commands.executor.sortedset;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,7 +35,6 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.resps.Tuple;
 
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 
 public abstract class AbstractZPopMinIntegrationTest implements RedisIntegrationTest {
   private JedisCluster jedis;
@@ -58,14 +59,14 @@ public abstract class AbstractZPopMinIntegrationTest implements RedisIntegration
   public void shouldError_givenTooManyArguments() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.ZPOPMIN, "key", "1", "2"))
-            .hasMessageContaining(RedisConstants.ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenWrongNumberFormat() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.ZPOPMIN, "key", "wat"))
-            .hasMessageContaining(RedisConstants.ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMinIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZPopMinIntegrationTest.java
@@ -59,14 +59,14 @@ public abstract class AbstractZPopMinIntegrationTest implements RedisIntegration
   public void shouldError_givenTooManyArguments() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.ZPOPMIN, "key", "1", "2"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenWrongNumberFormat() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.ZPOPMIN, "key", "wat"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
@@ -70,44 +70,44 @@ public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegra
   @Parameters({"a", "--", "++"})
   public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
     assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", invalidArgument, "+"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", "-", invalidArgument))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", invalidArgument, invalidArgument))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
   }
 
   @Test
   public void shouldError_givenInvalidLimitFormat() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LAMAT", "0", "10"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNonIntegerLimitArguments() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0", "invalid"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "invalid", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenNegativeZeroLimitOffset() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "-0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -115,12 +115,12 @@ public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegra
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0", "invalid",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -128,12 +128,12 @@ public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegra
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0", "10",
         "LIMIT", "0", "invalid"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0", "10",
         "LIMIT", "0"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByLexIntegrationTest.java
@@ -70,70 +70,60 @@ public abstract class AbstractZRangeByLexIntegrationTest implements RedisIntegra
   @Parameters({"a", "--", "++"})
   public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
     assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", invalidArgument, "+"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", "-", invalidArgument))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zrangeByLex("fakeKey", invalidArgument, invalidArgument))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
   }
 
   @Test
   public void shouldError_givenInvalidLimitFormat() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
-        "LIMIT"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LIMIT")).hasMessage(ERROR_SYNTAX);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
-        "LIMIT", "0"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LIMIT", "0")).hasMessage(ERROR_SYNTAX);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
-        "LAMAT", "0", "10"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LAMAT", "0", "10")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNonIntegerLimitArguments() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
-        "LIMIT", "0", "invalid"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "invalid")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
-        "LIMIT", "invalid", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "invalid", "10")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenNegativeZeroLimitOffset() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
-        "LIMIT", "-0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "-0", "10")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenMultipleLimits_withFirstLimitIncorrectlySpecified() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0", "invalid",
-        "LIMIT", "0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "10")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0",
-        "LIMIT", "0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "10")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenMultipleLimits_withLastLimitIncorrectlySpecified() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0", "10",
-        "LIMIT", "0", "invalid"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "invalid")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYLEX, KEY, "-", "+",
         "LIMIT", "0", "10",
-        "LIMIT", "0"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LIMIT", "0")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
@@ -64,23 +64,23 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
   @Test
   public void shouldError_givenInvalidMinOrMax() {
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "notANumber", "1"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "1", "notANumber"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "notANumber", "notANumber"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "((", "1"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "1", "(("))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "(a", "(b"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "str", "1"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "1", "str"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "1", "NaN"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
   }
 
   @Test
@@ -286,39 +286,34 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10", "LIMIT"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10", "LIMIT", "0"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
-        "LIMIT", "0", "invalid"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "invalid")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenMultipleLimits_withFirstLimitIncorrectlySpecified() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "invalid",
-        "LIMIT", "0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "10")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0",
-        "LIMIT", "0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "10")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenMultipleLimits_withLastLimitIncorrectlySpecified() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "10",
-        "LIMIT", "0", "invalid"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "invalid")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "10",
-        "LIMIT", "0"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LIMIT", "0")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -326,14 +321,12 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "WITHSCORES",
         "LIMIT", "0", "invalid",
-        "LIMIT", "0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "10")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0",
         "LIMIT", "0", "10",
-        "WITHSCORES"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "WITHSCORES")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -341,14 +334,12 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "WITHSCORES",
         "LIMIT", "0", "10",
-        "LIMIT", "0", "invalid"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "invalid")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "10",
         "LIMIT", "0",
-        "WITHSCORES"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "WITHSCORES")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeByScoreIntegrationTest.java
@@ -64,23 +64,23 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
   @Test
   public void shouldError_givenInvalidMinOrMax() {
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "notANumber", "1"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "1", "notANumber"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "notANumber", "notANumber"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "((", "1"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "1", "(("))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "(a", "(b"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "str", "1"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "1", "str"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zrangeByScore("fakeKey", "1", "NaN"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
   }
 
   @Test
@@ -286,13 +286,13 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10", "LIMIT"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10", "LIMIT", "0"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "invalid"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -300,12 +300,12 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "invalid",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -313,12 +313,12 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "10",
         "LIMIT", "0", "invalid"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "10",
         "LIMIT", "0"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -327,13 +327,13 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
         "WITHSCORES",
         "LIMIT", "0", "invalid",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0",
         "LIMIT", "0", "10",
         "WITHSCORES"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -342,13 +342,13 @@ public abstract class AbstractZRangeByScoreIntegrationTest implements RedisInteg
         "WITHSCORES",
         "LIMIT", "0", "10",
         "LIMIT", "0", "invalid"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZRANGEBYSCORE, KEY, "0", "10",
         "LIMIT", "0", "10",
         "LIMIT", "0",
         "WITHSCORES"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
@@ -64,7 +64,7 @@ public abstract class AbstractZRangeIntegrationTest implements RedisIntegrationT
     jedis.set(STRING_KEY, "value");
     assertThatThrownBy(
         () -> jedis.sendCommand(STRING_KEY, Protocol.Command.ZRANGE, STRING_KEY, "1", "2"))
-            .hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
+            .hasMessage(RedisConstants.ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -74,20 +74,16 @@ public abstract class AbstractZRangeIntegrationTest implements RedisIntegrationT
     String tooBig = Long.MAX_VALUE + "0";
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY,
-            "NOT_AN_INT", "2"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "NOT_AN_INT", "2")).hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY, "1",
-            "ALSO_NOT_AN_INT"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "ALSO_NOT_AN_INT")).hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY, tooSmall,
-            "1"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "1")).hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY, "1",
-            tooBig))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            tooBig)).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -95,8 +91,7 @@ public abstract class AbstractZRangeIntegrationTest implements RedisIntegrationT
     jedis.zadd(SORTED_SET_KEY, 1.0, "member");
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY, "1", "2",
-            "WITSCOREZ"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "WITSCOREZ")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRangeIntegrationTest.java
@@ -75,19 +75,19 @@ public abstract class AbstractZRangeIntegrationTest implements RedisIntegrationT
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY,
             "NOT_AN_INT", "2"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY, "1",
             "ALSO_NOT_AN_INT"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY, tooSmall,
             "1"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY, "1",
             tooBig))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -96,7 +96,7 @@ public abstract class AbstractZRangeIntegrationTest implements RedisIntegrationT
     assertThatThrownBy(
         () -> jedis.sendCommand(SORTED_SET_KEY, Protocol.Command.ZRANGE, SORTED_SET_KEY, "1", "2",
             "WITSCOREZ"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemIntegrationTest.java
@@ -64,8 +64,7 @@ public abstract class AbstractZRemIntegrationTest implements RedisIntegrationTes
     String member = "member1";
     jedis.sadd(key, member);
 
-    assertThatThrownBy(() -> jedis.zrem(key, member))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.zrem(key, member)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemIntegrationTest.java
@@ -65,7 +65,7 @@ public abstract class AbstractZRemIntegrationTest implements RedisIntegrationTes
     jedis.sadd(key, member);
 
     assertThatThrownBy(() -> jedis.zrem(key, member))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByLexIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByLexIntegrationTest.java
@@ -65,11 +65,11 @@ public abstract class AbstractZRemRangeByLexIntegrationTest implements RedisInte
   @Parameters({"a", "--", "++", "4"})
   public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
     assertThatThrownBy(() -> jedis.zremrangeByLex("fakeKey", invalidArgument, "+"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zremrangeByLex("fakeKey", "-", invalidArgument))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zremrangeByLex("fakeKey", invalidArgument, invalidArgument))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByLexIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByLexIntegrationTest.java
@@ -65,11 +65,11 @@ public abstract class AbstractZRemRangeByLexIntegrationTest implements RedisInte
   @Parameters({"a", "--", "++", "4"})
   public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
     assertThatThrownBy(() -> jedis.zremrangeByLex("fakeKey", invalidArgument, "+"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zremrangeByLex("fakeKey", "-", invalidArgument))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zremrangeByLex("fakeKey", invalidArgument, invalidArgument))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByRankIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByRankIntegrationTest.java
@@ -62,13 +62,12 @@ public abstract class AbstractZRemRangeByRankIntegrationTest implements RedisInt
   public void shouldError_givenInvalidStartOrStop(String invalidArgument) {
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREMRANGEBYRANK, KEY, "1", invalidArgument))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREMRANGEBYRANK, KEY, invalidArgument, "5"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREMRANGEBYRANK, KEY,
-        invalidArgument, invalidArgument))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        invalidArgument, invalidArgument)).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByRankIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByRankIntegrationTest.java
@@ -62,13 +62,13 @@ public abstract class AbstractZRemRangeByRankIntegrationTest implements RedisInt
   public void shouldError_givenInvalidStartOrStop(String invalidArgument) {
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREMRANGEBYRANK, KEY, "1", invalidArgument))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREMRANGEBYRANK, KEY, invalidArgument, "5"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREMRANGEBYRANK, KEY,
         invalidArgument, invalidArgument))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByScoreIntegrationTest.java
@@ -57,23 +57,23 @@ public abstract class AbstractZRemRangeByScoreIntegrationTest implements RedisIn
   @Test
   public void shouldError_givenInvalidMinOrMax() {
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "notANumber", "1"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "notANumber"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "notANumber", "notANumber"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "((", "1"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "(("))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "(a", "(b"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "str", "1"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "str"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "NaN"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRemRangeByScoreIntegrationTest.java
@@ -57,23 +57,23 @@ public abstract class AbstractZRemRangeByScoreIntegrationTest implements RedisIn
   @Test
   public void shouldError_givenInvalidMinOrMax() {
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "notANumber", "1"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "notANumber"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "notANumber", "notANumber"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "((", "1"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "(("))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "(a", "(b"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "str", "1"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "str"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
     assertThatThrownBy(() -> jedis.zremrangeByScore("fakeKey", "1", "NaN"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByLexIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByLexIntegrationTest.java
@@ -71,70 +71,60 @@ public abstract class AbstractZRevRangeByLexIntegrationTest implements RedisInte
   @Parameters({"a", "--", "++"})
   public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
     assertThatThrownBy(() -> jedis.zrevrangeByLex("fakeKey", invalidArgument, "-"))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zrevrangeByLex("fakeKey", "+", invalidArgument))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zrevrangeByLex("fakeKey", invalidArgument, invalidArgument))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_VALID_STRING);
   }
 
   @Test
   public void shouldError_givenInvalidLimitFormat() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
-        "LIMIT"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LIMIT")).hasMessage(ERROR_SYNTAX);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
-        "LIMIT", "0"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LIMIT", "0")).hasMessage(ERROR_SYNTAX);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
-        "LAMAT", "0", "10"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LAMAT", "0", "10")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNonIntegerLimitArguments() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
-        "LIMIT", "0", "invalid"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "invalid")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
-        "LIMIT", "invalid", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "invalid", "10")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenNegativeZeroLimitOffset() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
-        "LIMIT", "-0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "-0", "10")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenMultipleLimits_withFirstLimitIncorrectlySpecified() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0", "invalid",
-        "LIMIT", "0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "10")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0",
-        "LIMIT", "0", "10"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "10")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenMultipleLimits_withLastLimitIncorrectlySpecified() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0", "10",
-        "LIMIT", "0", "invalid"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        "LIMIT", "0", "invalid")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0", "10",
-        "LIMIT", "0"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+        "LIMIT", "0")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByLexIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByLexIntegrationTest.java
@@ -71,44 +71,44 @@ public abstract class AbstractZRevRangeByLexIntegrationTest implements RedisInte
   @Parameters({"a", "--", "++"})
   public void shouldError_givenInvalidMinOrMax(String invalidArgument) {
     assertThatThrownBy(() -> jedis.zrevrangeByLex("fakeKey", invalidArgument, "-"))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zrevrangeByLex("fakeKey", "+", invalidArgument))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
     assertThatThrownBy(() -> jedis.zrevrangeByLex("fakeKey", invalidArgument, invalidArgument))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_VALID_STRING);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_VALID_STRING);
   }
 
   @Test
   public void shouldError_givenInvalidLimitFormat() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LAMAT", "0", "10"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNonIntegerLimitArguments() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0", "invalid"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "invalid", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldError_givenNegativeZeroLimitOffset() {
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "-0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -116,12 +116,12 @@ public abstract class AbstractZRevRangeByLexIntegrationTest implements RedisInte
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0", "invalid",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0",
         "LIMIT", "0", "10"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -129,12 +129,12 @@ public abstract class AbstractZRevRangeByLexIntegrationTest implements RedisInte
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0", "10",
         "LIMIT", "0", "invalid"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYLEX, KEY, "+", "-",
         "LIMIT", "0", "10",
         "LIMIT", "0"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
   @TestCaseName("{method}: max:{0}, min:{1}")
   public void shouldError_givenInvalidMinOrMax(String max, String min) {
     assertThatThrownBy(() -> jedis.zrevrangeByScore("fakeKey", max, min))
-        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage(ERROR_MIN_MAX_NOT_A_FLOAT);
   }
 
   @Test
@@ -80,7 +80,7 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
     jedis.zadd(KEY, 1.0, MEMBER_BASE_NAME);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "1", "2", "WITSCOREZ"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -279,39 +279,32 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
-            "0"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "0")).hasMessage(ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LOMIT",
-            "0", "1"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "0", "1")).hasMessage(ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0",
-            "LIMIT", "0", "invalid"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "LIMIT", "0", "invalid")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void shouldReturnProperError_givenMultipleLimitsIncludingWrongFormat() {
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
-            "0", "1", "LIMIT"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "0", "1", "LIMIT")).hasMessage(ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
-            "0", "1", "WITHSCORES", "LIMIT"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "0", "1", "WITHSCORES", "LIMIT")).hasMessage(ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
-            "0", "invalid", "LIMIT", "0", "5"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "0", "invalid", "LIMIT", "0", "5")).hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
-            "0", "invalid", "WITHSCORES", "LIMIT", "0", "5"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "0", "invalid", "WITHSCORES", "LIMIT", "0", "5")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeByScoreIntegrationTest.java
@@ -72,7 +72,7 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
   @TestCaseName("{method}: max:{0}, min:{1}")
   public void shouldError_givenInvalidMinOrMax(String max, String min) {
     assertThatThrownBy(() -> jedis.zrevrangeByScore("fakeKey", max, min))
-        .hasMessageContaining(ERROR_MIN_MAX_NOT_A_FLOAT);
+        .hasMessage("ERR " + ERROR_MIN_MAX_NOT_A_FLOAT);
   }
 
   @Test
@@ -80,7 +80,7 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
     jedis.zadd(KEY, 1.0, MEMBER_BASE_NAME);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "1", "2", "WITSCOREZ"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -279,19 +279,19 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
             "0"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LOMIT",
             "0", "1"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0",
             "LIMIT", "0", "invalid"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -299,19 +299,19 @@ public abstract class AbstractZRevRangeByScoreIntegrationTest implements RedisIn
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
             "0", "1", "LIMIT"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
             "0", "1", "WITHSCORES", "LIMIT"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
             "0", "invalid", "LIMIT", "0", "5"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGEBYSCORE, KEY, "10", "0", "LIMIT",
             "0", "invalid", "WITHSCORES", "LIMIT", "0", "5"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeIntegrationTest.java
@@ -66,16 +66,16 @@ public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrati
     String tooBig = Long.MAX_VALUE + "0";
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "NOT_AN_INT", "2"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "1", "NOT_AN_INT"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, tooSmall, "1"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "1", tooBig))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -83,7 +83,7 @@ public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrati
     jedis.zadd(KEY, 1.0, MEMBER_BASE_NAME);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "1", "2", "WITSCOREZ"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZRevRangeIntegrationTest.java
@@ -66,16 +66,16 @@ public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrati
     String tooBig = Long.MAX_VALUE + "0";
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "NOT_AN_INT", "2"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "1", "NOT_AN_INT"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, tooSmall, "1"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "1", tooBig))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -83,7 +83,7 @@ public abstract class AbstractZRevRangeIntegrationTest implements RedisIntegrati
     jedis.zadd(KEY, 1.0, MEMBER_BASE_NAME);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZREVRANGE, KEY, "1", "2", "WITSCOREZ"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZScanIntegrationTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "MATCH"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -114,7 +114,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -131,7 +131,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "a*", "1"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -140,7 +140,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
             "MATCH"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -150,7 +150,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
             "3",
             "COUNT", "sjlfs", "COUNT", "1"))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -160,7 +160,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
             ZERO_CURSOR))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -170,7 +170,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
             "-37"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -182,7 +182,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
             "COUNT", "3",
             "COUNT", "0",
             "COUNT", "1"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -191,7 +191,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
         ZERO_CURSOR))
-            .hasMessageContaining(ERROR_WRONG_TYPE);
+            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -199,14 +199,14 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, "member");
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, "sjfls"))
-        .hasMessageContaining(ERROR_CURSOR);
+        .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
   public void givenNonexistentKey_andCursorIsNotAnInteger_returnsCursorError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("notReal", Protocol.Command.ZSCAN, "notReal", "sjfls"))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
@@ -214,7 +214,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, "sjfls"))
-        .hasMessageContaining(ERROR_CURSOR);
+        .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test
@@ -248,7 +248,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
         UNSIGNED_LONG_CAPACITY.add(new BigInteger("10")).toString()))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZScanIntegrationTest.java
@@ -96,7 +96,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "MATCH"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -114,7 +114,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -131,7 +131,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "a*", "1"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -139,8 +139,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
-            "MATCH"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "MATCH")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -149,8 +148,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
             "3",
-            "COUNT", "sjlfs", "COUNT", "1"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "COUNT", "sjlfs", "COUNT", "1")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -159,8 +157,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
-            ZERO_CURSOR))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            ZERO_CURSOR)).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -169,8 +166,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
 
     assertThatThrownBy(
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR, "COUNT",
-            "-37"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "-37")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -181,8 +177,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
         () -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, ZERO_CURSOR,
             "COUNT", "3",
             "COUNT", "0",
-            "COUNT", "1"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "COUNT", "1")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -190,8 +185,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, "member");
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
-        ZERO_CURSOR))
-            .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        ZERO_CURSOR)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -199,14 +193,14 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.sadd(KEY, "member");
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, "sjfls"))
-        .hasMessage("ERR " + ERROR_CURSOR);
+        .hasMessage(ERROR_CURSOR);
   }
 
   @Test
   public void givenNonexistentKey_andCursorIsNotAnInteger_returnsCursorError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("notReal", Protocol.Command.ZSCAN, "notReal", "sjfls"))
-            .hasMessage("ERR " + ERROR_CURSOR);
+            .hasMessage(ERROR_CURSOR);
   }
 
   @Test
@@ -214,7 +208,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY, "sjfls"))
-        .hasMessage("ERR " + ERROR_CURSOR);
+        .hasMessage(ERROR_CURSOR);
   }
 
   @Test
@@ -247,8 +241,7 @@ public abstract class AbstractZScanIntegrationTest implements RedisIntegrationTe
     jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
-        UNSIGNED_LONG_CAPACITY.add(new BigInteger("10")).toString()))
-            .hasMessage("ERR " + ERROR_CURSOR);
+        UNSIGNED_LONG_CAPACITY.add(new BigInteger("10")).toString())).hasMessage(ERROR_CURSOR);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.commands.executor.sortedset;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -67,7 +68,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2", stringKey,
             KEY1))
-                .hasMessage("WRONGTYPE " + RedisConstants.ERROR_WRONG_TYPE);
+                .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -78,7 +79,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zunionstore(NEW_SET, stringKey, KEY1, KEY2))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -89,7 +90,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zunionstore(NEW_SET, KEY1, KEY2, stringKey))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -99,7 +100,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zunionstore(NEW_SET, "{tag1}nonExistentKey", KEY1, stringKey))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/AbstractZUnionStoreIntegrationTest.java
@@ -67,8 +67,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2", stringKey,
-            KEY1))
-                .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+            KEY1)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -79,7 +78,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zunionstore(NEW_SET, stringKey, KEY1, KEY2))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -90,7 +89,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zunionstore(NEW_SET, KEY1, KEY2, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -100,7 +99,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     jedis.set(stringKey, "value");
 
     assertThatThrownBy(() -> jedis.zunionstore(NEW_SET, "{tag1}nonExistentKey", KEY1, stringKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -108,8 +107,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     final String crossSlotKey = "{tag2}another";
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2", crossSlotKey,
-            KEY1))
-                .hasMessage("CROSSSLOT " + RedisConstants.ERROR_WRONG_SLOT);
+            KEY1)).hasMessage(RedisConstants.ERROR_WRONG_SLOT);
   }
 
   @Test
@@ -121,84 +119,77 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
   public void shouldError_givenNumkeysTooLarge() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2", KEY1))
-            .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            .hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNumkeysTooSmall() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "1", KEY1, KEY2))
-            .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            .hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenNumKeysOfZero() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "0", KEY1, KEY2))
-            .hasMessage("ERR " + RedisConstants.ERROR_KEY_REQUIRED_ZUNIONSTORE);
+            .hasMessage(RedisConstants.ERROR_KEY_REQUIRED_ZUNIONSTORE);
   }
 
   @Test
   public void shouldError_givenNegativeNumKeys() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "-2", KEY1, KEY2))
-            .hasMessage("ERR " + RedisConstants.ERROR_KEY_REQUIRED_ZUNIONSTORE);
+            .hasMessage(RedisConstants.ERROR_KEY_REQUIRED_ZUNIONSTORE);
   }
 
   @Test
   public void shouldError_givenTooManyWeights() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "1", KEY1,
-            "WEIGHTS", "2", "3"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            "WEIGHTS", "2", "3")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenTooFewWeights() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "2",
-            KEY1, KEY2, "WEIGHTS", "1"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, KEY2, "WEIGHTS", "1")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenWeightNotANumber() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "1",
-            KEY1, "WEIGHTS", "not-a-number"))
-                .hasMessage("ERR " + RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT);
+            KEY1, "WEIGHTS", "not-a-number")).hasMessage(RedisConstants.ERROR_WEIGHT_NOT_A_FLOAT);
   }
 
   @Test
   public void shouldError_givenWeightsWithoutAnyValues() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "1",
-            KEY1, "WEIGHTS"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "WEIGHTS")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenMultipleWeightKeywords() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "1",
-            KEY1, "WEIGHT", "1.0", "WEIGHT", "2.0"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "WEIGHT", "1.0", "WEIGHT", "2.0")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenUnknownAggregate() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "1",
-            KEY1, "AGGREGATE", "UNKNOWN", "WEIGHTS", "1"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "AGGREGATE", "UNKNOWN", "WEIGHTS", "1")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
   public void shouldError_givenAggregateKeywordWithoutValue() {
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "1",
-            KEY1, "AGGREGATE"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+            KEY1, "AGGREGATE")).hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test
@@ -206,7 +197,7 @@ public abstract class AbstractZUnionStoreIntegrationTest implements RedisIntegra
     assertThatThrownBy(
         () -> jedis.sendCommand(NEW_SET, Protocol.Command.ZUNIONSTORE, NEW_SET, "1",
             KEY1, "WEIGHTS", "1", "AGGREGATE", "SUM", "MIN"))
-                .hasMessage("ERR " + RedisConstants.ERROR_SYNTAX);
+                .hasMessage(RedisConstants.ERROR_SYNTAX);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZScanIntegrationTest.java
@@ -43,6 +43,6 @@ public class ZScanIntegrationTest extends AbstractZScanIntegrationTest {
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
         GREATER_THAN_LONG_MAX))
-            .hasMessageContaining(ERROR_CURSOR);
+            .hasMessage("ERR " + ERROR_CURSOR);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZScanIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/sortedset/ZScanIntegrationTest.java
@@ -42,7 +42,6 @@ public class ZScanIntegrationTest extends AbstractZScanIntegrationTest {
     jedis.zadd(KEY, SCORE_ONE, MEMBER_ONE);
 
     assertThatThrownBy(() -> jedis.sendCommand(KEY, Protocol.Command.ZSCAN, KEY,
-        GREATER_THAN_LONG_MAX))
-            .hasMessage("ERR " + ERROR_CURSOR);
+        GREATER_THAN_LONG_MAX)).hasMessage(ERROR_CURSOR);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitCountIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitCountIntegrationTest.java
@@ -54,8 +54,7 @@ public abstract class AbstractBitCountIntegrationTest implements RedisIntegratio
   @Test
   public void bitcount_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.bitcount("key"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.bitcount("key")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitCountIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitCountIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -53,7 +54,8 @@ public abstract class AbstractBitCountIntegrationTest implements RedisIntegratio
   @Test
   public void bitcount_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.bitcount("key")).hasMessageContaining("WRONGTYPE");
+    assertThatThrownBy(() -> jedis.bitcount("key"))
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitOpIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitOpIntegrationTest.java
@@ -64,20 +64,16 @@ public abstract class AbstractBitOpIntegrationTest implements RedisIntegrationTe
   public void bitop_givenInvalidOperationType_returnsSyntaxError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(hashTag, Protocol.Command.BITOP, "invalidOp", destKey,
-            srcKey)).hasMessage("ERR " + ERROR_SYNTAX);
+            srcKey)).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void bitop_givenSetFails() {
     jedis.sadd(srcKey, "m1");
-    assertThatThrownBy(() -> jedis.bitop(BitOP.AND, destKey, srcKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
-    assertThatThrownBy(() -> jedis.bitop(BitOP.OR, destKey, srcKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
-    assertThatThrownBy(() -> jedis.bitop(BitOP.XOR, destKey, srcKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
-    assertThatThrownBy(() -> jedis.bitop(BitOP.NOT, destKey, srcKey))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.bitop(BitOP.AND, destKey, srcKey)).hasMessage(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.bitop(BitOP.OR, destKey, srcKey)).hasMessage(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.bitop(BitOP.XOR, destKey, srcKey)).hasMessage(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.bitop(BitOP.NOT, destKey, srcKey)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -85,7 +81,7 @@ public abstract class AbstractBitOpIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(
             hashTag, Protocol.Command.BITOP, "NOT", destKey, srcKey, "srcKey2" + hashTag))
-                .hasMessage("ERR " + ERROR_BITOP_NOT_MUST_USE_SINGLE_KEY);
+                .hasMessage(ERROR_BITOP_NOT_MUST_USE_SINGLE_KEY);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitOpIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitOpIntegrationTest.java
@@ -15,9 +15,9 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_BITOP_NOT_MUST_USE_SINGLE_KEY;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
-import static org.apache.geode.redis.internal.commands.executor.string.BitOpExecutor.ERROR_BITOP_NOT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -64,20 +64,20 @@ public abstract class AbstractBitOpIntegrationTest implements RedisIntegrationTe
   public void bitop_givenInvalidOperationType_returnsSyntaxError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(hashTag, Protocol.Command.BITOP, "invalidOp", destKey,
-            srcKey)).hasMessageContaining(ERROR_SYNTAX);
+            srcKey)).hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void bitop_givenSetFails() {
     jedis.sadd(srcKey, "m1");
     assertThatThrownBy(() -> jedis.bitop(BitOP.AND, destKey, srcKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
     assertThatThrownBy(() -> jedis.bitop(BitOP.OR, destKey, srcKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
     assertThatThrownBy(() -> jedis.bitop(BitOP.XOR, destKey, srcKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
     assertThatThrownBy(() -> jedis.bitop(BitOP.NOT, destKey, srcKey))
-        .hasMessageContaining(ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -85,7 +85,7 @@ public abstract class AbstractBitOpIntegrationTest implements RedisIntegrationTe
     assertThatThrownBy(
         () -> jedis.sendCommand(
             hashTag, Protocol.Command.BITOP, "NOT", destKey, srcKey, "srcKey2" + hashTag))
-                .hasMessageContaining(ERROR_BITOP_NOT);
+                .hasMessage("ERR " + ERROR_BITOP_NOT_MUST_USE_SINGLE_KEY);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitPosIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitPosIntegrationTest.java
@@ -54,10 +54,8 @@ public abstract class AbstractBitPosIntegrationTest implements RedisIntegrationT
   @Test
   public void bitpos_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.bitpos("key", false))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
-    assertThatThrownBy(() -> jedis.bitpos("key", true))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.bitpos("key", false)).hasMessage(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.bitpos("key", true)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitPosIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractBitPosIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertAtLeastNArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -53,8 +54,10 @@ public abstract class AbstractBitPosIntegrationTest implements RedisIntegrationT
   @Test
   public void bitpos_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.bitpos("key", false)).hasMessageContaining("WRONGTYPE");
-    assertThatThrownBy(() -> jedis.bitpos("key", true)).hasMessageContaining("WRONGTYPE");
+    assertThatThrownBy(() -> jedis.bitpos("key", false))
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.bitpos("key", true))
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractDecrByIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractDecrByIntegrationTest.java
@@ -112,7 +112,7 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
     assertThatThrownBy(
         () -> jedis.sendCommand(hashTag, Protocol.Command.DECRBY,
             someKey, String.valueOf(biggerThanMaxLongValue)))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     jedis.set("key", String.valueOf((Long.MIN_VALUE)));
   }
@@ -129,7 +129,7 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
         () -> jedis.sendCommand(hashTag,
             Protocol.Command.DECRBY, someKey,
             smallerThanMinLongValue.toString()))
-                .hasMessageContaining(ERROR_NOT_INTEGER);
+                .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -142,7 +142,7 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
         () -> jedis.sendCommand(hashTag,
             Protocol.Command.DECRBY, someKey,
             "1"))
-                .hasMessageContaining(ERROR_OVERFLOW);
+                .hasMessage("ERR " + ERROR_OVERFLOW);
   }
 
 
@@ -151,7 +151,7 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
 
     jedis.hset("setKey", "1", "1");
     assertThatThrownBy(
-        () -> jedis.decrBy("setKey", 1)).hasMessageContaining(ERROR_WRONG_TYPE);
+        () -> jedis.decrBy("setKey", 1)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -160,6 +160,6 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
     jedis.set("key", "walrus");
 
     assertThatThrownBy(
-        () -> jedis.decrBy("key", 1)).hasMessageContaining(ERROR_NOT_INTEGER);
+        () -> jedis.decrBy("key", 1)).hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractDecrByIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractDecrByIntegrationTest.java
@@ -111,8 +111,7 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
 
     assertThatThrownBy(
         () -> jedis.sendCommand(hashTag, Protocol.Command.DECRBY,
-            someKey, String.valueOf(biggerThanMaxLongValue)))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            someKey, String.valueOf(biggerThanMaxLongValue))).hasMessage(ERROR_NOT_INTEGER);
 
     jedis.set("key", String.valueOf((Long.MIN_VALUE)));
   }
@@ -128,8 +127,7 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
     assertThatThrownBy(
         () -> jedis.sendCommand(hashTag,
             Protocol.Command.DECRBY, someKey,
-            smallerThanMinLongValue.toString()))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            smallerThanMinLongValue.toString())).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -141,8 +139,7 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
     assertThatThrownBy(
         () -> jedis.sendCommand(hashTag,
             Protocol.Command.DECRBY, someKey,
-            "1"))
-                .hasMessage("ERR " + ERROR_OVERFLOW);
+            "1")).hasMessage(ERROR_OVERFLOW);
   }
 
 
@@ -151,7 +148,7 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
 
     jedis.hset("setKey", "1", "1");
     assertThatThrownBy(
-        () -> jedis.decrBy("setKey", 1)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        () -> jedis.decrBy("setKey", 1)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -160,6 +157,6 @@ public abstract class AbstractDecrByIntegrationTest implements RedisIntegrationT
     jedis.set("key", "walrus");
 
     assertThatThrownBy(
-        () -> jedis.decrBy("key", 1)).hasMessage("ERR " + ERROR_NOT_INTEGER);
+        () -> jedis.decrBy("key", 1)).hasMessage(ERROR_NOT_INTEGER);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetBitIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetBitIntegrationTest.java
@@ -54,8 +54,7 @@ public abstract class AbstractGetBitIntegrationTest implements RedisIntegrationT
   @Test
   public void getbit_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.getbit("key", 1))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.getbit("key", 1)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetBitIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetBitIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -53,7 +54,8 @@ public abstract class AbstractGetBitIntegrationTest implements RedisIntegrationT
   @Test
   public void getbit_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.getbit("key", 1)).hasMessageContaining("WRONGTYPE");
+    assertThatThrownBy(() -> jedis.getbit("key", 1))
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetIntegrationTest.java
@@ -88,6 +88,6 @@ public abstract class AbstractGetIntegrationTest implements RedisIntegrationTest
     String member = "member";
 
     jedis.sadd(key, field, member);
-    assertThatThrownBy(() -> jedis.get(key)).hasMessageContaining(ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.get(key)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetIntegrationTest.java
@@ -88,6 +88,6 @@ public abstract class AbstractGetIntegrationTest implements RedisIntegrationTest
     String member = "member";
 
     jedis.sadd(key, field, member);
-    assertThatThrownBy(() -> jedis.get(key)).hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.get(key)).hasMessage(ERROR_WRONG_TYPE);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetRangeIntegrationTest.java
@@ -63,14 +63,14 @@ public abstract class AbstractGetRangeIntegrationTest implements RedisIntegratio
   public void givenStartIndexIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.GETRANGE, key, "NaN", "5"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenEndIndexIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.GETRANGE, key, "0", "NaN"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetRangeIntegrationTest.java
@@ -63,38 +63,36 @@ public abstract class AbstractGetRangeIntegrationTest implements RedisIntegratio
   public void givenStartIndexIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.GETRANGE, key, "NaN", "5"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenEndIndexIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.GETRANGE, key, "0", "NaN"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenRangeIsBiggerThanMinOrMax_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.GETRANGE, key, "0",
-            "9223372036854775808"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "9223372036854775808")).hasMessage(ERROR_NOT_INTEGER);
 
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.GETRANGE, key, "0",
-            "-9223372036854775809"))
-                .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            "-9223372036854775809")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenWrongType_returnsWrongTypeError() {
     jedis.sadd("set", value);
     assertThatThrownBy(() -> jedis.sendCommand("set", Protocol.Command.GETRANGE, "set", "0", "1"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
 
     jedis.hset("hash", "field", value);
     assertThatThrownBy(() -> jedis.sendCommand("hash", Protocol.Command.GETRANGE, "hash", "0", "1"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetSetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetSetIntegrationTest.java
@@ -29,7 +29,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -109,8 +108,7 @@ public abstract class AbstractGetSetIntegrationTest implements RedisIntegrationT
     jedis.hset(key, "field", "some hash value");
 
     assertThatThrownBy(() -> jedis.getSet(key, "this value doesn't matter"))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+        .hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetSetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractGetSetIntegrationTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.redis.internal.commands.executor.string;
 
 import static java.lang.Integer.parseInt;
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -32,7 +33,6 @@ import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 
 public abstract class AbstractGetSetIntegrationTest implements RedisIntegrationTest {
 
@@ -110,7 +110,7 @@ public abstract class AbstractGetSetIntegrationTest implements RedisIntegrationT
 
     assertThatThrownBy(() -> jedis.getSet(key, "this value doesn't matter"))
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrByFloatIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrByFloatIntegrationTest.java
@@ -15,6 +15,9 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NAN_OR_INFINITY;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_A_VALID_FLOAT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -31,7 +34,6 @@ import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegrationTest {
@@ -91,7 +93,7 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
     jedis.set("nan", "abc");
 
     assertThatThrownBy(() -> jedis.incrByFloat("nan", 1))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -99,7 +101,7 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
     jedis.sadd("set", "abc");
 
     assertThatThrownBy(() -> jedis.incrByFloat("set", 1))
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -109,7 +111,7 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
     jedis.set(key, "" + number1);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, " a b c"))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -118,28 +120,28 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
     jedis.set(key, "1.4");
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "+inf"))
-        .hasMessageContaining(RedisConstants.ERROR_NAN_OR_INFINITY);
+        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "-inf"))
-        .hasMessageContaining(RedisConstants.ERROR_NAN_OR_INFINITY);
+        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "inf"))
-        .hasMessageContaining(RedisConstants.ERROR_NAN_OR_INFINITY);
+        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "+infinity"))
-        .hasMessageContaining(RedisConstants.ERROR_NAN_OR_INFINITY);
+        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "-infinity"))
-        .hasMessageContaining(RedisConstants.ERROR_NAN_OR_INFINITY);
+        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "infinity"))
-        .hasMessageContaining(RedisConstants.ERROR_NAN_OR_INFINITY);
+        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "nan"))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "infant"))
-        .hasMessageContaining(RedisConstants.ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrByFloatIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrByFloatIntegrationTest.java
@@ -92,16 +92,14 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
   public void testCorrectErrorIsReturned_whenKeyIsNotANumber() {
     jedis.set("nan", "abc");
 
-    assertThatThrownBy(() -> jedis.incrByFloat("nan", 1))
-        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+    assertThatThrownBy(() -> jedis.incrByFloat("nan", 1)).hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
   public void testCorrectErrorIsReturned_whenKeyIsAnIncorrectType() {
     jedis.sadd("set", "abc");
 
-    assertThatThrownBy(() -> jedis.incrByFloat("set", 1))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.incrByFloat("set", 1)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -111,7 +109,7 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
     jedis.set(key, "" + number1);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, " a b c"))
-        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test
@@ -120,28 +118,28 @@ public abstract class AbstractIncrByFloatIntegrationTest implements RedisIntegra
     jedis.set(key, "1.4");
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "+inf"))
-        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
+        .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "-inf"))
-        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
+        .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "inf"))
-        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
+        .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "+infinity"))
-        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
+        .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "-infinity"))
-        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
+        .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "infinity"))
-        .hasMessage("ERR " + ERROR_NAN_OR_INFINITY);
+        .hasMessage(ERROR_NAN_OR_INFINITY);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "nan"))
-        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage(ERROR_NOT_A_VALID_FLOAT);
 
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.INCRBYFLOAT, key, "infant"))
-        .hasMessage("ERR " + ERROR_NOT_A_VALID_FLOAT);
+        .hasMessage(ERROR_NOT_A_VALID_FLOAT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrByIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrByIntegrationTest.java
@@ -16,6 +16,8 @@ package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_OVERFLOW;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -64,7 +66,7 @@ public abstract class AbstractIncrByIntegrationTest implements RedisIntegrationT
     String key = "key";
     jedis1.sadd(key, "member");
     assertThatThrownBy(() -> jedis1.incrBy(key, 1))
-        .hasMessageContaining("WRONGTYPE Operation against a key holding the wrong kind of value");
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -102,7 +104,7 @@ public abstract class AbstractIncrByIntegrationTest implements RedisIntegrationT
 
     jedis1.set(key, String.valueOf(Long.MAX_VALUE));
     assertThatThrownBy(() -> jedis1.incrBy(key, increment))
-        .hasMessageContaining("ERR increment or decrement would overflow");
+        .hasMessage("ERR " + ERROR_OVERFLOW);
   }
 
   @Test
@@ -131,7 +133,7 @@ public abstract class AbstractIncrByIntegrationTest implements RedisIntegrationT
   public void testIncrByErrorsForValuesGreaterThatMaxInt() {
     jedis1.set("key", "9223372036854775808");
 
-    assertThatThrownBy(() -> jedis1.incrBy("key", 1)).hasMessageContaining(ERROR_NOT_INTEGER);
+    assertThatThrownBy(() -> jedis1.incrBy("key", 1)).hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrByIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrByIntegrationTest.java
@@ -65,8 +65,7 @@ public abstract class AbstractIncrByIntegrationTest implements RedisIntegrationT
   public void testIncrBy_failsWhenPerformedOnNonIntegerValue() {
     String key = "key";
     jedis1.sadd(key, "member");
-    assertThatThrownBy(() -> jedis1.incrBy(key, 1))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis1.incrBy(key, 1)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -103,8 +102,7 @@ public abstract class AbstractIncrByIntegrationTest implements RedisIntegrationT
     Long increment = Long.MAX_VALUE / 2;
 
     jedis1.set(key, String.valueOf(Long.MAX_VALUE));
-    assertThatThrownBy(() -> jedis1.incrBy(key, increment))
-        .hasMessage("ERR " + ERROR_OVERFLOW);
+    assertThatThrownBy(() -> jedis1.incrBy(key, increment)).hasMessage(ERROR_OVERFLOW);
   }
 
   @Test
@@ -133,7 +131,7 @@ public abstract class AbstractIncrByIntegrationTest implements RedisIntegrationT
   public void testIncrByErrorsForValuesGreaterThatMaxInt() {
     jedis1.set("key", "9223372036854775808");
 
-    assertThatThrownBy(() -> jedis1.incrBy("key", 1)).hasMessage("ERR " + ERROR_NOT_INTEGER);
+    assertThatThrownBy(() -> jedis1.incrBy("key", 1)).hasMessage(ERROR_NOT_INTEGER);
   }
 
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrIntegrationTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractIncrIntegrationTest implements RedisIntegrationTes
     String max64BitIntegerValue = "9223372036854775807";
     jedis.set(key, max64BitIntegerValue);
 
-    assertThatThrownBy(() -> jedis.incr(key)).hasMessage("ERR " + ERROR_OVERFLOW);
+    assertThatThrownBy(() -> jedis.incr(key)).hasMessage(ERROR_OVERFLOW);
     assertThat(jedis.get(key)).isEqualTo(max64BitIntegerValue);
   }
 
@@ -91,7 +91,7 @@ public abstract class AbstractIncrIntegrationTest implements RedisIntegrationTes
     String nonIntegerValue = "I am not a number! I am a free man!";
 
     assertThat(jedis.set(key, nonIntegerValue)).isEqualTo("OK");
-    assertThatThrownBy(() -> jedis.incr(key)).hasMessage("ERR " + ERROR_NOT_INTEGER);
+    assertThatThrownBy(() -> jedis.incr(key)).hasMessage(ERROR_NOT_INTEGER);
     assertThat(jedis.get(key)).isEqualTo(nonIntegerValue);
   }
 
@@ -112,7 +112,7 @@ public abstract class AbstractIncrIntegrationTest implements RedisIntegrationTes
   public void testIncr_shouldError_onValueGreaterThanMax() {
     jedis.set("key", "9223372036854775808");
 
-    assertThatThrownBy(() -> jedis.incr("key")).hasMessage("ERR " + ERROR_NOT_INTEGER);
+    assertThatThrownBy(() -> jedis.incr("key")).hasMessage(ERROR_NOT_INTEGER);
   }
 
   private String randString() {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractIncrIntegrationTest.java
@@ -81,7 +81,7 @@ public abstract class AbstractIncrIntegrationTest implements RedisIntegrationTes
     String max64BitIntegerValue = "9223372036854775807";
     jedis.set(key, max64BitIntegerValue);
 
-    assertThatThrownBy(() -> jedis.incr(key)).hasMessageContaining(ERROR_OVERFLOW);
+    assertThatThrownBy(() -> jedis.incr(key)).hasMessage("ERR " + ERROR_OVERFLOW);
     assertThat(jedis.get(key)).isEqualTo(max64BitIntegerValue);
   }
 
@@ -91,7 +91,7 @@ public abstract class AbstractIncrIntegrationTest implements RedisIntegrationTes
     String nonIntegerValue = "I am not a number! I am a free man!";
 
     assertThat(jedis.set(key, nonIntegerValue)).isEqualTo("OK");
-    assertThatThrownBy(() -> jedis.incr(key)).hasMessageContaining(ERROR_NOT_INTEGER);
+    assertThatThrownBy(() -> jedis.incr(key)).hasMessage("ERR " + ERROR_NOT_INTEGER);
     assertThat(jedis.get(key)).isEqualTo(nonIntegerValue);
   }
 
@@ -112,7 +112,7 @@ public abstract class AbstractIncrIntegrationTest implements RedisIntegrationTes
   public void testIncr_shouldError_onValueGreaterThanMax() {
     jedis.set("key", "9223372036854775808");
 
-    assertThatThrownBy(() -> jedis.incr("key")).hasMessageContaining(ERROR_NOT_INTEGER);
+    assertThatThrownBy(() -> jedis.incr("key")).hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   private String randString() {

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetIntegrationTest.java
@@ -52,13 +52,13 @@ public abstract class AbstractMSetIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("any", Protocol.Command.MSET))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "mset"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "mset"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.MSET, "key"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "mset"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "mset"));
   }
 
   @Test
@@ -66,14 +66,14 @@ public abstract class AbstractMSetIntegrationTest implements RedisIntegrationTes
     assertThatThrownBy(
         () -> jedis.sendCommand(HASHTAG, Protocol.Command.MSET, "key1" + HASHTAG, "value1",
             "key2" + HASHTAG, "value2", "key3" + HASHTAG))
-                .hasMessage("ERR " + WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET);
+                .hasMessage(WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET);
   }
 
   @Test
   public void givenDifferentSlots_returnsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key1", Protocol.Command.MSET, "key1", "value1", "key2", "value2"))
-            .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+            .hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,29 +52,28 @@ public abstract class AbstractMSetIntegrationTest implements RedisIntegrationTes
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("any", Protocol.Command.MSET))
-        .hasMessageContaining("ERR wrong number of arguments for 'mset' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "mset"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.MSET, "key"))
-        .hasMessageContaining("ERR wrong number of arguments for 'mset' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "mset"));
   }
 
   @Test
   public void givenEvenNumberOfArgumentsProvided_returnsWrongNumberOfArgumentsError() {
-    // Redis returns this message in this scenario: "ERR wrong number of arguments for MSET"
     assertThatThrownBy(
         () -> jedis.sendCommand(HASHTAG, Protocol.Command.MSET, "key1" + HASHTAG, "value1",
             "key2" + HASHTAG, "value2", "key3" + HASHTAG))
-                .hasMessageContaining("ERR wrong number of arguments");
+                .hasMessage("ERR " + WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET);
   }
 
   @Test
   public void givenDifferentSlots_returnsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key1", Protocol.Command.MSET, "key1", "value1", "key2", "value2"))
-            .hasMessageContaining("CROSSSLOT " + ERROR_WRONG_SLOT);
+            .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetNXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetNXIntegrationTest.java
@@ -53,13 +53,13 @@ public abstract class AbstractMSetNXIntegrationTest implements RedisIntegrationT
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("any", Protocol.Command.MSETNX))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "msetnx"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "msetnx"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.MSETNX, "key"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "msetnx"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "msetnx"));
   }
 
   @Test
@@ -68,15 +68,14 @@ public abstract class AbstractMSetNXIntegrationTest implements RedisIntegrationT
     assertThatThrownBy(
         () -> jedis.sendCommand(HASHTAG, Protocol.Command.MSETNX, "key1" + HASHTAG, "value1",
             "key2" + HASHTAG, "value2", "key3" + HASHTAG))
-                .hasMessage("ERR " + WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET);
+                .hasMessage(WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET);
   }
 
   @Test
   public void givenDifferentSlots_returnsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key1", Protocol.Command.MSETNX, "key1", "value1", "key2",
-            "value2"))
-                .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
+            "value2")).hasMessage(ERROR_WRONG_SLOT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetNXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetNXIntegrationTest.java
@@ -21,6 +21,7 @@ import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADD
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static redis.clients.jedis.Protocol.Command.MSETNX;
 
 import java.util.List;
 
@@ -29,7 +30,6 @@ import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
@@ -52,29 +52,28 @@ public abstract class AbstractMSetNXIntegrationTest implements RedisIntegrationT
 
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
-    assertThatThrownBy(() -> jedis.sendCommand("any", Protocol.Command.MSETNX))
+    assertThatThrownBy(() -> jedis.sendCommand("any", MSETNX))
         .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "msetnx"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
-    assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.MSETNX, "key"))
+    assertThatThrownBy(() -> jedis.sendCommand("key", MSETNX, "key"))
         .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "msetnx"));
   }
 
   @Test
   public void givenEvenNumberOfArgumentsProvided_returnsWrongNumberOfArgumentsError() {
     // Redis returns this message in this scenario: "ERR wrong number of arguments for MSET"
-    assertThatThrownBy(
-        () -> jedis.sendCommand(HASHTAG, Protocol.Command.MSETNX, "key1" + HASHTAG, "value1",
-            "key2" + HASHTAG, "value2", "key3" + HASHTAG))
-                .hasMessage(WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET);
+    assertThatThrownBy(() -> jedis.sendCommand(HASHTAG, MSETNX, "key1" + HASHTAG, "value1",
+        "key2" + HASHTAG, "value2", "key3" + HASHTAG))
+            .hasMessage(WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET);
   }
 
   @Test
   public void givenDifferentSlots_returnsError() {
     assertThatThrownBy(
-        () -> jedis.sendCommand("key1", Protocol.Command.MSETNX, "key1", "value1", "key2",
+        () -> jedis.sendCommand("key1", MSETNX, "key1", "value1", "key2",
             "value2")).hasMessage(ERROR_WRONG_SLOT);
   }
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetNXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetNXIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,22 +53,22 @@ public abstract class AbstractMSetNXIntegrationTest implements RedisIntegrationT
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("any", Protocol.Command.MSETNX))
-        .hasMessageContaining("ERR wrong number of arguments for 'msetnx' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "msetnx"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.MSETNX, "key"))
-        .hasMessageContaining("ERR wrong number of arguments for 'msetnx' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "msetnx"));
   }
 
   @Test
   public void givenEvenNumberOfArgumentsProvided_returnsWrongNumberOfArgumentsError() {
-    // Redis returns this message in this scenario: "ERR wrong number of arguments for MSETNX"
+    // Redis returns this message in this scenario: "ERR wrong number of arguments for MSET"
     assertThatThrownBy(
         () -> jedis.sendCommand(HASHTAG, Protocol.Command.MSETNX, "key1" + HASHTAG, "value1",
             "key2" + HASHTAG, "value2", "key3" + HASHTAG))
-                .hasMessageContaining("ERR wrong number of arguments");
+                .hasMessage("ERR " + WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET);
   }
 
   @Test
@@ -74,7 +76,7 @@ public abstract class AbstractMSetNXIntegrationTest implements RedisIntegrationT
     assertThatThrownBy(
         () -> jedis.sendCommand("key1", Protocol.Command.MSETNX, "key1", "value1", "key2",
             "value2"))
-                .hasMessageContaining("CROSSSLOT " + ERROR_WRONG_SLOT);
+                .hasMessage("CROSSSLOT " + ERROR_WRONG_SLOT);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractPSetEXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractPSetEXIntegrationTest.java
@@ -15,15 +15,17 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_EXPIRE_TIME;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static redis.clients.jedis.Protocol.Command.PSETEX;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
-import redis.clients.jedis.Protocol;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
@@ -47,7 +49,7 @@ public abstract class AbstractPSetEXIntegrationTest implements RedisIntegrationT
 
   @Test
   public void errors_givenWrongNumberOfArguments() {
-    assertExactNumberOfArgs(jedis, Protocol.Command.PSETEX, 3);
+    assertExactNumberOfArgs(jedis, PSETEX, 3);
   }
 
   @Test
@@ -58,8 +60,14 @@ public abstract class AbstractPSetEXIntegrationTest implements RedisIntegrationT
   }
 
   @Test
-  public void testSetEXWithIllegalMilliseconds() {
+  public void testPSetEXWithIllegalMilliseconds() {
     assertThatThrownBy(() -> jedis.psetex("key", -1L, "value"))
-        .hasMessage("ERR invalid expire time in psetex");
+        .hasMessage(String.format(ERROR_INVALID_EXPIRE_TIME, "psetex"));
+  }
+
+  @Test
+  public void pSetEXWithNonIntegerExpiration_returnsError() {
+    assertThatThrownBy(() -> jedis.sendCommand("key", PSETEX, "key", "notAnInteger", "value"))
+        .hasMessage(ERROR_NOT_INTEGER);
   }
 }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetBitIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetBitIntegrationTest.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -54,13 +56,14 @@ public abstract class AbstractSetBitIntegrationTest implements RedisIntegrationT
   public void givenMoreThanFourArgumentsProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.SETBIT, "key", "1", "value", "extraArg"))
-            .hasMessageContaining("ERR wrong number of arguments for 'setbit' command");
+            .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setbit"));
   }
 
   @Test
   public void setbit_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.setbit("key", 1, true)).hasMessageContaining("WRONGTYPE");
+    assertThatThrownBy(() -> jedis.setbit("key", 1, true))
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetBitIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetBitIntegrationTest.java
@@ -56,14 +56,13 @@ public abstract class AbstractSetBitIntegrationTest implements RedisIntegrationT
   public void givenMoreThanFourArgumentsProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.SETBIT, "key", "1", "value", "extraArg"))
-            .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setbit"));
+            .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setbit"));
   }
 
   @Test
   public void setbit_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.setbit("key", 1, true))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.setbit("key", 1, true)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetIntegrationTest.java
@@ -35,7 +35,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisDataException;
 import redis.clients.jedis.params.SetParams;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
@@ -62,75 +61,74 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.SET))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "set"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "set"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.SET, key))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "set"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "set"));
   }
 
   @Test
   public void givenEXKeyword_withoutParameter_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "EX"))
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenEXKeyword_whenParameterIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "EX", "NaN"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenEXKeyword_whenParameterIsZero_returnsInvalidExpireTimeError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "0"))
-            .hasMessage("ERR " + ERROR_INVALID_EXPIRE_TIME);
+            .hasMessage(ERROR_INVALID_EXPIRE_TIME);
   }
 
   @Test
   public void givenPXKeyword_withoutParameter_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX"))
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenPXKeyword_whenParameterIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "NaN"))
-            .hasMessage("ERR " + ERROR_NOT_INTEGER);
+            .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenPXKeyword_whenParameterIsZero_returnsInvalidExpireTimeError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "0"))
-            .hasMessage("ERR " + ERROR_INVALID_EXPIRE_TIME);
+            .hasMessage(ERROR_INVALID_EXPIRE_TIME);
   }
 
   @Test
   public void givenPXAndEXInSameCommand_returnsSyntaxError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "3000", "EX",
-            "3"))
-                .hasMessage("ERR " + ERROR_SYNTAX);
+            "3")).hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenNXAndXXInSameCommand_returnsSyntaxError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "NX", "XX"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
   public void givenInvalidKeyword_returnsSyntaxError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "invalidKeyword"))
-            .hasMessage("ERR " + ERROR_SYNTAX);
+            .hasMessage(ERROR_SYNTAX);
   }
 
   @Test
@@ -281,8 +279,7 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
     setParams.ex(millisecondsUntilExpiration);
 
     assertThatThrownBy(() -> jedis.set(key, value, setParams))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_INVALID_EXPIRE_TIME);
+        .hasMessage(ERROR_INVALID_EXPIRE_TIME);
   }
 
   @Test
@@ -307,8 +304,7 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
     setParams.px(millisecondsUntilExpiration);
 
     assertThatThrownBy(() -> jedis.set(key, value, setParams))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_INVALID_EXPIRE_TIME);
+        .hasMessage(ERROR_INVALID_EXPIRE_TIME);
   }
 
   @Test
@@ -480,52 +476,43 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET))
         .as("no key")
-        .isInstanceOf(JedisDataException.class);
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "set"));
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "EX", "0"))
         .as("no value")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "EX", "a"))
         .as("non-integer expiration value")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_NOT_INTEGER);
+        .hasMessage(ERROR_NOT_INTEGER);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "1", "EX", "0"))
         .as("both PX and EX provided")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "1", "XX", "0"))
         .as("extra integer option as last option")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "XX", "0"))
         .as("expiration option used with no integer value")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "1", "PX", "1"))
         .as("extra integer option as first option")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "NX", "XX"))
         .as("both NX and XX provided")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "NX", "a"))
         .as("invalid option after valid option")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "blah"))
         .as("invalid option")
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("ERR " + ERROR_SYNTAX);
+        .hasMessage(ERROR_SYNTAX);
 
     soft.assertAll();
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetIntegrationTest.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.commands.executor.string;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_EXPIRE_TIME;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -39,7 +40,6 @@ import redis.clients.jedis.params.SetParams;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 
 public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest {
 
@@ -62,53 +62,53 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.SET))
-        .hasMessageContaining("ERR wrong number of arguments for 'set' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "set"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.SET, key))
-        .hasMessageContaining("ERR wrong number of arguments for 'set' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "set"));
   }
 
   @Test
   public void givenEXKeyword_withoutParameter_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "EX"))
-        .hasMessageContaining(ERROR_SYNTAX);
+        .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void givenEXKeyword_whenParameterIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "EX", "NaN"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenEXKeyword_whenParameterIsZero_returnsInvalidExpireTimeError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "0"))
-            .hasMessageContaining(ERROR_INVALID_EXPIRE_TIME);
+            .hasMessage("ERR " + ERROR_INVALID_EXPIRE_TIME);
   }
 
   @Test
   public void givenPXKeyword_withoutParameter_returnsSyntaxError() {
     assertThatThrownBy(() -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX"))
-        .hasMessageContaining(ERROR_SYNTAX);
+        .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void givenPXKeyword_whenParameterIsNotAnInteger_returnsNotIntegerError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "NaN"))
-            .hasMessageContaining(ERROR_NOT_INTEGER);
+            .hasMessage("ERR " + ERROR_NOT_INTEGER);
   }
 
   @Test
   public void givenPXKeyword_whenParameterIsZero_returnsInvalidExpireTimeError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "0"))
-            .hasMessageContaining(ERROR_INVALID_EXPIRE_TIME);
+            .hasMessage("ERR " + ERROR_INVALID_EXPIRE_TIME);
   }
 
   @Test
@@ -116,21 +116,21 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "3000", "EX",
             "3"))
-                .hasMessageContaining(ERROR_SYNTAX);
+                .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void givenNXAndXXInSameCommand_returnsSyntaxError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "NX", "XX"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
   public void givenInvalidKeyword_returnsSyntaxError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "invalidKeyword"))
-            .hasMessageContaining(ERROR_SYNTAX);
+            .hasMessage("ERR " + ERROR_SYNTAX);
   }
 
   @Test
@@ -282,7 +282,7 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
 
     assertThatThrownBy(() -> jedis.set(key, value, setParams))
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining(RedisConstants.ERROR_INVALID_EXPIRE_TIME);
+        .hasMessage("ERR " + ERROR_INVALID_EXPIRE_TIME);
   }
 
   @Test
@@ -308,7 +308,7 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
 
     assertThatThrownBy(() -> jedis.set(key, value, setParams))
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining(RedisConstants.ERROR_INVALID_EXPIRE_TIME);
+        .hasMessage("ERR " + ERROR_INVALID_EXPIRE_TIME);
   }
 
   @Test
@@ -485,47 +485,47 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, "EX", "0"))
         .as("no value")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("syntax error");
+        .hasMessage("ERR " + ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "EX", "a"))
         .as("non-integer expiration value")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("value is not an integer");
+        .hasMessage("ERR " + ERROR_NOT_INTEGER);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "1", "EX", "0"))
         .as("both PX and EX provided")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("syntax error");
+        .hasMessage("ERR " + ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "1", "XX", "0"))
         .as("extra integer option as last option")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("syntax error");
+        .hasMessage("ERR " + ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "PX", "XX", "0"))
         .as("expiration option used with no integer value")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("syntax error");
+        .hasMessage("ERR " + ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "1", "PX", "1"))
         .as("extra integer option as first option")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("syntax error");
+        .hasMessage("ERR " + ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "NX", "XX"))
         .as("both NX and XX provided")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("syntax error");
+        .hasMessage("ERR " + ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "NX", "a"))
         .as("invalid option after valid option")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("syntax error");
+        .hasMessage("ERR " + ERROR_SYNTAX);
 
     soft.assertThatThrownBy(() -> jedis.sendCommand(key, SET, key, value, "blah"))
         .as("invalid option")
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining("syntax error");
+        .hasMessage("ERR " + ERROR_SYNTAX);
 
     soft.assertAll();
   }

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetIntegrationTest.java
@@ -87,7 +87,7 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
   public void givenEXKeyword_whenParameterIsZero_returnsInvalidExpireTimeError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "0"))
-            .hasMessage(ERROR_INVALID_EXPIRE_TIME);
+            .hasMessage(String.format(ERROR_INVALID_EXPIRE_TIME, "set"));
   }
 
   @Test
@@ -107,7 +107,7 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
   public void givenPXKeyword_whenParameterIsZero_returnsInvalidExpireTimeError() {
     assertThatThrownBy(
         () -> jedis.sendCommand(key, Protocol.Command.SET, key, value, "PX", "0"))
-            .hasMessage(ERROR_INVALID_EXPIRE_TIME);
+            .hasMessage(String.format(ERROR_INVALID_EXPIRE_TIME, "set"));
   }
 
   @Test
@@ -279,7 +279,13 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
     setParams.ex(millisecondsUntilExpiration);
 
     assertThatThrownBy(() -> jedis.set(key, value, setParams))
-        .hasMessage(ERROR_INVALID_EXPIRE_TIME);
+        .hasMessage(String.format(ERROR_INVALID_EXPIRE_TIME, "set"));
+  }
+
+  @Test
+  public void set_withEX_withNonIntegerExpiration_returnsError() {
+    assertThatThrownBy(() -> jedis.sendCommand("key", SET, "key", "value", "EX", "notAnInteger"))
+        .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test
@@ -304,7 +310,13 @@ public abstract class AbstractSetIntegrationTest implements RedisIntegrationTest
     setParams.px(millisecondsUntilExpiration);
 
     assertThatThrownBy(() -> jedis.set(key, value, setParams))
-        .hasMessage(ERROR_INVALID_EXPIRE_TIME);
+        .hasMessage(String.format(ERROR_INVALID_EXPIRE_TIME, "set"));
+  }
+
+  @Test
+  public void set_withPX_withNonIntegerExpiration_returnsError() {
+    assertThatThrownBy(() -> jedis.sendCommand("key", SET, "key", "value", "EX", "notAnInteger"))
+        .hasMessage(ERROR_NOT_INTEGER);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetNXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetNXIntegrationTest.java
@@ -51,20 +51,20 @@ public abstract class AbstractSetNXIntegrationTest implements RedisIntegrationTe
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("any", Protocol.Command.SETNX))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SETNX, "key"))
-        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
+        .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
   }
 
   @Test
   public void givenMoreThanThreeArgumentsProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.SETNX, "key", "value", "extraArg"))
-            .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
+            .hasMessage(String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetNXIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetNXIntegrationTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.redis.internal.commands.executor.string;
 
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -50,20 +51,20 @@ public abstract class AbstractSetNXIntegrationTest implements RedisIntegrationTe
   @Test
   public void givenKeyNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("any", Protocol.Command.SETNX))
-        .hasMessageContaining("ERR wrong number of arguments for 'setnx' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
   }
 
   @Test
   public void givenValueNotProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(() -> jedis.sendCommand("key", Protocol.Command.SETNX, "key"))
-        .hasMessageContaining("ERR wrong number of arguments for 'setnx' command");
+        .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
   }
 
   @Test
   public void givenMoreThanThreeArgumentsProvided_returnsWrongNumberOfArgumentsError() {
     assertThatThrownBy(
         () -> jedis.sendCommand("key", Protocol.Command.SETNX, "key", "value", "extraArg"))
-            .hasMessageContaining("ERR wrong number of arguments for 'setnx' command");
+            .hasMessage("ERR " + String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND, "setnx"));
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetRangeIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -102,7 +103,8 @@ public abstract class AbstractSetRangeIntegrationTest implements RedisIntegratio
   @Test
   public void setRange_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.setrange("key", 0, "abc")).hasMessageContaining("WRONGTYPE");
+    assertThatThrownBy(() -> jedis.setrange("key", 0, "abc"))
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetRangeIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractSetRangeIntegrationTest.java
@@ -103,8 +103,7 @@ public abstract class AbstractSetRangeIntegrationTest implements RedisIntegratio
   @Test
   public void setRange_givenSetFails() {
     jedis.sadd("key", "m1");
-    assertThatThrownBy(() -> jedis.setrange("key", 0, "abc"))
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis.setrange("key", 0, "abc")).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractStringIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractStringIntegrationTest.java
@@ -27,7 +27,6 @@ import org.junit.Test;
 import redis.clients.jedis.HostAndPort;
 import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.Protocol;
-import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.RedisIntegrationTest;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
@@ -76,9 +75,7 @@ public abstract class AbstractStringIntegrationTest implements RedisIntegrationT
     String key = "hashKey";
     jedis1.hset(key, "field", "this value doesn't matter");
 
-    assertThatThrownBy(() -> jedis1.strlen(key))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis1.strlen(key)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -134,9 +131,7 @@ public abstract class AbstractStringIntegrationTest implements RedisIntegrationT
     String key = "hashKey";
     jedis1.hset(key, "field", "non-int value");
 
-    assertThatThrownBy(() -> jedis1.decr(key))
-        .isInstanceOf(JedisDataException.class)
-        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
+    assertThatThrownBy(() -> jedis1.decr(key)).hasMessage(ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractStringIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractStringIntegrationTest.java
@@ -15,6 +15,7 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -29,7 +30,6 @@ import redis.clients.jedis.Protocol;
 import redis.clients.jedis.exceptions.JedisDataException;
 
 import org.apache.geode.redis.RedisIntegrationTest;
-import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 
 public abstract class AbstractStringIntegrationTest implements RedisIntegrationTest {
@@ -78,7 +78,7 @@ public abstract class AbstractStringIntegrationTest implements RedisIntegrationT
 
     assertThatThrownBy(() -> jedis1.strlen(key))
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test
@@ -136,7 +136,7 @@ public abstract class AbstractStringIntegrationTest implements RedisIntegrationT
 
     assertThatThrownBy(() -> jedis1.decr(key))
         .isInstanceOf(JedisDataException.class)
-        .hasMessageContaining(RedisConstants.ERROR_WRONG_TYPE);
+        .hasMessage("WRONGTYPE " + ERROR_WRONG_TYPE);
   }
 
   @Test

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -25,81 +25,82 @@ public class RedisConstants {
    * Error responses
    */
   public static final String PARSING_EXCEPTION_MESSAGE =
-      "The command received by GeodeRedisServer was improperly formatted";
+      "ERR The command received by GeodeRedisServer was improperly formatted";
   public static final String SERVER_ERROR_MESSAGE =
-      "The server had an internal error please try again";
-  public static final String ERROR_SELECT = "Only DB 0 supported";
-  public static final String ERROR_CURSOR = "invalid cursor";
+      "ERR The server had an internal error please try again";
+  public static final String ERROR_SELECT = "ERR Only DB 0 supported";
+  public static final String ERROR_CURSOR = "ERR invalid cursor";
   public static final String ERROR_UNKNOWN_COMMAND =
-      "unknown command `%s`, with args beginning with: %s";
-  public static final String ERROR_OUT_OF_RANGE = "The number provided is out of range";
-  public static final String ERROR_NOT_AUTHENTICATED = "Authentication required.";
-  public static final String ERROR_NOT_AUTHORIZED = "Authorization failed.";
+      "ERR unknown command `%s`, with args beginning with: %s";
+  public static final String ERROR_OUT_OF_RANGE = "ERR The number provided is out of range";
+  public static final String ERROR_NOT_AUTHENTICATED = "NOAUTH Authentication required.";
+  public static final String ERROR_NOT_AUTHORIZED = "ERR Authorization failed.";
   public static final String ERROR_WRONG_TYPE =
-      "Operation against a key holding the wrong kind of value";
-  public static final String ERROR_NOT_INTEGER = "value is not an integer or out of range";
+      "WRONGTYPE Operation against a key holding the wrong kind of value";
+  public static final String ERROR_NOT_INTEGER = "ERR value is not an integer or out of range";
   public static final String ERROR_VALUE_MUST_BE_POSITIVE =
-      "value is out of range, must be positive";
-  public static final String ERROR_OVERFLOW = "increment or decrement would overflow";
-  public static final String ERROR_NAN_OR_INFINITY = "increment would produce NaN or Infinity";
-  public static final String ERROR_OPERATION_PRODUCED_NAN = "resulting score is not a number (NaN)";
-  public static final String ERROR_NO_SUCH_KEY = "no such key";
-  public static final String ERROR_SYNTAX = "syntax error";
-  public static final String ERROR_INVALID_EXPIRE_TIME = "invalid expire time in set";
-  public static final String ERROR_NOT_A_VALID_FLOAT = "value is not a valid float";
+      "ERR value is out of range, must be positive";
+  public static final String ERROR_OVERFLOW = "ERR increment or decrement would overflow";
+  public static final String ERROR_NAN_OR_INFINITY = "ERR increment would produce NaN or Infinity";
+  public static final String ERROR_OPERATION_PRODUCED_NAN =
+      "ERR resulting score is not a number (NaN)";
+  public static final String ERROR_NO_SUCH_KEY = "ERR no such key";
+  public static final String ERROR_SYNTAX = "ERR syntax error";
+  public static final String ERROR_INVALID_EXPIRE_TIME = "ERR invalid expire time in set";
+  public static final String ERROR_NOT_A_VALID_FLOAT = "ERR value is not a valid float";
   public static final String ERROR_MIN_MAX_NOT_A_VALID_STRING =
-      "min or max not valid string range item";
-  public static final String ERROR_MIN_MAX_NOT_A_FLOAT = "min or max is not a float";
+      "ERR min or max not valid string range item";
+  public static final String ERROR_MIN_MAX_NOT_A_FLOAT = "ERR min or max is not a float";
   public static final String ERROR_OOM_COMMAND_NOT_ALLOWED =
-      "command not allowed when used memory > 'maxmemory'";
+      "OOM command not allowed when used memory > 'maxmemory'";
   public static final String ERROR_UNKNOWN_SLOWLOG_SUBCOMMAND =
-      "Unknown subcommand or wrong number of arguments for '%s'. Try SLOWLOG HELP.";
+      "ERR Unknown subcommand or wrong number of arguments for '%s'. Try SLOWLOG HELP.";
   public static final String ERROR_UNKNOWN_CLIENT_SUBCOMMAND =
-      "Unknown subcommand or wrong number of arguments for '%s'. Supported subcommands are: "
+      "ERR Unknown subcommand or wrong number of arguments for '%s'. Supported subcommands are: "
           + ClientExecutor.getSupportedSubcommands();
   public static final String ERROR_INVALID_CLIENT_NAME =
-      "Client names cannot contain spaces, newlines or special characters.";
+      "ERR Client names cannot contain spaces, newlines or special characters.";
   public static final String ERROR_UNKNOWN_CLUSTER_SUBCOMMAND =
-      "Unknown subcommand or wrong number of arguments for '%s'. Supported subcommands are: "
+      "ERR Unknown subcommand or wrong number of arguments for '%s'. Supported subcommands are: "
           + ClusterExecutor.getSupportedSubcommands();
   public static final String ERROR_UNKNOWN_COMMAND_COMMAND_SUBCOMMAND =
-      "Unknown subcommand or wrong number of arguments for '%s'. Supported subcommands are: "
+      "ERR Unknown subcommand or wrong number of arguments for '%s'. Supported subcommands are: "
           + CommandCommandExecutor.getSupportedSubcommands();
   public static final String ERROR_INVALID_ZADD_OPTION_NX_XX =
-      "XX and NX options at the same time are not compatible";
+      "ERR XX and NX options at the same time are not compatible";
   public static final String ERROR_UNKNOWN_PUBSUB_SUBCOMMAND =
-      "Unknown subcommand or wrong number of arguments for '%s'";
+      "ERR Unknown subcommand or wrong number of arguments for '%s'";
   public static final String ERROR_ZADD_OPTION_TOO_MANY_INCR_PAIR =
-      "INCR option supports a single increment-element pair";
+      "ERR INCR option supports a single increment-element pair";
   public static final String ERROR_KEY_EXISTS =
-      "Target key name already exists.";
-  public static final String ERROR_INVALID_TTL = "Invalid TTL value, must be >= 0";
+      "BUSYKEY Target key name already exists.";
+  public static final String ERROR_INVALID_TTL = "ERR Invalid TTL value, must be >= 0";
   public static final String ERROR_RESTORE_INVALID_PAYLOAD =
-      "DUMP payload version or checksum are wrong";
+      "ERR DUMP payload version or checksum are wrong";
   public static final String ERROR_WRONG_SLOT =
-      "Keys in request don't hash to the same slot";
+      "CROSSSLOT Keys in request don't hash to the same slot";
   public static final String ERROR_WEIGHT_NOT_A_FLOAT =
-      "weight value is not a float";
+      "ERR weight value is not a float";
   public static final String ERROR_INVALID_USERNAME_OR_PASSWORD =
-      "invalid username-password pair or user is disabled.";
+      "WRONGPASS invalid username-password pair or user is disabled.";
   public static final String ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED =
-      "AUTH called without a Security Manager configured.";
+      "ERR AUTH called without a Security Manager configured.";
   public static final String ERROR_KEY_REQUIRED_ZINTERSTORE =
-      "at least 1 input key is needed for zinterstore";
+      "ERR at least 1 input key is needed for zinterstore";
   public static final String ERROR_KEY_REQUIRED_ZUNIONSTORE =
-      "at least 1 input key is needed for zunionstore";
+      "ERR at least 1 input key is needed for zunionstore";
   public static final String ERROR_UNAUTHENTICATED_MULTIBULK =
-      "Protocol error: unauthenticated multibulk length";
+      "ERR Protocol error: unauthenticated multibulk length";
   public static final String ERROR_UNAUTHENTICATED_BULK =
-      "Protocol error: unauthenticated bulk length";
-  public static final String INTERNAL_SERVER_ERROR = "Internal server error: ";
+      "ERR Protocol error: unauthenticated bulk length";
+  public static final String INTERNAL_SERVER_ERROR = "ERR Internal server error: ";
   public static final String ERROR_PUBSUB_WRONG_COMMAND =
-      "Can't execute '%s': only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT / RESET are allowed in this context";
-  public static final String HASH_VALUE_NOT_FLOAT = "hash value is not a float";
+      "ERR Can't execute '%s': only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT / RESET are allowed in this context";
+  public static final String HASH_VALUE_NOT_FLOAT = "ERR hash value is not a float";
   public static final String WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET =
-      "wrong number of arguments for MSET";
+      "ERR wrong number of arguments for MSET";
   public static final String WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND =
-      "wrong number of arguments for '%s' command";
+      "ERR wrong number of arguments for '%s' command";
   public static final String ERROR_BITOP_NOT_MUST_USE_SINGLE_KEY =
-      "BITOP NOT must be called with a single source key.";
+      "ERR BITOP NOT must be called with a single source key.";
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -95,4 +95,11 @@ public class RedisConstants {
   public static final String INTERNAL_SERVER_ERROR = "Internal server error: ";
   public static final String ERROR_PUBSUB_WRONG_COMMAND =
       "Can't execute '%s': only (P)SUBSCRIBE / (P)UNSUBSCRIBE / PING / QUIT / RESET are allowed in this context";
+  public static final String HASH_VALUE_NOT_FLOAT = "hash value is not a float";
+  public static final String WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET =
+      "wrong number of arguments for MSET";
+  public static final String WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND =
+      "wrong number of arguments for '%s' command";
+  public static final String ERROR_BITOP_NOT_MUST_USE_SINGLE_KEY =
+      "BITOP NOT must be called with a single source key.";
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/RedisConstants.java
@@ -46,7 +46,7 @@ public class RedisConstants {
       "ERR resulting score is not a number (NaN)";
   public static final String ERROR_NO_SUCH_KEY = "ERR no such key";
   public static final String ERROR_SYNTAX = "ERR syntax error";
-  public static final String ERROR_INVALID_EXPIRE_TIME = "ERR invalid expire time in set";
+  public static final String ERROR_INVALID_EXPIRE_TIME = "ERR invalid expire time in %s";
   public static final String ERROR_NOT_A_VALID_FLOAT = "ERR value is not a valid float";
   public static final String ERROR_MIN_MAX_NOT_A_VALID_STRING =
       "ERR min or max not valid string range item";

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/Command.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/Command.java
@@ -15,6 +15,7 @@
  */
 package org.apache.geode.redis.internal.commands;
 
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.nio.channels.SocketChannel;
@@ -216,7 +217,7 @@ public class Command {
 
   public String wrongNumberOfArgumentsErrorMessage() {
     String result;
-    result = String.format("wrong number of arguments for '%s' command",
+    result = String.format(WRONG_NUMBER_OF_ARGUMENTS_FOR_COMMAND,
         getCommandType().toString().toLowerCase());
     return result;
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
@@ -16,6 +16,7 @@
 package org.apache.geode.redis.internal.commands;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
+import static org.apache.geode.redis.internal.RedisConstants.WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET;
 import static org.apache.geode.redis.internal.commands.RedisCommandSupportLevel.SUPPORTED;
 import static org.apache.geode.redis.internal.commands.RedisCommandSupportLevel.UNSUPPORTED;
 import static org.apache.geode.redis.internal.commands.RedisCommandType.Flag.DENYOOM;
@@ -247,8 +248,8 @@ public enum RedisCommandType {
       new Parameter().exact(3).flags(WRITE, DENYOOM, FAST)),
   MGET(new MGetExecutor(), Category.STRING, SUPPORTED,
       new Parameter().min(2).lastKey(-1).flags(READONLY, FAST)),
-  MSET(new MSetExecutor(), Category.STRING, SUPPORTED,
-      new Parameter().min(3).odd().lastKey(-1).step(2).flags(WRITE, DENYOOM)),
+  MSET(new MSetExecutor(), Category.STRING, SUPPORTED, new Parameter().min(3)
+      .odd(WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET).lastKey(-1).step(2).flags(WRITE, DENYOOM)),
   MSETNX(new MSetNXExecutor(), Category.STRING, SUPPORTED,
       new Parameter().min(3).odd().lastKey(-1).step(2).flags(WRITE, DENYOOM)),
   PSETEX(new PSetEXExecutor(), Category.STRING, SUPPORTED,

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
@@ -250,8 +250,8 @@ public enum RedisCommandType {
       new Parameter().min(2).lastKey(-1).flags(READONLY, FAST)),
   MSET(new MSetExecutor(), Category.STRING, SUPPORTED, new Parameter().min(3)
       .odd(WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET).lastKey(-1).step(2).flags(WRITE, DENYOOM)),
-  MSETNX(new MSetNXExecutor(), Category.STRING, SUPPORTED,
-      new Parameter().min(3).odd().lastKey(-1).step(2).flags(WRITE, DENYOOM)),
+  MSETNX(new MSetNXExecutor(), Category.STRING, SUPPORTED, new Parameter().min(3)
+      .odd(WRONG_NUMBER_OF_ARGUMENTS_FOR_MSET).odd().lastKey(-1).step(2).flags(WRITE, DENYOOM)),
   PSETEX(new PSetEXExecutor(), Category.STRING, SUPPORTED,
       new Parameter().exact(4).flags(WRITE, DENYOOM)),
   SET(new SetExecutor(), Category.STRING, SUPPORTED,

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/RedisResponse.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/RedisResponse.java
@@ -16,6 +16,14 @@
 
 package org.apache.geode.redis.internal.commands.executor;
 
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_USERNAME_OR_PASSWORD;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_KEY_EXISTS;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_AUTHENTICATED;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_OOM_COMMAND_NOT_ALLOWED;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.redis.internal.RedisConstants.INTERNAL_SERVER_ERROR;
+
 import java.math.BigDecimal;
 import java.nio.charset.Charset;
 import java.util.Arrays;
@@ -91,7 +99,7 @@ public class RedisResponse {
       try {
         return Coder.getStringResponse(buffer, value, true);
       } catch (CoderException e) {
-        return Coder.getInternalErrorResponse(buffer, e.getMessage());
+        return Coder.getErrorResponse(buffer, INTERNAL_SERVER_ERROR + e.getMessage());
       }
     });
   }
@@ -121,7 +129,7 @@ public class RedisResponse {
       try {
         return Coder.getFlattenedArrayResponse(buffer, nestedCollection);
       } catch (CoderException e) {
-        return Coder.getInternalErrorResponse(buffer, e.getMessage());
+        return Coder.getErrorResponse(buffer, INTERNAL_SERVER_ERROR + e.getMessage());
       }
     });
   }
@@ -134,7 +142,7 @@ public class RedisResponse {
       try {
         return Coder.getArrayResponse(buffer, collection, useBulkStrings);
       } catch (CoderException e) {
-        return Coder.getInternalErrorResponse(buffer, e.getMessage());
+        return Coder.getErrorResponse(buffer, INTERNAL_SERVER_ERROR + e.getMessage());
       }
     });
   }
@@ -163,31 +171,33 @@ public class RedisResponse {
   }
 
   public static RedisResponse moved(String error) {
-    return new RedisResponse((buffer) -> Coder.getMovedResponse(buffer, error));
+    return new RedisResponse((buffer) -> Coder.getErrorResponse(buffer, error));
   }
 
-  public static RedisResponse oom(String error) {
-    return new RedisResponse((bba) -> Coder.getOOMResponse(bba, error));
+  public static RedisResponse oom() {
+    return new RedisResponse(
+        buffer -> Coder.getErrorResponse(buffer, ERROR_OOM_COMMAND_NOT_ALLOWED));
   }
 
-  public static RedisResponse crossSlot(String error) {
-    return new RedisResponse((bba) -> Coder.getCrossSlotResponse(bba, error));
+  public static RedisResponse crossSlot() {
+    return new RedisResponse(buffer -> Coder.getErrorResponse(buffer, ERROR_WRONG_SLOT));
   }
 
-  public static RedisResponse busykey(String error) {
-    return new RedisResponse((bba) -> Coder.getBusyKeyResponse(bba, error));
+  public static RedisResponse busykey() {
+    return new RedisResponse(buffer -> Coder.getErrorResponse(buffer, ERROR_KEY_EXISTS));
   }
 
-  public static RedisResponse wrongpass(String error) {
-    return new RedisResponse((bba) -> Coder.getWrongpassResponse(bba, error));
+  public static RedisResponse wrongpass() {
+    return new RedisResponse(
+        buffer -> Coder.getErrorResponse(buffer, ERROR_INVALID_USERNAME_OR_PASSWORD));
   }
 
-  public static RedisResponse wrongType(String error) {
-    return new RedisResponse((buffer) -> Coder.getWrongTypeResponse(buffer, error));
+  public static RedisResponse wrongType() {
+    return new RedisResponse(buffer -> Coder.getErrorResponse(buffer, ERROR_WRONG_TYPE));
   }
 
-  public static RedisResponse noAuth(String error) {
-    return new RedisResponse((buffer) -> Coder.getNoAuthResponse(buffer, error));
+  public static RedisResponse noAuth() {
+    return new RedisResponse(buffer -> Coder.getErrorResponse(buffer, ERROR_NOT_AUTHENTICATED));
   }
 
   public static RedisResponse scan(int cursor, List<?> scanResult) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/connection/AuthExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/connection/AuthExecutor.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.commands.executor.connection;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_AUTH_CALLED_WITHOUT_SECURITY_CONFIGURED;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_USERNAME_OR_PASSWORD;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
 import java.util.List;
@@ -44,7 +43,7 @@ public class AuthExecutor implements CommandExecutor {
     try {
       context.login(props);
     } catch (AuthenticationFailedException | AuthenticationExpiredException ex) {
-      return RedisResponse.wrongpass(ERROR_INVALID_USERNAME_OR_PASSWORD);
+      return RedisResponse.wrongpass();
     }
 
     return RedisResponse.ok();

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/AbstractScanExecutor.java
@@ -18,7 +18,6 @@ package org.apache.geode.redis.internal.commands.executor.key;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_CURSOR;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.equalsIgnoreCaseBytes;
 import static org.apache.geode.redis.internal.netty.Coder.narrowLongToInt;
@@ -70,7 +69,7 @@ public abstract class AbstractScanExecutor implements CommandExecutor {
       }
 
       if (value.getType() != getDataType()) {
-        throw new RedisDataTypeMismatchException(ERROR_WRONG_TYPE);
+        throw new RedisDataTypeMismatchException();
       }
 
       command.getCommandType().checkDeferredParameters(command, context);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/RestoreExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/RestoreExecutor.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.commands.executor.key;
 
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_TTL;
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_KEY_EXISTS;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_SYNTAX;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ABSTTL;
@@ -66,7 +65,7 @@ public class RestoreExecutor implements CommandExecutor {
     try {
       restore(context, key, ttl, commandElems.get(3), options);
     } catch (RedisKeyExistsException redisKeyExistsException) {
-      return RedisResponse.busykey(ERROR_KEY_EXISTS);
+      return RedisResponse.busykey();
     }
 
     return RedisResponse.ok();

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetExecutor.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.redis.internal.commands.executor.string;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,7 +42,7 @@ public abstract class AbstractMSetExecutor implements CommandExecutor {
       RedisKey key = new RedisKey(commandElems.get(i));
 
       if (previousKey != null && key.getSlot() != previousKey.getSlot()) {
-        return RedisResponse.crossSlot(ERROR_WRONG_SLOT);
+        return RedisResponse.crossSlot();
       }
       keys.add(key);
       values.add(commandElems.get(i + 1));

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/BitOpExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/BitOpExecutor.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.geode.annotations.Immutable;
+import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.commands.Command;
 import org.apache.geode.redis.internal.commands.executor.CommandExecutor;
 import org.apache.geode.redis.internal.commands.executor.RedisResponse;
@@ -31,9 +32,6 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.services.RegionProvider;
 
 public class BitOpExecutor implements CommandExecutor {
-
-  protected static final String ERROR_BITOP_NOT =
-      "BITOP NOT must be called with a single source key";
 
   @Override
   public RedisResponse executeCommand(Command command,
@@ -58,7 +56,7 @@ public class BitOpExecutor implements CommandExecutor {
       values.add(key);
     }
     if (operation.equals("NOT") && values.size() != 1) {
-      return RedisResponse.error(ERROR_BITOP_NOT);
+      return RedisResponse.error(RedisConstants.ERROR_BITOP_NOT_MUST_USE_SINGLE_KEY);
     }
 
     int result = bitop(context, operation, destKey, values);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/SetEXExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/SetEXExecutor.java
@@ -15,6 +15,8 @@
 package org.apache.geode.redis.internal.commands.executor.string;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_INVALID_EXPIRE_TIME;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.commands.executor.BaseSetOptions.Exists.NONE;
 import static org.apache.geode.redis.internal.commands.executor.string.SetExecutor.set;
 
@@ -28,12 +30,6 @@ import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 public class SetEXExecutor implements CommandExecutor {
-
-  private static final String ERROR_SECONDS_NOT_A_NUMBER =
-      "The expiration argument provided was not a number";
-
-  private static final String ERROR_SECONDS_NOT_LEGAL =
-      "invalid expire time";
 
   private static final int VALUE_INDEX = 3;
 
@@ -50,12 +46,12 @@ public class SetEXExecutor implements CommandExecutor {
     try {
       expiration = Coder.bytesToLong(expirationArray);
     } catch (NumberFormatException e) {
-      return RedisResponse.error(ERROR_SECONDS_NOT_A_NUMBER);
+      return RedisResponse.error(ERROR_NOT_INTEGER);
     }
 
     if (expiration <= 0) {
-      return RedisResponse.error(
-          ERROR_SECONDS_NOT_LEGAL + " in " + command.getCommandType().toString().toLowerCase());
+      return RedisResponse.error(String.format(ERROR_INVALID_EXPIRE_TIME,
+          command.getCommandType().toString().toLowerCase()));
     }
 
     if (!timeUnitMillis()) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/SetExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/string/SetExecutor.java
@@ -82,7 +82,7 @@ public class SetExecutor implements CommandExecutor {
     }
 
     if ((executorState.foundPX || executorState.foundEX) && executorState.expirationMillis <= 0) {
-      throw new IllegalArgumentException(ERROR_INVALID_EXPIRE_TIME);
+      throw new IllegalArgumentException(String.format(ERROR_INVALID_EXPIRE_TIME, "set"));
     }
 
     return new SetOptions(executorState.existsOption, executorState.expirationMillis, false);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisCrossSlotException.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisCrossSlotException.java
@@ -23,8 +23,4 @@ public class RedisCrossSlotException extends RedisException {
   public RedisCrossSlotException() {
     super();
   }
-
-  public RedisCrossSlotException(String message) {
-    super(message);
-  }
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisDataMovedException.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisDataMovedException.java
@@ -26,6 +26,6 @@ public class RedisDataMovedException extends RedisException {
   }
 
   public RedisDataMovedException(Integer slot, String host, Integer port) {
-    super(String.format("%d %s:%d", slot, host, port));
+    super(String.format("MOVED %d %s:%d", slot, host, port));
   }
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisDataTypeMismatchException.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisDataTypeMismatchException.java
@@ -29,9 +29,4 @@ public class RedisDataTypeMismatchException extends RedisException {
   public RedisDataTypeMismatchException() {
     super();
   }
-
-  public RedisDataTypeMismatchException(String message) {
-    super(message);
-  }
-
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisHash.java
@@ -19,6 +19,7 @@ package org.apache.geode.redis.internal.data;
 import static org.apache.geode.internal.JvmSizeUtils.memoryOverhead;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_NOT_INTEGER;
 import static org.apache.geode.redis.internal.RedisConstants.ERROR_OVERFLOW;
+import static org.apache.geode.redis.internal.RedisConstants.HASH_VALUE_NOT_FLOAT;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToLong;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
 
@@ -296,14 +297,14 @@ public class RedisHash extends AbstractRedisData {
 
     String valueS = bytesToString(oldValue);
     if (valueS.contains(" ")) {
-      throw new NumberFormatException("hash value is not a float");
+      throw new NumberFormatException(HASH_VALUE_NOT_FLOAT);
     }
 
     BigDecimal value;
     try {
       value = new BigDecimal(valueS);
     } catch (NumberFormatException ex) {
-      throw new NumberFormatException("hash value is not a float");
+      throw new NumberFormatException(HASH_VALUE_NOT_FLOAT);
     }
 
     value = value.add(increment);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/Coder.java
@@ -17,35 +17,26 @@ package org.apache.geode.redis.internal.netty;
 
 import static java.lang.Double.NEGATIVE_INFINITY;
 import static java.lang.Double.POSITIVE_INFINITY;
-import static org.apache.geode.redis.internal.RedisConstants.INTERNAL_SERVER_ERROR;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ARRAY_ID;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.BULK_STRING_ID;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.BUSYKEY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CRLF;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.CROSSSLOT;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.EMPTY_ARRAY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.EMPTY_STRING;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ERR;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ERROR_ID;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INFINITY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.INTEGER_ID;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.MOVED;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NIL;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NOAUTH;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.N_INF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.N_INFINITY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.N_INF_STRING;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.NaN;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.OK;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ONE_INT;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.OOM;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.P_INF;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.P_INFINITY;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.P_INF_STRING;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.SIMPLE_STRING_ID;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.WRONGPASS;
-import static org.apache.geode.redis.internal.netty.StringBytesGlossary.WRONGTYPE;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.ZERO_INT;
 
 import java.io.UnsupportedEncodingException;
@@ -209,49 +200,12 @@ public class Coder {
     return buffer;
   }
 
-  private static ByteBuf getErrorResponse0(ByteBuf buffer, byte[] type, String error) {
+  public static ByteBuf getErrorResponse(ByteBuf buffer, String error) {
     byte[] errorAr = stringToBytes(error);
     buffer.writeByte(ERROR_ID);
-    buffer.writeBytes(type);
     buffer.writeBytes(errorAr);
     buffer.writeBytes(CRLF);
     return buffer;
-  }
-
-  public static ByteBuf getInternalErrorResponse(ByteBuf buffer, String error) {
-    return getErrorResponse(buffer, INTERNAL_SERVER_ERROR + error);
-  }
-
-  public static ByteBuf getErrorResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, ERR, error);
-  }
-
-  public static ByteBuf getMovedResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, MOVED, error);
-  }
-
-  public static ByteBuf getOOMResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, OOM, error);
-  }
-
-  public static ByteBuf getWrongTypeResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, WRONGTYPE, error);
-  }
-
-  public static ByteBuf getCrossSlotResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, CROSSSLOT, error);
-  }
-
-  public static ByteBuf getWrongpassResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, WRONGPASS, error);
-  }
-
-  public static ByteBuf getBusyKeyResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, BUSYKEY, error);
-  }
-
-  public static ByteBuf getNoAuthResponse(ByteBuf buffer, String error) {
-    return getErrorResponse0(buffer, NOAUTH, error);
   }
 
   public static ByteBuf getIntegerResponse(ByteBuf buffer, int integer) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -181,9 +181,9 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     if (rootCause instanceof RedisDataMovedException) {
       return RedisResponse.moved(rootCause.getMessage());
     } else if (rootCause instanceof RedisDataTypeMismatchException) {
-      return RedisResponse.wrongType(rootCause.getMessage());
+      return RedisResponse.wrongType();
     } else if (rootCause instanceof RedisCrossSlotException) {
-      return RedisResponse.crossSlot(rootCause.getMessage());
+      return RedisResponse.crossSlot();
     } else if (rootCause instanceof IllegalStateException
         || rootCause instanceof RedisParametersMismatchException
         || rootCause instanceof RedisException
@@ -191,7 +191,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
         || rootCause instanceof ArithmeticException) {
       return RedisResponse.error(rootCause.getMessage());
     } else if (rootCause instanceof LowMemoryException) {
-      return RedisResponse.oom(RedisConstants.ERROR_OOM_COMMAND_NOT_ALLOWED);
+      return RedisResponse.oom();
     } else if (rootCause instanceof RedisCommandParserException) {
       return RedisResponse
           .error(RedisConstants.PARSING_EXCEPTION_MESSAGE + ": " + rootCause.getMessage());
@@ -296,7 +296,7 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     if (command.isOfType(RedisCommandType.AUTH)) {
       response = command.execute(this);
     } else {
-      response = RedisResponse.noAuth(RedisConstants.ERROR_NOT_AUTHENTICATED);
+      response = RedisResponse.noAuth();
     }
     return response;
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/StringBytesGlossary.java
@@ -82,30 +82,6 @@ public class StringBytesGlossary {
   @Immutable
   public static final byte[] ONE_INT = stringToBytes(":1\r\n");
 
-  @MakeImmutable
-  public static final byte[] ERR = stringToBytes("ERR ");
-
-  @MakeImmutable
-  public static final byte[] OOM = stringToBytes("OOM ");
-
-  @MakeImmutable
-  public static final byte[] WRONGTYPE = stringToBytes("WRONGTYPE ");
-
-  @MakeImmutable
-  public static final byte[] MOVED = stringToBytes("MOVED ");
-
-  @MakeImmutable
-  public static final byte[] BUSYKEY = stringToBytes("BUSYKEY ");
-
-  @MakeImmutable
-  public static final byte[] CROSSSLOT = stringToBytes("CROSSSLOT ");
-
-  @MakeImmutable
-  public static final byte[] WRONGPASS = stringToBytes("WRONGPASS ");
-
-  @MakeImmutable
-  public static final byte[] NOAUTH = stringToBytes("NOAUTH ");
-
   // ********** Redis Command constants **********
 
   // ClientExecutor

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Publisher.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/pubsub/Publisher.java
@@ -18,8 +18,9 @@ package org.apache.geode.redis.internal.pubsub;
 import static java.util.Arrays.asList;
 import static org.apache.geode.internal.lang.utils.JavaWorkarounds.computeIfAbsent;
 import static org.apache.geode.logging.internal.executors.LoggingExecutors.newCachedThreadPool;
+import static org.apache.geode.redis.internal.RedisConstants.INTERNAL_SERVER_ERROR;
 import static org.apache.geode.redis.internal.netty.Coder.bytesToString;
-import static org.apache.geode.redis.internal.netty.Coder.getInternalErrorResponse;
+import static org.apache.geode.redis.internal.netty.Coder.getErrorResponse;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.MESSAGE;
 import static org.apache.geode.redis.internal.netty.StringBytesGlossary.PMESSAGE;
 
@@ -193,7 +194,7 @@ public class Publisher {
       Coder.getArrayResponse(buffer, asList(items), true);
     } catch (CoderException e) {
       buffer.resetWriterIndex();
-      getInternalErrorResponse(buffer, e.getMessage());
+      getErrorResponse(buffer, INTERNAL_SERVER_ERROR + e.getMessage());
     }
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/services/RegionProvider.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/services/RegionProvider.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.redis.internal.services;
 
-import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
 import static org.apache.geode.redis.internal.RedisProperties.REDIS_REGION_NAME_PROPERTY;
 import static org.apache.geode.redis.internal.RedisProperties.REGION_BUCKETS;
 import static org.apache.geode.redis.internal.RedisProperties.getIntegerSystemProperty;
@@ -45,7 +44,6 @@ import org.apache.geode.internal.cache.control.HeapMemoryMonitor;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
 import org.apache.geode.internal.cache.control.MemoryThresholds;
 import org.apache.geode.internal.cache.execute.BucketMovedException;
-import org.apache.geode.redis.internal.RedisConstants;
 import org.apache.geode.redis.internal.RedisException;
 import org.apache.geode.redis.internal.commands.executor.cluster.RedisPartitionResolver;
 import org.apache.geode.redis.internal.data.RedisCrossSlotException;
@@ -147,7 +145,7 @@ public class RegionProvider {
   public <T> T lockedExecute(RedisKey key, List<RedisKey> keysToLock, Callable<T> callable) {
     try {
       if (areKeysCrossSlots(keysToLock)) {
-        throw new RedisCrossSlotException(ERROR_WRONG_SLOT);
+        throw new RedisCrossSlotException();
       }
       return partitionedRegion.computeWithPrimaryLocked(key,
           () -> stripedCoordinator.execute(keysToLock, callable));
@@ -289,7 +287,7 @@ public class RegionProvider {
       return null;
     }
     if (redisData.getType() != type) {
-      throw new RedisDataTypeMismatchException(RedisConstants.ERROR_WRONG_TYPE);
+      throw new RedisDataTypeMismatchException();
     }
     return UncheckedUtils.uncheckedCast(redisData);
   }


### PR DESCRIPTION
 - Replace all uses of hasMessageContaining() with hasMessage() in Redis
 tests that assert on the error message returned, with the exception of
 CLIENT, CLUSTER and COMMAND, which return a more complex error message
 - Return correct error messages for MSET and MSETNX with even
 number of arguments
 - Return correct error message for BITOP NOT when called with too many
 arguments
 - Simplify error message generation in UnknownExecutor
 - Remove tests for behaviour with no longer existent internal commands

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
