### PR TITLE
GEODE-10117: Added section in docs about memory

### DIFF
--- a/geode-docs/developing/storing_data_on_disk/storing_data_on_disk.html.md.erb
+++ b/geode-docs/developing/storing_data_on_disk/storing_data_on_disk.html.md.erb
@@ -47,11 +47,10 @@ Use the following steps to configure your data regions for persistence and overf
           </region-attributes>
         </region>
         ```
-        **Note:** For partition regions if the partition region attribute `local-max-memory` is set then the eviction attribute `lru-memory-size maximum` is overwritten with the value of `local-max-memory`
-        Both `local-max-memory` and `lru-memory-size maximum` are local member attributes and not cluster-wide.
-        gfsh:
-
-        You cannot configure `lru-memory-size` using gfsh.
+        **Notes:**
+        - For partitioned regions, if the partition region attribute `local-max-memory` is set, then the eviction attribute `lru-memory-size maximum` is overwritten with the value \
+of `local-max-memory`. Both `local-max-memory` and `lru-memory-size maximum` are local member attributes and not cluster-wide.
+        - You cannot configure `lru-memory-size` using gfsh.
     -   For persistence, set the `data-policy` to `persistent-replicate` and name the disk store to use.
 
         Example:

--- a/geode-docs/developing/storing_data_on_disk/storing_data_on_disk.html.md.erb
+++ b/geode-docs/developing/storing_data_on_disk/storing_data_on_disk.html.md.erb
@@ -47,7 +47,8 @@ Use the following steps to configure your data regions for persistence and overf
           </region-attributes>
         </region>
         ```
-
+        **Note:** For partition regions if the partition region attribute `local-max-memory` is set then the eviction attribute `lru-memory-size maximum` is overwritten with the value of `local-max-memory`
+        Both `local-max-memory` and `lru-memory-size maximum` are local member attributes and not cluster-wide.
         gfsh:
 
         You cannot configure `lru-memory-size` using gfsh.


### PR DESCRIPTION
* Added section in the doc about lru max memory being over written if
local max memory is set.
* Also mentioned that these two settings are local and not cluster wide

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
