### PR TITLE
GEODE-288: Adds @Deprecated annotation to old admin service.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/admin/AdminConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/AdminConfig.java
@@ -40,6 +40,7 @@ import java.util.Date;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class AdminConfig {
   // Name, Type, Host, Port
   public static Entry[] loadConfig(File file) throws IOException {

--- a/geode-core/src/main/java/org/apache/geode/admin/AdminDistributedSystem.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/AdminDistributedSystem.java
@@ -36,6 +36,7 @@ import org.apache.geode.distributed.DistributedMember;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface AdminDistributedSystem {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/AdminDistributedSystemFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/AdminDistributedSystemFactory.java
@@ -33,6 +33,7 @@ import org.apache.geode.internal.logging.LocalLogWriter;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class AdminDistributedSystemFactory {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/AdminException.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/AdminException.java
@@ -26,6 +26,7 @@ import org.apache.geode.GemFireCheckedException;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class AdminException extends GemFireCheckedException {
   private static final long serialVersionUID = 879398950879472021L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/AdminXmlException.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/AdminXmlException.java
@@ -24,6 +24,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class AdminXmlException extends RuntimeAdminException {
   private static final long serialVersionUID = -6848726449157550169L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/Alert.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/Alert.java
@@ -24,6 +24,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface Alert {
 
   /** The level at which this alert is issued */

--- a/geode-core/src/main/java/org/apache/geode/admin/AlertLevel.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/AlertLevel.java
@@ -25,6 +25,7 @@ import org.apache.geode.internal.admin.Alert;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 @Immutable
 public class AlertLevel implements java.io.Serializable {
   private static final long serialVersionUID = -4752438966587392126L;

--- a/geode-core/src/main/java/org/apache/geode/admin/AlertListener.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/AlertListener.java
@@ -21,6 +21,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface AlertListener extends java.util.EventListener {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/BackupStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/BackupStatus.java
@@ -29,6 +29,7 @@ import org.apache.geode.distributed.DistributedMember;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface BackupStatus {
   /**
    * Returns a map of disk stores that were successfully backed up. The key is an online distributed

--- a/geode-core/src/main/java/org/apache/geode/admin/CacheDoesNotExistException.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/CacheDoesNotExistException.java
@@ -24,6 +24,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class CacheDoesNotExistException extends AdminException {
   private static final long serialVersionUID = -1639933911265729978L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/CacheHealthConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/CacheHealthConfig.java
@@ -64,6 +64,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface CacheHealthConfig {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/CacheVm.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/CacheVm.java
@@ -27,6 +27,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface CacheVm extends SystemMember, ManagedEntity {
   /**
    * Returns the configuration of this cache vm

--- a/geode-core/src/main/java/org/apache/geode/admin/CacheVmConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/CacheVmConfig.java
@@ -25,6 +25,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface CacheVmConfig extends ManagedEntityConfig {
   /**
    * Returns the <code>cache.xml</code> declarative caching initialization file used to configure

--- a/geode-core/src/main/java/org/apache/geode/admin/ConfigurationParameter.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/ConfigurationParameter.java
@@ -24,6 +24,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface ConfigurationParameter {
 
   /** Gets the identifying name of this configuration parameter. */

--- a/geode-core/src/main/java/org/apache/geode/admin/DistributedSystemConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/DistributedSystemConfig.java
@@ -62,6 +62,7 @@ import org.apache.geode.distributed.internal.DistributionConfig;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface DistributedSystemConfig extends Cloneable {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/DistributedSystemHealthConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/DistributedSystemHealthConfig.java
@@ -46,6 +46,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface DistributedSystemHealthConfig {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/DistributionLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/DistributionLocator.java
@@ -27,6 +27,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface DistributionLocator extends ManagedEntity {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/DistributionLocatorConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/DistributionLocatorConfig.java
@@ -38,6 +38,7 @@ import java.util.Properties;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface DistributionLocatorConfig extends ManagedEntityConfig {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/GemFireHealth.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/GemFireHealth.java
@@ -39,6 +39,7 @@ import org.apache.geode.internal.Assert;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface GemFireHealth {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/GemFireHealthConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/GemFireHealthConfig.java
@@ -24,6 +24,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface GemFireHealthConfig extends MemberHealthConfig, CacheHealthConfig {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/GemFireMemberStatus.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/GemFireMemberStatus.java
@@ -54,6 +54,7 @@ import org.apache.geode.internal.inet.LocalHostUtil;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class GemFireMemberStatus implements Serializable {
   private static final long serialVersionUID = 3389997790525991310L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/ManagedEntity.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/ManagedEntity.java
@@ -24,6 +24,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface ManagedEntity {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/ManagedEntityConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/ManagedEntityConfig.java
@@ -26,6 +26,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface ManagedEntityConfig extends Cloneable {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/MemberHealthConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/MemberHealthConfig.java
@@ -47,6 +47,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface MemberHealthConfig {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/OperationCancelledException.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/OperationCancelledException.java
@@ -25,6 +25,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class OperationCancelledException extends RuntimeAdminException {
   private static final long serialVersionUID = 5474068770227602546L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/RegionNotFoundException.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/RegionNotFoundException.java
@@ -28,6 +28,7 @@ import org.apache.geode.cache.CacheRuntimeException;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class RegionNotFoundException extends CacheRuntimeException {
   private static final long serialVersionUID = 1758668137691463909L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/RegionSubRegionSnapshot.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/RegionSubRegionSnapshot.java
@@ -38,6 +38,7 @@ import org.apache.geode.internal.cache.PartitionedRegion;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class RegionSubRegionSnapshot implements DataSerializable {
   private static final long serialVersionUID = -8052137675270041871L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/RuntimeAdminException.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/RuntimeAdminException.java
@@ -25,6 +25,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class RuntimeAdminException extends org.apache.geode.GemFireException {
 
   private static final long serialVersionUID = -7512771113818634005L;

--- a/geode-core/src/main/java/org/apache/geode/admin/Statistic.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/Statistic.java
@@ -24,6 +24,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface Statistic extends java.io.Serializable {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/StatisticResource.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/StatisticResource.java
@@ -24,6 +24,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface StatisticResource {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMember.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMember.java
@@ -27,6 +27,7 @@ import org.apache.geode.distributed.DistributedMember;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMember {
 
   /** Gets the {@link AdminDistributedSystem} this member belongs to. */

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMemberCache.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMemberCache.java
@@ -25,6 +25,7 @@ import org.apache.geode.cache.RegionAttributes;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMemberCache {
   // attributes
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMemberCacheEvent.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMemberCacheEvent.java
@@ -25,6 +25,7 @@ import org.apache.geode.cache.Operation;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMemberCacheEvent extends SystemMembershipEvent {
   /**
    * Returns the actual operation that caused this event.

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMemberCacheListener.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMemberCacheListener.java
@@ -30,6 +30,7 @@ import org.apache.geode.cache.Region;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMemberCacheListener {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMemberCacheServer.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMemberCacheServer.java
@@ -27,6 +27,7 @@ import org.apache.geode.cache.server.ServerLoadProbe;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMemberCacheServer {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMemberRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMemberRegion.java
@@ -38,6 +38,7 @@ import org.apache.geode.cache.SubscriptionAttributes;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMemberRegion {
   // attributes
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMemberRegionEvent.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMemberRegionEvent.java
@@ -23,6 +23,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMemberRegionEvent extends SystemMemberCacheEvent {
   /**
    * Returns the full path of the region the event was done on.

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMemberType.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMemberType.java
@@ -26,6 +26,7 @@ import org.apache.geode.annotations.Immutable;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 @Immutable
 public class SystemMemberType implements java.io.Serializable {
   private static final long serialVersionUID = 3284366994485749302L;

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMembershipEvent.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMembershipEvent.java
@@ -26,6 +26,7 @@ import org.apache.geode.distributed.DistributedMember;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMembershipEvent {
   /**
    * Returns the distributed member as a String.

--- a/geode-core/src/main/java/org/apache/geode/admin/SystemMembershipListener.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/SystemMembershipListener.java
@@ -25,6 +25,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface SystemMembershipListener {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/UnmodifiableConfigurationException.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/UnmodifiableConfigurationException.java
@@ -25,6 +25,7 @@ package org.apache.geode.admin;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class UnmodifiableConfigurationException extends AdminException {
   private static final long serialVersionUID = -7653547392992060646L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/AbstractHealthEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/AbstractHealthEvaluator.java
@@ -35,6 +35,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public abstract class AbstractHealthEvaluator {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/AdminDistributedSystemImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/AdminDistributedSystemImpl.java
@@ -106,6 +106,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class AdminDistributedSystemImpl implements org.apache.geode.admin.AdminDistributedSystem,
     org.apache.geode.internal.admin.JoinLeaveListener,
     org.apache.geode.internal.admin.AlertListener,

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/BackupStatusImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/BackupStatusImpl.java
@@ -26,6 +26,7 @@ import org.apache.geode.distributed.DistributedMember;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class BackupStatusImpl implements BackupStatus {
   private static final long serialVersionUID = 3704162840296921841L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/CacheHealthConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/CacheHealthConfigImpl.java
@@ -22,6 +22,7 @@ import org.apache.geode.admin.CacheHealthConfig;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public abstract class CacheHealthConfigImpl extends MemberHealthConfigImpl
     implements CacheHealthConfig {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/CacheHealthEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/CacheHealthEvaluator.java
@@ -37,6 +37,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 class CacheHealthEvaluator extends AbstractHealthEvaluator implements CacheLifecycleListener {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/CacheServerConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/CacheServerConfigImpl.java
@@ -25,6 +25,7 @@ import org.apache.geode.internal.admin.GemFireVM;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public class CacheServerConfigImpl extends ManagedEntityConfigImpl
     implements CacheVmConfig, CacheServerConfig {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/CacheServerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/CacheServerImpl.java
@@ -33,6 +33,7 @@ import org.apache.geode.internal.admin.remote.RemoteApplicationVM;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class CacheServerImpl extends ManagedSystemMemberImpl implements CacheVm, CacheServer {
 
   /** How many new <code>CacheServer</code>s have been created? */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ConfigurationParameterImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ConfigurationParameterImpl.java
@@ -32,6 +32,7 @@ import org.apache.geode.admin.UnmodifiableConfigurationException;
  * @since GemFire 3.5
  *
  */
+@Deprecated
 public class ConfigurationParameterImpl implements org.apache.geode.admin.ConfigurationParameter {
 
   /** Identifying name of this configuration parameter */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ConfigurationParameterListener.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ConfigurationParameterListener.java
@@ -24,6 +24,7 @@ import org.apache.geode.admin.ConfigurationParameter;
  * @since GemFire 3.5
  *
  */
+@Deprecated
 public interface ConfigurationParameterListener {
   void configurationParameterValueChanged(ConfigurationParameter parm);
 }

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DisabledManagedEntityController.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DisabledManagedEntityController.java
@@ -29,6 +29,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  * DisabledManagedEntityController as a place holder.
  *
  */
+@Deprecated
 class DisabledManagedEntityController implements ManagedEntityController {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemConfigImpl.java
@@ -68,6 +68,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class DistributedSystemConfigImpl implements DistributedSystemConfig {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthConfigImpl.java
@@ -24,6 +24,7 @@ import org.apache.geode.admin.DistributedSystemHealthConfig;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class DistributedSystemHealthConfigImpl implements DistributedSystemHealthConfig {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthEvaluator.java
@@ -37,6 +37,7 @@ import org.apache.geode.distributed.internal.membership.InternalDistributedMembe
  *
  * @since GemFire 3.5
  */
+@Deprecated
 class DistributedSystemHealthEvaluator extends AbstractHealthEvaluator
     implements MembershipListener {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributedSystemHealthMonitor.java
@@ -54,6 +54,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 class DistributedSystemHealthMonitor implements Runnable, GemFireVM {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributionLocatorConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributionLocatorConfigImpl.java
@@ -35,6 +35,7 @@ import org.apache.geode.internal.security.SecurableCommunicationChannel;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public class DistributionLocatorConfigImpl extends ManagedEntityConfigImpl
     implements DistributionLocatorConfig {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/DistributionLocatorImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/DistributionLocatorImpl.java
@@ -41,6 +41,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class DistributionLocatorImpl implements DistributionLocator, InternalManagedEntity {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/EnabledManagedEntityController.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/EnabledManagedEntityController.java
@@ -48,6 +48,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 class EnabledManagedEntityController implements ManagedEntityController {
   private static final Logger logger = LogService.getLogger();
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/GemFireHealthConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/GemFireHealthConfigImpl.java
@@ -25,6 +25,7 @@ import org.apache.geode.admin.GemFireHealthConfig;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class GemFireHealthConfigImpl extends CacheHealthConfigImpl implements GemFireHealthConfig {
 
   private static final long serialVersionUID = -6797673296902808018L;

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/GemFireHealthEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/GemFireHealthEvaluator.java
@@ -40,6 +40,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class GemFireHealthEvaluator {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/GemFireHealthImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/GemFireHealthImpl.java
@@ -42,6 +42,7 @@ import org.apache.geode.internal.admin.JoinLeaveListener;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class GemFireHealthImpl implements GemFireHealth, JoinLeaveListener, HealthListener {
 
   /** The distributed system whose health is being monitored */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/InetAddressUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/InetAddressUtils.java
@@ -26,6 +26,7 @@ import org.apache.geode.internal.inet.LocalHostUtil;
  * strings.
  */
 @SuppressWarnings("unused")
+@Deprecated
 public class InetAddressUtils {
 
   private InetAddressUtils() {

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/InternalManagedEntity.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/InternalManagedEntity.java
@@ -24,6 +24,7 @@ import org.apache.geode.admin.ManagedEntityConfig;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public interface InternalManagedEntity extends ManagedEntity {
 
   /** The state of a managed entity is unknown. */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/LogCollator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/LogCollator.java
@@ -29,6 +29,7 @@ import org.apache.geode.internal.admin.GemFireVM;
 import org.apache.geode.internal.admin.GfManagerAgent;
 import org.apache.geode.internal.logging.MergeLogFiles;
 
+@Deprecated
 public class LogCollator {
 
   private GfManagerAgent system;

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityConfigImpl.java
@@ -33,6 +33,7 @@ import org.apache.geode.internal.inet.LocalHostUtil;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public abstract class ManagedEntityConfigImpl implements ManagedEntityConfig {
 
   /** The name of the host on which the managed entity runs */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityConfigXml.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityConfigXml.java
@@ -33,6 +33,7 @@ import org.apache.geode.internal.classloader.ClassPathLoader;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 abstract class ManagedEntityConfigXml implements EntityResolver, ErrorHandler {
 
   /** The location of the DTD file */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityConfigXmlGenerator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityConfigXmlGenerator.java
@@ -56,6 +56,7 @@ import org.apache.geode.internal.Assert;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public class ManagedEntityConfigXmlGenerator extends ManagedEntityConfigXml implements XMLReader {
 
   /** An empty <code>Attributes</code> */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityConfigXmlParser.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityConfigXmlParser.java
@@ -40,6 +40,7 @@ import org.apache.geode.internal.Assert;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public class ManagedEntityConfigXmlParser extends ManagedEntityConfigXml implements ContentHandler {
 
   /** The <code>DistributedSystemConfig</code> to be configured */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityController.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityController.java
@@ -22,6 +22,7 @@ import org.apache.geode.admin.ManagedEntityConfig;
  * Defines the actual administration (starting, stopping, etc.) of GemFire {@link ManagedEntity}s.
  *
  */
+@Deprecated
 interface ManagedEntityController {
   /**
    * Starts a managed entity.

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityControllerFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedEntityControllerFactory.java
@@ -27,6 +27,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  * {@link ManagedEntity}s.
  *
  */
+@Deprecated
 public class ManagedEntityControllerFactory {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedSystemMemberImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/ManagedSystemMemberImpl.java
@@ -29,6 +29,7 @@ import org.apache.geode.internal.admin.GemFireVM;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public abstract class ManagedSystemMemberImpl extends SystemMemberImpl
     implements InternalManagedEntity {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/MemberHealthConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/MemberHealthConfigImpl.java
@@ -24,6 +24,7 @@ import org.apache.geode.admin.MemberHealthConfig;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public abstract class MemberHealthConfigImpl implements MemberHealthConfig, java.io.Serializable {
 
   private static final long serialVersionUID = 3966032573073580490L;

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/MemberHealthEvaluator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/MemberHealthEvaluator.java
@@ -35,6 +35,7 @@ import org.apache.geode.logging.internal.OSProcess;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 class MemberHealthEvaluator extends AbstractHealthEvaluator {
 
   /** The config from which we get the evaluation criteria */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/StatisticImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/StatisticImpl.java
@@ -23,6 +23,7 @@ import org.apache.geode.internal.admin.Stat;
  * @since GemFire 3.5
  *
  */
+@Deprecated
 public class StatisticImpl implements org.apache.geode.admin.Statistic {
 
   private static final long serialVersionUID = 3899296873901634399L;

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/StatisticResourceImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/StatisticResourceImpl.java
@@ -29,6 +29,7 @@ import org.apache.geode.internal.admin.StatResource;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class StatisticResourceImpl implements org.apache.geode.admin.StatisticResource {
 
   /** The underlying remote StatResource which this object delegates to */

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberBridgeServerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberBridgeServerImpl.java
@@ -30,6 +30,7 @@ import org.apache.geode.internal.admin.GemFireVM;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public class SystemMemberBridgeServerImpl
     implements SystemMemberCacheServer, SystemMemberBridgeServer {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberCacheEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberCacheEventImpl.java
@@ -25,6 +25,7 @@ import org.apache.geode.distributed.DistributedMember;
  *
  * @since GemFire 5.0
  */
+@Deprecated
 public class SystemMemberCacheEventImpl extends SystemMembershipEventImpl
     implements SystemMemberCacheEvent {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberCacheEventProcessor.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberCacheEventProcessor.java
@@ -43,6 +43,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 5.0
  */
+@Deprecated
 public class SystemMemberCacheEventProcessor {
   private static final Logger logger = LogService.getLogger();
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberCacheImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberCacheImpl.java
@@ -44,6 +44,7 @@ import org.apache.geode.internal.admin.StatResource;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class SystemMemberCacheImpl implements SystemMemberCache {
   protected final GemFireVM vm;
   protected CacheInfo info;

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberImpl.java
@@ -54,6 +54,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class SystemMemberImpl implements org.apache.geode.admin.SystemMember,
     org.apache.geode.admin.internal.ConfigurationParameterListener {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberRegionEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberRegionEventImpl.java
@@ -25,6 +25,7 @@ import org.apache.geode.distributed.DistributedMember;
  *
  * @since GemFire 5.0
  */
+@Deprecated
 public class SystemMemberRegionEventImpl extends SystemMemberCacheEventImpl
     implements SystemMemberRegionEvent {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberRegionImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMemberRegionImpl.java
@@ -42,6 +42,7 @@ import org.apache.geode.internal.admin.remote.AdminRegion;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class SystemMemberRegionImpl implements SystemMemberRegion {
 
   private final AdminRegion r;

--- a/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMembershipEventImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/internal/SystemMembershipEventImpl.java
@@ -24,6 +24,7 @@ import org.apache.geode.distributed.DistributedMember;
  *
  * @since GemFire 5.0
  */
+@Deprecated
 public class SystemMembershipEventImpl implements SystemMembershipEvent {
 
   /** The id of the member that generated this event */

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/Agent.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/Agent.java
@@ -61,6 +61,7 @@ import org.apache.geode.admin.AdminException;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface Agent {
 
   /** Lookup name for RMIConnector when rmi-registry-enabled is true */

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/AgentConfig.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/AgentConfig.java
@@ -254,6 +254,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public interface AgentConfig extends DistributedSystemConfig {
 
   /** The prefix for JMX Agent configuration system properties */

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/AgentFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/AgentFactory.java
@@ -26,6 +26,7 @@ import org.apache.geode.admin.jmx.internal.AgentImpl;
  *             "{@docRoot}/org/apache/geode/management/package-summary.html">management</a></code>
  *             package instead
  */
+@Deprecated
 public class AgentFactory {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AdminDistributedSystemJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AdminDistributedSystemJmxImpl.java
@@ -99,6 +99,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class AdminDistributedSystemJmxImpl extends AdminDistributedSystemImpl
     implements ManagedResource, DistributedSystemConfig, StatAlertsAggregator {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AgentConfigImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AgentConfigImpl.java
@@ -63,6 +63,7 @@ import org.apache.geode.internal.util.IOUtils;
  *
  * @since GemFire 3.5 (in which it was named AgentConfig)
  */
+@Deprecated
 public class AgentConfigImpl extends DistributedSystemConfigImpl implements AgentConfig {
 
   // -------------------------------------------------------------------------

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AgentImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AgentImpl.java
@@ -77,6 +77,7 @@ import org.apache.geode.logging.internal.spi.LogConfigSupplier;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class AgentImpl implements org.apache.geode.admin.jmx.Agent,
     org.apache.geode.admin.jmx.internal.ManagedResource, LogConfigSupplier {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AgentLauncher.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/AgentLauncher.java
@@ -58,6 +58,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class AgentLauncher {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/CacheServerJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/CacheServerJmxImpl.java
@@ -52,6 +52,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public class CacheServerJmxImpl extends CacheServerImpl
     implements ManagedResource, CacheVmConfig, CacheServerConfig, SystemMemberJmx {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/ConfigurationParameterJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/ConfigurationParameterJmxImpl.java
@@ -35,6 +35,7 @@ import org.apache.geode.admin.UnmodifiableConfigurationException;
  * @since GemFire 3.5
  *
  */
+@Deprecated
 public class ConfigurationParameterJmxImpl
     extends org.apache.geode.admin.internal.ConfigurationParameterImpl implements Serializable {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/DistributedSystemHealthConfigJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/DistributedSystemHealthConfigJmxImpl.java
@@ -31,6 +31,7 @@ import org.apache.geode.admin.internal.DistributedSystemHealthConfigImpl;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class DistributedSystemHealthConfigJmxImpl extends DistributedSystemHealthConfigImpl
     implements ManagedResource {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/DistributionLocatorJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/DistributionLocatorJmxImpl.java
@@ -24,6 +24,7 @@ import org.apache.geode.admin.internal.AdminDistributedSystemImpl;
  * Provides MBean support for managing a distribution locator.
  *
  */
+@Deprecated
 public class DistributionLocatorJmxImpl
     extends org.apache.geode.admin.internal.DistributionLocatorImpl
     implements org.apache.geode.admin.jmx.internal.ManagedResource, DistributionLocatorConfig {

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/DynamicManagedBean.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/DynamicManagedBean.java
@@ -29,6 +29,7 @@ import org.apache.commons.modeler.OperationInfo;
  *
  * @since GemFire 5.0.1
  */
+@Deprecated
 public class DynamicManagedBean extends org.apache.commons.modeler.ManagedBean {
   private static final long serialVersionUID = 4051924500150228160L;
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/GemFireHealthJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/GemFireHealthJmxImpl.java
@@ -39,6 +39,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class GemFireHealthJmxImpl extends GemFireHealthImpl implements ManagedResource {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/GenerateMBeanHTML.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/GenerateMBeanHTML.java
@@ -42,6 +42,7 @@ import org.apache.geode.internal.classloader.ClassPathLoader;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class GenerateMBeanHTML extends DefaultHandler {
 
   /** The location of the DTD for the MBean descriptions */

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MBeanUtils.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MBeanUtils.java
@@ -51,6 +51,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  * @since GemFire 3.5
  *
  */
+@Deprecated
 public class MBeanUtils {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MX4JModelMBean.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MX4JModelMBean.java
@@ -61,6 +61,7 @@ import mx4j.util.Utils;
  * @author <a href="mailto:biorn_steedom@users.sourceforge.net">Simone Bordet</a>
  * @version $Revision: 1.14 $
  */
+@Deprecated
 public class MX4JModelMBean implements ModelMBean, MBeanRegistration, NotificationEmitter {
   private static final String OBJECT_RESOURCE_TYPE = "ObjectReference";
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MX4JServerSocketFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MX4JServerSocketFactory.java
@@ -45,6 +45,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 3.5 (old name was SSLAdaptorServerSocketFactory)
  */
+@Deprecated
 public class MX4JServerSocketFactory implements mx4j.tools.adaptor.AdaptorServerSocketFactory,
     java.rmi.server.RMIServerSocketFactory {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MailManager.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MailManager.java
@@ -38,6 +38,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  *
  * @since GemFire 5.1
  */
+@Deprecated
 public class MailManager {
 
   private static final Logger logger = LogService.getLogger();

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/ManagedResource.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/ManagedResource.java
@@ -24,6 +24,7 @@ import javax.management.modelmbean.ModelMBean;
  * @since GemFire 3.5
  *
  */
+@Deprecated
 public interface ManagedResource {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MemberInfoWithStatsMBean.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/MemberInfoWithStatsMBean.java
@@ -81,6 +81,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *
  * @since GemFire 6.5
  */
+@Deprecated
 public class MemberInfoWithStatsMBean extends AbstractDynamicMBean implements NotificationEmitter {
   private static final Logger logger = LogService.getLogger();
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/RMIRegistryService.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/RMIRegistryService.java
@@ -30,6 +30,7 @@ import java.rmi.server.UnicastRemoteObject;
  * This MBean is an implementation of {@link RMIRegistryServiceMBean}.
  *
  */
+@Deprecated
 public class RMIRegistryService implements RMIRegistryServiceMBean {
   /* RMI Registry host */
   private String host;

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/RMIRegistryServiceMBean.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/RMIRegistryServiceMBean.java
@@ -24,6 +24,7 @@ import java.rmi.RemoteException;
  * get bound to. 2. Port property can not be changed once set.
  *
  */
+@Deprecated
 public interface RMIRegistryServiceMBean {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/StatAlertNotification.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/StatAlertNotification.java
@@ -35,6 +35,7 @@ import org.apache.geode.internal.serialization.SerializationContext;
  *
  * @since GemFire 5.7
  */
+@Deprecated
 public class StatAlertNotification extends StatAlert
     implements Serializable, DataSerializableFixedID {
   private static final long serialVersionUID = -1634729103430107871L;

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/StatAlertsAggregator.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/StatAlertsAggregator.java
@@ -30,6 +30,7 @@ import org.apache.geode.internal.admin.StatAlertDefinition;
  * </ol>
  *
  */
+@Deprecated
 public interface StatAlertsAggregator {
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/StatisticResourceJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/StatisticResourceJmxImpl.java
@@ -35,6 +35,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  * @since GemFire 3.5
  *
  */
+@Deprecated
 public class StatisticResourceJmxImpl extends org.apache.geode.admin.internal.StatisticResourceImpl
     implements javax.management.NotificationListener,
     org.apache.geode.admin.jmx.internal.ManagedResource {

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberBridgeServerJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberBridgeServerJmxImpl.java
@@ -28,6 +28,7 @@ import org.apache.geode.internal.admin.GemFireVM;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public class SystemMemberBridgeServerJmxImpl extends SystemMemberBridgeServerImpl
     implements ManagedResource {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberCacheJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberCacheJmxImpl.java
@@ -42,6 +42,7 @@ import org.apache.geode.internal.admin.GemFireVM;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class SystemMemberCacheJmxImpl extends org.apache.geode.admin.internal.SystemMemberCacheImpl
     implements org.apache.geode.admin.jmx.internal.ManagedResource {
 

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberJmx.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberJmx.java
@@ -47,6 +47,7 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *
  * @since GemFire 4.0
  */
+@Deprecated
 public interface SystemMemberJmx extends SystemMember, NotificationListener {
   /**
    * Notification type for indicating a cache got created on a member of this distributed system.

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberJmxImpl.java
@@ -55,6 +55,7 @@ import org.apache.geode.logging.internal.log4j.api.LogService;
  * @since GemFire 3.5
  *
  */
+@Deprecated
 public class SystemMemberJmxImpl extends org.apache.geode.admin.internal.SystemMemberImpl
     implements SystemMemberJmx, javax.management.NotificationListener,
     org.apache.geode.admin.jmx.internal.ManagedResource {

--- a/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberRegionJmxImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/admin/jmx/internal/SystemMemberRegionJmxImpl.java
@@ -26,6 +26,7 @@ import org.apache.geode.internal.admin.GemFireVM;
  *
  * @since GemFire 3.5
  */
+@Deprecated
 public class SystemMemberRegionJmxImpl
     extends org.apache.geode.admin.internal.SystemMemberRegionImpl
     implements org.apache.geode.admin.jmx.internal.ManagedResource {


### PR DESCRIPTION
The public API and some internal classes had doclet tags but not class
level @Deprecated annotations.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
