### PR TITLE
GEODE-10108: Add version field to AbstractRedisData and deltas

### DIFF
--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/string/StringsDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/string/StringsDUnitTest.java
@@ -30,7 +30,6 @@ import java.util.function.Consumer;
 
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -320,12 +319,12 @@ public class StringsDUnitTest {
       int subsectionStart = Math.max(0, idx - (2 * expectedValue.length()));
       int subsectionEnd = Math.min(storedString.length(), idx + (2 * expectedValue.length()));
 
-      if (!foundValue.equals(expectedValue)) {
-        Assert.fail("unexpected " + foundValue + " at index " + i + " iterationCount="
-            + iterationCount
-            + " in String subsection: " + storedString.substring(subsectionStart, subsectionEnd));
-        break;
-      }
+      assertThat(foundValue)
+          .as("unexpected " + foundValue + " at index " + i + " iterationCount="
+              + iterationCount
+              + " in String subsection: " + storedString.substring(subsectionStart, subsectionEnd))
+          .isEqualTo(expectedValue);
+
       idx += expectedValue.length();
       i++;
     }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/string/StringsDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/string/StringsDUnitTest.java
@@ -19,11 +19,8 @@ import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADD
 import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
@@ -39,7 +36,6 @@ import redis.clients.jedis.JedisCluster;
 import redis.clients.jedis.params.SetParams;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
-import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
 import org.apache.geode.test.junit.rules.ExecutorServiceRule;
@@ -55,14 +51,17 @@ public class StringsDUnitTest {
   private static final int LIST_SIZE = 1000;
   private static final int NUM_ITERATIONS = 1000;
   private static JedisCluster jedisCluster;
+  private static MemberVM server1;
+  private static MemberVM server2;
+  private static MemberVM server3;
 
   @BeforeClass
   public static void classSetup() {
     MemberVM locator = clusterStartUp.startLocatorVM(0);
     int locatorPort = locator.getPort();
-    clusterStartUp.startRedisVM(1, locatorPort);
-    clusterStartUp.startRedisVM(2, locatorPort);
-    clusterStartUp.startRedisVM(3, locatorPort);
+    server1 = clusterStartUp.startRedisVM(1, locatorPort);
+    server2 = clusterStartUp.startRedisVM(2, locatorPort);
+    server3 = clusterStartUp.startRedisVM(3, locatorPort);
 
     int redisServerPort1 = clusterStartUp.getRedisPort(1);
     jedisCluster =
@@ -253,49 +252,23 @@ public class StringsDUnitTest {
   }
 
   @Test
-  public void givenBucketsMoveDuringAppend_thenDataIsNotLost() throws Exception {
-    AtomicBoolean running = new AtomicBoolean(true);
+  public void givenBucketsMoveAndPrimarySwitches_thenNoDuplicateAppendsOccur() {
+    String KEY = "APPEND";
+    AtomicInteger counter = new AtomicInteger(0);
 
-    List<String> hashtags = new ArrayList<>();
-    hashtags.add(clusterStartUp.getKeyOnServer("append", 1));
-    hashtags.add(clusterStartUp.getKeyOnServer("append", 2));
-    hashtags.add(clusterStartUp.getKeyOnServer("append", 3));
-
-    Runnable task1 = () -> appendPerformAndVerify(1, hashtags.get(0), running);
-    Runnable task2 = () -> appendPerformAndVerify(2, hashtags.get(1), running);
-    Runnable task3 = () -> appendPerformAndVerify(3, hashtags.get(2), running);
-
-    Future<Void> future1 = executor.runAsync(task1);
-    Future<Void> future2 = executor.runAsync(task2);
-    Future<Void> future3 = executor.runAsync(task3);
-
-    for (int i = 0; i < 100 && running.get(); i++) {
-      clusterStartUp.moveBucketForKey(hashtags.get(i % hashtags.size()));
-      GeodeAwaitility.await().during(Duration.ofMillis(200)).until(() -> true);
-    }
-
-    running.set(false);
-
-    future1.get();
-    future2.get();
-    future3.get();
+    new ConcurrentLoopingThreads(1000,
+        i -> {
+          String appendString = "-" + KEY + "-" + i + "-";
+          jedisCluster.append(KEY, appendString);
+          counter.incrementAndGet();
+        },
+        i -> clusterStartUp.moveBucketForKey(KEY)).runWithAction(() -> {
+          clusterStartUp.switchPrimaryForKey(KEY, server1, server2, server3);
+          verifyAppendResult(KEY, counter.get());
+        });
   }
 
-  private void appendPerformAndVerify(int index, String hashtag, AtomicBoolean isRunning) {
-    String key = "{" + hashtag + "}-key-" + index;
-    int iterationCount = 0;
-
-    while (isRunning.get()) {
-      String appendString = "-" + key + "-" + iterationCount + "-";
-      try {
-        jedisCluster.append(key, appendString);
-      } catch (Exception ex) {
-        isRunning.set(false);
-        throw new RuntimeException("Exception performing APPEND " + appendString, ex);
-      }
-      iterationCount++;
-    }
-
+  private void verifyAppendResult(String key, int iterationCount) {
     String storedString = jedisCluster.get(key);
 
     int startIndex = 0;

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/DeltaDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/data/DeltaDUnitTest.java
@@ -171,14 +171,7 @@ public class DeltaDUnitTest {
         assertThat(buckets.size()).isEqualTo(2);
         Map<Object, Object> bucket1 = buckets.get(0).getValues();
         Map<Object, Object> bucket2 = buckets.get(1).getValues();
-        assertThat(bucket1).containsExactlyInAnyOrderEntriesOf(bucket2);
-
-        bucket1.keySet().forEach(key -> {
-          RedisData value1 = (RedisData) bucket1.get(key);
-          RedisData value2 = (RedisData) bucket2.get(key);
-
-          assertThat(value1.getExpirationTimestamp()).isEqualTo(value2.getExpirationTimestamp());
-        });
+        assertThat(bucket1).containsExactlyEntriesOf(bucket2);
       }
     });
   }

--- a/geode-for-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
+++ b/geode-for-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/sanctionedDataSerializables.txt
@@ -1,6 +1,6 @@
 org/apache/geode/redis/internal/data/AbstractRedisData,2
-fromData,11
-toData,11
+fromData,21
+toData,21
 
 org/apache/geode/redis/internal/data/NullRedisData,2
 fromData,8
@@ -37,3 +37,4 @@ toData,61
 org/apache/geode/redis/internal/services/cluster/RedisMemberInfo,2
 fromData,28
 toData,27
+

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -87,7 +87,7 @@ public abstract class AbstractRedisData implements RedisData {
   private volatile long expirationTimestamp = NO_EXPIRATION;
   private static final ThreadLocal<DeltaInfo> deltaInfo = new ThreadLocal<>();
 
-  public int getVersion() {
+  public short getVersion() {
     return version;
   }
 
@@ -401,7 +401,8 @@ public abstract class AbstractRedisData implements RedisData {
       return false;
     }
     AbstractRedisData that = (AbstractRedisData) o;
-    return getExpirationTimestamp() == that.getExpirationTimestamp();
+    return getVersion() == that.getVersion() &&
+        getExpirationTimestamp() == that.getExpirationTimestamp();
   }
 
   @Override
@@ -411,7 +412,7 @@ public abstract class AbstractRedisData implements RedisData {
 
   @Override
   public String toString() {
-    return "expirationTimestamp=" + expirationTimestamp;
+    return "version=" + version + ", expirationTimestamp=" + expirationTimestamp;
   }
 
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -76,7 +76,7 @@ public abstract class AbstractRedisData implements RedisData {
 
   public static final long NO_EXPIRATION = -1L;
 
-  protected short version = 0;
+  private byte version = 0;
 
   /**
    * The timestamp at which this instance should expire.
@@ -87,11 +87,15 @@ public abstract class AbstractRedisData implements RedisData {
   private volatile long expirationTimestamp = NO_EXPIRATION;
   private static final ThreadLocal<DeltaInfo> deltaInfo = new ThreadLocal<>();
 
-  public short getVersion() {
+  public byte getVersion() {
     return version;
   }
 
-  public void setVersion(short version) {
+  public byte incrementAndGetVersion() {
+    return ++version;
+  }
+
+  public void setVersion(byte version) {
     this.version = version;
   }
 
@@ -203,14 +207,14 @@ public abstract class AbstractRedisData implements RedisData {
 
   @Override
   public void toData(DataOutput out, SerializationContext context) throws IOException {
-    out.writeShort(version);
+    out.writeByte(version);
     out.writeLong(expirationTimestamp);
   }
 
   @Override
   public void fromData(DataInput in, DeserializationContext context)
       throws IOException, ClassNotFoundException {
-    version = in.readShort();
+    version = in.readByte();
     expirationTimestamp = in.readLong();
   }
 
@@ -233,7 +237,7 @@ public abstract class AbstractRedisData implements RedisData {
     DeltaType deltaType = readEnum(DeltaType.class, in);
 
     if (deltaType.isVersioned()) {
-      short deltaVersion = DataSerializer.readPrimitiveShort(in);
+      byte deltaVersion = DataSerializer.readPrimitiveByte(in);
       if (deltaVersion == getVersion()) {
         return;
       }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -230,13 +230,15 @@ public abstract class AbstractRedisData implements RedisData {
 
   @Override
   public void fromDelta(DataInput in) throws IOException, InvalidDeltaException {
-    short deltaVersion = DataSerializer.readPrimitiveShort(in);
     DeltaType deltaType = readEnum(DeltaType.class, in);
 
-    if (deltaType.isVersioned() && deltaVersion == getVersion()) {
-      return;
+    if (deltaType.isVersioned()) {
+      short deltaVersion = DataSerializer.readPrimitiveShort(in);
+      if (deltaVersion == getVersion()) {
+        return;
+      }
+      setVersion(deltaVersion);
     }
-    setVersion(deltaVersion);
 
     switch (deltaType) {
       case SET_TIMESTAMP:

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -72,7 +72,10 @@ public class RedisString extends AbstractRedisData {
   }
 
   public int append(Region<RedisKey, RedisData> region, RedisKey key, byte[] appendValue) {
-    valueAppend(appendValue);
+    synchronized (this) {
+      valueAppend(appendValue);
+      version++;
+    }
     storeChanges(region, key, new AppendByteArray(version, appendValue));
     return value.length;
   }
@@ -464,14 +467,13 @@ public class RedisString extends AbstractRedisData {
 
   ////// methods that modify the "value" field ////////////
 
-  protected synchronized void valueAppend(byte[] bytes) {
+  protected void valueAppend(byte[] bytes) {
     int initialLength = value.length;
     int additionalLength = bytes.length;
     byte[] combined = new byte[initialLength + additionalLength];
     System.arraycopy(value, 0, combined, 0, initialLength);
     System.arraycopy(bytes, 0, combined, initialLength, additionalLength);
     value = combined;
-    version++;
   }
 
   @Override

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -72,11 +72,12 @@ public class RedisString extends AbstractRedisData {
   }
 
   public int append(Region<RedisKey, RedisData> region, RedisKey key, byte[] appendValue) {
+    byte newVersion;
     synchronized (this) {
       valueAppend(appendValue);
-      version++;
+      newVersion = incrementAndGetVersion();
     }
-    storeChanges(region, key, new AppendByteArray(version, appendValue));
+    storeChanges(region, key, new AppendByteArray(newVersion, appendValue));
     return value.length;
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisString.java
@@ -73,7 +73,7 @@ public class RedisString extends AbstractRedisData {
 
   public int append(Region<RedisKey, RedisData> region, RedisKey key, byte[] appendValue) {
     valueAppend(appendValue);
-    storeChanges(region, key, new AppendByteArray(appendValue));
+    storeChanges(region, key, new AppendByteArray(version, appendValue));
     return value.length;
   }
 
@@ -464,13 +464,14 @@ public class RedisString extends AbstractRedisData {
 
   ////// methods that modify the "value" field ////////////
 
-  protected void valueAppend(byte[] bytes) {
+  protected synchronized void valueAppend(byte[] bytes) {
     int initialLength = value.length;
     int additionalLength = bytes.length;
     byte[] combined = new byte[initialLength + additionalLength];
     System.arraycopy(value, 0, combined, 0, initialLength);
     System.arraycopy(bytes, 0, combined, initialLength, additionalLength);
     value = combined;
+    version++;
   }
 
   @Override

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayDoublePairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayDoublePairs.java
@@ -31,11 +31,12 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class AddByteArrayDoublePairs implements DeltaInfo {
+public class AddByteArrayDoublePairs extends DeltaInfo {
   private final List<byte[]> byteArrays;
   private final double[] doubles;
 
   public AddByteArrayDoublePairs(int size) {
+    super((short) 0);
     byteArrays = new ArrayList<>(size);
     doubles = new double[size];
   }
@@ -46,6 +47,7 @@ public class AddByteArrayDoublePairs implements DeltaInfo {
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(ADD_BYTE_ARRAY_DOUBLE_PAIRS, out);
     InternalDataSerializer.writeArrayLength(byteArrays.size(), out);
     for (int i = 0; i < byteArrays.size(); i++) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayDoublePairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayDoublePairs.java
@@ -40,6 +40,11 @@ public class AddByteArrayDoublePairs extends DeltaInfo {
     doubles = new double[size];
   }
 
+  @Override
+  public DeltaType getType() {
+    return ADD_BYTE_ARRAY_DOUBLE_PAIRS;
+  }
+
   public void add(byte[] byteArray, double doubleValue) {
     doubles[byteArrays.size()] = doubleValue;
     byteArrays.add(byteArray);
@@ -47,7 +52,6 @@ public class AddByteArrayDoublePairs extends DeltaInfo {
 
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(ADD_BYTE_ARRAY_DOUBLE_PAIRS, out);
     InternalDataSerializer.writeArrayLength(byteArrays.size(), out);
     for (int i = 0; i < byteArrays.size(); i++) {
       DataSerializer.writeByteArray(byteArrays.get(i), out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayDoublePairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayDoublePairs.java
@@ -36,7 +36,6 @@ public class AddByteArrayDoublePairs extends DeltaInfo {
   private final double[] doubles;
 
   public AddByteArrayDoublePairs(int size) {
-    super((short) 0);
     byteArrays = new ArrayList<>(size);
     doubles = new double[size];
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayPairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayPairs.java
@@ -41,6 +41,11 @@ public class AddByteArrayPairs extends DeltaInfo {
     add(fieldName, fieldValue);
   }
 
+  @Override
+  public DeltaType getType() {
+    return ADD_BYTE_ARRAY_PAIRS;
+  }
+
   public final void add(byte[] byteArray1, byte[] byteArray2) {
     byteArrayPairs.add(byteArray1);
     byteArrayPairs.add(byteArray2);
@@ -48,7 +53,6 @@ public class AddByteArrayPairs extends DeltaInfo {
 
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(ADD_BYTE_ARRAY_PAIRS, out);
     InternalDataSerializer.writeArrayLength(byteArrayPairs.size(), out);
     for (byte[] bytes : byteArrayPairs) {
       DataSerializer.writeByteArray(bytes, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayPairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayPairs.java
@@ -29,10 +29,11 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class AddByteArrayPairs implements DeltaInfo {
+public class AddByteArrayPairs extends DeltaInfo {
   private final List<byte[]> byteArrayPairs;
 
   public AddByteArrayPairs(int size) {
+    super((short) 0);
     byteArrayPairs = new ArrayList<>(size);
   }
 
@@ -47,6 +48,7 @@ public class AddByteArrayPairs implements DeltaInfo {
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(ADD_BYTE_ARRAY_PAIRS, out);
     InternalDataSerializer.writeArrayLength(byteArrayPairs.size(), out);
     for (byte[] bytes : byteArrayPairs) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayPairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrayPairs.java
@@ -33,7 +33,6 @@ public class AddByteArrayPairs extends DeltaInfo {
   private final List<byte[]> byteArrayPairs;
 
   public AddByteArrayPairs(int size) {
-    super((short) 0);
     byteArrayPairs = new ArrayList<>(size);
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrays.java
@@ -30,14 +30,15 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class AddByteArrays implements DeltaInfo {
+public class AddByteArrays extends DeltaInfo {
   private final List<byte[]> byteArrays;
 
   public AddByteArrays() {
-    byteArrays = new ArrayList<>();
+    this(new ArrayList<>());
   }
 
   public AddByteArrays(List<byte[]> deltas) {
+    super((short) 0);
     byteArrays = deltas;
   }
 
@@ -46,6 +47,7 @@ public class AddByteArrays implements DeltaInfo {
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(ADD_BYTE_ARRAYS, out);
     InternalDataSerializer.writeArrayLength(byteArrays.size(), out);
     for (byte[] bytes : byteArrays) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrays.java
@@ -38,7 +38,6 @@ public class AddByteArrays extends DeltaInfo {
   }
 
   public AddByteArrays(List<byte[]> deltas) {
-    super((short) 0);
     byteArrays = deltas;
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AddByteArrays.java
@@ -41,13 +41,17 @@ public class AddByteArrays extends DeltaInfo {
     byteArrays = deltas;
   }
 
+  @Override
+  public DeltaType getType() {
+    return ADD_BYTE_ARRAYS;
+  }
+
   public void add(byte[] delta) {
     byteArrays.add(delta);
   }
 
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(ADD_BYTE_ARRAYS, out);
     InternalDataSerializer.writeArrayLength(byteArrays.size(), out);
     for (byte[] bytes : byteArrays) {
       DataSerializer.writeByteArray(bytes, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AppendByteArray.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AppendByteArray.java
@@ -26,14 +26,16 @@ import java.io.IOException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class AppendByteArray implements DeltaInfo {
+public class AppendByteArray extends DeltaInfo {
   private final byte[] byteArray;
 
-  public AppendByteArray(byte[] value) {
+  public AppendByteArray(short version, byte[] value) {
+    super(version);
     byteArray = value;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(APPEND_BYTE_ARRAY, out);
     DataSerializer.writeByteArray(byteArray, out);
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AppendByteArray.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AppendByteArray.java
@@ -29,7 +29,7 @@ import org.apache.geode.redis.internal.data.AbstractRedisData;
 public class AppendByteArray extends DeltaInfo {
   private final byte[] byteArray;
 
-  public AppendByteArray(short version, byte[] value) {
+  public AppendByteArray(byte version, byte[] value) {
     super(version);
     byteArray = value;
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AppendByteArray.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/AppendByteArray.java
@@ -34,9 +34,13 @@ public class AppendByteArray extends DeltaInfo {
     byteArray = value;
   }
 
+  @Override
+  public DeltaType getType() {
+    return APPEND_BYTE_ARRAY;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(APPEND_BYTE_ARRAY, out);
     DataSerializer.writeByteArray(byteArray, out);
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
@@ -35,7 +35,7 @@ public abstract class DeltaInfo {
 
   public void serializeTo(DataOutput out) throws IOException {
     DataSerializer.writePrimitiveShort(version, out);
-  };
+  }
 
   public short getVersion() {
     return version;

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
@@ -23,13 +23,13 @@ import org.apache.geode.DataSerializer;
 
 public abstract class DeltaInfo {
 
-  private final short version;
+  private final byte version;
 
   protected DeltaInfo() {
-    this((short) 0);
+    this((byte) 0);
   }
 
-  protected DeltaInfo(short version) {
+  protected DeltaInfo(byte version) {
     this.version = version;
   }
 
@@ -38,11 +38,11 @@ public abstract class DeltaInfo {
   public void serializeTo(DataOutput out) throws IOException {
     DataSerializer.writeEnum(getType(), out);
     if (getType().isVersioned()) {
-      DataSerializer.writePrimitiveShort(version, out);
+      DataSerializer.writePrimitiveByte(version, out);
     }
   }
 
-  public short getVersion() {
+  public byte getVersion() {
     return version;
   }
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
@@ -19,6 +19,21 @@ package org.apache.geode.redis.internal.data.delta;
 import java.io.DataOutput;
 import java.io.IOException;
 
-public interface DeltaInfo {
-  void serializeTo(DataOutput out) throws IOException;
+import org.apache.geode.DataSerializer;
+
+public abstract class DeltaInfo {
+
+  private final short version;
+
+  public DeltaInfo(short version) {
+    this.version = version;
+  }
+
+  public void serializeTo(DataOutput out) throws IOException {
+    DataSerializer.writePrimitiveShort(version, out);
+  };
+
+  public short getVersion() {
+    return version;
+  }
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
@@ -25,7 +25,11 @@ public abstract class DeltaInfo {
 
   private final short version;
 
-  public DeltaInfo(short version) {
+  protected DeltaInfo() {
+    this((short) 0);
+  }
+
+  protected DeltaInfo(short version) {
     this.version = version;
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaInfo.java
@@ -33,8 +33,13 @@ public abstract class DeltaInfo {
     this.version = version;
   }
 
+  public abstract DeltaType getType();
+
   public void serializeTo(DataOutput out) throws IOException {
-    DataSerializer.writePrimitiveShort(version, out);
+    DataSerializer.writeEnum(getType(), out);
+    if (getType().isVersioned()) {
+      DataSerializer.writePrimitiveShort(version, out);
+    }
   }
 
   public short getVersion() {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaType.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/DeltaType.java
@@ -20,7 +20,7 @@ public enum DeltaType {
   ADD_BYTE_ARRAYS,
   ADD_BYTE_ARRAY_PAIRS,
   ADD_BYTE_ARRAY_DOUBLE_PAIRS,
-  APPEND_BYTE_ARRAY,
+  APPEND_BYTE_ARRAY(true),
   REMOVE_BYTE_ARRAYS,
   REPLACE_BYTE_ARRAYS,
   REPLACE_BYTE_ARRAY_AT_OFFSET,
@@ -29,5 +29,19 @@ public enum DeltaType {
   SET_BYTE_ARRAY,
   SET_BYTE_ARRAY_AND_TIMESTAMP,
   SET_TIMESTAMP,
-  REMOVE_ELEMENTS_BY_INDEX
+  REMOVE_ELEMENTS_BY_INDEX;
+
+  private final boolean versioned;
+
+  DeltaType() {
+    this(false);
+  }
+
+  DeltaType(boolean versioned) {
+    this.versioned = versioned;
+  }
+
+  public boolean isVersioned() {
+    return versioned;
+  }
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveByteArrays.java
@@ -39,7 +39,6 @@ public class RemoveByteArrays extends DeltaInfo {
   }
 
   public RemoveByteArrays(List<byte[]> deltas) {
-    super((short) 0);
     byteArrays = deltas;
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveByteArrays.java
@@ -42,13 +42,17 @@ public class RemoveByteArrays extends DeltaInfo {
     byteArrays = deltas;
   }
 
+  @Override
+  public DeltaType getType() {
+    return REMOVE_BYTE_ARRAYS;
+  }
+
   public void add(byte[] delta) {
     byteArrays.add(delta);
   }
 
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(REMOVE_BYTE_ARRAYS, out);
     InternalDataSerializer.writeArrayLength(byteArrays.size(), out);
     for (byte[] bytes : byteArrays) {
       DataSerializer.writeByteArray(bytes, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveByteArrays.java
@@ -31,14 +31,15 @@ import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class RemoveByteArrays implements DeltaInfo {
+public class RemoveByteArrays extends DeltaInfo {
   private final List<byte[]> byteArrays;
 
   public RemoveByteArrays() {
-    byteArrays = new ArrayList<>();
+    this(new ArrayList<>());
   }
 
   public RemoveByteArrays(List<byte[]> deltas) {
+    super((short) 0);
     byteArrays = deltas;
   }
 
@@ -47,6 +48,7 @@ public class RemoveByteArrays implements DeltaInfo {
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(REMOVE_BYTE_ARRAYS, out);
     InternalDataSerializer.writeArrayLength(byteArrays.size(), out);
     for (byte[] bytes : byteArrays) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveElementsByIndex.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveElementsByIndex.java
@@ -29,18 +29,20 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class RemoveElementsByIndex implements DeltaInfo {
+public class RemoveElementsByIndex extends DeltaInfo {
   private final List<Integer> indexes;
+
+  public RemoveElementsByIndex() {
+    super((short) 0);
+    this.indexes = new ArrayList<>();
+  }
 
   public void add(int index) {
     indexes.add(index);
   }
 
-  public RemoveElementsByIndex() {
-    this.indexes = new ArrayList<>();
-  }
-
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(REMOVE_ELEMENTS_BY_INDEX, out);
     InternalDataSerializer.writeArrayLength(indexes.size(), out);
     for (int index : indexes) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveElementsByIndex.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveElementsByIndex.java
@@ -33,7 +33,6 @@ public class RemoveElementsByIndex extends DeltaInfo {
   private final List<Integer> indexes;
 
   public RemoveElementsByIndex() {
-    super((short) 0);
     this.indexes = new ArrayList<>();
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveElementsByIndex.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/RemoveElementsByIndex.java
@@ -36,13 +36,17 @@ public class RemoveElementsByIndex extends DeltaInfo {
     this.indexes = new ArrayList<>();
   }
 
+  @Override
+  public DeltaType getType() {
+    return REMOVE_ELEMENTS_BY_INDEX;
+  }
+
   public void add(int index) {
     indexes.add(index);
   }
 
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(REMOVE_ELEMENTS_BY_INDEX, out);
     InternalDataSerializer.writeArrayLength(indexes.size(), out);
     for (int index : indexes) {
       DataSerializer.writePrimitiveInt(index, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayAtOffset.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayAtOffset.java
@@ -32,7 +32,6 @@ public class ReplaceByteArrayAtOffset extends DeltaInfo {
   private final byte[] byteArray;
 
   public ReplaceByteArrayAtOffset(int offset, byte[] bytes) {
-    super((short) 0);
     this.offset = offset;
     byteArray = bytes;
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayAtOffset.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayAtOffset.java
@@ -36,6 +36,11 @@ public class ReplaceByteArrayAtOffset extends DeltaInfo {
     byteArray = bytes;
   }
 
+  @Override
+  public DeltaType getType() {
+    return REPLACE_BYTE_ARRAY_AT_OFFSET;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
     DataSerializer.writeEnum(REPLACE_BYTE_ARRAY_AT_OFFSET, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayAtOffset.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayAtOffset.java
@@ -27,16 +27,18 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class ReplaceByteArrayAtOffset implements DeltaInfo {
+public class ReplaceByteArrayAtOffset extends DeltaInfo {
   private final int offset;
   private final byte[] byteArray;
 
   public ReplaceByteArrayAtOffset(int offset, byte[] bytes) {
+    super((short) 0);
     this.offset = offset;
     byteArray = bytes;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(REPLACE_BYTE_ARRAY_AT_OFFSET, out);
     InternalDataSerializer.writeArrayLength(offset, out);
     DataSerializer.writeByteArray(byteArray, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayDoublePairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayDoublePairs.java
@@ -32,7 +32,6 @@ public class ReplaceByteArrayDoublePairs extends DeltaInfo {
   private final RedisSortedSet.MemberMap members;
 
   public ReplaceByteArrayDoublePairs(RedisSortedSet.MemberMap members) {
-    super((short) 0);
     this.members = members;
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayDoublePairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayDoublePairs.java
@@ -35,9 +35,13 @@ public class ReplaceByteArrayDoublePairs extends DeltaInfo {
     this.members = members;
   }
 
+  @Override
+  public DeltaType getType() {
+    return REPLACE_BYTE_ARRAY_DOUBLE_PAIRS;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(REPLACE_BYTE_ARRAY_DOUBLE_PAIRS, out);
     InternalDataSerializer.writeArrayLength(members.size(), out);
     for (byte[] member : members.keySet()) {
       DataSerializer.writeByteArray(member, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayDoublePairs.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrayDoublePairs.java
@@ -28,14 +28,16 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 import org.apache.geode.redis.internal.data.RedisSortedSet;
 
-public class ReplaceByteArrayDoublePairs implements DeltaInfo {
+public class ReplaceByteArrayDoublePairs extends DeltaInfo {
   private final RedisSortedSet.MemberMap members;
 
   public ReplaceByteArrayDoublePairs(RedisSortedSet.MemberMap members) {
+    super((short) 0);
     this.members = members;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(REPLACE_BYTE_ARRAY_DOUBLE_PAIRS, out);
     InternalDataSerializer.writeArrayLength(members.size(), out);
     for (byte[] member : members.keySet()) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrays.java
@@ -28,14 +28,16 @@ import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 import org.apache.geode.redis.internal.data.RedisSet;
 
-public class ReplaceByteArrays implements DeltaInfo {
+public class ReplaceByteArrays extends DeltaInfo {
   private final Set<byte[]> byteArrays;
 
   public ReplaceByteArrays(Set<byte[]> deltas) {
+    super((short) 0);
     this.byteArrays = deltas;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(REPLACE_BYTE_ARRAYS, out);
     InternalDataSerializer.writeArrayLength(byteArrays.size(), out);
     for (byte[] bytes : byteArrays) {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrays.java
@@ -32,7 +32,6 @@ public class ReplaceByteArrays extends DeltaInfo {
   private final Set<byte[]> byteArrays;
 
   public ReplaceByteArrays(Set<byte[]> deltas) {
-    super((short) 0);
     this.byteArrays = deltas;
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrays.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteArrays.java
@@ -35,9 +35,13 @@ public class ReplaceByteArrays extends DeltaInfo {
     this.byteArrays = deltas;
   }
 
+  @Override
+  public DeltaType getType() {
+    return REPLACE_BYTE_ARRAYS;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(REPLACE_BYTE_ARRAYS, out);
     InternalDataSerializer.writeArrayLength(byteArrays.size(), out);
     for (byte[] bytes : byteArrays) {
       DataSerializer.writeByteArray(bytes, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteAtOffset.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteAtOffset.java
@@ -27,16 +27,18 @@ import org.apache.geode.DataSerializer;
 import org.apache.geode.internal.InternalDataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class ReplaceByteAtOffset implements DeltaInfo {
+public class ReplaceByteAtOffset extends DeltaInfo {
   private final int offset;
   private final byte byteValue;
 
   public ReplaceByteAtOffset(int offset, byte bits) {
+    super((short) 0);
     this.offset = offset;
     byteValue = bits;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(REPLACE_BYTE_AT_OFFSET, out);
     InternalDataSerializer.writeArrayLength(offset, out);
     DataSerializer.writePrimitiveByte(byteValue, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteAtOffset.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteAtOffset.java
@@ -36,9 +36,13 @@ public class ReplaceByteAtOffset extends DeltaInfo {
     byteValue = bits;
   }
 
+  @Override
+  public DeltaType getType() {
+    return REPLACE_BYTE_AT_OFFSET;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(REPLACE_BYTE_AT_OFFSET, out);
     InternalDataSerializer.writeArrayLength(offset, out);
     DataSerializer.writePrimitiveByte(byteValue, out);
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteAtOffset.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/ReplaceByteAtOffset.java
@@ -32,7 +32,6 @@ public class ReplaceByteAtOffset extends DeltaInfo {
   private final byte byteValue;
 
   public ReplaceByteAtOffset(int offset, byte bits) {
-    super((short) 0);
     this.offset = offset;
     byteValue = bits;
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArray.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArray.java
@@ -33,7 +33,6 @@ public class SetByteArray extends DeltaInfo {
   private final byte[] byteArray;
 
   public SetByteArray(byte[] value) {
-    super((short) 0);
     byteArray = value;
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArray.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArray.java
@@ -36,9 +36,13 @@ public class SetByteArray extends DeltaInfo {
     byteArray = value;
   }
 
+  @Override
+  public DeltaType getType() {
+    return SET_BYTE_ARRAY;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(SET_BYTE_ARRAY, out);
     DataSerializer.writeByteArray(byteArray, out);
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArray.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArray.java
@@ -29,14 +29,16 @@ import org.apache.geode.redis.internal.data.AbstractRedisData;
  * This delta info simply sets a RedisData's current
  * byte array overwriting any existing one.
  */
-public class SetByteArray implements DeltaInfo {
+public class SetByteArray extends DeltaInfo {
   private final byte[] byteArray;
 
   public SetByteArray(byte[] value) {
+    super((short) 0);
     byteArray = value;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(SET_BYTE_ARRAY, out);
     DataSerializer.writeByteArray(byteArray, out);
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArrayAndTimestamp.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArrayAndTimestamp.java
@@ -34,7 +34,6 @@ public class SetByteArrayAndTimestamp extends DeltaInfo {
   private final long timestamp;
 
   public SetByteArrayAndTimestamp(byte[] bytes, long timestamp) {
-    super((short) 0);
     byteArray = bytes;
     this.timestamp = timestamp;
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArrayAndTimestamp.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArrayAndTimestamp.java
@@ -29,16 +29,18 @@ import org.apache.geode.redis.internal.data.AbstractRedisData;
  * This delta info is used by RedisString set ops to set the bytes
  * and the timestamp.
  */
-public class SetByteArrayAndTimestamp implements DeltaInfo {
+public class SetByteArrayAndTimestamp extends DeltaInfo {
   private final byte[] byteArray;
   private final long timestamp;
 
   public SetByteArrayAndTimestamp(byte[] bytes, long timestamp) {
+    super((short) 0);
     byteArray = bytes;
     this.timestamp = timestamp;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(DeltaType.SET_BYTE_ARRAY_AND_TIMESTAMP, out);
     DataSerializer.writeByteArray(byteArray, out);
     DataSerializer.writePrimitiveLong(timestamp, out);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArrayAndTimestamp.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetByteArrayAndTimestamp.java
@@ -17,6 +17,7 @@ package org.apache.geode.redis.internal.data.delta;
 
 import static org.apache.geode.DataSerializer.readByteArray;
 import static org.apache.geode.DataSerializer.readPrimitiveLong;
+import static org.apache.geode.redis.internal.data.delta.DeltaType.SET_BYTE_ARRAY_AND_TIMESTAMP;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -38,9 +39,13 @@ public class SetByteArrayAndTimestamp extends DeltaInfo {
     this.timestamp = timestamp;
   }
 
+  @Override
+  public DeltaType getType() {
+    return SET_BYTE_ARRAY_AND_TIMESTAMP;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(DeltaType.SET_BYTE_ARRAY_AND_TIMESTAMP, out);
     DataSerializer.writeByteArray(byteArray, out);
     DataSerializer.writePrimitiveLong(timestamp, out);
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetTimestamp.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetTimestamp.java
@@ -33,9 +33,13 @@ public class SetTimestamp extends DeltaInfo {
     timestamp = value;
   }
 
+  @Override
+  public DeltaType getType() {
+    return SET_TIMESTAMP;
+  }
+
   public void serializeTo(DataOutput out) throws IOException {
     super.serializeTo(out);
-    DataSerializer.writeEnum(SET_TIMESTAMP, out);
     DataSerializer.writePrimitiveLong(timestamp, out);
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetTimestamp.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetTimestamp.java
@@ -30,7 +30,6 @@ public class SetTimestamp extends DeltaInfo {
   private final long timestamp;
 
   public SetTimestamp(long value) {
-    super((short) 0);
     timestamp = value;
   }
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetTimestamp.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/delta/SetTimestamp.java
@@ -26,14 +26,16 @@ import java.io.IOException;
 import org.apache.geode.DataSerializer;
 import org.apache.geode.redis.internal.data.AbstractRedisData;
 
-public class SetTimestamp implements DeltaInfo {
+public class SetTimestamp extends DeltaInfo {
   private final long timestamp;
 
   public SetTimestamp(long value) {
+    super((short) 0);
     timestamp = value;
   }
 
   public void serializeTo(DataOutput out) throws IOException {
+    super.serializeTo(out);
     DataSerializer.writeEnum(SET_TIMESTAMP, out);
     DataSerializer.writePrimitiveLong(timestamp, out);
   }

--- a/geode-for-redis/src/main/resources/org/apache/geode/redis/internal/services/sanctioned-geode-for-redis-serializables.txt
+++ b/geode-for-redis/src/main/resources/org/apache/geode/redis/internal/services/sanctioned-geode-for-redis-serializables.txt
@@ -3,6 +3,6 @@ org/apache/geode/redis/internal/commands/executor/BaseSetOptions$Exists,false
 org/apache/geode/redis/internal/commands/parameters/RedisParametersMismatchException,true,-643700717871858072
 org/apache/geode/redis/internal/data/RedisDataType,false,nullType:org/apache/geode/redis/internal/data/RedisData,toStringValue:java/lang/String
 org/apache/geode/redis/internal/data/RedisSortedSet$MemberAddResult,false
-org/apache/geode/redis/internal/data/delta/DeltaType,false
+org/apache/geode/redis/internal/data/delta/DeltaType,false,versioned:boolean
 org/apache/geode/redis/internal/netty/CoderException,true,4707944288714910949
 org/apache/geode/redis/internal/netty/RedisCommandParserException,true,4707944288714910949


### PR DESCRIPTION
This change is necessary because GII can retrieve a value that is
currently being updated. This can result in corruption if a Delta change
is subsequently applied.

- Convert DeltaInfo to an abstract class and add a version field
- DeltaTypes indicate whether the type is versioned
- Versioning needs to be added to any operations where the application
  of a Delta is not idempotent. In such cases, the version and data
  change MUST happen together under synchronization.
- Take care that the version is not inadvertently updated as a result of
  applying a delta change.
- Update the String APPEND command to use these changes.
- Other commands will be updated separately.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
