### PR TITLE
Revert "roll develop to 1.16.0 now that support/1.15 has been created"

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -81,7 +81,7 @@ java_test_versions:
   version: 11
 
 metadata:
-  initial_version: 1.16.0-((semver-prerelease-token)).0
+  initial_version: 1.15.0-((semver-prerelease-token)).0
   mass_test_run_iterations: 100
 
 publish_artifacts:

--- a/geode-book/config.yml
+++ b/geode-book/config.yml
@@ -21,17 +21,17 @@ public_host: localhost
 sections:
 - repository:
     name: geode-docs
-  directory: docs/guide/116
+  directory: docs/guide/115
   subnav_template: geode-subnav
 
 template_variables:
   product_name_long: Apache Geode
   product_name: Geode
   product_name_lowercase: geode
-  product_version: '1.16'
-  product_version_nodot: '116'
-  product_version_old_minor: '1.15'
-  product_version_geode: '1.16'
+  product_version: '1.15'
+  product_version_nodot: '115'
+  product_version_old_minor: '1.14'
+  product_version_geode: '1.15'
   min_java_version: '8'
   min_java_update: '121'
   support_url: http://geode.apache.org/community

--- a/geode-book/redirects.rb
+++ b/geode-book/redirects.rb
@@ -14,5 +14,5 @@
 #permissions and limitations under the License.
 
 r301 %r{/releases/latest/javadoc/(.*)}, 'http://geode.apache.org/releases/latest/javadoc/$1'
-rewrite '/', '/docs/guide/116/about_geode.html'
-rewrite '/index.html', '/docs/guide/116/about_geode.html'
+rewrite '/', '/docs/guide/115/about_geode.html'
+rewrite '/index.html', '/docs/guide/115/about_geode.html'

--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/KnownVersion.java
@@ -48,7 +48,7 @@ public class KnownVersion extends AbstractVersion {
   private final byte patch;
   private final boolean modifiesClientServerProtocol;
 
-  public static final int HIGHEST_VERSION = 160;
+  public static final int HIGHEST_VERSION = 150;
 
   @Immutable
   private static final KnownVersion[] VALUES = new KnownVersion[HIGHEST_VERSION + 1];
@@ -209,13 +209,6 @@ public class KnownVersion extends AbstractVersion {
       new KnownVersion("GEODE", "1.15.0", (byte) 1, (byte) 15, (byte) 0, (byte) 0,
           GEODE_1_15_0_ORDINAL, true);
 
-  private static final short GEODE_1_16_0_ORDINAL = 160;
-
-  @Immutable
-  public static final KnownVersion GEODE_1_16_0 =
-      new KnownVersion("GEODE", "1.16.0", (byte) 1, (byte) 16, (byte) 0, (byte) 0,
-          GEODE_1_16_0_ORDINAL);
-
   /* NOTE: when adding a new version bump the ordinal by 10. Ordinals can be short ints */
 
   /**
@@ -229,7 +222,7 @@ public class KnownVersion extends AbstractVersion {
    * HIGHEST_VERSION when changing CURRENT !!!
    */
   @Immutable
-  public static final KnownVersion CURRENT = GEODE_1_16_0;
+  public static final KnownVersion CURRENT = GEODE_1_15_0;
 
   /**
    * A lot of versioning code needs access to the current version's ordinal

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@
 #   <blank>   - release
 #
 # The full version string consists of 'versionNumber + releaseQualifier + releaseType'
-version = 1.16.0-build.0
+version = 1.15.0-build.0
 
 # Default Maven targets
 mavenSnapshotUrl = gcs://maven.apachegeode-ci.info/snapshots


### PR DESCRIPTION
per dev list discussion on Mar 16, we will roll back the support/1.15 branch cut and return develop to being 1.15 until we are in a better place to try cutting the branch again