### PR TITLE
GEODE-10111: Introduce COMMITWATCHERS

### DIFF
--- a/CODEWATCHERS
+++ b/CODEWATCHERS
@@ -27,6 +27,7 @@
 #-----------------------------------------------------------------
 CODEOWNERS                                                        @onichols-pivotal @rhoughton-pivot
 CODEWATCHERS                                                      @onichols-pivotal @rhoughton-pivot
+COMMITWATCHERS                                                    @onichols-pivotal
 .asf.yaml                                                         @onichols-pivotal @rhoughton-pivot
 
 

--- a/COMMITWATCHERS
+++ b/COMMITWATCHERS
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Add your github username to one or both sections below to opt-in for
+# automated feedback on your commit message.
+
+[Draft]
+ezoerner
+
+[Non-Draft]
+kirklund
+ezoerner
+kohlmu-pivotal
+
+
+# By opting-in, the commit message of the first commit in your PR will
+# be compared to the guidelines in
+# https://cwiki.apache.org/confluence/display/GEODE/Commit+Message+Format
+# and a comment will be added to your PR if improvements are recommended.
+# 
+# Please note that these guidelines are totally optional.  What matters
+# most is not formatting, but including enough detail for future
+# contributors to understand what you changed and why.
+#
+# Q. Why is this opt-in?  Wouldn't this be good feedback for all PRs?
+# A. The Geode community embraces diversity of opinions.  Rather than
+#    rules, "we like to work on trust, not unnecessary restrictions".
+#
+# Q. Why is only my first commit message inspected?
+# A. Because it is most likely to be used as the actual commit message
+#    or the start of the squash commit message when your PR is merged.
+#
+# Q. Isn't this redundant with the PR title and description in github?
+# A. It can be; some contributors copy&paste their commit message
+#    there as well.  Or you can use that space for notes to reviewers,
+#    such as how you tested or specific feedback you'd like.
+#
+# Q. How do I push changes to my commit message?
+# A. Using interactive rebase (git rebase -i HEAD~n, where n is the 
+#    number of commits in your PR so far), change "pick" to "r" to
+#    reword the first commit, then git push --force.
+#
+# Q. Will a force push mess up reviews I've already received?
+# A. Yes.  Opt-in your draft PRs too to get feedback (and have a chance
+#    to make fixes) prior to marking your PR as ready for review.
+#
+# Q. Can I just write or fix my commit message when I merge my PR? 
+# A. If you're a committer and if you remember to, sure, although this
+#    will deprive you of review feedback on your actual commit message.
+#
+# Q. Can I update my commit message after my PR is merged?
+# A. No, Geode's branch protection disallows force push on develop.


### PR DESCRIPTION
Previously, opt-in and unsubscribe required a dev list email,
and this led to complaints.

This self-serve mechanism achieves the same goal of a public
record of opt-in requests, without adding noise to the dev list.