### PR TITLE
GEODE-10100: Replace 1.13.7 with 1.13.8 as old version

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -87,7 +87,7 @@ include 'geode-server-all'
  '1.12.9',
  '1.13.0', // Include for SSL protocol configuration changes in 1.13.1
  '1.13.1',
- '1.13.7',
+ '1.13.8',
  '1.14.0', // Include for SSL protocol configuration changes in 1.14.0
  '1.14.3'].each {
   include 'geode-old-versions:'.concat(it)


### PR DESCRIPTION
Replace 1.13.7 with 1.13.8 in old versions on develop
to enable rolling upgrade tests from 1.13.8

The serialization version has not changed between 1.13.7 and 1.13.8,
so there should be no need to keep both

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
