### PR TITLE
GEODE-10087: Enhance off-heap fragmentation visibility.

### DIFF
--- a/buildSrc/src/main/resources/japicmp_exceptions.json
+++ b/buildSrc/src/main/resources/japicmp_exceptions.json
@@ -1,9 +1,13 @@
 {
   "Class org.apache.geode.management.builder.GeodeClusterManagementServiceBuilder": "Moved internal class to fix split packages between geode-core and geode-management",
   "Class org.apache.geode.management.api.ClusterManagementOperation": "Fixed missing @Experimental annotation",
+  "Class org.apache.geode.management.MemberMXBean": "Added new stats",
   "Method org.apache.geode.management.api.ClusterManagementOperation.getEndpoint()": "Fixed missing @Experimental annotation",
   "Method org.apache.geode.management.api.ClusterManagementOperation.getOperator()": "Fixed missing @Experimental annotation",
   "Class org.apache.geode.cache.query.IndexStatistics": "Added new methods.",
   "Method org.apache.geode.cache.query.IndexStatistics.getNumberOfBucketIndexesLong()": "Added new methods.",
-  "Method org.apache.geode.cache.query.IndexStatistics.getReadLockCountLong()": "Added new methods."
+  "Method org.apache.geode.cache.query.IndexStatistics.getReadLockCountLong()": "Added new methods.",
+  "Method org.apache.geode.management.MemberMXBean.getOffHeapFragments()": "Added new stat",
+  "Method org.apache.geode.management.MemberMXBean.getOffHeapFreedChunks()": "Added new stat",
+  "Method org.apache.geode.management.MemberMXBean.getOffHeapLargestFragment()": "Added new stat"
 }

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanAttributesDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanAttributesDistributedTest.java
@@ -23,6 +23,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.JMX_MANAGER_START;
+import static org.apache.geode.distributed.ConfigurationProperties.OFF_HEAP_MEMORY_SIZE;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLE_RATE;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLING_ENABLED;
 import static org.apache.geode.internal.process.ProcessUtils.identifyPidAsUnchecked;
@@ -41,6 +42,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache30.CacheTestCase;
 import org.apache.geode.internal.NanoTimer;
+import org.apache.geode.internal.offheap.MemoryAllocatorImpl;
 import org.apache.geode.internal.statistics.HostStatSampler;
 import org.apache.geode.internal.statistics.SampleCollector;
 import org.apache.geode.management.internal.SystemManagementService;
@@ -162,6 +164,50 @@ public class MemberMXBeanAttributesDistributedTest extends CacheTestCase {
     assertThat(memberMXBean.isManagerCreated()).isFalse();
   }
 
+  @Test
+  public void testOffHeapMemoryAttributes() {
+    MemberMXBean memberMXBean = getSystemManagementService().getMemberMXBean();
+    sampleStatistics();
+
+    int initialLargestFragment = (int) (((4096 * BYTES_PER_MEGABYTE) / 2) - 1);
+    assertThat(memberMXBean.getOffHeapFragments()).isEqualTo(2);
+    assertThat(memberMXBean.getOffHeapLargestFragment()).isEqualTo(initialLargestFragment);
+    assertThat(memberMXBean.getOffHeapFreedChunks()).isEqualTo(0);
+
+    RegionFactory regionFactory =
+        getCache().createRegionFactory(PARTITION_REDUNDANT);
+    regionFactory.setConcurrencyChecksEnabled(false);
+    regionFactory.setOffHeap(true);
+
+    regionFactory.create("testPRRegion1");
+    Region region1 = getCache().getRegion(SEPARATOR + "testPRRegion1");
+
+    // fill first fragment
+    int hugeAllocations = 100;
+    for (int i = 0; i < hugeAllocations; i++) {
+      region1.put(i + 10, new byte[initialLargestFragment / hugeAllocations]);
+    }
+    for (int i = 0; i < hugeAllocations; i++) {
+      region1.remove(i + 10);
+    }
+
+    region1.put(1, new byte[100]);
+    region1.remove(1);
+    // Release the memory of the object so that the next allocation reuses the freed chunk
+    region1.put(2, new byte[100]);
+    region1.remove(2);
+    region1.put(3, new byte[200]);
+    region1.remove(3);
+
+    sampleStatistics();
+
+    assertThat(memberMXBean.getOffHeapFragments()).isEqualTo(2);
+    await().untilAsserted(() -> assertThat(memberMXBean.getOffHeapLargestFragment())
+        .isLessThan(initialLargestFragment));
+    await().untilAsserted(
+        () -> assertThat(memberMXBean.getOffHeapFreedChunks()).isEqualTo(hugeAllocations + 2));
+  }
+
   @Override
   public Properties getDistributedSystemProperties() {
     Properties props = new Properties();
@@ -174,7 +220,10 @@ public class MemberMXBeanAttributesDistributedTest extends CacheTestCase {
   }
 
   private void createMember() {
-    getCache(getDistributedSystemProperties());
+    Properties props = getDistributedSystemProperties();
+    props.setProperty(OFF_HEAP_MEMORY_SIZE, "4096");
+    MemoryAllocatorImpl.setUpdateOffHeapStatsFrequencyMs(1000);
+    getCache(props);
   }
 
   private void createManager() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanAttributesDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/MemberMXBeanAttributesDistributedTest.java
@@ -42,11 +42,11 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.cache.RegionFactory;
 import org.apache.geode.cache30.CacheTestCase;
 import org.apache.geode.internal.NanoTimer;
-import org.apache.geode.internal.offheap.MemoryAllocatorImpl;
 import org.apache.geode.internal.statistics.HostStatSampler;
 import org.apache.geode.internal.statistics.SampleCollector;
 import org.apache.geode.management.internal.SystemManagementService;
 import org.apache.geode.test.dunit.rules.DistributedRestoreSystemProperties;
+import org.apache.geode.util.internal.GeodeGlossary;
 
 /**
  * Distributed tests for {@link MemberMXBean} attributes.
@@ -222,7 +222,7 @@ public class MemberMXBeanAttributesDistributedTest extends CacheTestCase {
   private void createMember() {
     Properties props = getDistributedSystemProperties();
     props.setProperty(OFF_HEAP_MEMORY_SIZE, "4096");
-    MemoryAllocatorImpl.setUpdateOffHeapStatsFrequencyMs(1000);
+    System.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "off-heap-stats-update-frequency-ms", "1000");
     getCache(props);
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/FreeListManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/FreeListManager.java
@@ -544,8 +544,7 @@ public class FreeListManager {
     for (int i = 0; i < tinyFreeLists.length(); i++) {
       OffHeapStoredObjectAddressStack cl = tinyFreeLists.get(i);
       if (cl != null) {
-        int length = cl.getLength();
-        fragmentCount += length;
+        fragmentCount += cl.size();
       }
     }
     return fragmentCount;
@@ -558,18 +557,12 @@ public class FreeListManager {
   private int getLargestFragment() {
     int largestFreeSpaceFromFragments = 0;
     for (Fragment f : fragmentList) {
-      int offset = f.getFreeIndex();
-      int diff = f.getSize() - offset;
-      if (diff < OffHeapStoredObject.MIN_CHUNK_SIZE) {
-        assert diff == 0;
-        continue;
-      }
-      if (diff > largestFreeSpaceFromFragments) {
-        largestFreeSpaceFromFragments = diff;
+      int fragmentFreeSpace = f.freeSpace();
+      if (fragmentFreeSpace > largestFreeSpaceFromFragments) {
+        largestFreeSpaceFromFragments = fragmentFreeSpace;
       }
     }
     return largestFreeSpaceFromFragments;
-
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/FreeListManager.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/FreeListManager.java
@@ -526,7 +526,7 @@ public class FreeListManager {
   }
 
   public void updateNonRealTimeStats() {
-    ma.getStats().setLargestFragment(getLargestFragment());
+    ma.getStats().setLargestFragment(largestFragmentSize());
     ma.getStats().setFreedChunks(getFreedChunks());
   }
 
@@ -554,7 +554,7 @@ public class FreeListManager {
     return hugeChunkSet.size();
   }
 
-  private int getLargestFragment() {
+  private int largestFragmentSize() {
     int largestFreeSpaceFromFragments = 0;
     for (Fragment f : fragmentList) {
       int fragmentFreeSpace = f.freeSpace();

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapMemoryStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapMemoryStats.java
@@ -43,6 +43,8 @@ public interface OffHeapMemoryStats {
 
   void setFragmentation(int value);
 
+  void setFreedChunks(int value);
+
   long getFreeMemory();
 
   long getMaxMemory();
@@ -58,6 +60,8 @@ public interface OffHeapMemoryStats {
   int getDefragmentationsInProgress();
 
   long getFragments();
+
+  long getFreedChunks();
 
   int getLargestFragment();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapMemoryStats.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapMemoryStats.java
@@ -43,7 +43,7 @@ public interface OffHeapMemoryStats {
 
   void setFragmentation(int value);
 
-  void setFreedChunks(int value);
+  void setFreedChunks(long value);
 
   long getFreeMemory();
 

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapStorage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapStorage.java
@@ -61,6 +61,7 @@ public class OffHeapStorage implements OffHeapMemoryStats {
   private static final int defragmentationTimeId;
   private static final int fragmentationId;
   private static final int defragmentationsInProgressId;
+  private static final int freedChunksId;
   // NOTE!!!! When adding new stats make sure and update the initialize method on this class
 
   // creates and registers the statistics type
@@ -78,10 +79,12 @@ public class OffHeapStorage implements OffHeapMemoryStats {
         "The percentage of off-heap free memory that is fragmented.  Updated every time a defragmentation is performed.";
     final String fragmentsDesc =
         "The number of fragments of free off-heap memory. Updated every time a defragmentation is done.";
+    final String freedChunksDesc =
+        "The number of off-heap memory chunks that have been freed since the last defragmentation and that are not currently being used to store an object in the off-heap memory space. Updated every time a defragmentation is done and periodically according to update-off-heap-stats-frequency-ms system property (default 3600 seconds).";
     final String freeMemoryDesc =
         "The amount of off-heap memory, in bytes, that is not being used.";
     final String largestFragmentDesc =
-        "The largest fragment of memory found by the last defragmentation of off heap memory. Updated every time a defragmentation is done.";
+        "The largest fragment of off-heap memory that can be used to allocate an object. Updated every time a defragmentation is done and periodically according to update-off-heap-stats-frequency-ms system property (default 3600 seconds)";
     final String objectsDesc = "The number of objects stored in off-heap memory.";
     final String readsDesc =
         "The total number of reads of off-heap memory. Only reads of a full object increment this statistic. If only a part of the object is read this statistic is not incremented.";
@@ -94,6 +97,7 @@ public class OffHeapStorage implements OffHeapMemoryStats {
     final String defragmentationTime = "defragmentationTime";
     final String fragmentation = "fragmentation";
     final String fragments = "fragments";
+    final String freedChunks = "freedChunks";
     final String freeMemory = "freeMemory";
     final String largestFragment = "largestFragment";
     final String objects = "objects";
@@ -108,6 +112,7 @@ public class OffHeapStorage implements OffHeapMemoryStats {
             f.createLongCounter(defragmentationTime, defragmentationTimeDesc, "nanoseconds", false),
             f.createIntGauge(fragmentation, fragmentationDesc, "percentage"),
             f.createLongGauge(fragments, fragmentsDesc, "fragments"),
+            f.createLongGauge(freedChunks, freedChunksDesc, "freedChunks"),
             f.createLongGauge(freeMemory, freeMemoryDesc, "bytes"),
             f.createIntGauge(largestFragment, largestFragmentDesc, "bytes"),
             f.createIntGauge(objects, objectsDesc, "objects"),
@@ -116,6 +121,7 @@ public class OffHeapStorage implements OffHeapMemoryStats {
 
     usedMemoryId = statsType.nameToId(usedMemory);
     defragmentationId = statsType.nameToId(defragmentations);
+    freedChunksId = statsType.nameToId(freedChunks);
     defragmentationsInProgressId = statsType.nameToId(defragmentationsInProgress);
     defragmentationTimeId = statsType.nameToId(defragmentationTime);
     fragmentationId = statsType.nameToId(fragmentation);
@@ -343,6 +349,11 @@ public class OffHeapStorage implements OffHeapMemoryStats {
   }
 
   @Override
+  public long getFreedChunks() {
+    return this.stats.getLong(freedChunksId);
+  }
+
+  @Override
   public void setLargestFragment(int value) {
     stats.setInt(largestFragmentId, value);
   }
@@ -381,6 +392,12 @@ public class OffHeapStorage implements OffHeapMemoryStats {
   public void setFragmentation(int value) {
     stats.setInt(fragmentationId, value);
   }
+
+  @Override
+  public void setFreedChunks(int value) {
+    this.stats.setInt(freedChunksId, value);
+  }
+
 
   @Override
   public int getFragmentation() {

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapStoredObjectAddressStack.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapStoredObjectAddressStack.java
@@ -27,7 +27,8 @@ public class OffHeapStoredObjectAddressStack implements LongStack {
   // Ok to read without sync but must be synced on write
   private volatile long topAddr;
 
-  private volatile int length = 0;
+  // Ok to read without sync but must be synced on write
+  private volatile int size = 0;
 
   public OffHeapStoredObjectAddressStack(long addr) {
     if (addr != 0L) {
@@ -50,12 +51,12 @@ public class OffHeapStoredObjectAddressStack implements LongStack {
     synchronized (this) {
       OffHeapStoredObject.setNext(e, topAddr);
       topAddr = e;
-      length++;
+      size++;
     }
   }
 
-  public int getLength() {
-    return length;
+  public int size() {
+    return size;
   }
 
   @Override
@@ -65,7 +66,7 @@ public class OffHeapStoredObjectAddressStack implements LongStack {
       result = topAddr;
       if (result != 0L) {
         topAddr = OffHeapStoredObject.getNext(result);
-        length--;
+        size--;
       }
 
     }
@@ -90,7 +91,7 @@ public class OffHeapStoredObjectAddressStack implements LongStack {
       if (result != 0L) {
         topAddr = 0L;
       }
-      length = 0;
+      size = 0;
     }
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapStoredObjectAddressStack.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/offheap/OffHeapStoredObjectAddressStack.java
@@ -27,6 +27,8 @@ public class OffHeapStoredObjectAddressStack implements LongStack {
   // Ok to read without sync but must be synced on write
   private volatile long topAddr;
 
+  private volatile int length = 0;
+
   public OffHeapStoredObjectAddressStack(long addr) {
     if (addr != 0L) {
       MemoryAllocatorImpl.validateAddress(addr);
@@ -48,7 +50,12 @@ public class OffHeapStoredObjectAddressStack implements LongStack {
     synchronized (this) {
       OffHeapStoredObject.setNext(e, topAddr);
       topAddr = e;
+      length++;
     }
+  }
+
+  public int getLength() {
+    return length;
   }
 
   @Override
@@ -58,7 +65,9 @@ public class OffHeapStoredObjectAddressStack implements LongStack {
       result = topAddr;
       if (result != 0L) {
         topAddr = OffHeapStoredObject.getNext(result);
+        length--;
       }
+
     }
     return result;
   }
@@ -81,6 +90,7 @@ public class OffHeapStoredObjectAddressStack implements LongStack {
       if (result != 0L) {
         topAddr = 0L;
       }
+      length = 0;
     }
     return result;
   }

--- a/geode-core/src/main/java/org/apache/geode/management/MemberMXBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/MemberMXBean.java
@@ -877,6 +877,12 @@ public interface MemberMXBean {
    */
   int getOffHeapFragmentation();
 
+  long getOffHeapFragments();
+
+  long getOffHeapFreedChunks();
+
+  int getOffHeapLargestFragment();
+
   /**
    * Returns the total time spent compacting in milliseconds.
    */

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/MemberMBean.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/MemberMBean.java
@@ -696,6 +696,18 @@ public class MemberMBean extends NotificationBroadcasterSupport implements Membe
     return bridge.getOffHeapFragmentation();
   }
 
+  public long getOffHeapFragments() {
+    return bridge.getOffHeapFragments();
+  }
+
+  public long getOffHeapFreedChunks() {
+    return bridge.getOffHeapFreedChunks();
+  }
+
+  public int getOffHeapLargestFragment() {
+    return bridge.getOffHeapLargestFragment();
+  }
+
   @Override
   public long getOffHeapCompactionTime() {
     return bridge.getOffHeapCompactionTime();

--- a/geode-core/src/main/java/org/apache/geode/management/internal/beans/MemberMBeanBridge.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/beans/MemberMBeanBridge.java
@@ -1352,6 +1352,36 @@ public class MemberMBeanBridge {
     return 0;
   }
 
+  long getOffHeapFragments() {
+    OffHeapMemoryStats stats = getOffHeapStats();
+
+    if (null != stats) {
+      return stats.getFragments();
+    }
+
+    return 0;
+  }
+
+  long getOffHeapFreedChunks() {
+    OffHeapMemoryStats stats = getOffHeapStats();
+
+    if (null != stats) {
+      return stats.getFreedChunks();
+    }
+
+    return 0;
+  }
+
+  int getOffHeapLargestFragment() {
+    OffHeapMemoryStats stats = getOffHeapStats();
+
+    if (null != stats) {
+      return stats.getLargestFragment();
+    }
+
+    return 0;
+  }
+
   long getOffHeapCompactionTime() {
     OffHeapMemoryStats stats = getOffHeapStats();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapStorageNonRuntimeStatsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapStorageNonRuntimeStatsJUnitTest.java
@@ -29,9 +29,8 @@ public class OffHeapStorageNonRuntimeStatsJUnitTest {
   public void testUpdateNonRealTimeOffHeapStorageStats() {
     StatisticsFactory localStatsFactory = new LocalStatisticsFactory(null);
     OutOfOffHeapMemoryListener ooohml = mock(OutOfOffHeapMemoryListener.class);
-    MemoryAllocatorImpl.setUpdateOffHeapStatsFrequencyMs(100);
     MemoryAllocator ma =
-        OffHeapStorage.basicCreateOffHeapStorage(localStatsFactory, 1024 * 1024, ooohml);
+        OffHeapStorage.basicCreateOffHeapStorage(localStatsFactory, 1024 * 1024, ooohml, 100);
     try {
       OffHeapMemoryStats stats = ma.getStats();
 

--- a/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapStorageNonRuntimeStatsJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/offheap/OffHeapStorageNonRuntimeStatsJUnitTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.offheap;
+
+import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import org.apache.geode.StatisticsFactory;
+import org.apache.geode.internal.statistics.LocalStatisticsFactory;
+
+public class OffHeapStorageNonRuntimeStatsJUnitTest {
+
+  @Test
+  public void testUpdateNonRealTimeOffHeapStorageStats() {
+    StatisticsFactory localStatsFactory = new LocalStatisticsFactory(null);
+    OutOfOffHeapMemoryListener ooohml = mock(OutOfOffHeapMemoryListener.class);
+    MemoryAllocatorImpl.setUpdateOffHeapStatsFrequencyMs(100);
+    MemoryAllocator ma =
+        OffHeapStorage.basicCreateOffHeapStorage(localStatsFactory, 1024 * 1024, ooohml);
+    try {
+      OffHeapMemoryStats stats = ma.getStats();
+
+      assertThat(stats.getFreeMemory()).isEqualTo(1024 * 1024);
+      assertThat(stats.getMaxMemory()).isEqualTo(1024 * 1024);
+      assertThat(stats.getUsedMemory()).isEqualTo(0);
+      assertThat(stats.getFragments()).isEqualTo(1);
+      assertThat(stats.getLargestFragment()).isEqualTo(1024 * 1024);
+      assertThat(stats.getFreedChunks()).isEqualTo(0);
+
+      FreeListManager freeListManager = ((MemoryAllocatorImpl) ma).getFreeListManager();
+      StoredObject storedObject1 = ma.allocate(10);
+      // Release the memory of the object so that the next allocation reuses the freed chunk
+      ReferenceCounter.release(storedObject1.getAddress(), freeListManager);
+      StoredObject storedObject2 = ma.allocate(10);
+      StoredObject storedObject3 = ma.allocate(10);
+
+      assertThat(stats.getFreeMemory()).isLessThan(1024 * 1024);
+      assertThat(stats.getUsedMemory()).isGreaterThan(0);
+      await().untilAsserted(() -> assertThat(stats.getLargestFragment()).isLessThan(1024 * 1024));
+      await().untilAsserted(() -> assertThat(stats.getFreedChunks()).isEqualTo(0));
+
+      ReferenceCounter.release(storedObject3.getAddress(), freeListManager);
+      ReferenceCounter.release(storedObject2.getAddress(), freeListManager);
+
+      assertThat(stats.getFreeMemory()).isEqualTo(1024 * 1024);
+      assertThat(stats.getUsedMemory()).isEqualTo(0);
+      await().untilAsserted(() -> assertThat(stats.getLargestFragment()).isLessThan(1024 * 1024));
+      await().untilAsserted(() -> assertThat(stats.getFreedChunks()).isEqualTo(2));
+    } finally {
+      System.setProperty(MemoryAllocatorImpl.FREE_OFF_HEAP_MEMORY_PROPERTY, "true");
+      try {
+        ma.close();
+      } finally {
+        System.clearProperty(MemoryAllocatorImpl.FREE_OFF_HEAP_MEMORY_PROPERTY);
+      }
+    }
+  }
+}

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/ShowMetricsCommand.java
@@ -502,6 +502,13 @@ public class ShowMetricsCommand extends GfshCommand {
       writeToTableAndCsv(metricsTable, "", "objects", memberMxBean.getOffHeapObjects(), csvBuilder);
       writeToTableAndCsv(metricsTable, "", "fragmentation", memberMxBean.getOffHeapFragmentation(),
           csvBuilder);
+      writeToTableAndCsv(metricsTable, "", "largestFragment",
+          memberMxBean.getOffHeapLargestFragment(),
+          csvBuilder);
+      writeToTableAndCsv(metricsTable, "", "fragments", memberMxBean.getOffHeapFragments(),
+          csvBuilder);
+      writeToTableAndCsv(metricsTable, "", "freedChunks", memberMxBean.getOffHeapFreedChunks(),
+          csvBuilder);
       writeToTableAndCsv(metricsTable, "", "compactionTime",
           memberMxBean.getOffHeapCompactionTime(), csvBuilder);
     }

--- a/geode-junit/src/main/java/org/apache/geode/internal/offheap/NullOffHeapMemoryStats.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/offheap/NullOffHeapMemoryStats.java
@@ -112,7 +112,7 @@ public class NullOffHeapMemoryStats implements OffHeapMemoryStats {
   public void setFragmentation(int value) {}
 
   @Override
-  public void setFreedChunks(int value) {}
+  public void setFreedChunks(long value) {}
 
   @Override
   public int getFragmentation() {

--- a/geode-junit/src/main/java/org/apache/geode/internal/offheap/NullOffHeapMemoryStats.java
+++ b/geode-junit/src/main/java/org/apache/geode/internal/offheap/NullOffHeapMemoryStats.java
@@ -88,6 +88,11 @@ public class NullOffHeapMemoryStats implements OffHeapMemoryStats {
   }
 
   @Override
+  public long getFreedChunks() {
+    return 0;
+  }
+
+  @Override
   public void setLargestFragment(int value) {}
 
   @Override
@@ -105,6 +110,9 @@ public class NullOffHeapMemoryStats implements OffHeapMemoryStats {
 
   @Override
   public void setFragmentation(int value) {}
+
+  @Override
+  public void setFreedChunks(int value) {}
 
   @Override
   public int getFragmentation() {


### PR DESCRIPTION
As per RFC https://cwiki.apache.org/confluence/display/GEODE/Enhance+Off-heap+memory+fragmentation+visibility
Geode's off-heap fragmentation visibility has been improved
by adding a new stat: "freedChunks" as well as
by the periodic update of the "largestFragment" stat.

The new one stat will also be periodically updated
with a default frequency of one hour that can be changed by the
update-off-heap-stats-frequency-ms system property.

Besides, the new stat, the "fragments" and the "largestFragment" stats
will be published via JMX.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
