### PR TITLE
GEODE-10010: Refine per-second Redis stats

### DIFF
--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsNativeRedisAcceptanceTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsNativeRedisAcceptanceTest.java
@@ -20,7 +20,7 @@ import redis.clients.jedis.Jedis;
 
 import org.apache.geode.NativeRedisTestRule;
 
-public class InfoStatsNativeRedisAcceptanceTest extends AbstractRedisInfoStatsIntegrationTest {
+public class InfoStatsNativeRedisAcceptanceTest extends AbstractInfoStatsIntegrationTest {
   @ClassRule
   public static NativeRedisTestRule redis = new NativeRedisTestRule();
 

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/InfoStatsIntegrationTest.java
@@ -20,7 +20,7 @@ import redis.clients.jedis.Jedis;
 
 import org.apache.geode.redis.GeodeRedisServerRule;
 
-public class InfoStatsIntegrationTest extends AbstractRedisInfoStatsIntegrationTest {
+public class InfoStatsIntegrationTest extends AbstractInfoStatsIntegrationTest {
   @ClassRule
   public static GeodeRedisServerRule server = new GeodeRedisServerRule();
 
@@ -35,7 +35,5 @@ public class InfoStatsIntegrationTest extends AbstractRedisInfoStatsIntegrationT
   }
 
   @Override
-  public void configureMaxMemory(Jedis jedis) {
-    return;
-  }
+  public void configureMaxMemory(Jedis jedis) {}
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/statistics/RedisStats.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/statistics/RedisStats.java
@@ -16,15 +16,18 @@
 
 package org.apache.geode.redis.internal.statistics;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
 import static org.apache.geode.internal.statistics.StatisticsClockFactory.getTime;
 import static org.apache.geode.logging.internal.executors.LoggingExecutors.newSingleThreadScheduledExecutor;
 
+import java.util.Arrays;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.geode.internal.statistics.StatisticsClock;
+import org.apache.geode.redis.internal.RedisException;
 import org.apache.geode.redis.internal.commands.RedisCommandType;
 
 public class RedisStats {
@@ -37,23 +40,25 @@ public class RedisStats {
   private final AtomicLong keyspaceMisses = new AtomicLong();
   private final AtomicLong uniqueChannelSubscriptions = new AtomicLong();
   private final AtomicLong uniquePatternSubscriptions = new AtomicLong();
-  private final ScheduledExecutorService perSecondExecutor;
+
+  private final ScheduledExecutorService rollingAverageExecutor;
+  private static final int ROLLING_AVERAGE_SAMPLES_PER_SECOND = 16;
+  private final RollingAverageStat networkBytesReadRollingAverageStat =
+      new RollingAverageStat(ROLLING_AVERAGE_SAMPLES_PER_SECOND, this::getTotalNetworkBytesRead);
   private volatile double networkKiloBytesReadOverLastSecond;
-  private volatile long opsPerformedLastTick;
-  private double opsPerformedOverLastSecond;
-  private long previousNetworkBytesRead;
+  private final RollingAverageStat opsPerformedRollingAverageStat =
+      new RollingAverageStat(ROLLING_AVERAGE_SAMPLES_PER_SECOND, this::getCommandsProcessed);
+  private volatile long opsPerformedOverLastSecond;
+
   private final StatisticsClock clock;
   private final GeodeRedisStats geodeRedisStats;
-  private final long START_TIME_IN_NANOS;
+  private final long startTimeInNanos;
 
-
-  public RedisStats(StatisticsClock clock,
-      GeodeRedisStats geodeRedisStats) {
-
+  public RedisStats(StatisticsClock clock, GeodeRedisStats geodeRedisStats) {
     this.clock = clock;
     this.geodeRedisStats = geodeRedisStats;
-    perSecondExecutor = startPerSecondUpdater();
-    START_TIME_IN_NANOS = clock.getTime();
+    rollingAverageExecutor = startRollingAverageUpdater();
+    startTimeInNanos = clock.getTime();
   }
 
   public void incCommandsProcessed() {
@@ -88,7 +93,7 @@ public class RedisStats {
     return networkKiloBytesReadOverLastSecond;
   }
 
-  public double getOpsPerformedOverLastSecond() {
+  public long getOpsPerformedOverLastSecond() {
     return opsPerformedOverLastSecond;
   }
 
@@ -114,7 +119,7 @@ public class RedisStats {
   }
 
   public long getUptimeInMilliseconds() {
-    long uptimeInNanos = getCurrentTimeNanos() - START_TIME_IN_NANOS;
+    long uptimeInNanos = getCurrentTimeNanos() - startTimeInNanos;
     return TimeUnit.NANOSECONDS.toMillis(uptimeInNanos);
   }
 
@@ -193,43 +198,57 @@ public class RedisStats {
 
   public void close() {
     geodeRedisStats.close();
-    stopPerSecondUpdater();
+    stopRollingAverageUpdater();
   }
 
-  private ScheduledExecutorService startPerSecondUpdater() {
-    int INTERVAL = 1;
+  private ScheduledExecutorService startRollingAverageUpdater() {
+    long microsPerSecond = 1_000_000;
+    final long delayMicros = microsPerSecond / ROLLING_AVERAGE_SAMPLES_PER_SECOND;
 
-    ScheduledExecutorService perSecondExecutor =
-        newSingleThreadScheduledExecutor("GemFireRedis-PerSecondUpdater-");
+    ScheduledExecutorService rollingAverageExecutor =
+        newSingleThreadScheduledExecutor("GemFireRedis-RollingAverageStatUpdater-");
 
-    perSecondExecutor.scheduleWithFixedDelay(
-        this::doPerSecondUpdates,
-        INTERVAL,
-        INTERVAL,
-        SECONDS);
+    rollingAverageExecutor.scheduleWithFixedDelay(this::doRollingAverageUpdates, delayMicros,
+        delayMicros, MICROSECONDS);
 
-    return perSecondExecutor;
+    return rollingAverageExecutor;
   }
 
-  private void stopPerSecondUpdater() {
-    perSecondExecutor.shutdownNow();
+  private void stopRollingAverageUpdater() {
+    rollingAverageExecutor.shutdownNow();
   }
 
-  private void doPerSecondUpdates() {
-    updateNetworkKilobytesReadLastSecond();
-    updateOpsPerformedOverLastSecond();
+  private void doRollingAverageUpdates() {
+    networkKiloBytesReadOverLastSecond = networkBytesReadRollingAverageStat.calculate() / 1024.0;
+    opsPerformedOverLastSecond = opsPerformedRollingAverageStat.calculate();
   }
 
-  private void updateNetworkKilobytesReadLastSecond() {
-    final long totalNetworkBytesRead = getTotalNetworkBytesRead();
-    long deltaNetworkBytesRead = totalNetworkBytesRead - previousNetworkBytesRead;
-    networkKiloBytesReadOverLastSecond = deltaNetworkBytesRead / 1024.0;
-    previousNetworkBytesRead = totalNetworkBytesRead;
-  }
+  private static class RollingAverageStat {
+    private int tickNumber = 0;
+    private long valueReadLastTick;
+    private final long[] valuesReadOverLastNSamples;
+    private final Callable<Long> statCallable;
 
-  private void updateOpsPerformedOverLastSecond() {
-    final long totalOpsPerformed = getCommandsProcessed();
-    opsPerformedOverLastSecond = totalOpsPerformed - opsPerformedLastTick;
-    opsPerformedLastTick = totalOpsPerformed;
+    private RollingAverageStat(int samplesPerSecond, Callable<Long> getCurrentValue) {
+      valuesReadOverLastNSamples = new long[samplesPerSecond];
+      statCallable = getCurrentValue;
+    }
+
+    private long calculate() {
+      long currentValue;
+      try {
+        currentValue = statCallable.call();
+      } catch (Exception e) {
+        throw new RedisException("Error while calculating RollingAverage stats", e);
+      }
+      long delta = currentValue - valueReadLastTick;
+      valueReadLastTick = currentValue;
+      valuesReadOverLastNSamples[tickNumber] = delta;
+      tickNumber++;
+      if (tickNumber >= valuesReadOverLastNSamples.length) {
+        tickNumber = 0;
+      }
+      return Arrays.stream(valuesReadOverLastNSamples).sum();
+    }
   }
 }


### PR DESCRIPTION
Code changes:
 - Rather than a value that updates once per second, instantaneous
 operations per second and instantaneous kilobytes read per second now
 return a rolling average of those stats updated 16 times per second
 - Change instantaneous operations per second type from double to int,
 since it's always a whole number
 - Introduce RollingAverageStat nested class in RedisStats to handle
 calculating the rolling average value of a given stat

Test changes:
 - Rename AbstractRedisInfoStatsIntegrationTest to match child classes
 - Rather than measuring instantaneous per second stats after
 operations have finished, sample them while operations are ongoing
 - Assert only that the stats have updated, not that they are close to a
 calculated expected value, as this proved too inconsistent and very
 flaky

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
