### PR TITLE
GEODE-10103: Retrieve full region path names

### DIFF
--- a/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RebalanceManagementDunitTest.java
+++ b/geode-assembly/src/distributedTest/java/org/apache/geode/management/internal/rest/RebalanceManagementDunitTest.java
@@ -100,7 +100,8 @@ public class RebalanceManagementDunitTest {
     RebalanceResult result = endResult.getOperationResult();
     assertThat(result.getRebalanceRegionResults().size()).isEqualTo(2);
     RebalanceRegionResult firstRegionSummary = result.getRebalanceRegionResults().get(0);
-    assertThat(firstRegionSummary.getRegionName()).isIn("customers1", "customers2");
+    assertThat(firstRegionSummary.getRegionName()).isIn(SEPARATOR + "customers1",
+        SEPARATOR + "customers2");
   }
 
   @Test
@@ -117,7 +118,7 @@ public class RebalanceManagementDunitTest {
         .getOperationResult();
     assertThat(result.getRebalanceRegionResults().size()).isEqualTo(1);
     RebalanceRegionResult firstRegionSummary = result.getRebalanceRegionResults().get(0);
-    assertThat(firstRegionSummary.getRegionName()).isEqualTo("customers2");
+    assertThat(firstRegionSummary.getRegionName()).isEqualTo(SEPARATOR + "customers2");
     assertThat(firstRegionSummary.getBucketCreateBytes()).isEqualTo(0);
     assertThat(firstRegionSummary.getTimeInMilliseconds()).isGreaterThanOrEqualTo(0);
 
@@ -137,7 +138,7 @@ public class RebalanceManagementDunitTest {
             .getOperationResult();
     assertThat(result.getRebalanceRegionResults().size()).isEqualTo(1);
     RebalanceRegionResult firstRegionSummary = result.getRebalanceRegionResults().get(0);
-    assertThat(firstRegionSummary.getRegionName()).isEqualTo("customers2");
+    assertThat(firstRegionSummary.getRegionName()).isEqualTo(SEPARATOR + "customers2");
     assertThat(firstRegionSummary.getBucketCreateBytes()).isEqualTo(0);
     assertThat(firstRegionSummary.getTimeInMilliseconds()).isGreaterThanOrEqualTo(0);
   }
@@ -195,7 +196,7 @@ public class RebalanceManagementDunitTest {
         .getOperationResult();
     assertThat(result.getRebalanceRegionResults().size()).isEqualTo(1);
     RebalanceRegionResult firstRegionSummary = result.getRebalanceRegionResults().get(0);
-    assertThat(firstRegionSummary.getRegionName()).isEqualTo("customers1");
+    assertThat(firstRegionSummary.getRegionName()).isEqualTo(SEPARATOR + "customers1");
     assertThat(firstRegionSummary.getBucketCreateBytes()).isEqualTo(0);
     assertThat(firstRegionSummary.getTimeInMilliseconds()).isGreaterThanOrEqualTo(0);
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformer.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformer.java
@@ -162,7 +162,7 @@ public class RebalanceOperationPerformer
 
       // translate to the return type we want
       RebalanceRegionResultImpl result = new RebalanceRegionResultImpl();
-      result.setRegionName(regionName.replace(SEPARATOR, ""));
+      result.setRegionName(regionName);
       result.setBucketCreateBytes(results.getTotalBucketCreateBytes());
       result.setBucketCreateTimeInMilliseconds(results.getTotalBucketCreateTime());
       result.setBucketCreatesCompleted(results.getTotalBucketCreatesCompleted());
@@ -214,7 +214,7 @@ public class RebalanceOperationPerformer
       List<String> listExcludedRegion) {
     List<MemberPRInfo> listMemberPRInfo = new ArrayList<>();
     String[] listDSRegions =
-        managementService.getDistributedSystemMXBean().listRegions();
+        managementService.getDistributedSystemMXBean().listAllRegionPaths();
     Set<DistributedMember> dsMembers = ManagementUtils.getAllMembers(cache);
 
     for (String regionName : listDSRegions) {
@@ -474,10 +474,10 @@ public class RebalanceOperationPerformer
     result.setTimeInMilliseconds(Long.parseLong(rstList.get(8)));
     if (rstList.size() < 11) {
       result.setNumOfMembers(-1);
-      result.setRegionName(rstList.get(9).replace(SEPARATOR, ""));
+      result.setRegionName(rstList.get(9));
     } else {
       result.setNumOfMembers(Integer.parseInt(rstList.get(9)));
-      result.setRegionName(rstList.get(10).replace(SEPARATOR, ""));
+      result.setRegionName(rstList.get(10));
     }
 
 

--- a/geode-core/src/test/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/operation/RebalanceOperationPerformerTest.java
@@ -57,7 +57,7 @@ public class RebalanceOperationPerformerTest {
   public void executeRebalanceOnDSWithNoRegionsReturnsSuccessAndNoRegionMessage() {
     ManagementService managementService = mock(ManagementService.class);
     DistributedSystemMXBean distributedSystemMXBean = mock(DistributedSystemMXBean.class);
-    when(distributedSystemMXBean.listRegions()).thenReturn(new String[] {});
+    when(distributedSystemMXBean.listAllRegionPaths()).thenReturn(new String[] {});
     when(managementService.getDistributedSystemMXBean()).thenReturn(distributedSystemMXBean);
     InternalDistributedSystem internalDistributedSystem = mock(InternalDistributedSystem.class);
     InternalCache cache = mock(InternalCache.class);
@@ -84,7 +84,7 @@ public class RebalanceOperationPerformerTest {
     when(managementService.getDistributedRegionMXBean(SEPARATOR + "region1"))
         .thenReturn(regionMXBean);
     DistributedSystemMXBean distributedSystemMXBean = mock(DistributedSystemMXBean.class);
-    when(distributedSystemMXBean.listRegions()).thenReturn(new String[] {"region1"});
+    when(distributedSystemMXBean.listAllRegionPaths()).thenReturn(new String[] {"region1"});
     when(managementService.getDistributedSystemMXBean()).thenReturn(distributedSystemMXBean);
     InternalDistributedSystem internalDistributedSystem = mock(InternalDistributedSystem.class);
     InternalCache cache = mock(InternalCache.class);
@@ -116,7 +116,7 @@ public class RebalanceOperationPerformerTest {
     when(managementService.getDistributedRegionMXBean(SEPARATOR + "region1"))
         .thenReturn(regionMXBean);
     DistributedSystemMXBean distributedSystemMXBean = mock(DistributedSystemMXBean.class);
-    when(distributedSystemMXBean.listRegions()).thenReturn(new String[] {"region1"});
+    when(distributedSystemMXBean.listAllRegionPaths()).thenReturn(new String[] {"region1"});
     when(managementService.getDistributedSystemMXBean()).thenReturn(distributedSystemMXBean);
     InternalDistributedSystem internalDistributedSystem = mock(InternalDistributedSystem.class);
     InternalCache cache = mock(InternalCache.class);
@@ -148,7 +148,7 @@ public class RebalanceOperationPerformerTest {
     assertThat(result.getRebalanceRegionResults()).isNotNull();
     assertThat(result.getRebalanceRegionResults()).hasSize(1);
     RebalanceRegionResult regionResult = result.getRebalanceRegionResults().get(0);
-    assertThat(regionResult.getRegionName()).isEqualTo("region1");
+    assertThat(regionResult.getRegionName()).isEqualTo(SEPARATOR + "region1");
     assertThat(regionResult.getBucketCreateBytes()).isEqualTo(0);
     assertThat(regionResult.getBucketCreateTimeInMilliseconds()).isEqualTo(1);
     assertThat(regionResult.getBucketCreatesCompleted()).isEqualTo(2);

--- a/geode-core/src/test/java/org/apache/geode/management/internal/operation/RestoreRedundancyPerformerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/operation/RestoreRedundancyPerformerTest.java
@@ -79,7 +79,7 @@ public class RestoreRedundancyPerformerTest {
         .thenReturn(new String[] {DS_MEMBER_NAME_SERVER1, DS_MEMBER_NAME_SERVER2});
     when(server1.getName()).thenReturn(DS_MEMBER_NAME_SERVER1);
     when(server2.getName()).thenReturn(DS_MEMBER_NAME_SERVER2);
-    when(distributedSystemMXBean.listRegions()).thenReturn(new String[] {REGION_1});
+    when(distributedSystemMXBean.listAllRegionPaths()).thenReturn(new String[] {REGION_1});
     when(internalDistributedSystem.getDistributionManager())
         .thenReturn(distributionManager);
     Set<InternalDistributedMember> dsMembers = new HashSet<>();

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RebalanceSubregionDistributedTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/RebalanceSubregionDistributedTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.cache.Region;
+import org.apache.geode.cache.RegionFactory;
+import org.apache.geode.cache.RegionShortcut;
+import org.apache.geode.management.internal.cli.result.model.ResultModel;
+import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.serializable.SerializableTestName;
+
+public class RebalanceSubregionDistributedTest implements Serializable {
+
+  @Rule
+  public ClusterStartupRule cluster = new ClusterStartupRule();
+
+  @ClassRule
+  public static GfshCommandRule gfsh = new GfshCommandRule();
+
+  @Rule
+  public SerializableTestName testName = new SerializableTestName();
+
+  private static final String ROOT_REGION_NAME = "root";
+
+  @Test
+  public void testRebalanceSubregion() throws Exception {
+    // Start locator
+    MemberVM locator = cluster.startLocatorVM(0);
+
+    // Start 2 servers
+    MemberVM server1 = cluster.startServerVM(1, locator.getPort());
+    MemberVM server2 = cluster.startServerVM(2, locator.getPort());
+
+    // Create region in server1
+    String regionName = testName.getMethodName();
+    server1.invoke(() -> createSubregion(regionName));
+
+    // Do puts in server1
+    server1.invoke(() -> doPuts(regionName));
+
+    // Create region in server2
+    server2.invoke(() -> createSubregion(regionName));
+
+    // Make sure the locator has the MBean
+    locator.waitUntilRegionIsReadyOnExactlyThisManyServers(
+        SEPARATOR + ROOT_REGION_NAME + SEPARATOR + regionName, 2);
+
+    // Connect gfsh to locator
+    gfsh.connectAndVerify(locator);
+
+    // Execute rebalance and verify it is successful
+    gfsh.executeAndAssertThat("rebalance").statusIsSuccess();
+
+    // Verify the results
+    ResultModel result = gfsh.getCommandResult().getResultData();
+    List<TabularResultModel> tableSections = result.getTableSections();
+    assertThat(tableSections.size()).isEqualTo(1);
+    assertThat(tableSections.get(0).getHeader()
+        .contains(SEPARATOR + ROOT_REGION_NAME + SEPARATOR + regionName)).isTrue();
+  }
+
+  private void createSubregion(String regionName) {
+    // Create the root region
+    RegionFactory<Object, Object> rootRegionFactory =
+        Objects.requireNonNull(ClusterStartupRule.getCache())
+            .createRegionFactory(RegionShortcut.REPLICATE);
+    Region<Object, Object> rootRegion = rootRegionFactory.create(ROOT_REGION_NAME);
+
+    // Create the subregion
+    RegionFactory<Integer, Integer> partitionedRegionFactory =
+        Objects.requireNonNull(ClusterStartupRule.getCache())
+            .createRegionFactory(RegionShortcut.PARTITION);
+    partitionedRegionFactory.setPartitionAttributes(new PartitionAttributesFactory().create());
+    partitionedRegionFactory.createSubregion(rootRegion, regionName);
+  }
+
+  private void doPuts(String regionName) {
+    Region<Integer, Integer> subregion = Objects.requireNonNull(ClusterStartupRule.getCache())
+        .getRegion(SEPARATOR + ROOT_REGION_NAME + SEPARATOR + regionName);
+    IntStream.range(0, 112).forEach(i -> subregion.put(i, i));
+  }
+}

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/RebalanceCommand.java
@@ -187,9 +187,9 @@ public class RebalanceCommand extends GfshCommand {
 
     String headerText;
     if (simulate) {
-      headerText = "Simulated partition regions";
+      headerText = "Simulated rebalance of partitioned region";
     } else {
-      headerText = "Rebalanced partition regions";
+      headerText = "Rebalanced partitioned region";
     }
     for (int i = resultItemCount; i < rstlist.size(); i++) {
       headerText = headerText + " " + rstlist.get(i);


### PR DESCRIPTION
This commit modifies RebalanceOperationPerformer getMemberRegionList
to invoke listAllRegionPaths instead of listNames.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
