### PR TITLE
GEODE-9484: Improve sending message to multy destinations

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/UpdatePropagationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/UpdatePropagationDUnitTest.java
@@ -20,6 +20,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
@@ -50,6 +51,8 @@ import org.apache.geode.cache.server.CacheServer;
 import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.distributed.internal.ServerLocationAndMemberId;
+import org.apache.geode.distributed.internal.membership.api.MembershipManagerHelper;
+import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
@@ -74,11 +77,16 @@ public class UpdatePropagationDUnitTest extends JUnit4CacheTestCase {
 
   private VM server1 = null;
   private VM server2 = null;
+  private VM server3 = null;
   private VM client1 = null;
   private VM client2 = null;
 
   private int PORT1;
   private int PORT2;
+  private int PORT3;
+
+  private String hostnameServer1;
+  private String hostnameServer3;
 
   @Override
   public final void postSetUp() throws Exception {
@@ -91,22 +99,50 @@ public class UpdatePropagationDUnitTest extends JUnit4CacheTestCase {
     // Server2 VM
     server2 = host.getVM(1);
 
+    // Server3 VM
+    server3 = host.getVM(2);
+
     // Client 1 VM
-    client1 = host.getVM(2);
+    client1 = host.getVM(3);
 
     // client 2 VM
-    client2 = host.getVM(3);
+    client2 = host.getVM(4);
 
-    PORT1 = server1.invoke(this::createServerCache);
-    PORT2 = server2.invoke(this::createServerCache);
+    PORT1 = server1.invoke(() -> createServerCache());
+    PORT2 = server2.invoke(() -> createServerCache());
+    PORT3 = server3.invoke(() -> createServerCache());
 
-    client1.invoke(
-        () -> createClientCache(NetworkUtils.getServerHostName(server1.getHost()), PORT1, PORT2));
-    client2.invoke(
-        () -> createClientCache(NetworkUtils.getServerHostName(server1.getHost()), PORT1, PORT2));
+    hostnameServer1 = NetworkUtils.getServerHostName(server1.getHost());
+    hostnameServer3 = NetworkUtils.getServerHostName(server3.getHost());
 
     IgnoredException.addIgnoredException("java.net.SocketException");
     IgnoredException.addIgnoredException("Unexpected IOException");
+  }
+
+
+
+  @Test
+  public void updatesArePropagatedToAllMembersWhenOneKilled() throws Exception {
+    client1.invoke(
+        () -> createClientCache(hostnameServer1, PORT1));
+    client2.invoke(
+        () -> createClientCache(hostnameServer3, PORT3));
+    int entries = 20;
+    AsyncInvocation invocation = client1.invokeAsync(() -> doPuts(entries));
+
+    // Wait for some entries to be put
+    Thread.sleep(5000);
+
+    // Simulate crash
+    server2.invoke(() -> {
+      MembershipManagerHelper.crashDistributedSystem(getSystemStatic());
+    });
+
+    invocation.await();
+
+    int notNullEntriesIn1 = client1.invoke(() -> getNotNullEntriesNumber(entries));
+    int notNullEntriesIn3 = client2.invoke(() -> getNotNullEntriesNumber(entries));
+    assertThat(notNullEntriesIn3).isEqualTo(notNullEntriesIn1);
   }
 
   /**
@@ -115,6 +151,11 @@ public class UpdatePropagationDUnitTest extends JUnit4CacheTestCase {
    */
   @Test
   public void updatesAreProgegatedAfterFailover() {
+    client1.invoke(
+        () -> createClientCache(hostnameServer1, PORT1, PORT2));
+    client2.invoke(
+        () -> createClientCache(hostnameServer1, PORT1, PORT2));
+
     // First create entries on both servers via the two client
     client1.invoke(this::createEntriesK1andK2);
     client2.invoke(this::createEntriesK1andK2);
@@ -248,6 +289,18 @@ public class UpdatePropagationDUnitTest extends JUnit4CacheTestCase {
         .addCacheListener(new EventTrackingCacheListener()).create(REGION_NAME);
   }
 
+  private void createClientCache(String host, Integer port1) {
+    Properties props = new Properties();
+    props.setProperty(LOCATORS, "");
+    ClientCacheFactory cf = new ClientCacheFactory();
+    cf.addPoolServer(host, port1).setPoolSubscriptionEnabled(false)
+        .setPoolSubscriptionRedundancy(-1).setPoolMinConnections(4).setPoolSocketBufferSize(1000)
+        .setPoolReadTimeout(100).setPoolPingInterval(300);
+    ClientCache cache = getClientCache(cf);
+    cache.createClientRegionFactory(ClientRegionShortcut.PROXY)
+        .create(REGION_NAME);
+  }
+
   private Integer createServerCache() throws Exception {
     Cache cache = getCache();
     RegionAttributes attrs = createCacheServerAttributes();
@@ -258,7 +311,7 @@ public class UpdatePropagationDUnitTest extends JUnit4CacheTestCase {
     server.setPort(port);
     server.setNotifyBySubscription(true);
     server.start();
-    return server.getPort();
+    return new Integer(server.getPort());
   }
 
   protected RegionAttributes createCacheServerAttributes() {
@@ -303,6 +356,32 @@ public class UpdatePropagationDUnitTest extends JUnit4CacheTestCase {
         assertEquals("server-value1", r.get("key1"));
       }
     });
+  }
+
+  private void doPuts(int entries) throws Exception {
+    Region r1 = getCache().getRegion(REGION_NAME);
+    assertNotNull(r1);
+    for (int i = 0; i < entries; i++) {
+      try {
+        r1.put("" + i, "" + i);
+      } catch (Exception e) {
+        // ignore
+      }
+      Thread.sleep(1000);
+    }
+  }
+
+  private int getNotNullEntriesNumber(int entries) {
+    int notNullEntries = 0;
+    Region r1 = getCache().getRegion(SEPARATOR + REGION_NAME);
+    assertNotNull(r1);
+    for (int i = 0; i < entries; i++) {
+      Object value = r1.get("" + i, "" + i);
+      if (value != null) {
+        notNullEntries++;
+      }
+    }
+    return notNullEntries;
   }
 
   private static class EventTrackingCacheListener extends CacheListenerAdapter {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/UpdatePropagationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/UpdatePropagationDistributedTest.java
@@ -357,12 +357,13 @@ public class UpdatePropagationDistributedTest extends JUnit4CacheTestCase {
   }
 
   private void verifyMinEntriesInserted() {
-    await().until(() -> getRegionSizeGreaterThen(minNumEntries));
+    await().untilAsserted(() -> assertThat(getCache().getRegion(SEPARATOR + REGION_NAME))
+        .hasSizeGreaterThan(minNumEntries));
   }
 
   private void doPuts(int entries) throws Exception {
     Region<String, String> r1 = getCache().getRegion(REGION_NAME);
-    assertNotNull(r1);
+    assertThat(r1).isNotNull();
     for (int i = 0; i < entries; i++) {
       try {
         r1.put("" + i, "" + i);
@@ -372,16 +373,10 @@ public class UpdatePropagationDistributedTest extends JUnit4CacheTestCase {
     }
   }
 
-  private boolean getRegionSizeGreaterThen(int numEntries) {
-    Region<String, String> r1 = getCache().getRegion(SEPARATOR + REGION_NAME);
-    assertNotNull(r1);
-    return (r1.size() > numEntries);
-  }
-
   private int getNotNullEntriesNumber(int entries) {
     int notNullEntries = 0;
     Region<String, String> r1 = getCache().getRegion(SEPARATOR + REGION_NAME);
-    assertNotNull(r1);
+    assertThat(r1).isNotNull();
     for (int i = 0; i < entries; i++) {
       Object value = r1.get("" + i, "" + i);
       if (value != null) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/UpdatePropagationPRDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/UpdatePropagationPRDistributedTest.java
@@ -21,7 +21,7 @@ import org.apache.geode.cache.RegionAttributes;
 /**
  * subclass of UpdatePropagationDUnitTest to exercise partitioned regions
  */
-public class UpdatePropagationPRDUnitTest extends UpdatePropagationDUnitTest {
+public class UpdatePropagationPRDistributedTest extends UpdatePropagationDistributedTest {
 
   @Override
   protected RegionAttributes createCacheServerAttributes() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/CloseConnectionTest.java
@@ -110,7 +110,7 @@ public class CloseConnectionTest implements Serializable {
       InternalDistributedSystem distributedSystem = getCache().getInternalDistributedSystem();
       InternalDistributedMember otherMember = distributedSystem.getDistributionManager()
           .getOtherNormalDistributionManagerIds().iterator().next();
-      Connection connection = conTable.getConduit().getConnection(otherMember, true, false,
+      Connection connection = conTable.getConduit().getConnection(otherMember, true,
           System.currentTimeMillis(), 15000, 0);
       await().untilAsserted(() -> {
         // grab the shared, ordered "sender" connection to vm0. It should have a residual

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/TCPConduitDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/TCPConduitDUnitTest.java
@@ -110,7 +110,7 @@ public class TCPConduitDUnitTest extends DistributedTestCase {
     assertThat(connectionTable.hasReceiversFor(otherMember)).isTrue();
 
     Connection sharedUnordered = connectionTable.get(otherMember, false,
-        System.currentTimeMillis(), 15000, 0);
+        System.currentTimeMillis(), 15000, 0, false);
     sharedUnordered.requestClose("for testing");
     // the sender connection has been closed so we should only have 2 senders now
     assertThat(ConnectionTable.getNumSenderSharedConnections()).isEqualTo(2);

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/direct/DirectChannel.java
@@ -437,13 +437,13 @@ public class DirectChannel {
    * @param retry whether this is a retransmission
    * @param ackTimeout the ack warning timeout
    * @param ackSDTimeout the ack severe alert timeout
-   * @param cons a list to hold the connections
+   * @param connectionsList a list to hold the connections
    * @return null if everything went okay, or a ConnectExceptions object if some connections
    *         couldn't be obtained
    */
   private ConnectExceptions getConnections(Membership mgr, DistributionMessage msg,
       InternalDistributedMember[] destinations, boolean preserveOrder, boolean retry,
-      long ackTimeout, long ackSDTimeout, List cons) {
+      long ackTimeout, long ackSDTimeout, List<Connection> connectionsList) {
     ConnectExceptions ce = null;
     for (InternalDistributedMember destination : destinations) {
       if (destination == null) {
@@ -472,18 +472,18 @@ public class DirectChannel {
           if (ackTimeout > 0) {
             startTime = System.currentTimeMillis();
           }
-          Connection con;
+          final Connection connection;
           if (!retry) {
-            con = conduit.getFirstScanForConnection(destination, preserveOrder, startTime,
+            connection = conduit.getFirstScanForConnection(destination, preserveOrder, startTime,
                 ackTimeout, ackSDTimeout);
           } else {
-            con = conduit.getConnection(destination, preserveOrder, startTime,
+            connection = conduit.getConnection(destination, preserveOrder, startTime,
                 ackTimeout, ackSDTimeout);
           }
 
-          con.setInUse(true, startTime, 0, 0, null); // fix for bug#37657
-          cons.add(con);
-          if (con.isSharedResource() && msg instanceof DirectReplyMessage) {
+          connection.setInUse(true, startTime, 0, 0, null); // fix for bug#37657
+          connectionsList.add(connection);
+          if (connection.isSharedResource() && msg instanceof DirectReplyMessage) {
             DirectReplyMessage directMessage = (DirectReplyMessage) msg;
             directMessage.registerProcessor();
           }

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -961,7 +961,7 @@ public class Connection implements Runnable {
       final ConnectionTable t,
       final boolean preserveOrder, final InternalDistributedMember remoteAddr,
       final boolean sharedResource,
-      final long startTime, final long ackTimeout, final long ackSATimeout, boolean onlyOneTry)
+      final long startTime, final long ackTimeout, final long ackSATimeout, boolean doNotRetry)
       throws IOException, DistributedSystemDisconnectedException {
     boolean success = false;
     Connection conn = null;
@@ -1021,7 +1021,7 @@ public class Connection implements Runnable {
             // do not change the text of this exception - it is looked for in exception handlers
             throw new IOException("Cannot form connection to alert listener " + remoteAddr);
           }
-          if (onlyOneTry) {
+          if (doNotRetry) {
             throw new IOException("Connection not created in first try to " + remoteAddr);
           }
           // Wait briefly...

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/Connection.java
@@ -961,7 +961,7 @@ public class Connection implements Runnable {
       final ConnectionTable t,
       final boolean preserveOrder, final InternalDistributedMember remoteAddr,
       final boolean sharedResource,
-      final long startTime, final long ackTimeout, final long ackSATimeout)
+      final long startTime, final long ackTimeout, final long ackSATimeout, boolean onlyOneTry)
       throws IOException, DistributedSystemDisconnectedException {
     boolean success = false;
     Connection conn = null;
@@ -1021,7 +1021,9 @@ public class Connection implements Runnable {
             // do not change the text of this exception - it is looked for in exception handlers
             throw new IOException("Cannot form connection to alert listener " + remoteAddr);
           }
-
+          if (onlyOneTry) {
+            throw new IOException("Connection not created in first try to " + remoteAddr);
+          }
           // Wait briefly...
           interrupted = Thread.interrupted() || interrupted;
           try {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -905,7 +905,6 @@ public class TCPConduit implements Runnable {
     }
   }
 
-
   /**
    * Return a connection to the given member. This method performs quick scan for connection.
    * Only one attempt to create a connection to the given member .
@@ -933,10 +932,8 @@ public class TCPConduit implements Runnable {
 
       Exception problem = null;
       try {
-
         connection = getConnectionThatIsNotClosed(memberAddress, preserveOrder, startTime,
             ackTimeout, ackSATimeout);
-        // Get (or regenerate) the connection
 
         // we have a connection; fall through and return it
       } catch (ConnectionException e) {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -719,7 +719,6 @@ public class TCPConduit implements Runnable {
    *
    * @param memberAddress the IDS associated with the remoteId
    * @param preserveOrder whether this is an ordered or unordered connection
-   * @param retry false if this is the first attempt
    * @param startTime the time this operation started
    * @param ackTimeout the ack-wait-threshold * 1000 for the operation to be transmitted (or zero)
    * @param ackSATimeout the ack-severe-alert-threshold * 1000 for the operation to be transmitted
@@ -728,7 +727,7 @@ public class TCPConduit implements Runnable {
    * @return the connection
    */
   public Connection getConnection(InternalDistributedMember memberAddress,
-      final boolean preserveOrder, boolean retry, long startTime, long ackTimeout,
+      final boolean preserveOrder, long startTime, long ackTimeout,
       long ackSATimeout) throws IOException, DistributedSystemDisconnectedException {
     if (stopped) {
       throw new DistributedSystemDisconnectedException("The conduit is stopped");
@@ -742,7 +741,7 @@ public class TCPConduit implements Runnable {
       try {
         // If this is the second time through this loop, we had problems.
         // Tear down the connection so that it gets rebuilt.
-        if (retry || conn != null) { // not first time in loop
+        if (conn != null) { // not first time in loop
           if (!membership.memberExists(memberAddress)
               || membership.isShunned(memberAddress)
               || membership.shutdownInProgress()) {
@@ -777,18 +776,16 @@ public class TCPConduit implements Runnable {
 
           // Close the connection (it will get rebuilt later).
           getStats().incReconnectAttempts();
-          if (conn != null) {
-            try {
-              if (logger.isDebugEnabled()) {
-                logger.debug("Closing old connection.  conn={} before retrying. memberInTrouble={}",
-                    conn, memberInTrouble);
-              }
-              conn.closeForReconnect("closing before retrying");
-            } catch (CancelException ex) {
-              throw ex;
-            } catch (Exception ex) {
-              // ignored
+          try {
+            if (logger.isDebugEnabled()) {
+              logger.debug("Closing old connection.  conn={} before retrying. memberInTrouble={}",
+                  conn, memberInTrouble);
             }
+            conn.closeForReconnect("closing before retrying");
+          } catch (CancelException ex) {
+            throw ex;
+          } catch (Exception ex) {
+            // ignored
           }
         } // not first time in loop
 
@@ -801,7 +798,7 @@ public class TCPConduit implements Runnable {
           do {
             retryForOldConnection = false;
             conn = getConTable().get(memberAddress, preserveOrder, startTime, ackTimeout,
-                ackSATimeout);
+                ackSATimeout, false);
             if (conn == null) {
               // conduit may be closed - otherwise an ioexception would be thrown
               problem = new IOException(
@@ -908,6 +905,104 @@ public class TCPConduit implements Runnable {
       }
     }
   }
+
+
+  /**
+   * Return a connection to the given member. This method performs quick scan for connection.
+   * Only one attempt to create a connection to the given member .
+   *
+   * @param memberAddress the IDS associated with the remoteId
+   * @param preserveOrder whether this is an ordered or unordered connection
+   * @param startTime the time this operation started
+   * @param ackTimeout the ack-wait-threshold * 1000 for the operation to be transmitted (or zero)
+   * @param ackSATimeout the ack-severe-alert-threshold * 1000 for the operation to be transmitted
+   *        (or zero)
+   *
+   * @return the connection
+   */
+  public Connection getFirstScanForConnection(InternalDistributedMember memberAddress,
+      final boolean preserveOrder, long startTime, long ackTimeout,
+      long ackSATimeout) throws IOException, DistributedSystemDisconnectedException {
+    if (stopped) {
+      throw new DistributedSystemDisconnectedException("The conduit is stopped");
+    }
+
+    InternalDistributedMember memberInTrouble = null;
+    Connection conn = null;
+    stopper.checkCancelInProgress(null);
+    boolean interrupted = Thread.interrupted();
+    try {
+      // If this is the second time through this loop, we had problems.
+      // Tear down the connection so that it gets rebuilt.
+
+      Exception problem = null;
+      try {
+        // Get (or regenerate) the connection
+        // this could generate a ConnectionException, so it must be caught and retried
+        boolean retryForOldConnection;
+        boolean debugRetry = false;
+        do {
+          retryForOldConnection = false;
+          conn = getConTable().get(memberAddress, preserveOrder, startTime, ackTimeout,
+              ackSATimeout, true);
+          if (conn == null) {
+            // conduit may be closed - otherwise an ioexception would be thrown
+            problem = new IOException(
+                String.format("Unable to reconnect to server; possible shutdown: %s",
+                    memberAddress));
+          } else if (conn.isClosing() || !conn.getRemoteAddress().equals(memberAddress)) {
+            if (logger.isDebugEnabled()) {
+              logger.debug("Got an old connection for {}: {}@{}", memberAddress, conn,
+                  conn.hashCode());
+            }
+            conn.closeOldConnection("closing old connection");
+            conn = null;
+            retryForOldConnection = true;
+            debugRetry = true;
+          }
+        } while (retryForOldConnection);
+        if (debugRetry && logger.isDebugEnabled()) {
+          logger.debug("Done removing old connections");
+        }
+
+        // we have a connection; fall through and return it
+      } catch (ConnectionException e) {
+        // Race condition between acquiring the connection and attempting
+        // to use it: another thread closed it.
+        problem = e;
+        // No need to retry since Connection.createSender has already
+        // done retries and now member is really unreachable for some reason
+        // even though it may be in the view
+      } catch (IOException e) {
+        problem = e;
+        // don't keep trying to connect to an alert listener
+        if (AlertingAction.isThreadAlerting()) {
+          if (logger.isDebugEnabled()) {
+            logger.debug("Giving up connecting to alert listener {}", memberAddress);
+          }
+        }
+      }
+
+      if (problem != null) {
+        if (problem instanceof IOException) {
+          if (problem.getMessage().startsWith("Cannot form connection to alert listener")) {
+            throw new AlertingIOException((IOException) problem);
+          }
+          throw (IOException) problem;
+        }
+        throw new IOException(
+            String.format("Problem connecting to %s", memberAddress), problem);
+      }
+      // Success!
+
+      return conn;
+    } finally {
+      if (interrupted) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
 
   @Override
   public String toString() {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/TCPConduit.java
@@ -927,8 +927,7 @@ public class TCPConduit implements Runnable {
       throw new DistributedSystemDisconnectedException("The conduit is stopped");
     }
 
-    InternalDistributedMember memberInTrouble = null;
-    Connection conn = null;
+    Connection connection = null;
     stopper.checkCancelInProgress(null);
     boolean interrupted = Thread.interrupted();
     try {
@@ -943,20 +942,21 @@ public class TCPConduit implements Runnable {
         boolean debugRetry = false;
         do {
           retryForOldConnection = false;
-          conn = getConTable().get(memberAddress, preserveOrder, startTime, ackTimeout,
+          connection = getConTable().get(memberAddress, preserveOrder, startTime, ackTimeout,
               ackSATimeout, true);
-          if (conn == null) {
+          if (connection == null) {
             // conduit may be closed - otherwise an ioexception would be thrown
             problem = new IOException(
                 String.format("Unable to reconnect to server; possible shutdown: %s",
                     memberAddress));
-          } else if (conn.isClosing() || !conn.getRemoteAddress().equals(memberAddress)) {
+          } else if (connection.isClosing()
+              || !connection.getRemoteAddress().equals(memberAddress)) {
             if (logger.isDebugEnabled()) {
-              logger.debug("Got an old connection for {}: {}@{}", memberAddress, conn,
-                  conn.hashCode());
+              logger.debug("Got an old connection for {}: {}@{}", memberAddress, connection,
+                  connection.hashCode());
             }
-            conn.closeOldConnection("closing old connection");
-            conn = null;
+            connection.closeOldConnection("closing old connection");
+            connection = null;
             retryForOldConnection = true;
             debugRetry = true;
           }
@@ -995,7 +995,7 @@ public class TCPConduit implements Runnable {
       }
       // Success!
 
-      return conn;
+      return connection;
     } finally {
       if (interrupted) {
         Thread.currentThread().interrupt();

--- a/geode-core/src/test/java/org/apache/geode/internal/tcp/ConnectionTransmissionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/tcp/ConnectionTransmissionTest.java
@@ -168,7 +168,7 @@ public class ConnectionTransmissionTest {
     senderAddr.setDirectChannelPort(conduit.getPort());
 
     return spy(Connection.createSender(membership, writerTable, true, remoteAddr, true,
-        System.currentTimeMillis(), 1000, 1000));
+        System.currentTimeMillis(), 1000, 1000, false));
   }
 
   private Connection createReceiverConnectionOnFirstAccept(final ServerSocketChannel acceptorSocket,


### PR DESCRIPTION
Problem:
When replicating to other servers, current logic would first create connections toward all servers, and then replicate data over those connections. Creation of connections will last, until all connections are created, or destination server/s is/are declared dead.

Solution:
New proposal is, when replicating data, first try to create connections to all destinations in one attempt. For all created connections we will replicate data. After this step is completed, we will try to create remaining connections to all unreachable destinations, until connections are established, or destination is declared dead. If connections are established we will replicate data.

For more info see https://cwiki.apache.org/confluence/display/GEODE/Improve+data+inconsistency+in+replicated+regions

### For all changes:
- [*] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [*] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [*] Is your initial contribution a single, squashed commit?

- [*] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
