### PR TITLE
GEODE-10053: Use stored DistributionConfig to create SSL configurations

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherLocalIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/LocatorLauncherLocalIntegrationTest.java
@@ -25,6 +25,9 @@ import static org.apache.geode.distributed.ConfigurationProperties.NAME;
 import static org.apache.geode.internal.inet.LocalHostUtil.getLocalHost;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.net.BindException;
@@ -72,6 +75,25 @@ public class LocatorLauncherLocalIntegrationTest extends LocatorLauncherIntegrat
     launcher = givenLocatorLauncher();
 
     assertThat(launcher.start().getStatus()).isEqualTo(ONLINE);
+  }
+
+  @Test
+  public void whenLocatorIsPresetThenItWillNotReadThePropertyFiles() {
+    launcher = givenLocatorLauncher();
+
+    assertThat(launcher.start().getStatus()).isEqualTo(ONLINE);
+    LocatorLauncher locatorLauncher = spy(launcher);
+    locatorLauncher.status();
+    /*
+     * We want to verify that no DistributedConfigImpl is constructed.
+     * But that's hard/impossible to mock.
+     * We happen to know that in the case where
+     * SSLConfigurationFactory.getSSLConfigForComponent()
+     * constructs one, getProperties() is always called first.
+     * That's why we're asserting getProperties()
+     * isn't called.
+     */
+    verify(locatorLauncher, times((0))).getProperties();
   }
 
   @Test


### PR DESCRIPTION
* While creating SSLConfig no new DistributionConfigImpl is created.
* Now, the DistributionConfig is taken from the InternalLocator class.
*

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
