### PR TITLE
GEODE-10123: Improve create region checks

### DIFF
--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommandDUnitTest.java
@@ -639,7 +639,7 @@ public class CreateRegionCommandDUnitTest {
         .statusIsError().containsOutput("already exists on the cluster");
     gfsh.executeAndAssertThat(
         "create region --type=REPLICATE_PROXY --group=group1 --name=" + regionName).statusIsError()
-        .containsOutput("already exists on these members: server-1");
+        .containsOutput("already exists in groups: group1");
   }
 
   @Test
@@ -657,7 +657,7 @@ public class CreateRegionCommandDUnitTest {
         .statusIsError().containsOutput("already exists on the cluster");
     gfsh.executeAndAssertThat(
         "create region --type=PARTITION_PROXY --group=group1 --name=" + regionName).statusIsError()
-        .containsOutput("already exists on these members: server-1");
+        .containsOutput("already exists in groups: group1");
   }
 
   @Test
@@ -675,13 +675,13 @@ public class CreateRegionCommandDUnitTest {
     locator.waitUntilRegionIsReadyOnExactlyThisManyServers(SEPARATOR + regionName, 2);
     gfsh.executeAndAssertThat("create region --type=PARTITION --group=group2 --name=" + regionName)
         .statusIsError()
-        .containsOutput("Region " + SEPARATOR + regionName + " already exists on the cluster");
+        .containsOutput("Region " + SEPARATOR + regionName + " already exists on the cluster.");
     gfsh.executeAndAssertThat(
         "create region --type=REPLICATE_PROXY --group=group2 --name=" + regionName).statusIsError()
         .containsOutput("The existing region is not a replicate region");
     gfsh.executeAndAssertThat(
         "create region --type=PARTITION_PROXY --group=group1 --name=" + regionName).statusIsError()
-        .containsOutput("already exists on these members: server-1");
+        .containsOutput("already exists in groups: group1");
   }
 
   @Test
@@ -699,7 +699,7 @@ public class CreateRegionCommandDUnitTest {
     gfsh.executeAndAssertThat(
         "create region --type=PARTITION_PROXY --group=group2 --name=" + regionName).statusIsError()
         .containsOutput(
-            "Region " + SEPARATOR + "startWithLocalRegion already exists on the cluster");
+            "The existing region is not a partitioned region");
   }
 
   @Test

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionSecurityDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateRegionSecurityDUnitTest.java
@@ -84,6 +84,6 @@ public class CreateRegionSecurityDUnitTest {
     gfsh.executeAndAssertThat("create region --type=REPLICATE_PROXY --name=" + regionName)
         .statusIsError()
         .containsOutput(
-            "Region " + SEPARATOR + "dataManageAuthorized already exists on these members");
+            "Region " + SEPARATOR + "dataManageAuthorized already exists on the cluster");
   }
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateRegionCommand.java
@@ -608,8 +608,94 @@ public class CreateRegionCommand extends SingleGfshCommand {
     return false;
   }
 
+  RegionConfig findNonProxyRegionsInClusterConfigurationByName(String regionName,
+      InternalConfigurationPersistenceService persistenceService) {
+    RegionConfig regionConfig;
+    for (String group : persistenceService.getGroups()) {
+      CacheConfig config = persistenceService.getCacheConfig(group);
+      if (config != null) {
+        regionConfig =
+            config.getRegions().stream().filter(
+                region -> region.getName().equals(regionName) && !region.getType()
+                    .contains("PROXY"))
+                .findFirst().orElse(null);
+        if (regionConfig != null) {
+          return regionConfig;
+        }
+      }
+    }
+    return null;
+  }
+
+  boolean isRegionExistsInGroup(String regionName, String group,
+      InternalConfigurationPersistenceService persistenceService) {
+    CacheConfig config = persistenceService.getCacheConfig(group);
+    RegionConfig regionConfig = null;
+    if (config != null) {
+      regionConfig =
+          config.getRegions().stream().filter(region -> region.getName().equals(regionName))
+              .findFirst().orElse(null);
+    }
+    return regionConfig != null;
+  }
+
+  private void failIfRegionExistsInClusterConfiguration(String regionPathFull, String[] groups,
+      RegionShortcut regionShortcut) {
+    InternalConfigurationPersistenceService persistenceService =
+        getConfigurationPersistenceService();
+    if (persistenceService == null) {
+      return;
+    }
+
+    RegionPath regionPath = new RegionPath(regionPathFull);
+    RegionConfig regionConfig =
+        findNonProxyRegionsInClusterConfigurationByName(regionPath.getName(), persistenceService);
+    if (regionConfig == null) {
+      return;
+    }
+
+    String existingDataPolicy = regionConfig.getType();
+    boolean existingRegionIsNotProxy = !existingDataPolicy.contains("PROXY");
+    if (regionShortcut.isLocal() || existingDataPolicy.equals("NORMAL")
+        || (!regionShortcut.isProxy() && existingRegionIsNotProxy)) {
+      throw new EntityExistsException(
+          String.format("Region %s already exists on the cluster.", regionPath.getRegionPath()));
+    }
+
+    if (regionShortcut.isPartition() && !existingDataPolicy.contains("PARTITION")) {
+      LogService.getLogger().info("Create region command: got EntityExists exception");
+      throw new EntityExistsException("The existing region is not a partitioned region");
+    }
+
+    if (regionShortcut.isReplicate() && !existingDataPolicy.equals("EMPTY")
+        && !existingDataPolicy.contains("REPLICATE") && !existingDataPolicy.contains("PRELOADED")) {
+      throw new EntityExistsException("The existing region is not a replicate region");
+    }
+
+    if (groups == null) {
+      if (isRegionExistsInGroup(regionPath.getName(), null, persistenceService)) {
+        throw new EntityExistsException(
+            String.format("Region %s already exists on the cluster.", regionPath.getRegionPath()));
+      }
+    } else {
+      List<String> groupsExists = new ArrayList<>();
+      for (String group : groups) {
+        if (isRegionExistsInGroup(regionPath.getName(), group, persistenceService)) {
+          groupsExists.add(group);
+        }
+      }
+      if (!groupsExists.isEmpty()) {
+        throw new EntityExistsException(
+            String.format("Region %s already exists in groups: %s.", regionPath.getRegionPath(),
+                StringUtils.join(groupsExists, ",")));
+      }
+    }
+  }
+
   private void failIfRegionAlreadyExists(String regionPath, RegionShortcut regionShortcut,
       String[] groups) throws EntityExistsException {
+
+    failIfRegionExistsInClusterConfiguration(regionPath, groups, regionShortcut);
     /*
      * Adding name collision check for regions created with regionShortcut only.
      * Regions can be categories as Proxy(replicate/partition), replicate/partition, and local


### PR DESCRIPTION
Sometimes the "create region" command executes successfully during
servers restart even though region is already available in the cluster
configuration. When this happens, cluster configuration contains a
duplicated region, and servers throw
"org.apache.geode.cache.RegionExistsException" at startup.

CreateRegionCommand checks whether there is already an existing
region using the DistributedRegionMXBean service. This service is
unreliable during restarts, as it takes some time for the locator to
accumulate region information.

In addition to checks done against the DistributedRegionMXBean
information, this solution introduces the same checks against cluster
configuration (if used) stored in locators. This way, the "create region"
command is rejected immediately by the locator instead of the
servers.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
