### PR TITLE
GEODE-10083: Fix RedisProxy to correctly process MOVED responses

### DIFF
--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
@@ -17,6 +17,8 @@ package org.apache.geode.redis.internal.proxy;
 
 import java.net.InetSocketAddress;
 import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.Unpooled;
@@ -53,6 +55,7 @@ public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
   private final ClusterSlotsResponseProcessor slotsResponseProcessor;
   private final ClusterNodesResponseProcessor nodesResponseProcessor;
   private MovedResponseHandler movedResponseHandler;
+  private Queue<RedisResponseProcessor> processors;
 
   public RedisProxyInboundHandler(Channel inboundChannel, String remoteHost, int remotePort,
       Map<HostPort, HostPort> mappings) {
@@ -67,8 +70,9 @@ public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
   @Override
   public void channelActive(ChannelHandlerContext ctx) {
     Channel inboundChannel = ctx.channel();
-    outboundHandler = new RedisProxyOutboundHandler(inboundChannel);
-    movedResponseHandler = new MovedResponseHandler(inboundChannel, mappings);
+    processors = new LinkedBlockingQueue<>();
+    outboundHandler = new RedisProxyOutboundHandler(inboundChannel, processors);
+    movedResponseHandler = new MovedResponseHandler(inboundChannel, mappings, processors);
 
     // Start the connection attempt.
     Bootstrap b = new Bootstrap();
@@ -128,9 +132,9 @@ public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
         case "cluster":
           String sub = getArg(rMessage, 1);
           if ("slots".equals(sub)) {
-            outboundHandler.addResponseProcessor(slotsResponseProcessor);
+            processors.add(slotsResponseProcessor);
           } else if ("nodes".equals(sub)) {
-            outboundHandler.addResponseProcessor(nodesResponseProcessor);
+            processors.add(nodesResponseProcessor);
           }
           break;
         case "hello":
@@ -141,7 +145,7 @@ public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
           inboundChannel.writeAndFlush(error);
           return;
         default:
-          outboundHandler.addResponseProcessor(NoopRedisResponseProcessor.INSTANCE);
+          processors.add(NoopRedisResponseProcessor.INSTANCE);
       }
 
       outboundChannel.writeAndFlush(msg)

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyOutboundHandler.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyOutboundHandler.java
@@ -16,7 +16,6 @@
 package org.apache.geode.redis.internal.proxy;
 
 import java.util.Queue;
-import java.util.concurrent.LinkedBlockingQueue;
 
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
@@ -29,11 +28,13 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
 public class RedisProxyOutboundHandler extends ChannelInboundHandlerAdapter {
 
   private static final Logger logger = LogService.getLogger();
-  private final Queue<RedisResponseProcessor> processors = new LinkedBlockingQueue<>();
+  private final Queue<RedisResponseProcessor> processors;
   private final Channel inboundChannel;
 
-  public RedisProxyOutboundHandler(Channel inboundChannel) {
+  public RedisProxyOutboundHandler(Channel inboundChannel,
+      Queue<RedisResponseProcessor> processors) {
     this.inboundChannel = inboundChannel;
+    this.processors = processors;
   }
 
   @Override
@@ -71,7 +72,4 @@ public class RedisProxyOutboundHandler extends ChannelInboundHandlerAdapter {
     RedisProxyInboundHandler.closeOnFlush(ctx.channel());
   }
 
-  public void addResponseProcessor(RedisResponseProcessor processor) {
-    processors.add(processor);
-  }
 }


### PR DESCRIPTION
- When a MOVED response is received, the already queued processor needs
  to be discarded otherwise subsequent requests may possibly be
  corrupted.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
