### PR TITLE
GEODE-10110: Do not wrap CacheClosedException unexpectedly.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -8537,7 +8537,8 @@ public class PartitionedRegion extends LocalRegion
     return new ArrayList<>(indexes);
   }
 
-  private boolean createEmptyIndexes(HashSet<IndexCreationData> indexDefinitions,
+  @VisibleForTesting
+  boolean createEmptyIndexes(HashSet<IndexCreationData> indexDefinitions,
       boolean remotelyOriginated, Set<Index> indexes, HashMap<String, Exception> exceptionsMap) {
     boolean throwException = false;
     for (IndexCreationData icd : indexDefinitions) {
@@ -8550,6 +8551,9 @@ public class PartitionedRegion extends LocalRegion
         if (ind != null) {
           indexes.add(ind);
         }
+      } catch (CancelException cancelException) {
+        // Do not add cancel exception to exceptionsMap, re-throw instead.
+        throw cancelException;
       } catch (Exception ex) {
         // If an index creation fails, add the exception to the map and
         // continue creating rest of the indexes.The failed indexes will


### PR DESCRIPTION
  * When creating index, throw CacheClosedException instead of adding it
    to exceptionsMap which will eventually converted to
    MultiIndexCreationException, with InternalGemFireException thrown
    to the user.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
