### PR TITLE
GEODE-10066: Don't wrap IOExceptions in IllegalStateExceptions.

### DIFF
--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -36,11 +36,13 @@ dependencies {
   testImplementation('com.github.stefanbirkner:system-rules') {
     exclude module: 'junit-dep'
   }
+  testImplementation('org.junit.jupiter:junit-jupiter-api')
   testImplementation('junit:junit')
   testImplementation('org.apache.commons:commons-lang3')
   testImplementation('org.assertj:assertj-core')
   testImplementation('org.mockito:mockito-core')
   testRuntimeOnly('org.junit.vintage:junit-vintage-engine')
+  testRuntimeOnly('org.junit.jupiter:junit-jupiter-engine')
 
 
   // jmhTest

--- a/geode-common/src/main/java/org/apache/geode/internal/lang/utils/function/Checked.java
+++ b/geode-common/src/main/java/org/apache/geode/internal/lang/utils/function/Checked.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.internal.lang.utils.function;
+
+import java.util.function.Function;
+
+public class Checked {
+
+  @FunctionalInterface
+  public interface CheckedFunction<T, R, E extends Exception> {
+    R apply(T t) throws E;
+  }
+
+  /**
+   * Allows for the execution of a {@link Function} that throws checked exceptions. Uses trick to
+   * rethrow a checked exception as unchecked.
+   *
+   * @param function to apply.
+   * @param <T> the type of the input to the function
+   * @param <R> the type of the result of the function
+   * @param <E> the checked exception to be rethrown
+   *
+   * @return the function results
+   */
+  public static <T, R, E extends Exception> Function<T, R> rethrowFunction(
+      CheckedFunction<T, R, E> function) {
+    return t -> {
+      try {
+        return function.apply(t);
+      } catch (Exception e) {
+        throwAsUnchecked(e);
+      }
+      // never actually reaches here.
+      return null;
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <E extends Throwable> void throwAsUnchecked(Exception exception) throws E {
+    throw (E) exception;
+  }
+}

--- a/geode-common/src/test/java/org/apache/geode/internal/lang/utils/function/CheckedTest.java
+++ b/geode-common/src/test/java/org/apache/geode/internal/lang/utils/function/CheckedTest.java
@@ -13,16 +13,27 @@
  * the License.
  */
 
-package org.apache.geode.distributed.internal.tcpserver;
+package org.apache.geode.internal.lang.utils.function;
 
+import static org.apache.geode.internal.lang.utils.function.Checked.rethrowFunction;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import org.apache.geode.internal.serialization.BasicSerializable;
+import org.junit.jupiter.api.Test;
 
-/**
- * A request to the TCP server to shutdown
- *
- * @see TcpClient#requestToServer(HostAndPort, Object, int, boolean)
- * @see ShutdownResponse
- */
-public class ShutdownRequest implements BasicSerializable {
+class CheckedTest {
+
+  @Test
+  void rethrowFunctionThrowsCheckedException() {
+    assertThatThrownBy(() -> rethrowFunction(t -> {
+      throw new Exception();
+    }).apply(null)).isExactlyInstanceOf(Exception.class);
+  }
+
+  @Test
+  void rethrowFunctionReturnsResults() {
+    final Object o = new Object();
+    assertThat(rethrowFunction(t -> o).apply(null)).isSameAs(o);
+  }
+
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/ClientServerHostNameVerificationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/ClientServerHostNameVerificationDistributedTest.java
@@ -36,6 +36,7 @@ import org.apache.geode.cache.client.ClientCache;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.client.ClientRegionFactory;
 import org.apache.geode.cache.client.ClientRegionShortcut;
+import org.apache.geode.cache.client.NoAvailableLocatorsException;
 import org.apache.geode.cache.client.NoAvailableServersException;
 import org.apache.geode.cache.ssl.CertStores;
 import org.apache.geode.cache.ssl.CertificateBuilder;
@@ -63,9 +64,9 @@ public class ClientServerHostNameVerificationDistributedTest {
   }
 
   private static void createServerRegion() {
-    RegionFactory factory =
+    RegionFactory<String, String> factory =
         ClusterStartupRule.getCache().createRegionFactory(RegionShortcut.REPLICATE);
-    Region r = factory.create("region");
+    Region<String, String> r = factory.create("region");
     r.put("serverkey", "servervalue");
   }
 
@@ -129,7 +130,7 @@ public class ClientServerHostNameVerificationDistributedTest {
 
     validateClientConnection(locatorCertificate, serverCertificate, clientCertificate, false, false,
         true,
-        IllegalStateException.class);
+        NoAvailableLocatorsException.class);
   }
 
   @Test
@@ -155,7 +156,7 @@ public class ClientServerHostNameVerificationDistributedTest {
 
     validateClientConnection(locatorCertificate, serverCertificate, clientCertificate, false, false,
         true,
-        IllegalStateException.class);
+        NoAvailableLocatorsException.class);
   }
 
   @Test

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplIntegrationTest.java
@@ -84,7 +84,7 @@ import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 @Category(ClientServerTest.class)
-public class AutoConnectionSourceImplJUnitTest {
+public class AutoConnectionSourceImplIntegrationTest {
 
   private Cache cache;
   private int port;
@@ -162,7 +162,7 @@ public class AutoConnectionSourceImplJUnitTest {
   }
 
   /**
-   * This test validates the AutoConnectionSourceImpl.addbadLocators method. That method adds
+   * This test validates the AutoConnectionSourceImpl.addBadLocators method. That method adds
    * badLocator from badLocator list to new Locator list. And it make sure that new locator list
    * doesn't have similar entry. For that it checks hostname and port only.
    */
@@ -184,7 +184,7 @@ public class AutoConnectionSourceImplJUnitTest {
     badLocators.add(new HostAndPort(badLocator1.getHostName(), badLocator1.getPort()));
     badLocators.add(new HostAndPort(badLocator2.getHostName(), badLocator2.getPort()));
 
-    autoConnectionSource.addbadLocators(hostAndPortList, badLocators);
+    autoConnectionSource.addBadLocators(hostAndPortList, badLocators);
 
     System.out.println("new locatores " + hostAndPortList);
     assertThat(hostAndPortList).hasSize(3);

--- a/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLInegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/distributed/internal/tcpserver/TCPServerSSLInegrationTest.java
@@ -32,7 +32,6 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.concurrent.Executors;
 
-import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -48,14 +47,11 @@ import org.apache.geode.internal.net.SSLConfigurationFactory;
 import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.net.SocketCreatorFailHandshake;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
-import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.test.junit.categories.MembershipTest;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 @Category({MembershipTest.class})
-public class TCPServerSSLJUnitTest {
-
-  Logger logger = LogService.getLogger();
+public class TCPServerSSLInegrationTest {
 
   private InetAddress localhost;
   private int port;
@@ -117,12 +113,12 @@ public class TCPServerSSLJUnitTest {
   }
 
   @Test
-  public void testSSLSocketTimeOut() throws IOException, ClassNotFoundException {
+  public void testSSLSocketTimeOut() throws ClassNotFoundException {
 
     try {
 
       getTcpClient().requestToServer(new HostAndPort(localhost.getHostAddress(), port),
-          Boolean.FALSE, 5 * 1000);
+          Boolean.FALSE, 5 * 1000, true);
       throw new AssertionError("expected to get an exception but didn't");
 
     } catch (final IllegalStateException | IOException t) {

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/AutoConnectionSourceImplTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.cache.client.internal;
+
+import static java.net.InetSocketAddress.createUnresolved;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.junit.jupiter.api.Test;
+
+import org.apache.geode.cache.client.internal.locator.ServerLocationRequest;
+import org.apache.geode.cache.client.internal.locator.ServerLocationResponse;
+import org.apache.geode.distributed.internal.tcpserver.ClusterSocketCreator;
+import org.apache.geode.distributed.internal.tcpserver.HostAndPort;
+import org.apache.geode.distributed.internal.tcpserver.TcpClient;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketCreator;
+import org.apache.geode.distributed.internal.tcpserver.TcpSocketFactory;
+import org.apache.geode.distributed.internal.tcpserver.VersionResponse;
+import org.apache.geode.internal.cache.PoolStats;
+import org.apache.geode.internal.serialization.ObjectDeserializer;
+import org.apache.geode.internal.serialization.ObjectSerializer;
+
+class AutoConnectionSourceImplTest {
+
+  @Test
+  void queryLocatorsTriesNextLocatorOnSSLExceptions() throws IOException, ClassNotFoundException {
+    final HostAndPort locator1 = mock(HostAndPort.class);
+    final HostAndPort locator2 = mock(HostAndPort.class);
+    final TcpSocketCreator socketCreator = mock(TcpSocketCreator.class);
+    final ObjectSerializer objectSerializer = mock(ObjectSerializer.class);
+    final ObjectDeserializer objectDeserializer = mock(ObjectDeserializer.class);
+    final TcpSocketFactory socketFactory = mock(TcpSocketFactory.class);
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final Socket socket = mock(Socket.class);
+    final InternalPool internalPool = mock(InternalPool.class);
+    final ServerLocationRequest request = mock(ServerLocationRequest.class);
+    final ServerLocationResponse response = mock(ServerLocationResponse.class);
+
+    final List<HostAndPort> locators = Arrays.asList(locator1, locator2);
+    final TcpClient tcpClient =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    when(locator1.getSocketInetAddress()).thenReturn(createUnresolved("locator1", 1234));
+    when(locator2.getSocketInetAddress()).thenReturn(createUnresolved("locator2", 1234));
+    when(internalPool.getStats()).thenReturn(mock(PoolStats.class));
+    when(response.hasResult()).thenReturn(true);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(locator1), anyInt(), any(), same(socketFactory)))
+        .thenThrow(new SSLHandshakeException("ouch"));
+    when(clusterSocketCreator.connect(eq(locator2), anyInt(), any(), same(socketFactory)))
+        .thenReturn(socket);
+    when(socket.getInputStream()).thenReturn(mock(InputStream.class));
+    when(socket.getOutputStream()).thenReturn(mock(OutputStream.class));
+    when(objectDeserializer.readObject(any())).thenReturn(new VersionResponse(), response);
+
+    final AutoConnectionSourceImpl autoConnectionSource =
+        new AutoConnectionSourceImpl(locators, "", 42, tcpClient);
+    autoConnectionSource.start(internalPool);
+
+    assertThat(autoConnectionSource.queryLocators(request)).isSameAs(response);
+
+    verify(socketCreator, times(4)).forCluster();
+    verify(objectDeserializer, times(2)).readObject(any());
+    verify(response).hasResult();
+
+    verifyNoMoreInteractions(response, socketCreator, objectDeserializer);
+  }
+}

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/GfshHostNameVerificationDistributedTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/GfshHostNameVerificationDistributedTest.java
@@ -119,7 +119,7 @@ public class GfshHostNameVerificationDistributedTest {
         .issuedBy(ca)
         .generate();
 
-    validateGfshConnection(locatorCertificate);
+    validateGfshConnectionFailure(locatorCertificate, "No name matching");
   }
 
   @Test
@@ -130,10 +130,11 @@ public class GfshHostNameVerificationDistributedTest {
         .sanDnsName("example.com")
         .generate();
 
-    validateGfshConnection(locatorCertificate);
+    validateGfshConnectionFailure(locatorCertificate, "No subject alternative DNS name matching");
   }
 
-  private void validateGfshConnection(CertificateMaterial locatorCertificate)
+  private void validateGfshConnectionFailure(final CertificateMaterial locatorCertificate,
+      final String failure)
       throws Exception {
     CertificateMaterial gfshCertificate = new CertificateBuilder()
         .commonName("gfsh")
@@ -165,7 +166,7 @@ public class GfshHostNameVerificationDistributedTest {
         "connect --locator=" + locator.getVM().getHost().getHostName() + "[" + locator.getPort()
             + "] --security-properties-file=" + sslConfigFile.getAbsolutePath();
     gfsh.executeAndAssertThat(connectCommand).statusIsError()
-        .containsOutput("Unable to form SSL connection");
+        .containsOutput(failure);
     IgnoredException.removeAllExpectedExceptions();
   }
 

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionedDataOutputStream.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/VersionedDataOutputStream.java
@@ -18,7 +18,6 @@ package org.apache.geode.internal.serialization;
 import java.io.DataOutputStream;
 import java.io.OutputStream;
 
-
 /**
  * An extension of {@link DataOutputStream} that implements {@link VersionedDataStream}.
  *
@@ -39,9 +38,6 @@ public class VersionedDataOutputStream extends DataOutputStream implements Versi
     this.version = version;
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public KnownVersion getVersion() {
     return version;

--- a/geode-tcp-server/build.gradle
+++ b/geode-tcp-server/build.gradle
@@ -20,14 +20,20 @@ apply from: "${rootDir}/${scriptDir}/warnings.gradle"
 
 dependencies {
   api(platform(project(':boms:geode-all-bom')))
+  compileOnly(platform(project(':boms:geode-all-bom')))
+
+  compileOnly('org.jetbrains:annotations')
 
   implementation(project(':geode-logging'))
   implementation(project(':geode-serialization'))
+  implementation(project(':geode-common'))
 
   implementation('org.apache.logging.log4j:log4j-api')
 
   //Commons validator is used to validate inet addresses
   implementation('commons-validator:commons-validator')
+
+
   testImplementation(project(':geode-junit')) {
     exclude module: 'geode-core'
   }

--- a/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/ShutdownResponse.java
+++ b/geode-tcp-server/src/main/java/org/apache/geode/distributed/internal/tcpserver/ShutdownResponse.java
@@ -21,7 +21,7 @@ import org.apache.geode.internal.serialization.BasicSerializable;
 /**
  * A response from the TCP server that it received a ShutdownRequest
  *
- * @see TcpClient#requestToServer(HostAndPort, Object, int)
+ * @see TcpClient#requestToServer(HostAndPort, Object, int, boolean)
  * @see ShutdownRequest
  * @since GemFire 5.7
  */

--- a/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpClientTest.java
+++ b/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpClientTest.java
@@ -1,0 +1,636 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.apache.geode.distributed.internal.tcpserver;
+
+import static org.apache.geode.distributed.internal.tcpserver.TcpClient.assertNotSslAlert;
+import static org.apache.geode.distributed.internal.tcpserver.TcpClient.createDataInputStream;
+import static org.apache.geode.distributed.internal.tcpserver.TcpClient.createDataOutputStream;
+import static org.apache.geode.distributed.internal.tcpserver.TcpClient.createEOFException;
+import static org.apache.geode.distributed.internal.tcpserver.TcpClient.resetSocketAndLogExceptions;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+import java.net.Socket;
+import java.net.SocketException;
+
+import javax.net.ssl.SSLHandshakeException;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import org.apache.geode.internal.serialization.KnownVersion;
+import org.apache.geode.internal.serialization.ObjectDeserializer;
+import org.apache.geode.internal.serialization.ObjectSerializer;
+import org.apache.geode.internal.serialization.VersionedDataInputStream;
+import org.apache.geode.internal.serialization.VersionedDataOutputStream;
+
+class TcpClientTest {
+
+  final TcpSocketCreator socketCreator = mock(TcpSocketCreator.class);
+  final ObjectSerializer objectSerializer = mock(ObjectSerializer.class);
+  final ObjectDeserializer objectDeserializer = mock(ObjectDeserializer.class);
+  final TcpSocketFactory socketFactory = mock(TcpSocketFactory.class);
+
+  @Test
+  void resetSocketAndLogExceptionsIgnoresExceptionsOnSetSoLinger() throws IOException {
+    final Socket socket = mock(Socket.class);
+    when(socket.isClosed()).thenReturn(false);
+    doThrow(new SocketException()).when(socket).setSoLinger(eq(true), eq(0));
+
+    assertDoesNotThrow(() -> resetSocketAndLogExceptions(socket));
+
+    final InOrder order = inOrder(socket);
+    order.verify(socket).isClosed();
+    order.verify(socket).setSoLinger(eq(true), eq(0));
+    order.verify(socket).close();
+    verifyNoMoreInteractions(socket);
+  }
+
+  @Test
+  void resetSocketAndLogExceptionsIgnoresExceptionsOnClose() throws IOException {
+    final Socket socket = mock(Socket.class);
+    when(socket.isClosed()).thenReturn(false);
+    doThrow(new IOException()).when(socket).close();
+
+    assertDoesNotThrow(() -> resetSocketAndLogExceptions(socket));
+
+    final InOrder order = inOrder(socket);
+    order.verify(socket).isClosed();
+    order.verify(socket).setSoLinger(eq(true), eq(0));
+    order.verify(socket).close();
+    verifyNoMoreInteractions(socket);
+  }
+
+  @Test
+  void resetSocketAndLogExceptionsDoesNothingWhenSocketIsClosed() {
+    final Socket socket = mock(Socket.class);
+    when(socket.isClosed()).thenReturn(true);
+
+    assertDoesNotThrow(() -> resetSocketAndLogExceptions(socket));
+
+    verify(socket).isClosed();
+    verifyNoMoreInteractions(socket);
+  }
+
+  @Test
+  void sendRequestWritesHeaderRequestAndFlushes() throws IOException {
+    final DataOutputStream out = mock(DataOutputStream.class);
+
+    final short ordinalVersion = 42;
+    final Object request = new Serializable() {};
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertDoesNotThrow(() -> client.sendRequest(out, ordinalVersion, request));
+
+    final InOrder order = inOrder(out, objectSerializer);
+    order.verify(out).writeInt(eq(TcpServer.GOSSIPVERSION));
+    order.verify(out).writeShort(eq((int) ordinalVersion));
+    order.verify(objectSerializer).writeObject(same(request), same(out));
+    order.verify(out).flush();
+
+    verifyNoMoreInteractions(out, objectSerializer);
+  }
+
+  @Test
+  void getServerVersionReturnsVersionOrdinal() throws IOException, ClassNotFoundException {
+    final DataInputStream in = mock(DataInputStream.class);
+    final DataOutputStream out = mock(DataOutputStream.class);
+    final short versionOrdinal = (short) 42;
+    final VersionResponse versionResponse = new VersionResponse();
+    versionResponse.setVersionOrdinal(versionOrdinal);
+
+    when(objectDeserializer.readObject(same(in))).thenReturn(versionResponse);
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThat(client.getServerVersion(in, out))
+        .isEqualTo(versionOrdinal);
+
+    final InOrder order = inOrder(objectSerializer, objectDeserializer);
+    order.verify(objectSerializer).writeObject(any(VersionRequest.class), same(out));
+    order.verify(objectDeserializer).readObject(same(in));
+
+    verifyNoMoreInteractions(objectDeserializer, objectSerializer);
+  }
+
+  @Test
+  void getServerVersionThrowsIOExceptionWhenReadingWrongResponse()
+      throws IOException, ClassNotFoundException {
+    final DataInputStream in = mock(DataInputStream.class);
+    final DataOutputStream out = mock(DataOutputStream.class);
+
+    when(objectDeserializer.readObject(same(in))).thenReturn(new Object());
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThatThrownBy(() -> client.getServerVersion(in, out))
+        .isInstanceOf(IOException.class).hasCauseInstanceOf(ClassCastException.class);
+
+    final InOrder order = inOrder(objectSerializer, objectDeserializer);
+    order.verify(objectSerializer).writeObject(any(VersionRequest.class), same(out));
+    order.verify(objectDeserializer).readObject(same(in));
+
+    verifyNoMoreInteractions(objectDeserializer, objectSerializer);
+  }
+
+  @Test
+  void getServerVersionThrowsIOExceptionWhenClassNotFoundException()
+      throws IOException, ClassNotFoundException {
+    final DataInputStream in = mock(DataInputStream.class);
+    final DataOutputStream out = mock(DataOutputStream.class);
+
+    when(objectDeserializer.readObject(same(in))).thenThrow(new ClassNotFoundException());
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThatThrownBy(() -> client.getServerVersion(in, out))
+        .isInstanceOf(IOException.class).hasCauseInstanceOf(ClassNotFoundException.class);
+
+    final InOrder order = inOrder(objectSerializer, objectDeserializer);
+    order.verify(objectSerializer).writeObject(any(VersionRequest.class), same(out));
+    order.verify(objectDeserializer).readObject(same(in));
+
+    verifyNoMoreInteractions(objectDeserializer, objectSerializer);
+  }
+
+  @Test
+  void getServerVersionReturnOldestVersionOnEndOfFile() throws IOException, ClassNotFoundException {
+    final DataInputStream in = mock(DataInputStream.class);
+    final DataOutputStream out = mock(DataOutputStream.class);
+
+    when(objectDeserializer.readObject(same(in))).thenThrow(new EOFException());
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThat(client.getServerVersion(in, out)).isEqualTo(KnownVersion.OLDEST.ordinal());
+
+    final InOrder order = inOrder(objectSerializer, objectDeserializer);
+    order.verify(objectSerializer).writeObject(any(VersionRequest.class), same(out));
+    order.verify(objectDeserializer).readObject(same(in));
+
+    verifyNoMoreInteractions(objectDeserializer, objectSerializer);
+  }
+
+  @Test
+  void getServerVersionResetsSocketOnSetSoTimeoutException() throws IOException {
+    final int timeout = 42;
+
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+    final Socket socket = mock(Socket.class);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(address), eq(timeout), any(), same(socketFactory)))
+        .thenReturn(socket);
+    doThrow(new SocketException()).when(socket).setSoTimeout(eq(timeout));
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThatThrownBy(() -> client.getServerVersion(address, timeout))
+        .isInstanceOf(IOException.class);
+
+    final InOrder order = inOrder(socket);
+    order.verify(socket).setSoTimeout(eq(timeout));
+    order.verify(socket).isClosed();
+    order.verify(socket).setSoLinger(eq(true), eq(0));
+    order.verify(socket).close();
+
+    verifyNoMoreInteractions(socket);
+    verifyNoInteractions(objectDeserializer, objectSerializer);
+  }
+
+  @Test
+  void getServerVersionDoesNotCatchSSLHandshakeException() throws IOException {
+    final int timeout = 42;
+    final SSLHandshakeException sslHandshakeException = new SSLHandshakeException("");
+
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(address), eq(timeout), any(), same(socketFactory)))
+        .thenThrow(sslHandshakeException);
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThatThrownBy(() -> client.getServerVersion(address, timeout))
+        .isSameAs(sslHandshakeException);
+
+    verifyNoInteractions(objectDeserializer, objectSerializer);
+  }
+
+  @Test
+  void getServerVersionResetsSocketOnIOException() throws IOException {
+    final int timeout = 42;
+
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+    final Socket socket = mock(Socket.class);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(address), eq(timeout), any(), same(socketFactory)))
+        .thenReturn(socket);
+    doThrow(new IOException()).when(objectSerializer).writeObject(any(), any());
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThatThrownBy(() -> client.getServerVersion(address, timeout))
+        .isInstanceOf(IOException.class);
+
+    final InOrder order = inOrder(objectSerializer, socket);
+    order.verify(socket).setSoTimeout(eq(timeout));
+    verify(socket).getInputStream();
+    verify(socket).getOutputStream();
+    order.verify(objectSerializer).writeObject(any(), any());
+    order.verify(socket).isClosed();
+    order.verify(socket).setSoLinger(eq(true), eq(0));
+    order.verify(socket).close();
+
+    verifyNoMoreInteractions(socket, objectSerializer);
+    verifyNoInteractions(objectDeserializer);
+  }
+
+  @Test
+  void getServerVersionResetsSocketOnReturn() throws IOException, ClassNotFoundException {
+    final int timeout = 42;
+
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+    final Socket socket = mock(Socket.class);
+    final InputStream in = mock(InputStream.class);
+    final OutputStream out = mock(OutputStream.class);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(address), eq(timeout), any(), same(socketFactory)))
+        .thenReturn(socket);
+    when(socket.getInputStream()).thenReturn(in);
+    when(socket.getOutputStream()).thenReturn(out);
+    when(objectDeserializer.readObject(any())).thenReturn(new VersionResponse());
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertDoesNotThrow(() -> client.getServerVersion(address, timeout));
+
+    final InOrder order = inOrder(objectSerializer, objectDeserializer, socket);
+    order.verify(socket).setSoTimeout(eq(timeout));
+    verify(socket).getInputStream();
+    verify(socket).getOutputStream();
+    order.verify(objectSerializer).writeObject(any(VersionRequest.class), any());
+    order.verify(objectDeserializer).readObject(any());
+    order.verify(socket).isClosed();
+    order.verify(socket).setSoLinger(eq(true), eq(0));
+    order.verify(socket).close();
+
+    verifyNoMoreInteractions(socket, objectSerializer, objectDeserializer);
+  }
+
+  @Test
+  void getServerVersionReturnsCachedVersion() throws IOException, ClassNotFoundException {
+    final int timeout = 0;
+    final short ordinalVersion = 42;
+    final VersionResponse versionResponse = new VersionResponse();
+    versionResponse.setVersionOrdinal(ordinalVersion);
+
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+    final Socket socket = mock(Socket.class);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(address), eq(timeout), any(), same(socketFactory)))
+        .thenReturn(socket);
+    when(socket.getInputStream()).thenReturn(mock(InputStream.class));
+    when(socket.getOutputStream()).thenReturn(mock(OutputStream.class));
+    when(objectDeserializer.readObject(any())).thenReturn(versionResponse);
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThat(client.getServerVersion(address, timeout)).isEqualTo(ordinalVersion);
+    // second invocation should not open sockets, as verified below.
+    assertThat(client.getServerVersion(address, timeout)).isEqualTo(ordinalVersion);
+
+    verify(socketCreator).forCluster();
+    verify(clusterSocketCreator).connect(same(address), eq(timeout), any(), same(socketFactory));
+    verify(objectSerializer).writeObject(any(VersionRequest.class), any());
+    verify(objectDeserializer).readObject(any());
+
+    verifyNoMoreInteractions(socketCreator, objectSerializer, objectDeserializer, socketFactory,
+        clusterSocketCreator, address);
+  }
+
+  @Test
+  void createDataOutputStreamIsVersionedWhenVersionOlderThanCurrent() throws IOException {
+    final Socket socket = mock(Socket.class);
+    final KnownVersion version = KnownVersion.GEODE_1_1_0;
+
+    assertThat(createDataOutputStream(socket, version))
+        .isInstanceOf(VersionedDataOutputStream.class)
+        .satisfies(
+            v -> assertThat(((VersionedDataOutputStream) v).getVersion()).isEqualTo(version));
+  }
+
+  @Test
+  void createDataOutputStreamIsNotVersionedWhenVersionIsCurrent() throws IOException {
+    final Socket socket = mock(Socket.class);
+    final KnownVersion version = KnownVersion.CURRENT;
+
+    assertThat(createDataOutputStream(socket, version))
+        .isNotInstanceOf(VersionedDataOutputStream.class);
+  }
+
+  @Test
+  void createDataInputStreamIsVersionedWhenVersionOlderThanCurrent() throws IOException {
+    final Socket socket = mock(Socket.class);
+    final KnownVersion version = KnownVersion.GEODE_1_1_0;
+
+    assertThat(createDataInputStream(socket, version))
+        .isInstanceOf(VersionedDataInputStream.class)
+        .satisfies(v -> assertThat(((VersionedDataInputStream) v).getVersion()).isEqualTo(version));
+  }
+
+  @Test
+  void createDataInputStreamIsNotVersionedWhenVersionIsCurrent() throws IOException {
+    final Socket socket = mock(Socket.class);
+    final KnownVersion version = KnownVersion.CURRENT;
+
+    assertThat(createDataInputStream(socket, version))
+        .isNotInstanceOf(VersionedDataInputStream.class);
+  }
+
+
+  @Test
+  void createEOFExceptionAddsCause() {
+    final HostAndPort address = new HostAndPort("localhost", 1234);
+    final Exception cause = new Exception("ouch");
+
+    assertThat(createEOFException(address, cause))
+        .isInstanceOf(EOFException.class)
+        .hasRootCause(cause);
+  }
+
+  @Test
+  void receiveResponseThrowsEOFException() throws IOException, ClassNotFoundException {
+    final DataInputStream in = mock(DataInputStream.class);
+
+    final HostAndPort address = new HostAndPort("localhost", 1234);
+    final EOFException exception = new EOFException("ouch");
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    when(objectDeserializer.readObject(same(in))).thenThrow(exception);
+
+    assertThatThrownBy(() -> client.receiveResponse(in, address))
+        .isInstanceOf(EOFException.class)
+        .hasRootCause(exception);
+
+    verify(objectDeserializer).readObject(same(in));
+
+    verifyNoMoreInteractions(objectDeserializer);
+    verifyNoInteractions(socketCreator, objectSerializer, socketFactory);
+  }
+
+  @Test
+  void requestToServerReturnsNullIfNoReplyExpected() throws IOException, ClassNotFoundException {
+    final Object request = new Object();
+    final int timeout = 42;
+    final short serverVersionOrdinal = KnownVersion.CURRENT.ordinal();
+    final KnownVersion serverVersion = KnownVersion.CURRENT;
+
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+    final Socket socket = mock(Socket.class);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(address), eq(timeout), any(), same(socketFactory)))
+        .thenReturn(socket);
+    when(socket.getOutputStream()).thenReturn(mock(OutputStream.class));
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThat(client.requestToServer(address, request, timeout, false, serverVersionOrdinal,
+        serverVersion, null)).isNull();
+
+    final InOrder order = inOrder(socketCreator, clusterSocketCreator, socket, objectSerializer);
+    order.verify(socketCreator).forCluster();
+    order.verify(clusterSocketCreator).connect(eq(address), eq(timeout), any(),
+        same(socketFactory));
+    order.verify(socket).setSoTimeout(eq(timeout));
+    order.verify(socket).getOutputStream();
+    order.verify(objectSerializer).writeObject(same(request), any());
+    order.verify(socket).close();
+
+    verifyNoMoreInteractions(socketCreator, clusterSocketCreator, socket, objectSerializer);
+    verifyNoInteractions(objectDeserializer, socketFactory);
+  }
+
+  @Test
+  void requestToServerReturnsResponseIfReplyExpected() throws IOException, ClassNotFoundException {
+    final Object request = new Object();
+    final Object response = new Object();
+    final int timeout = 42;
+    final short serverVersionOrdinal = KnownVersion.CURRENT.ordinal();
+    final KnownVersion serverVersion = KnownVersion.CURRENT;
+
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+    final Socket socket = mock(Socket.class);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(address), eq(timeout), any(), same(socketFactory)))
+        .thenReturn(socket);
+    when(socket.getInputStream()).thenReturn(mock(InputStream.class));
+    when(socket.getOutputStream()).thenReturn(mock(OutputStream.class));
+    when(objectDeserializer.readObject(any())).thenReturn(response);
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThat(client.requestToServer(address, request, timeout, true, serverVersionOrdinal,
+        serverVersion, null)).isSameAs(response);
+
+    final InOrder order =
+        inOrder(socketCreator, clusterSocketCreator, socket, objectSerializer, objectDeserializer);
+    order.verify(socketCreator).forCluster();
+    order.verify(clusterSocketCreator).connect(eq(address), eq(timeout), any(),
+        same(socketFactory));
+    order.verify(socket).setSoTimeout(eq(timeout));
+    order.verify(socket).getOutputStream();
+    order.verify(objectSerializer).writeObject(same(request), any());
+    order.verify(socket).getInputStream();
+    order.verify(objectDeserializer).readObject(any());
+    verify(socketCreator, atLeast(0)).forCluster();
+    verify(socket, atLeast(0)).isClosed();
+    verify(clusterSocketCreator, atLeast(0)).useSSL();
+    order.verify(socket).setSoLinger(eq(true), eq(0));
+    order.verify(socket).close();
+
+    verifyNoMoreInteractions(socketCreator, clusterSocketCreator, socket, objectSerializer,
+        objectDeserializer);
+    verifyNoInteractions(socketFactory);
+  }
+
+  @Test
+  void requestToServerDoesNotSetSoLingerWhenUsingSsl() throws IOException, ClassNotFoundException {
+    final Object request = new Object();
+    final Object response = new Object();
+    final int timeout = 42;
+    final short serverVersionOrdinal = KnownVersion.CURRENT.ordinal();
+    final KnownVersion serverVersion = KnownVersion.CURRENT;
+
+    final ClusterSocketCreator clusterSocketCreator = mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+    final Socket socket = mock(Socket.class);
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(eq(address), eq(timeout), any(), same(socketFactory)))
+        .thenReturn(socket);
+    when(clusterSocketCreator.useSSL()).thenReturn(true);
+    when(socket.getInputStream()).thenReturn(mock(InputStream.class));
+    when(socket.getOutputStream()).thenReturn(mock(OutputStream.class));
+    when(objectDeserializer.readObject(any())).thenReturn(response);
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThat(client.requestToServer(address, request, timeout, true, serverVersionOrdinal,
+        serverVersion, null)).isSameAs(response);
+
+    final InOrder order =
+        inOrder(socketCreator, clusterSocketCreator, socket, objectSerializer, objectDeserializer);
+    order.verify(socketCreator).forCluster();
+    order.verify(clusterSocketCreator).connect(eq(address), eq(timeout), any(),
+        same(socketFactory));
+    order.verify(socket).setSoTimeout(eq(timeout));
+    order.verify(socket).getOutputStream();
+    order.verify(objectSerializer).writeObject(same(request), any());
+    order.verify(socket).getInputStream();
+    order.verify(objectDeserializer).readObject(any());
+    verify(socketCreator, atLeast(0)).forCluster();
+    verify(socket, atLeast(0)).isClosed();
+    verify(clusterSocketCreator, atLeast(0)).useSSL();
+    order.verify(socket).close();
+
+    verifyNoMoreInteractions(socketCreator, clusterSocketCreator, socket, objectSerializer,
+        objectDeserializer);
+    verifyNoInteractions(socketFactory);
+  }
+
+  @Test
+  void requestToServerPassesSSLHandshakeExceptionCausedByEOFException() throws Exception {
+    final ClusterSocketCreator clusterSocketCreator = Mockito.mock(ClusterSocketCreator.class);
+    final HostAndPort address = mock(HostAndPort.class);
+
+    final SSLHandshakeException sslHandshakeException =
+        new SSLHandshakeException("Remote host terminated the handshake");
+    sslHandshakeException.initCause(new EOFException("SSL peer shut down incorrectly"));
+
+    when(socketCreator.forCluster()).thenReturn(clusterSocketCreator);
+    when(clusterSocketCreator.connect(any(), anyInt(), any(), any()))
+        .thenThrow(sslHandshakeException);
+
+    final TcpClient client =
+        new TcpClient(socketCreator, objectSerializer, objectDeserializer, socketFactory);
+
+    assertThatExceptionOfType(SSLHandshakeException.class)
+        .isThrownBy(() -> client.requestToServer(address, new Object(), 42, false))
+        .withRootCauseInstanceOf(EOFException.class);
+  }
+
+  @Test
+  void assertNotSslAlertThrowSSLHandshakeExceptionWhenAlertIsDetected() throws IOException {
+    final DataInputStream in = mock(DataInputStream.class);
+    when(in.read()).thenReturn(0x15);
+
+    assertThatThrownBy(() -> assertNotSslAlert(in))
+        .isInstanceOf(SSLHandshakeException.class)
+        .hasMessage("Server expecting SSL handshake.");
+
+    final InOrder order = inOrder(in);
+    order.verify(in).mark(eq(1));
+    // noinspection ResultOfMethodCallIgnored
+    order.verify(in).read();
+    order.verify(in).reset();
+
+    verifyNoMoreInteractions(in);
+  }
+
+  @Test
+  void assertNotSslAlertDoesNotThrowWhenAlertIsNotDetectedAndStreamIsReset() throws IOException {
+    final DataInputStream in = mock(DataInputStream.class);
+    when(in.read()).thenReturn(0);
+
+    assertDoesNotThrow(() -> assertNotSslAlert(in));
+
+    final InOrder order = inOrder(in);
+    order.verify(in).mark(eq(1));
+    // noinspection ResultOfMethodCallIgnored
+    order.verify(in).read();
+    order.verify(in).reset();
+
+    verifyNoMoreInteractions(in);
+  }
+
+  @Test
+  void assertNotSslAlertDoesNotThrowOnIOExceptionAndStreamIsReset() throws IOException {
+    final DataInputStream in = mock(DataInputStream.class);
+    when(in.read()).thenReturn(-1);
+
+    assertDoesNotThrow(() -> assertNotSslAlert(in));
+
+    final InOrder order = inOrder(in);
+    order.verify(in).mark(eq(1));
+    // noinspection ResultOfMethodCallIgnored
+    order.verify(in).read();
+    order.verify(in).reset();
+
+    verifyNoMoreInteractions(in);
+  }
+
+}

--- a/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
+++ b/geode-tcp-server/src/test/java/org/apache/geode/distributed/internal/tcpserver/TcpServerDependenciesTest.java
@@ -48,6 +48,7 @@ public class TcpServerDependenciesTest {
               .or(resideInAPackage("org.apache.geode.internal.serialization.."))
               .or(resideInAPackage("org.apache.geode.logging.internal.log4j.api.."))
               .or(resideInAPackage("org.apache.geode.logging.internal.executors.."))
+              .or(resideInAPackage("org.apache.geode.internal.lang.utils.."))
 
               .or(not(resideInAPackage("org.apache.geode..")))
               .or(resideInAPackage("org.apache.geode.test.."))

--- a/geode-tcp-server/src/test/resources/expected-pom.xml
+++ b/geode-tcp-server/src/test/resources/expected-pom.xml
@@ -57,6 +57,11 @@
       <scope>runtime</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.geode</groupId>
+      <artifactId>geode-common</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
       <scope>runtime</scope>

--- a/geode-tcp-server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/geode-tcp-server/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.mockito.internal.creation.bytebuddy.InlineByteBuddyMockMaker

--- a/geode-tcp-server/src/upgradeTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionUpgradeTest.java
+++ b/geode-tcp-server/src/upgradeTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionUpgradeTest.java
@@ -72,7 +72,7 @@ import org.apache.geode.test.version.VersionManager;
 @Category({MembershipTest.class})
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
-public class TcpServerProductVersionDUnitTest implements Serializable {
+public class TcpServerProductVersionUpgradeTest implements Serializable {
 
   private static final TestVersion FIRST_NEW_VERSION = TestVersion.valueOf("1.12.0");
 
@@ -112,7 +112,7 @@ public class TcpServerProductVersionDUnitTest implements Serializable {
     final List<TestVersion> olderVersions = groups.get(true);
 
     if (olderVersions.size() < 1) {
-      throw new AssertionError("Time to decommission TcpServerProductVersionDUnitTest "
+      throw new AssertionError("Time to decommission TcpServerProductVersionUpgradeTest "
           + "because there are no supported versions older than " + FIRST_NEW_VERSION);
     }
 
@@ -144,7 +144,7 @@ public class TcpServerProductVersionDUnitTest implements Serializable {
 
   private final VersionConfiguration versions;
 
-  public TcpServerProductVersionDUnitTest(final VersionConfiguration versions) {
+  public TcpServerProductVersionUpgradeTest(final VersionConfiguration versions) {
     this.versions = versions;
   }
 
@@ -201,6 +201,7 @@ public class TcpServerProductVersionDUnitTest implements Serializable {
             InfoResponse.class.getName()));
   }
 
+  @SuppressWarnings("JavaReflectionMemberAccess")
   private SerializableRunnableIF createRequestResponseFunction(
       final int locatorPort,
       final String requestClassName,
@@ -229,10 +230,9 @@ public class TcpServerProductVersionDUnitTest implements Serializable {
         response = requestToServer.invoke(tcpClient, localHost, locatorPort,
             requestMessage, 1000);
       } catch (NoSuchMethodException e) {
-        response = tcpClient
-            .requestToServer(
-                new HostAndPort(localHost.getHostAddress(), locatorPort),
-                requestMessage, 1000);
+        response =
+            tcpClient.requestToServer(new HostAndPort(localHost.getHostAddress(), locatorPort),
+                requestMessage, 1000, true);
       }
 
       final Class<?> responseClass = Class.forName(responseClassName);
@@ -241,16 +241,16 @@ public class TcpServerProductVersionDUnitTest implements Serializable {
     };
 
   }
-  /*
+
+  /**
    * The TcpClient class changed in version FIRST_NEW_VERSION. That version (and later)
    * no longer has the old constructor TcpClient(final Properties), so we have to access
    * that constructor via reflection.
    */
-
+  @SuppressWarnings("JavaReflectionMemberAccess")
   private TcpClient getLegacyTcpClient()
       throws NoSuchMethodException, IllegalAccessException, InvocationTargetException,
       InstantiationException {
-
     final Constructor<TcpClient> constructor = TcpClient.class.getConstructor(Properties.class);
     return constructor.newInstance(getDistributedSystemProperties());
   }

--- a/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandWithSSLMultiKeyTest.java
+++ b/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandWithSSLMultiKeyTest.java
@@ -127,7 +127,7 @@ public class ConnectCommandWithSSLMultiKeyTest {
     // should fail at connecting to locator stage
     assertThat(gfsh.getGfshOutput()).doesNotContain("Connecting to Manager at");
     assertThat(gfsh.getGfshOutput()).containsPattern(
-        "trying to connect a non-SSL-enabled client to an SSL-enabled locator|Broken pipe \\(Write failed\\)|Connection reset");
+        "Server expecting SSL handshake|Read timed out|Broken pipe \\(Write failed\\)|Connection reset");
 
     failToConnectWithoutSSLTo(locator.getJmxPort(), GfshCommandRule.PortType.jmxManager);
     assertThat(gfsh.getGfshOutput()).contains("non-JRMP server at remote endpoint");

--- a/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandWithSSLTest.java
+++ b/geode-web/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/ConnectCommandWithSSLTest.java
@@ -187,7 +187,7 @@ public class ConnectCommandWithSSLTest {
     // should fail at connecting to locator stage
     assertThat(gfsh.getGfshOutput()).doesNotContain("Connecting to Manager at");
     assertThat(gfsh.getGfshOutput()).containsPattern(
-        "trying to connect a non-SSL-enabled client to an SSL-enabled locator|Broken pipe \\(Write failed\\)|Connection reset");
+        "Server expecting SSL handshake|Read timed out|Broken pipe \\(Write failed\\)|Connection reset");
 
     failToConnectWithoutSSLTo(locator.getJmxPort(), GfshCommandRule.PortType.jmxManager);
     assertThat(gfsh.getGfshOutput()).contains("non-JRMP server at remote endpoint");
@@ -220,7 +220,7 @@ public class ConnectCommandWithSSLTest {
     failToConnectWithSSLTo(locator.getPort(), GfshCommandRule.PortType.locator);
     assertThat(gfsh.getGfshOutput()).doesNotContain("Connecting to Manager at");
     assertThat(gfsh.getGfshOutput()).containsPattern(
-        "trying to connect a non-SSL-enabled client to an SSL-enabled locator|Broken pipe \\(Write failed\\)|Connection reset");
+        "Server expecting SSL handshake|Read timed out|Broken pipe \\(Write failed\\)|Connection reset");
 
 
     // can connect to jmx


### PR DESCRIPTION
* IOExceptions thrown by the SSL layer will now bubble up to the
  appropriate handlers and cause retries on other locators.

* Refactored for better testing.

* Adds checked exception function utils.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
