### PR TITLE
GEODE-10089: update release scripts to handle 1.15

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -28,7 +28,7 @@ benchmarks:
   - title: 'with-ssl'
     flag: '-PwithSsl -PtestJVM=/usr/lib/jvm/bellsoft-java11-amd64'
     options: '--tests=org.apache.geode.benchmark.tests.*GetBenchmark --tests=org.apache.geode.benchmark.tests.*PutBenchmark'
-    max_in_flight: 1
+    max_in_flight: 2
     timeout: 5h
   - title: 'with-security-manager'
     flag: '-PwithSecurityManager'

--- a/dev-tools/release/commit_rc.sh
+++ b/dev-tools/release/commit_rc.sh
@@ -152,8 +152,9 @@ cd ${GEODE}/../..
 echo "1. In a separate terminal window, ${0%/*}/deploy_rc_pipeline.sh -v ${VERSION_MM}"
 echo "2. Monitor https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-support-${VERSION_MM//./-}-rc until all green"
 echo "3. If you haven't already, add a ${VERSION} section to https://cwiki.apache.org/confluence/display/GEODE/Release+Notes"
-jiraverid=$(curl -s 'https://issues.apache.org/jira/secure/ConfigureReleaseNote.jspa?projectId=12318420' | tr -d ' \n' | tr '<' '\n'| awk '/optionvalue.*'$VERSION'$/{sub(/optionvalue="/,"");sub(/">.*/,"");print}')
-echo "   The 'full list' link will be https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12318420&version=$jiraverid"
+JIRABASE=https://issues.apache.org/jira/secure
+jiraverid=$(curl -s $JIRABASE'/ConfigureReleaseNote.jspa?projectId=12318420' | tr -d ' \n' | tr '<' '\n'| awk '/optionvalue.*'$VERSION'$/{sub(/optionvalue="/,"");sub(/">.*/,"");print}')
+echo "   The 'full list' link will be $JIRABASE/ReleaseNote.jspa?projectId=12318420&version=$jiraverid"
 echo "4. Send the following email to announce the RC:"
 echo "To: dev@geode.apache.org"
 echo "Subject: [VOTE] Apache Geode ${FULL_VERSION}"

--- a/dev-tools/release/commit_rc.sh
+++ b/dev-tools/release/commit_rc.sh
@@ -152,6 +152,8 @@ cd ${GEODE}/../..
 echo "1. In a separate terminal window, ${0%/*}/deploy_rc_pipeline.sh -v ${VERSION_MM}"
 echo "2. Monitor https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-support-${VERSION_MM//./-}-rc until all green"
 echo "3. If you haven't already, add a ${VERSION} section to https://cwiki.apache.org/confluence/display/GEODE/Release+Notes"
+jiraverid=$(curl -s 'https://issues.apache.org/jira/secure/ConfigureReleaseNote.jspa?projectId=12318420' | tr -d ' \n' | tr '<' '\n'| awk '/optionvalue.*'$VERSION'$/{sub(/optionvalue="/,"");sub(/">.*/,"");print}')
+echo "   The 'full list' link will be https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12318420&version=$jiraverid"
 echo "4. Send the following email to announce the RC:"
 echo "To: dev@geode.apache.org"
 echo "Subject: [VOTE] Apache Geode ${FULL_VERSION}"

--- a/dev-tools/release/deploy_rc_pipeline.sh
+++ b/dev-tools/release/deploy_rc_pipeline.sh
@@ -47,8 +47,14 @@ else
     exit 1
 fi
 
+if [[ $VERSION_MM =~ ^(1\.1[0-4])$ ]]; then
+  needscmake=""
+else
+  needscmake="-e s/echo.skipping.latest.cmake.//"
+fi
+
 PIPEYML=$PWD/rc-pipeline.yml
-cat << "EOF" | sed -e "s/<VERSION_MM>/${VERSION_MM}/" > $PIPEYML
+cat << "EOF" | sed -e "s/<VERSION_MM>/${VERSION_MM}/" $needscmake > $PIPEYML
 ---
 
 resources:
@@ -297,6 +303,12 @@ jobs:
               tar xzf geode-bin.tgz
               apt-get update || true
               DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev zlib1g-dev
+
+              echo skipping latest cmake tmp=`mktemp`
+              echo skipping latest cmake curl -o ${tmp} -v -L https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.sh
+              echo skipping latest cmake bash ${tmp} --skip-license --prefix=/usr/local
+              echo skipping latest cmake rm -f ${tmp}
+
               #cmake wrongly assumes javah wasn't removed until JDK10, but adoptopenjdk removed it in JDK8
               echo '/opt/java/openjdk/bin/javac -h "$@"' > /opt/java/openjdk/bin/javah
               chmod +x /opt/java/openjdk/bin/javah
@@ -343,6 +355,12 @@ jobs:
               cd ..
               apt-get update || true
               DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev zlib1g-dev
+
+              echo skipping latest cmake tmp=`mktemp`
+              echo skipping latest cmake curl -o ${tmp} -v -L https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.sh
+              echo skipping latest cmake bash ${tmp} --skip-license --prefix=/usr/local
+              echo skipping latest cmake rm -f ${tmp}
+
               #cmake wrongly assumes javah wasn't removed until JDK10, but adoptopenjdk removed it in JDK8
               echo '/opt/java/openjdk/bin/javac -h "$@"' > /opt/java/openjdk/bin/javah
               chmod +x /opt/java/openjdk/bin/javah
@@ -503,10 +521,10 @@ jobs:
                 head -1 "${tld}/LICENSE" | grep -q "Apache License"
               }
               verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-${VERSION}-src          16000000  20000000
-              verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-${VERSION}             120000000 135000000
+              verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-${VERSION}             120000000 137000000
               verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-examples-${VERSION}-src   840000    900000
               verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-native-${VERSION}-src    2400000   3200000
-              verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-benchmarks-${VERSION}-src  85000    115000
+              verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-benchmarks-${VERSION}-src  85000    125000
               curl -L -s ${url}/ | awk '/>..</{next}/<li>/{gsub(/ *<[^>]*>/,"");print}' | sort > actual-file-list
               sort < exp > expected-file-list
               set +x

--- a/dev-tools/release/license_review.sh
+++ b/dev-tools/release/license_review.sh
@@ -83,7 +83,7 @@ function resolve() {
     spec=https://dist.apache.org/repos/dist/dev/geode/${spec}/apache-geode-${mmp}${suffix}.tgz
   elif [[ $spec =~ ^([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
     #bare released version -> release url
-    spec=https://downloads.apache.org/geode/${spec}/apache-geode-${spec}${suffix}.tgz
+    spec=https://archive.apache.org/dist/geode/${spec}/apache-geode-${spec}${suffix}.tgz
   elif echo "$spec" | grep -q '^http.*tgz$' ; then
     #tgz url
     echo "$spec" | grep -q -- "${suffix}.tgz$" || return
@@ -104,9 +104,9 @@ function resolve() {
 
   #extract it (if not already extracted)
   dirname=$(echo $spec | sed -e 's#.*/##' -e 's#.tgz$##')
-  [ "${licFromWs}" = "true" ] && rm -Rf ${EXTRACT}/$dirname
+  [ "${licFromWs}" = "true" ] && rm -Rf ${EXTRACT}/$dirname || true
   [ -d ${EXTRACT}/$dirname ] || tar xzf $spec -C ${EXTRACT}
-  [ -d ${EXTRACT}/$dirname ] && echo ${EXTRACT}/$dirname
+  [ -d ${EXTRACT}/$dirname ] && echo ${EXTRACT}/$dirname || true
 }
 
 NEW_DIR=$(resolve $NEW_VERSION)

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -266,7 +266,10 @@ rm Dockerfile.bak
 set -x
 git add Dockerfile
 git diff --staged --color | cat
-git commit -m "$JIRA: update Dockerfile to apache-geode ${VERSION}"
+git commit -m "$JIRA: update Dockerfile to apache-geode ${VERSION}
+
+The Dockerfile is updated _after_ the release is already tagged,
+because it needs to embed the sha256 of the release"
 git push
 set +x
 

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -484,11 +484,18 @@ else
 fi
 rm settings.gradle.bak
 
+action="Add"
+ser=""
 if [ $PATCH -ne 0 ] ; then
   #if the serialization version has not changed, we can drop the previous patch
   if [ "$cursver" = "$prevsver" ] ; then
     sed -e "/'${PREV}'/d" -i.bak settings.gradle
     rm settings.gradle.bak
+    action="Replace ${PREV} with"
+    ser="
+
+The serialization version has not changed between ${PREV} and ${VERSION},
+so there should be no need to keep both"
   fi
 fi
 
@@ -508,9 +515,10 @@ fi
 set -x
 git add settings.gradle
 git diff --staged --color | cat
-git commit -m "$JIRA: Add ${VERSION} as old version
+git commit -m "$JIRA: ${action} ${VERSION} as old version
 
-Adds ${VERSION} to old versions${BENCHMSG} on develop"
+${action} ${VERSION} in old versions${BENCHMSG} on develop
+to enable rolling upgrade tests from ${VERSION}${ser}"
 git push -u myfork
 set +x
 
@@ -529,11 +537,18 @@ sed -e "s/].each/,\\
  '${VERSION}'].each/" \
   -i.bak settings.gradle
 rm settings.gradle.bak
+action="Add"
+ser=""
 if [ $PATCH -ne 0 ] ; then
   #if the serialization version has not changed, we can drop the previous patch
   if [ "$cursver" = "$prevsver" ] ; then
     sed -e "/'${PREV}'/d" -i.bak settings.gradle
     rm settings.gradle.bak
+    action="Replace ${PREV} with"
+    ser="
+
+The serialization version has not changed between ${PREV} and ${VERSION},
+so there should be no need to keep both"
   fi
 else
   #also update benchmark baseline for support branch to its new minor
@@ -552,9 +567,10 @@ fi
 set -x
 git add settings.gradle
 git diff --staged --color | cat
-git commit -m "$JIRA: Add ${VERSION} as old version
+git commit -m "$JIRA: ${action} ${VERSION} as old version
 
-Adds ${VERSION} to old versions${BENCHMSG2} on support/$VERSION_MM"
+${action} ${VERSION} in old versions${BENCHMSG2} on support/$VERSION_MM
+to enable rolling upgrade tests from ${VERSION}${ser}"
 git push
 set +x
 

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -202,8 +202,12 @@ function waitforserver {
     fi
     url=${baseurl}${suffix}
     expectedsize=$(cd ${SVN_DIR}/../../release/geode/${VERSION}; ls -l ${file}${suffix} | awk '{print $5}')
+    if [ -z "$expectedsize" ] ; then
+      echo "internal error: unable to get size of ${SVN_DIR}/../../release/geode/${VERSION}/${file}${suffix}"
+      exit 1
+    fi
     actualsize=0
-    while [ $expectedsize -ne $actualsize ] ; do
+    while [ "$expectedsize" -ne "$actualsize" ] ; do
       while ! curl -sk --output /dev/null --head --fail "$url"; do
         echo -n .
         sleep 12
@@ -611,7 +615,7 @@ echo "Removing old Geode versions from mirrors"
 echo "============================================================"
 set -x
 cd ${SVN_DIR}/../../release/geode
-svn update --set-depth immediates
+svn update
 #identify the latest patch release for "N-2" (the latest 3 major.minor releases), remove anything else from mirrors (all releases remain available on non-mirrored archive site)
 RELEASES_TO_KEEP=3
 set +x
@@ -687,4 +691,5 @@ echo 'Send email!  Note: MUST be sent from your @apache.org email address (see h
 ${0%/*}/print_announce_email.sh -v "${VERSION}" -f "${LATER}"
 echo ""
 which pbcopy >/dev/null && ${0%/*}/print_announce_email.sh -v "${VERSION}" -f "${LATER}" | pbcopy && echo "(copied to clipboard)"
-waitforserver "dlcdn.apache.org/geode" "Please wait for this to complete before sending the announce email."
+waitforserver "dlcdn.apache.org/geode" "Please wait for this to complete before sending the above [ANNOUNCE] email.
+All other tasks above can be completed now (while you wait for dlcdn)."

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -179,17 +179,22 @@ for DIR in ${GEODE} ${GEODE_EXAMPLES} ${GEODE_NATIVE} ${GEODE_BENCHMARKS} ; do
 done
 
 
-for server in dlcdn.apache.org/geode downloads.apache.org/geode repo1.maven.org/maven2/org/apache/geode/apache-geode ; do
+function waitforserver {
+  server="$1"
+  msg="$2"
   file=apache-geode-${VERSION}.tgz
   baseurl=https://${server}/${VERSION}/${file}
   echo ""
   echo "============================================================"
   echo "Waiting for ${baseurl} to appear..."
-  if  echo "${server}" | grep -q repo1 ; then
+  if echo "${server}" | grep -q repo1 ; then
     echo "(may take up to one hour after clicking 'Release' on http://repository.apache.org/ )"
+  elif echo "${server}" | grep -q dlcdn ; then
+    echo "(may take a few hours)"
   else
     echo "(may take up to 15 minutes)"
   fi
+  [ -z "$msg" ] || echo "$msg"
   echo "============================================================"
   for suffix in "" .asc .sha256 ; do
     if [ "${suffix}" = ".sha256" ] && echo "${server}" | grep -q repo1 ; then
@@ -207,6 +212,9 @@ for server in dlcdn.apache.org/geode downloads.apache.org/geode repo1.maven.org/
     done
     echo "$url exists and is correct size"
   done
+}
+for server in downloads.apache.org/geode repo1.maven.org/maven2/org/apache/geode/apache-geode ; do
+  waitforserver "$server"
 done
 
 
@@ -662,3 +670,4 @@ echo 'Send email!  Note: MUST be sent from your @apache.org email address (see h
 ${0%/*}/print_announce_email.sh -v "${VERSION}" -f "${LATER}"
 echo ""
 which pbcopy >/dev/null && ${0%/*}/print_announce_email.sh -v "${VERSION}" -f "${LATER}" | pbcopy && echo "(copied to clipboard)"
+waitforserver "dlcdn.apache.org/geode" "Please wait for this to complete before sending the announce email."

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -213,9 +213,8 @@ function waitforserver {
     echo "$url exists and is correct size"
   done
 }
-for server in downloads.apache.org/geode repo1.maven.org/maven2/org/apache/geode/apache-geode ; do
-  waitforserver "$server"
-done
+
+waitforserver "downloads.apache.org/geode"
 
 
 echo ""
@@ -636,6 +635,8 @@ touch ../did.remove
 DID_REMOVE=$(cat ../did.remove)
 rm ../keep ../did.remove
 
+
+waitforserver "repo1.maven.org/maven2/org/apache/geode/apache-geode"
 
 echo ""
 NEWVERSION="${VERSION_MM}.$(( PATCH + 1 ))"


### PR DESCRIPTION
* increased RC pipeline file size check limits as 1.15 is a little bigger than 1.14
* modified RC pipeline native builds to obtain a required newer cmake than what is distributed by Ubuntu
