### PR TITLE
GEODE-10130: Check containsKey under synchronization.

### DIFF
--- a/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/ServerCQResultsCacheReplicateRegionImpl.java
+++ b/geode-cq/src/main/java/org/apache/geode/cache/query/cq/internal/ServerCQResultsCacheReplicateRegionImpl.java
@@ -123,9 +123,8 @@ class ServerCQResultsCacheReplicateRegionImpl implements ServerCQResultsCache {
     synchronized (LOCK) {
       destroysWhileCqResultsInProgress.forEach(cqResultKeys::remove);
       destroysWhileCqResultsInProgress.clear();
+      return cqResultKeys.containsKey(key);
     }
-
-    return cqResultKeys.containsKey(key);
   }
 
   /**

--- a/geode-cq/src/test/java/org/apache/geode/cache/query/cq/internal/ServerCQResultsCacheReplicateRegionImplTest.java
+++ b/geode-cq/src/test/java/org/apache/geode/cache/query/cq/internal/ServerCQResultsCacheReplicateRegionImplTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.query.cq.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+public class ServerCQResultsCacheReplicateRegionImplTest {
+  @Rule
+  public ExecutorServiceRule executorService = new ExecutorServiceRule();
+
+  private final ServerCQResultsCacheReplicateRegionImpl serverCQResultCache =
+      new ServerCQResultsCacheReplicateRegionImpl();
+  private final ArrayList<String> objects = new ArrayList<>();
+  private final Random random = new Random(1188999);
+  private String targetKey;
+  private boolean isDone = false;
+
+  @Before
+  public void setup() {
+    int index = 122;
+    String prefix = "object_";
+    targetKey = prefix + index;
+    int size = 1000;
+    for (int i = 0; i < size; i++) {
+      if (i != index) {
+        objects.add(prefix + i);
+      }
+    }
+  }
+
+  @Test
+  public void serverCQResultCacheContainsReturnsCorrectResult() throws Exception {
+    serverCQResultCache.setInitialized();
+    serverCQResultCache.add(targetKey);
+
+    Future<Void> future = executorService.submit(this::verifyContains);
+
+    int numberThreads = 10;
+    int numberOfOperations = 1000;
+    List<CompletableFuture<Void>> futures = new ArrayList<>();
+    for (int i = 0; i < numberThreads; i++) {
+      futures.add(executorService.runAsync(() -> doOperations(numberOfOperations)));
+    }
+
+    for (CompletableFuture<Void> completableFuture : futures) {
+      completableFuture.join();
+    }
+
+    isDone = true;
+    future.get();
+  }
+
+  private void verifyContains() {
+    while (!isDone) {
+      assertThat(serverCQResultCache.contains(targetKey)).isTrue();
+    }
+  }
+
+  private void doOperations(int numberOfOperations) {
+    int count = 0;
+    while (count < numberOfOperations) {
+      int index = random.nextInt(objects.size());
+      String key = objects.get(index);
+      assertThat(serverCQResultCache.contains(targetKey)).isTrue();
+
+      if (random.nextBoolean()) {
+        serverCQResultCache.add(key);
+      } else {
+        if (serverCQResultCache.contains(key)) {
+          serverCQResultCache.markAsDestroyed(key);
+          serverCQResultCache.remove(key, true);
+        }
+      }
+      ++count;
+    }
+  }
+}


### PR DESCRIPTION
 * containsKey in HashMap can return false even though the key exists in
   the map possibly due to map resizes as other concurrent operations
   occur. Now it will be checked under synchronized lock.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
