### PR TITLE
[1.14] GEODE-9817: Enable customized source set paths for ClassAnalysisRule

### DIFF
--- a/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeRedisSerializablesIntegrationTest.java
+++ b/geode-apis-compatible-with-redis/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeRedisSerializablesIntegrationTest.java
@@ -22,7 +22,8 @@ import org.apache.geode.redis.internal.RedisSanctionedSerializablesService;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzeRedisSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeRedisSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-connectors/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeConnectorsSerializablesIntegrationTest.java
+++ b/geode-connectors/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeConnectorsSerializablesIntegrationTest.java
@@ -23,7 +23,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
 public class AnalyzeConnectorsSerializablesIntegrationTest
-    extends AnalyzeSerializablesJUnitTestBase {
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-core/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeCoreSerializablesIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeCoreSerializablesIntegrationTest.java
@@ -22,7 +22,8 @@ import org.apache.geode.internal.CoreSanctionedSerializablesService;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzeCoreSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeCoreSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-cq/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeCQSerializablesIntegrationTest.java
+++ b/geode-cq/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeCQSerializablesIntegrationTest.java
@@ -23,7 +23,8 @@ import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category({ClientSubscriptionTest.class, SerializationTest.class})
-public class AnalyzeCQSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeCQSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-dunit/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeDUnitSerializablesIntegrationTest.java
+++ b/geode-dunit/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeDUnitSerializablesIntegrationTest.java
@@ -27,7 +27,9 @@ import org.apache.geode.test.dunit.internal.Master;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzeDUnitSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeDUnitSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
+
   private static final Logger logger = LogService.getLogger();
 
   private static final Set<Class<?>> IGNORE_CLASSES = new HashSet<>();

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeGfshSerializablesIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeGfshSerializablesIntegrationTest.java
@@ -22,7 +22,8 @@ import org.apache.geode.management.internal.GfshSanctionedSerializablesService;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzeGfshSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeGfshSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-junit/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeJUnitSerializablesIntegrationTest.java
+++ b/geode-junit/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeJUnitSerializablesIntegrationTest.java
@@ -28,7 +28,8 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 import org.apache.geode.test.junit.internal.JUnitSanctionedSerializablesService;
 
 @Category(SerializationTest.class)
-public class AnalyzeJUnitSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeJUnitSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   private static final Set<Class<?>> IGNORE_CLASSES = new HashSet<>(asList(
       PortfolioNoDS.class, PortfolioPdx.class));

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeDataSerializablesTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeDataSerializablesTestBase.java
@@ -16,6 +16,7 @@ package org.apache.geode.codeAnalysis;
 
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertTrue;
 
@@ -36,7 +37,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,18 +47,17 @@ import org.apache.geode.codeAnalysis.decode.CompiledMethod;
 import org.apache.geode.internal.serialization.BufferDataOutputStream;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.test.junit.categories.SerializationTest;
-import org.apache.geode.test.junit.rules.ClassAnalysisRule;
 
 /**
  * This abstract test class is the basis for all of our AnalyzeModuleNameSerializables tests.
  * Subclasses must provide serialization/deserialization methods.
  *
  * <p>
- * Most tests should subclass {@link AnalyzeSerializablesJUnitTestBase} instead of this
- * class because it ties into geode-core serialization and saves a lot of work.
+ * Most tests should subclass {@link AnalyzeSerializablesWithClassAnalysisRuleTestBase} instead of
+ * this class because it ties into geode-core serialization and saves a lot of work.
  */
 @Category({SerializationTest.class})
-public abstract class AnalyzeDataSerializablesJUnitTestBase {
+public abstract class AnalyzeDataSerializablesTestBase {
 
   private static final Path MODULE_ROOT = Paths.get("..", "..", "..").toAbsolutePath().normalize();
   private static final Path SOURCE_ROOT = MODULE_ROOT.resolve(Paths.get("src"));
@@ -100,14 +99,6 @@ public abstract class AnalyzeDataSerializablesJUnitTestBase {
   @Rule
   public TestName testName = new TestName();
 
-  @Rule
-  public ClassAnalysisRule classProvider = new ClassAnalysisRule(getModuleName());
-
-  @AfterClass
-  public static void afterClass() {
-    ClassAnalysisRule.clearCache();
-  }
-
   /**
    * implement this to return your module's name, such as "geode-core"
    */
@@ -147,8 +138,10 @@ public abstract class AnalyzeDataSerializablesJUnitTestBase {
     }
   }
 
+  protected abstract Map<String, CompiledClass> loadClasses();
+
   public void findClasses() throws Exception {
-    classes = classProvider.getClasses();
+    classes = loadClasses();
 
     List<String> excludedClasses = loadExcludedClasses(getResourceAsFile(EXCLUDED_CLASSES_TXT));
     List<String> openBugs = loadOpenBugs(getResourceAsFile(OPEN_BUGS_TXT));
@@ -209,9 +202,11 @@ public abstract class AnalyzeDataSerializablesJUnitTestBase {
         final Object excludedInstance;
         try {
           excludedInstance = excludedClass.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (IllegalAccessException | InstantiationException | NullPointerException e) {
           // okay - it's in the excludedClasses.txt file after all
-          // IllegalAccessException means that the constructor is private.
+          // IllegalAccessException: thrown when non-private constructor does not exist
+          // InstantiationException: thrown when no-arg constructor does not exist
+          // NullPointerException: thrown by constructors that fetch RMI dependencies
           continue;
         }
         serializeAndDeserializeObject(excludedInstance);
@@ -230,17 +225,33 @@ public abstract class AnalyzeDataSerializablesJUnitTestBase {
     BufferDataOutputStream outputStream = new BufferDataOutputStream(KnownVersion.CURRENT);
     try {
       serializeObject(object, outputStream);
-    } catch (IOException e) {
+    } catch (IOException | NullPointerException e) {
       // some classes, such as BackupLock, are Serializable because the extend something
       // like ReentrantLock but we never serialize them & it doesn't work to try to do so
       System.out.println("Not Serializable: " + object.getClass().getName());
+      return;
+    } catch (Exception e) {
+      /*
+       * NOTE:
+       * this block catches Exception instead of CacheClosedException so that modules without
+       * dependency on geode-core can be tested with Analyze Serializables.
+       *
+       * ex: geode-membership does not depend on geode-core, so it cannot load CacheClosedException
+       */
+      if ("org.apache.geode.cache.CacheClosedException".equals(e.getClass().getName())) {
+        System.out
+            .println("I was unable to serialize " + object.getClass().getName() + " due to " + e);
+        e.printStackTrace();
+        return;
+      }
+      throw e;
     }
-    try {
-      deserializeObject(outputStream);
-      fail("I was able to deserialize " + object.getClass().getName());
-    } catch (InvalidClassException e) {
-      // expected
-    }
+
+    Throwable thrown = catchThrowable(() -> deserializeObject(outputStream));
+
+    assertThat(thrown)
+        .withFailMessage("I was able to deserialize " + object.getClass().getName())
+        .isInstanceOf(InvalidClassException.class);
   }
 
   private String toBuildPathString(File file) {
@@ -338,28 +349,13 @@ public abstract class AnalyzeDataSerializablesJUnitTestBase {
   }
 
   File createEmptyFile(String fileName) throws IOException {
-    final String workingDir = System.getProperty("user.dir");
-    final String filePath;
-    if (isIntelliJDir(workingDir)) {
-      String buildDir = workingDir.replace(getModuleName(), "");
-      buildDir =
-          Paths.get(buildDir, "out", "production", "geode." + getModuleName() + ".integrationTest")
-              .toString();
-      filePath = buildDir + File.separator + fileName;
-    } else {
-      filePath = fileName;
-    }
-    File file = new File(filePath);
+    File file = new File(fileName);
     if (file.exists()) {
       assertThat(file.delete()).isTrue();
     }
     assertThat(file.createNewFile()).isTrue();
     assertThat(file).exists().canWrite();
     return file;
-  }
-
-  private boolean isIntelliJDir(final String workingDir) {
-    return !workingDir.contains("build");
   }
 
   /**

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeDataSerializablesWithClassAnalysisRuleTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeDataSerializablesWithClassAnalysisRuleTestBase.java
@@ -14,25 +14,27 @@
  */
 package org.apache.geode.codeAnalysis;
 
-import java.util.Optional;
+import java.util.Map;
 
-import org.junit.experimental.categories.Category;
+import org.junit.AfterClass;
+import org.junit.Rule;
 
-import org.apache.geode.internal.cache.wan.WANSanctionedSerializablesService;
-import org.apache.geode.test.junit.categories.SerializationTest;
-import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.codeAnalysis.decode.CompiledClass;
+import org.apache.geode.test.junit.rules.ClassAnalysisRule;
 
-@Category({WanTest.class, SerializationTest.class})
-public class AnalyzeWANSerializablesIntegrationTest
-    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
+public abstract class AnalyzeDataSerializablesWithClassAnalysisRuleTestBase
+    extends AnalyzeDataSerializablesTestBase {
 
-  @Override
-  protected String getModuleName() {
-    return "geode-wan";
+  @Rule
+  public ClassAnalysisRule classProvider = new ClassAnalysisRule(getModuleName());
+
+  @AfterClass
+  public static void afterClass() {
+    ClassAnalysisRule.clearCache();
   }
 
   @Override
-  protected Optional<Class<?>> getModuleClass() {
-    return Optional.of(WANSanctionedSerializablesService.class);
+  protected Map<String, CompiledClass> loadClasses() {
+    return classProvider.getClasses();
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesWithClassAnalysisRuleTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/AnalyzeSerializablesWithClassAnalysisRuleTestBase.java
@@ -14,25 +14,30 @@
  */
 package org.apache.geode.codeAnalysis;
 
-import java.util.Optional;
+import java.util.Map;
 
+import org.junit.AfterClass;
+import org.junit.Rule;
 import org.junit.experimental.categories.Category;
 
-import org.apache.geode.internal.cache.wan.WANSanctionedSerializablesService;
+import org.apache.geode.codeAnalysis.decode.CompiledClass;
 import org.apache.geode.test.junit.categories.SerializationTest;
-import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.test.junit.rules.ClassAnalysisRule;
 
-@Category({WanTest.class, SerializationTest.class})
-public class AnalyzeWANSerializablesIntegrationTest
-    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
+@Category(SerializationTest.class)
+public abstract class AnalyzeSerializablesWithClassAnalysisRuleTestBase
+    extends AnalyzeSerializablesTestBase {
 
-  @Override
-  protected String getModuleName() {
-    return "geode-wan";
+  @Rule
+  public ClassAnalysisRule classProvider = new ClassAnalysisRule(getModuleName());
+
+  @AfterClass
+  public static void afterClass() {
+    ClassAnalysisRule.clearCache();
   }
 
   @Override
-  protected Optional<Class<?>> getModuleClass() {
-    return Optional.of(WANSanctionedSerializablesService.class);
+  protected Map<String, CompiledClass> loadClasses() {
+    return classProvider.getClasses();
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/codeAnalysis/SanctionedSerializablesServiceIntegrationTestBase.java
+++ b/geode-junit/src/main/java/org/apache/geode/codeAnalysis/SanctionedSerializablesServiceIntegrationTestBase.java
@@ -38,7 +38,7 @@ public abstract class SanctionedSerializablesServiceIntegrationTestBase {
   }
 
   @Test
-  public final void serviceIsLoaded() {
+  public void serviceIsLoaded() {
     Collection<SanctionedSerializablesService> services = loadSanctionedSerializablesServices();
     SanctionedSerializablesService service = getService();
 
@@ -56,7 +56,7 @@ public abstract class SanctionedSerializablesServiceIntegrationTestBase {
   }
 
   @Test
-  public final void serviceResourceExists() {
+  public void serviceResourceExists() {
     SanctionedSerializablesService service = getService();
 
     URL url = service.getSanctionedSerializablesURL();
@@ -72,7 +72,7 @@ public abstract class SanctionedSerializablesServiceIntegrationTestBase {
   }
 
   @Test
-  public final void serviceResourceIsLoaded() throws IOException {
+  public void serviceResourceIsLoaded() throws IOException {
     SanctionedSerializablesService service = getService();
 
     Collection<String> serializables = service.getSerializationAcceptlist();

--- a/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ClassAnalysisRule.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/junit/rules/ClassAnalysisRule.java
@@ -49,13 +49,19 @@ public class ClassAnalysisRule implements TestRule {
       new AtomicReference<>(new HashMap<>());
 
   private final String moduleName;
+  private final String sourceSet;
   private final Map<String, CompiledClass> classes = new HashMap<>();
 
   /**
    * @param moduleName The name of the gradle module in which your test resides
    */
   public ClassAnalysisRule(String moduleName) {
+    this(moduleName, "main");
+  }
+
+  public ClassAnalysisRule(String moduleName, String sourceSet) {
     this.moduleName = moduleName;
+    this.sourceSet = sourceSet;
   }
 
   public Map<String, CompiledClass> getClasses() {
@@ -95,21 +101,18 @@ public class ClassAnalysisRule implements TestRule {
             .map(x -> new File(x))
             .collect(Collectors.toList());
 
+    // check for <module>/build/classes/java/**
     String gradleBuildDirName =
-        Paths.get(getModuleName(), "build", "classes", "java", "main").toString();
-    // System.out.println("gradleBuildDirName is " + gradleBuildDirName);
-    String ideaBuildDirName =
-        Paths.get(getModuleName(), "out", "production", "classes").toString();
-    // System.out.println("ideaBuildDirName is " + ideaBuildDirName);
-    String ideaFQCNBuildDirName =
-        Paths.get("out", "production", "geode." + getModuleName() + ".main").toString();
-    // System.out.println("idea build path with full package names is " + ideaFQCNBuildDirName);
+        Paths.get(getModuleName(), "build", "classes", "java", sourceSet).toString();
+
+    // check for <module>/build/classes/test/**
+    String alternateBuildDirName =
+        Paths.get(getModuleName(), "build", "classes", sourceSet).toString();
 
     String buildDir = null;
     for (File entry : entries) {
       if (entry.toString().endsWith(gradleBuildDirName)
-          || entry.toString().endsWith(ideaBuildDirName)
-          || entry.toString().endsWith(ideaFQCNBuildDirName)) {
+          || entry.toString().endsWith(alternateBuildDirName)) {
         buildDir = entry.toString();
         break;
       }

--- a/geode-lucene/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeLuceneSerializablesIntegrationTest.java
+++ b/geode-lucene/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeLuceneSerializablesIntegrationTest.java
@@ -23,7 +23,8 @@ import org.apache.geode.test.junit.categories.LuceneTest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category({LuceneTest.class, SerializationTest.class})
-public class AnalyzeLuceneSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeLuceneSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-management/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeManagementSerializablesIntegrationTest.java
+++ b/geode-management/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeManagementSerializablesIntegrationTest.java
@@ -23,7 +23,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
 public class AnalyzeManagementSerializablesIntegrationTest
-    extends AnalyzeSerializablesJUnitTestBase {
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-membership/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeMembershipSerializablesIntegrationTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeMembershipSerializablesIntegrationTest.java
@@ -36,7 +36,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
  */
 @Category({MembershipTest.class, SerializationTest.class})
 public class AnalyzeMembershipSerializablesIntegrationTest
-    extends AnalyzeDataSerializablesJUnitTestBase {
+    extends AnalyzeDataSerializablesWithClassAnalysisRuleTestBase {
 
   private final DSFIDSerializer dsfidSerializer = new DSFIDSerializerFactory().create();
 

--- a/geode-memcached/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeMemcachedSerializablesIntegrationTest.java
+++ b/geode-memcached/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeMemcachedSerializablesIntegrationTest.java
@@ -23,7 +23,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
 public class AnalyzeMemcachedSerializablesIntegrationTest
-    extends AnalyzeSerializablesJUnitTestBase {
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-pulse/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzePulseSerializablesIntegrationTest.java
+++ b/geode-pulse/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzePulseSerializablesIntegrationTest.java
@@ -21,7 +21,8 @@ import org.junit.experimental.categories.Category;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
-public class AnalyzePulseSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzePulseSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-serialization/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeSerializationSerializablesIntegrationTest.java
+++ b/geode-serialization/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeSerializationSerializablesIntegrationTest.java
@@ -23,7 +23,7 @@ import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category(SerializationTest.class)
 public class AnalyzeSerializationSerializablesIntegrationTest
-    extends AnalyzeSerializablesJUnitTestBase {
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {

--- a/geode-web-api/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeWebApiSerializablesIntegrationTest.java
+++ b/geode-web-api/src/integrationTest/java/org/apache/geode/codeAnalysis/AnalyzeWebApiSerializablesIntegrationTest.java
@@ -23,7 +23,8 @@ import org.apache.geode.test.junit.categories.RestAPITest;
 import org.apache.geode.test.junit.categories.SerializationTest;
 
 @Category({RestAPITest.class, SerializationTest.class})
-public class AnalyzeWebApiSerializablesIntegrationTest extends AnalyzeSerializablesJUnitTestBase {
+public class AnalyzeWebApiSerializablesIntegrationTest
+    extends AnalyzeSerializablesWithClassAnalysisRuleTestBase {
 
   @Override
   protected String getModuleName() {


### PR DESCRIPTION
Adds support for customizing source set paths of ClassAnalysisRule.

PROBLEM

Modules external to Geode must be structured the same as Geode
source code in order to use ClassAnalysisRule and the
Analyze*Serializables tests. This is necessary to better facilitate
pluggability of modules that need to provide sanctioned serializable
lists.

SOLUTION

Add source set path customization to ClassAnalysisRule, introduce
a new layer of Analyze*Serializables test base classes that can be
directly extended in order to customize source set paths in
ClassAnalysisRule. Also includes improvements to some iterating
of classes during analysis.

[prereq for backport of GEODE-9980 and GEODE-9758]

(cherry picked from commit 5d1e91932dff296632916a6ceccfb36039357acd)
