### PR TITLE
GEODE-8140: Set scope field in gfsh.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/i18n/CliStrings.java
@@ -1103,6 +1103,17 @@ public class CliStrings {
   public static final String CREATE_REGION__MSG__OBJECT_SIZER_MUST_BE_OBJECTSIZER_AND_DECLARABLE =
       "eviction-object-sizer must implement both ObjectSizer and Declarable interfaces";
 
+  public static final String CREATE_REGION__SCOPE = "scope";
+
+  public static final String CREATE_REGION__SCOPE__HELP =
+      "Sets the scope of the region. Scope cannot be set for Partitioned regions";
+
+  public static final String CREATE_REGION__MSG__SCOPE_CANNOT_BE_SET_ON_NON_REPLICATED_REGION =
+      "Scope cannot be set on non Replicated region types";
+
+  public static final String CREATE_REGION__SCOPE__SCOPE_CANNOT_BE_SET_IF_TYPE_NOT_SET =
+      "Scope cannot be used if --type is not set in the command";
+
   /* debug command */
   public static final String DEBUG = "debug";
   public static final String DEBUG__HELP = "Enable/Disable debugging output in GFSH.";

--- a/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/create.html.md.erb
@@ -861,7 +861,7 @@ for syntax details.
     [--recovery-delay=value] [--redundant-copies=value]
     [--startup-recovery-delay=value] [--total-max-memory=value]
     [--total-num-buckets=value] [--compressor=value] [--off-heap(=value)?]
-    [--partition-resolver=value] [--eviction-entry-count=value]
+    [--partition-resolver=value] [--eviction-entry-count=value] [--scope=value]
     [--eviction-max-memory=value] [--eviction-action=value] [--eviction-object-sizer=value]
 ```
 
@@ -1117,6 +1117,11 @@ If this option is specified without a value or is specified with a value of <cod
 <td><span class="keyword parmname">\-\-eviction-object-sizer</span></td>
 <td>Specifies your implementation of the ObjectSizer interface to measure the size of objects in the region.
 The sizer applies only to heap and memory based eviction.</td>
+<td></td>
+</tr>
+<tr>
+<td><span class="keyword parmname">\-\-scope</span></td>
+<td>Specifies the scope of the Replicated region. This field can be only used if the --type parameter is set with a replicated region type. This parameter is invalid for all other region types. If this parameter is not set and --type is set to a replicated region, the the default scope DISTRIBUTED_ACK is set.</td>
 <td></td>
 </tr>
 </tbody>

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/GfshParserAutoCompletionIntegrationTest.java
@@ -302,7 +302,7 @@ public class GfshParserAutoCompletionIntegrationTest {
   public void testCompleteWithRegionTypeWithSpace() {
     String buffer = "create region --name=test --type=REPLICATE ";
     CommandCandidate candidate = gfshParserRule.complete(buffer);
-    assertThat(candidate.getCandidates()).hasSize(45);
+    assertThat(candidate.getCandidates()).hasSize(46);
     assertThat(candidate.getFirstCandidate()).isEqualTo(buffer + "--async-event-queue-id");
   }
 

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/DescribeRegionCommand.java
@@ -84,7 +84,7 @@ public class DescribeRegionCommand extends GfshCommand {
       if (regionDescription.isPartition()) {
         regionDescription.getCndRegionAttributes().remove(RegionAttributesNames.SCOPE);
       } else {
-        String scope = regionDescription.getCndRegionAttributes().get(RegionAttributesNames.SCOPE);
+        String scope = regionDescription.getScope().toString();
         if (scope != null) {
           scope = scope.toLowerCase().replace('_', '-');
           regionDescription.getCndRegionAttributes().put(RegionAttributesNames.SCOPE, scope);

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandTest.java
@@ -42,6 +42,7 @@ import org.apache.geode.management.ManagementService;
 import org.apache.geode.management.configuration.ClassName;
 import org.apache.geode.management.internal.cli.GfshParseResult;
 import org.apache.geode.management.internal.cli.functions.CreateRegionFunctionArgs;
+import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.test.junit.rules.GfshParserRule;
 
 public class CreateRegionCommandTest {
@@ -77,6 +78,23 @@ public class CreateRegionCommandTest {
         .statusIsError()
         .hasInfoSection().hasOutput().contains("Invalid command");
   }
+
+  @Test
+  public void whenScopeIsSetForNonReplicatedRegionThenItMustFail() {
+    parser.executeAndAssertThat(command,
+        "create region --name=region --type=PARTITION --scope=DISTRIBUTED_NO_ACK").statusIsError()
+        .hasInfoSection().hasOutput().contains(
+            CliStrings.CREATE_REGION__MSG__SCOPE_CANNOT_BE_SET_ON_NON_REPLICATED_REGION);
+  }
+
+  @Test
+  public void whenScopeIsSetWithoutSettingRegionTypeThenItMustFail() {
+    parser.executeAndAssertThat(command,
+        "create region --name=region --scope=DISTRIBUTED_NO_ACK").statusIsError()
+        .hasInfoSection().hasOutput().contains(
+            CliStrings.CREATE_REGION__SCOPE__SCOPE_CANNOT_BE_SET_IF_TYPE_NOT_SET);
+  }
+
 
   @Test
   public void missingBothTypeAndUseAttributeFrom() {

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeRegionJUnitTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/DescribeRegionJUnitTest.java
@@ -104,7 +104,7 @@ public class DescribeRegionJUnitTest {
     commandAssert.hasDataSection("region-1").hasContent().containsEntry("Name", "testRegion")
         .containsEntry("Data Policy", "normal")
         .containsEntry("Hosting Members", "mockA");
-    commandAssert.hasTableSection("non-default-1").hasRowSize(3).hasColumns()
+    commandAssert.hasTableSection("non-default-1").hasRowSize(4).hasColumns()
         .containsExactly("Type", "Name", "Value")
         .hasAnyRow().containsExactly("Region", "regKey", "regVal")
         .hasAnyRow().containsExactly("Eviction", "evictKey", "evictVal")
@@ -138,7 +138,7 @@ public class DescribeRegionJUnitTest {
         .extracting(DescribeRegionJUnitTest::extractHostingMembers)
         .asList()
         .containsExactlyInAnyOrder("mockA", "mockB");
-    commandAssert.hasTableSection("non-default-1").hasRowSize(3).hasColumns()
+    commandAssert.hasTableSection("non-default-1").hasRowSize(4).hasColumns()
         .containsExactly("Type", "Name", "Value")
         .hasAnyRow().containsExactly("Region", "regKey", "regVal")
         .hasAnyRow().containsExactly("Eviction", "evictKey", "evictVal")
@@ -179,7 +179,7 @@ public class DescribeRegionJUnitTest {
         .extracting(DescribeRegionJUnitTest::extractHostingMembers)
         .asList()
         .containsExactlyInAnyOrder("mockA", "mockB");
-    commandAssert.hasTableSection("non-default-1").hasRowSize(1).hasColumns()
+    commandAssert.hasTableSection("non-default-1").hasRowSize(2).hasColumns()
         .containsExactly("Type", "Name", "Value").hasAnyRow()
         .containsExactly("Eviction", "sharedEvictionKey", "sharedEvictionValue");
     commandAssert.hasTableSection("member-non-default-1").hasRowSize(4).hasColumns()

--- a/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -17,12 +17,15 @@ package org.apache.geode.management.internal.cli.commands;
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
 
 import org.apache.geode.cache.Region;
 import org.apache.geode.test.dunit.IgnoredException;
@@ -31,8 +34,10 @@ import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.WanTest;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
 import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+import org.apache.geode.test.junit.runners.GeodeParamsRunner;
 
 @Category({WanTest.class})
+@RunWith(GeodeParamsRunner.class)
 public class CreateRegionCommandDUnitTest {
   private static MemberVM locator, server1, server2;
 
@@ -52,6 +57,63 @@ public class CreateRegionCommandDUnitTest {
     server2 = lsRule.startServerVM(2, locator.getPort());
 
     gfsh.connectAndVerify(locator);
+  }
+
+  public Object[] replicatedRegionAndScopePairs() {
+    String[] replicatedRegions = {"REPLICATE", "REPLICATE_PERSISTENT", "REPLICATE_PROXY",
+        "REPLICATE_OVERFLOW", "REPLICATE_PERSISTENT_OVERFLOW", "REPLICATE_HEAP_LRU"};
+    String[] scopes = {"DISTRIBUTED_NO_ACK", "DISTRIBUTED_ACK", "LOCAL", "GLOBAL"};
+    Object[] pairs = new Object[replicatedRegions.length * scopes.length];
+    int count = 0;
+    for (String replicatedRegion : replicatedRegions) {
+      for (String scope : scopes) {
+        pairs[count] = new Object[] {replicatedRegion, scope};
+        count++;
+      }
+    }
+    return pairs;
+  }
+
+  public Object[] nonReplicatedRegionAndScopePairs() {
+    String[] scopes = {"DISTRIBUTED_NO_ACK", "DISTRIBUTED_ACK", "LOCAL", "GLOBAL"};
+    String[] nonReplicatedRegions =
+        {"PARTITION", "PARTITION_PERSISTENT", "PARTITION_PROXY", "PARTITION_REDUNDANT",
+            "PARTITION_REDUNDANT_PERSISTENT", "PARTITION_OVERFLOW", "PARTITION_REDUNDANT_OVERFLOW",
+            "PARTITION_PERSISTENT_OVERFLOW", "PARTITION_REDUNDANT_PERSISTENT_OVERFLOW",
+            "PARTITION_HEAP_LRU", "PARTITION_REDUNDANT_HEAP_LRU", "LOCAL", "LOCAL_PERSISTENT",
+            "LOCAL_HEAP_LRU", "LOCAL_OVERFLOW", "LOCAL_PERSISTENT_OVERFLOW"};
+    int count = 0;
+    Object[] pairs = new Object[scopes.length * nonReplicatedRegions.length];
+    for (String nonReplicatedRegion : nonReplicatedRegions) {
+      for (String scope : scopes) {
+        pairs[count] = new Object[] {nonReplicatedRegion, scope};
+        count++;
+      }
+    }
+    return pairs;
+  }
+
+  @Test
+  @TestCaseName("[{index}] {method}(RegionType:{0},Scope:{1})")
+  @Parameters(method = "replicatedRegionAndScopePairs")
+  public void createReplicateRegionCommandWithScopeSetsTheScope(String regionType, String scope) {
+    String regionName = testName.getMethodName();
+    gfsh.executeAndAssertThat(
+        "create region --type=" + regionType + " --scope=" + scope + " --name=" + regionName)
+        .statusIsSuccess();
+    String describeOutputScope = scope.replace("_", "-").toLowerCase();
+    gfsh.executeAndAssertThat("describe region --name=" + regionName).statusIsSuccess()
+        .containsOutput(describeOutputScope);
+  }
+
+  @Test
+  @TestCaseName("[{index}] {method}(RegionType:{0},Scope:{1})")
+  @Parameters(method = "nonReplicatedRegionAndScopePairs")
+  public void createNonReplicatedRegionCommandWithScopeShouldFail(String regionType, String scope) {
+    String regionName = testName.getMethodName();
+    gfsh.executeAndAssertThat(
+        "create region --type=" + regionType + " --scope=" + scope + " --name=" + regionName)
+        .statusIsError();
   }
 
   @Test


### PR DESCRIPTION
* create region now includes a new field called
 scope to set the scope
* This field is only valid for Replicated Regions.
* describe region for replicated regions will now
 display the scope too.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
