### PR TITLE
GEODE-10094: Fix NPE when populating index in partitioned region.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -8581,7 +8581,8 @@ public class PartitionedRegion extends LocalRegion
     }
   }
 
-  private boolean populateEmptyIndexes(Set<Index> indexes,
+  @VisibleForTesting
+  boolean populateEmptyIndexes(Set<Index> indexes,
       HashMap<String, Exception> exceptionsMap) {
     boolean throwException = false;
     if (getDataStore() != null && indexes.size() > 0) {
@@ -8594,6 +8595,9 @@ public class PartitionedRegion extends LocalRegion
           continue;
         }
         IndexManager bucketIndexManager = IndexUtils.getIndexManager(cache, bucket, true);
+        if (bucketIndexManager == null) {
+          cache.getCancelCriterion().checkCancelInProgress();
+        }
         Set<Index> bucketIndexes = getBucketIndexesForPRIndexes(bucket, indexes);
         try {
           bucketIndexManager.populateIndexes(bucketIndexes);
@@ -8606,7 +8610,8 @@ public class PartitionedRegion extends LocalRegion
     return throwException;
   }
 
-  private Set<Index> getBucketIndexesForPRIndexes(Region bucket, Set<Index> indexes) {
+  @VisibleForTesting
+  Set<Index> getBucketIndexesForPRIndexes(Region bucket, Set<Index> indexes) {
     Set<Index> bucketIndexes = new HashSet<>();
     for (Index ind : indexes) {
       bucketIndexes.addAll(((PartitionedIndex) ind).getBucketIndexes(bucket));

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/PartitionedRegionTest.java
@@ -56,7 +56,6 @@ import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
 import org.apache.geode.CancelCriterion;
-import org.apache.geode.CancelException;
 import org.apache.geode.Statistics;
 import org.apache.geode.cache.AttributesFactory;
 import org.apache.geode.cache.CacheClosedException;
@@ -658,7 +657,7 @@ public class PartitionedRegionTest {
     setupCancelCriterion(cacheClosedException);
 
     assertThatThrownBy(() -> spyPartitionedRegion.populateEmptyIndexes(indexes, new HashMap<>()))
-        .isInstanceOf(CancelException.class).isEqualTo(cacheClosedException);
+        .isEqualTo(cacheClosedException);
   }
 
   @NotNull


### PR DESCRIPTION
  * IndexUtils.getIndexManager can return null if bucket region is
    destroyed due to cache is closing. Make sure CancelException is
    thrown in this case.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
