### PR TITLE
GEODE-10057: Correct geode-for-redis docs

### DIFF
--- a/geode-docs/tools_modules/geode_for_redis.html.md.erb
+++ b/geode-docs/tools_modules/geode_for_redis.html.md.erb
@@ -238,8 +238,8 @@ integer (+/-&nbsp;9223372036854775807) for CURSOR.
 
 Keys are expired in two ways, actively and passively:
 
--   With active expiration, expiration is evaluated **whenever a key is accessed**. If the key is due to expire, it is deleted.
--   With passive expiration, keys are evaluated **every three minutes**. If they are due to expire, they are deleted.
+-   With passive expiration, expiration is evaluated **whenever a key is accessed**. If the key is due to expire, it is deleted.
+-   With active expiration, keys are evaluated **every three minutes**. If they are due to expire, they are deleted.
 
 ## <a id="loss-of-connections"></a>Loss of Connections
 


### PR DESCRIPTION
 - Swap usage of active and passive in descriptions of expiration to
 match their usage in open source Redis documentation

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
