### PR TITLE
GEODE-10034: Organize Geode For Redis Stats By Category

### DIFF
--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/statistics/GeodeRedisStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/statistics/GeodeRedisStatsIntegrationTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.redis.internal.statistics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.apache.geode.Statistics;
+import org.apache.geode.cache.Cache;
+import org.apache.geode.cache.CacheFactory;
+import org.apache.geode.distributed.internal.InternalDistributedSystem;
+import org.apache.geode.internal.statistics.StatisticsManager;
+import org.apache.geode.redis.GeodeRedisServerRule;
+import org.apache.geode.redis.internal.commands.RedisCommandType;
+
+public class GeodeRedisStatsIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Test
+  public void checkGeodeRedisStatsExist() {
+    Cache cache = CacheFactory.getAnyInstance();
+    InternalDistributedSystem internalSystem =
+        (InternalDistributedSystem) cache.getDistributedSystem();
+    StatisticsManager statisticsManager = internalSystem.getStatisticsManager();
+
+    List<String> statDescriptions = statisticsManager.getStatsList()
+        .stream().map(Statistics::getTextId).collect(Collectors.toList());
+
+    assertThat(statDescriptions).contains(GeodeRedisStats.STATS_BASENAME);
+
+    for (RedisCommandType.Category category : RedisCommandType.Category.values()) {
+      String name = GeodeRedisStats.STATS_BASENAME + ":" + category.name();
+      assertThat(statDescriptions).contains(name);
+    }
+  }
+
+}

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -14,7 +14,6 @@
  */
 package org.apache.geode.redis.internal;
 
-import java.net.UnknownHostException;
 
 import org.apache.logging.log4j.Logger;
 
@@ -24,7 +23,6 @@ import org.apache.geode.distributed.DistributedMember;
 import org.apache.geode.distributed.internal.InternalDistributedSystem;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.PartitionedRegion;
-import org.apache.geode.internal.inet.LocalHostUtil;
 import org.apache.geode.internal.statistics.StatisticsClock;
 import org.apache.geode.internal.statistics.StatisticsClockFactory;
 import org.apache.geode.logging.internal.log4j.api.LogService;
@@ -110,23 +108,7 @@ public class GeodeRedisServer {
         StatisticsClockFactory.clock(true);
 
     return new RedisStats(statisticsClock,
-        new GeodeRedisStats(system.getStatisticsManager(), getServerName(bindAddress, port),
-            statisticsClock));
-  }
-
-  private static String getServerName(String bindAddress, int port) {
-    String name = "geodeForRedis:";
-    if (bindAddress != null && !bindAddress.isEmpty()) {
-      name += bindAddress;
-    } else {
-      try {
-        name += LocalHostUtil.getCanonicalLocalHostName();
-      } catch (UnknownHostException e) {
-        name += "*.*.*.*";
-      }
-    }
-    name += ':' + port;
-    return name;
+        new GeodeRedisStats(system.getStatisticsManager(), statisticsClock));
   }
 
   @VisibleForTesting

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/GeodeRedisServer.java
@@ -77,7 +77,7 @@ public class GeodeRedisServer {
 
     unsupportedCommandsEnabled = Boolean.getBoolean(ENABLE_UNSUPPORTED_COMMANDS_PARAM);
 
-    redisStats = createStats(cache, bindAddress, port);
+    redisStats = createStats(cache);
     StripedCoordinator stripedCoordinator = new LockingStripedCoordinator();
     RedisMemberInfoRetrievalFunction infoFunction = RedisMemberInfoRetrievalFunction.register();
 
@@ -102,7 +102,7 @@ public class GeodeRedisServer {
     return ((PubSubImpl) pubSub).getSubscriptionCount();
   }
 
-  private static RedisStats createStats(InternalCache cache, String bindAddress, int port) {
+  private static RedisStats createStats(InternalCache cache) {
     InternalDistributedSystem system = cache.getInternalDistributedSystem();
     StatisticsClock statisticsClock =
         StatisticsClockFactory.clock(true);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/statistics/GeodeRedisStats.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/statistics/GeodeRedisStats.java
@@ -199,9 +199,7 @@ public class GeodeRedisStats {
   }
 
   public void close() {
-    if (generalStats != null) {
-      generalStats.close();
-    }
+    generalStats.close();
   }
 
   private static StatisticDescriptor[] createCategoryStatisticDescriptors(


### PR DESCRIPTION
- Geode for Redis statistics are broken up by category. For example
  stats will appear as `GeodeForRedisStats:STRING` or
  `GeodeForRedisStats:HASH`. Each type will then only contain stats
  relevant to the commands associated with that category.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
