### PR TITLE
GEODE-10067: Optimize wan-copy region command

### DIFF
--- a/geode-wan/src/main/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionDelegate.java
+++ b/geode-wan/src/main/java/org/apache/geode/management/internal/cli/functions/WanCopyRegionFunctionDelegate.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -39,6 +40,7 @@ import org.apache.geode.cache.client.ServerConnectivityException;
 import org.apache.geode.cache.client.internal.Connection;
 import org.apache.geode.cache.client.internal.PoolImpl;
 import org.apache.geode.cache.client.internal.pooling.ConnectionDestroyedException;
+import org.apache.geode.cache.partition.PartitionRegionHelper;
 import org.apache.geode.cache.wan.GatewayQueueEvent;
 import org.apache.geode.cache.wan.GatewaySender;
 import org.apache.geode.cache.wan.internal.cli.commands.WanCopyRegionCommand;
@@ -184,11 +186,11 @@ public class WanCopyRegionFunctionDelegate implements Serializable {
     return batch;
   }
 
-  private List<?> getEntries(Region<?, ?> region, GatewaySender sender) {
+  private Collection<?> getEntries(Region<?, ?> region, GatewaySender sender) {
     if (region instanceof PartitionedRegion && sender.isParallel()) {
-      return ((PartitionedRegion) region).getDataStore().getEntries();
+      return PartitionRegionHelper.getLocalPrimaryData(region).entrySet();
     }
-    return new ArrayList<>(region.entrySet());
+    return region.entrySet();
   }
 
   /**
@@ -366,10 +368,6 @@ public class WanCopyRegionFunctionDelegate implements Serializable {
       }
       BucketRegion bucketRegion = ((PartitionedRegion) event.getRegion()).getDataStore()
           .getLocalBucketById(event.getKeyInfo().getBucketId());
-      if (bucketRegion != null && !bucketRegion.getBucketAdvisor().isPrimary()
-          && sender.isParallel()) {
-        return null;
-      }
       if (bucketRegion != null) {
         bucketRegion.handleWANEvent(event);
       }


### PR DESCRIPTION
When the region to copy is partitioned and
the gateway sender is parallel, the gateway
sender of each server will read and then send only the primary
copies in the local buckets of that server.
Deserialization of the entries will also avoided.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
