### PR TITLE
GEODE-10128: Open/export packages for JDK 17

### DIFF
--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -1,5 +1,4 @@
 import org.apache.geode.gradle.TestPropertiesWriter
-
 import org.apache.geode.gradle.plugins.DependencyConstraints
 import org.apache.geode.gradle.testing.repeat.RepeatTest
 
@@ -176,16 +175,48 @@ gradle.taskGraph.whenReady({ graph ->
       maxHeapSize '768m'
       jvmArgs += ['-XX:+HeapDumpOnOutOfMemoryError', '-ea']
       if (project.hasProperty('testJVMVer') && testJVMVer.toInteger() >= 9) {
-        jvmArgs += ["--add-opens", "java.xml/jdk.xml.internal=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "java.base/jdk.internal.module=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "java.base/java.lang.module=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "java.base/jdk.internal.ref=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "java.base/jdk.internal.reflect=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "java.base/jdk.internal.misc=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "java.base/jdk.internal.util.jar=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "jdk.management/com.sun.management.internal=ALL-UNNAMED"]
-        jvmArgs += ["--add-opens", "java.base/jdk.internal.platform.cgroupv1=ALL-UNNAMED"]
+        jvmArgs += [
+                "--add-opens=java.base/java.io=ALL-UNNAMED",
+                "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                "--add-opens=java.base/java.lang.ref=ALL-UNNAMED",
+                "--add-opens=java.base/java.lang.module=ALL-UNNAMED",
+                "--add-opens=java.base/java.math=ALL-UNNAMED",
+                "--add-opens=java.base/java.net=ALL-UNNAMED",
+                "--add-opens=java.base/java.nio=ALL-UNNAMED",
+                "--add-opens=java.base/java.nio.channels=ALL-UNNAMED",
+                "--add-opens=java.base/java.nio.channels.spi=ALL-UNNAMED",
+                "--add-opens=java.base/java.text=ALL-UNNAMED",
+                "--add-opens=java.base/java.util=ALL-UNNAMED",
+                "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+                "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+                "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+                "--add-opens=java.base/javax.net.ssl=ALL-UNNAMED",
+                "--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED",
+                "--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED",
+                "--add-opens=java.base/jdk.internal.module=ALL-UNNAMED",
+                "--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED",
+                "--add-opens=java.base/jdk.internal.reflect=ALL-UNNAMED",
+                "--add-opens=java.base/jdk.internal.util.jar=ALL-UNNAMED",
+                "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+                "--add-opens=java.base/sun.security.ssl=ALL-UNNAMED",
+                "--add-opens=java.base/sun.util.calendar=ALL-UNNAMED",
+                "--add-opens=java.base/sun.util.locale=ALL-UNNAMED",
+                "--add-opens=java.logging/java.util.logging=ALL-UNNAMED",
+                "--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED",
+                "--add-opens=java.xml/jdk.xml.internal=ALL-UNNAMED",
+                "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
+
+                "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+                "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
+                "--add-exports=java.management/com.sun.jmx.remote.security=ALL-UNNAMED",
+        ]
+
+        if (System.getProperty("os.name").startsWith('Linux')) {
+          jvmArgs += "--add-opens=java.base/jdk.internal.platform.cgroupv1=ALL-UNNAMED"
+        }
+        if(testJVMVer.toInteger() >= 17) {
+          jvmArgs += "--add-exports=java.base/jdk.internal.util.random=ALL-UNNAMED"
+        }
       }
       if (project.hasProperty('testJVM') && !testJVM.trim().isEmpty()) {
         executable = "${testJVM}/bin/java"


### PR DESCRIPTION
PROBLEM

JDK 17 throws exceptions when product and test code attempts to access
elements in modules that do not make those elements accessible.

SOLUTION

Open and export the required packages when starting a test JVM.
