### PR TITLE
GEODE-9990: turn DiskAccessException into CacheClosedException (#7334)

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateBucketMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/CreateBucketMessage.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.apache.geode.CancelException;
 import org.apache.geode.DataSerializer;
+import org.apache.geode.cache.DiskAccessException;
 import org.apache.geode.cache.PartitionedRegionStorageException;
 import org.apache.geode.distributed.internal.ClusterDistributionManager;
 import org.apache.geode.distributed.internal.DistributionManager;
@@ -339,9 +340,9 @@ public class CreateBucketMessage extends PartitionMessage {
         waitForRepliesUninterruptibly();
       } catch (ReplyException e) {
         Throwable t = e.getCause();
-        if (t instanceof CancelException) {
+        if (t instanceof DiskAccessException || t instanceof CancelException) {
           logger.debug(
-              "NodeResponse got remote cancellation, throwing PartitionedRegionCommunication Exception {}",
+              "NodeResponse got remote exception, throwing PartitionedRegionCommunication Exception {}",
               t.getMessage(), t);
           return null;
         }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PRHARedundancyProviderTest.java
@@ -16,16 +16,21 @@ package org.apache.geode.internal.cache;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -45,10 +50,13 @@ import org.mockito.stubbing.Answer;
 import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.CacheClosedException;
 import org.apache.geode.cache.DataPolicy;
+import org.apache.geode.cache.DiskAccessException;
 import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.RegionDestroyedException;
 import org.apache.geode.distributed.DistributedSystem;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.control.InternalResourceManager;
+import org.apache.geode.internal.cache.partitioned.Bucket;
 import org.apache.geode.internal.cache.partitioned.InternalPRInfo;
 import org.apache.geode.internal.cache.partitioned.LoadProbe;
 import org.apache.geode.internal.cache.partitioned.PartitionedRegionRebalanceOp;
@@ -245,6 +253,70 @@ public class PRHARedundancyProviderTest {
     prHaRedundancyProvider.startRedundancyRecovery();
 
     verify(providerStartupTask).complete(any());
+  }
+
+  @Test
+  public void createBucketAtomicallyConvertsDiskAccessExceptionWhenCacheCloseInProgress() {
+    String partitionName = "partitionName";
+    DiskAccessException diskAccessException = new DiskAccessException("boom");
+    CacheClosedException cacheClosedException = new CacheClosedException(diskAccessException);
+    InternalDistributedMember internalDistributedMember = mock(InternalDistributedMember.class);
+    Set<InternalDistributedMember> memberSet = Collections.singleton(internalDistributedMember);
+    InternalCache internalCache = mock(InternalCache.class);
+    RegionAdvisor regionAdvisor = mock(RegionAdvisor.class);
+    Bucket bucket = mock(Bucket.class);
+    BucketAdvisor bucketAdvisor = mock(BucketAdvisor.class);
+    CancelCriterion cancelCriterion = mock(CancelCriterion.class);
+
+    prHaRedundancyProvider = new PRHARedundancyProvider(partitionedRegion, resourceManager);
+
+    when(partitionedRegion.getRegionAdvisor()).thenReturn(regionAdvisor);
+    when(partitionedRegion.getCache()).thenReturn(internalCache);
+    when(partitionedRegion.getCancelCriterion()).thenReturn(cancelCriterion);
+    when(regionAdvisor.getBucket(anyInt())).thenReturn(bucket);
+    when(bucket.getBucketAdvisor()).thenReturn(bucketAdvisor);
+    when(internalCache.isCacheAtShutdownAll())
+        .thenReturn(Boolean.FALSE)
+        .thenThrow(diskAccessException);
+    when(cancelCriterion.isCancelInProgress()).thenReturn(Boolean.TRUE);
+    doThrow(cacheClosedException).when(cancelCriterion).checkCancelInProgress(diskAccessException);
+    when(partitionedRegion.getRegionAdvisor().adviseFixedPartitionDataStores(partitionName))
+        .thenReturn(memberSet);
+
+    assertThatThrownBy(
+        () -> prHaRedundancyProvider.createBucketAtomically(1, 5000, false, partitionName))
+            .isEqualTo(cacheClosedException);
+  }
+
+  @Test
+  public void createBucketAtomicallyPropagatesDiskAccessExceptionWhenCacheCloseNotInProgress() {
+    String partitionName = "partitionName";
+    DiskAccessException diskAccessException = new DiskAccessException("boom");
+    InternalDistributedMember internalDistributedMember = mock(InternalDistributedMember.class);
+    Set<InternalDistributedMember> memberSet = Collections.singleton(internalDistributedMember);
+    InternalCache internalCache = mock(InternalCache.class);
+    RegionAdvisor regionAdvisor = mock(RegionAdvisor.class);
+    Bucket bucket = mock(Bucket.class);
+    BucketAdvisor bucketAdvisor = mock(BucketAdvisor.class);
+    CancelCriterion cancelCriterion = mock(CancelCriterion.class);
+
+    prHaRedundancyProvider = new PRHARedundancyProvider(partitionedRegion, resourceManager);
+
+    when(partitionedRegion.getRegionAdvisor()).thenReturn(regionAdvisor);
+    when(partitionedRegion.getCache()).thenReturn(internalCache);
+    when(partitionedRegion.getCancelCriterion()).thenReturn(cancelCriterion);
+    when(regionAdvisor.getBucket(anyInt())).thenReturn(bucket);
+    when(bucket.getBucketAdvisor()).thenReturn(bucketAdvisor);
+    when(internalCache.isCacheAtShutdownAll())
+        .thenReturn(Boolean.FALSE)
+        .thenThrow(diskAccessException);
+    when(cancelCriterion.isCancelInProgress()).thenReturn(Boolean.FALSE);
+    when(partitionedRegion.getRegionAdvisor().adviseFixedPartitionDataStores(partitionName))
+        .thenReturn(memberSet);
+
+    assertThatThrownBy(
+        () -> prHaRedundancyProvider.createBucketAtomically(1, 5000, false, partitionName))
+            .isEqualTo(diskAccessException);
   }
 
   @Test


### PR DESCRIPTION
- when DiskInitFile is in closed state and DiskStoreImpl is closed or
  closing
- catch DiskAccessException in PRHARedundancyProvider and turn into
  CacheClosedException if cache closing is in progress
- change CreateBucketMessage to handle DiskAccessException as cause of
  ReplyException

(cherry picked from commit a98197b5d0a3a2547e0581e475dcabaa82e6e92f)

