### PR TITLE
GEODE-10129: Forward opens/exports to child JVMs

### DIFF
--- a/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ServerContainer.java
+++ b/geode-assembly/geode-assembly-test/src/main/java/org/apache/geode/session/tests/ServerContainer.java
@@ -14,7 +14,9 @@
  */
 package org.apache.geode.session.tests;
 
+import static java.util.stream.Collectors.joining;
 import static org.apache.geode.session.tests.ContainerInstall.TMP_DIR;
+import static org.apache.geode.test.process.JavaModuleHelper.getJvmModuleOptions;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,8 +29,6 @@ import java.util.function.IntSupplier;
 import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.logging.log4j.Logger;
 import org.codehaus.cargo.container.ContainerType;
 import org.codehaus.cargo.container.InstalledLocalContainer;
@@ -197,15 +197,8 @@ public abstract class ServerContainer {
     config.setProperty(GeneralPropertySet.PORT_OFFSET, "0");
     int jvmJmxPort = portSupplier.getAsInt();
     String jvmArgs = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + jvmJmxPort;
-    if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
-      jvmArgs += " --add-opens java.base/java.lang.module=ALL-UNNAMED" +
-          " --add-opens java.base/jdk.internal.module=ALL-UNNAMED" +
-          " --add-opens java.base/jdk.internal.reflect=ALL-UNNAMED" +
-          " --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" +
-          " --add-opens java.base/jdk.internal.ref=ALL-UNNAMED" +
-          " --add-opens java.base/jdk.internal.platform.cgroupv1=ALL-UNNAMED" +
-          " --add-opens jdk.management/com.sun.management.internal=ALL-UNNAMED";
-    }
+    jvmArgs += getJvmModuleOptions().stream()
+        .collect(joining(" ", " ", ""));
     config.setProperty(GeneralPropertySet.START_JVMARGS, jvmArgs);
     container.setConfiguration(config);
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/ServerLauncherDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/ServerLauncherDUnitTest.java
@@ -16,12 +16,14 @@
 package org.apache.geode.distributed;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.apache.geode.test.process.JavaModuleHelper.getJvmModuleOptions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.apache.logging.log4j.Logger;
 import org.junit.Rule;
@@ -102,8 +104,12 @@ public class ServerLauncherDUnitTest {
 
     ProcessBuilder pBuilder = new ProcessBuilder();
     pBuilder.directory(tempDir.newFolder());
-    pBuilder.command(javaBin.toString(), "-classpath", System.getProperty("java.class.path"),
-        serverLauncherClass, port + "");
+    pBuilder.command(javaBin.toString(), "-classpath", System.getProperty("java.class.path"));
+    // Copy all --add-opens and --add-exports options to the command line
+    List<String> command = pBuilder.command();
+    command.addAll(getJvmModuleOptions());
+    command.add(serverLauncherClass);
+    command.add(String.valueOf(port));
 
     pBuilder.redirectErrorStream(true);
     Process process = pBuilder.start();

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ProcessManager.java
@@ -46,6 +46,8 @@ import java.util.jar.Manifest;
 
 import org.apache.commons.io.FileUtils;
 
+import org.apache.geode.distributed.ConfigurationProperties;
+import org.apache.geode.distributed.internal.DistributionConfig;
 import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.membership.utils.AvailablePort;
 import org.apache.geode.test.dunit.VM;
@@ -299,6 +301,16 @@ class ProcessManager implements ChildVMLauncher {
     if (DUnitLauncher.LOG4J != null) {
       cmds.add("-Dlog4j.configurationFile=" + DUnitLauncher.LOG4J);
     }
+    cmds.add("-Djava.library.path=" + System.getProperty("java.library.path"));
+    cmds.add("-Xrunjdwp:transport=dt_socket,server=y,suspend=" + jdkSuspend + jdkDebug);
+    cmds.add("-XX:+HeapDumpOnOutOfMemoryError");
+    cmds.add("-Xmx512m");
+    cmds.add("-D" + GEMFIRE_PREFIX + "DEFAULT_MAX_OPLOG_SIZE=10");
+    cmds.add("-D" + GEMFIRE_PREFIX + "disallowMcastDefaults=true");
+    cmds.add("-D" + DistributionConfig.RESTRICT_MEMBERSHIP_PORT_RANGE + "=true");
+    cmds.add("-D" + GEMFIRE_PREFIX
+        + ConfigurationProperties.VALIDATE_SERIALIZABLE_OBJECTS + "=true");
+    cmds.add("-ea");
     cmds.add("-XX:MetaspaceSize=512m");
     cmds.add("-XX:SoftRefLRUPolicyMSPerMB=1");
     cmds.add(agent);

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/GfshCommandRule.java
@@ -14,7 +14,9 @@
  */
 package org.apache.geode.test.junit.rules;
 
+import static java.util.stream.Collectors.joining;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
+import static org.apache.geode.test.process.JavaModuleHelper.getJvmModuleOptions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
@@ -268,7 +270,15 @@ public class GfshCommandRule extends DescribedExternalResource {
    *             after that method call.
    */
   public CommandResult executeCommand(String command) {
-    gfsh.executeCommand(command);
+    String moduleArgs = "";
+    if (command.matches("^start +server.*") || command.matches("^start +locator.*")) {
+      moduleArgs = getJvmModuleOptions().stream()
+          .map(s -> "--J=" + s)
+          .collect(joining(" ", " ", ""));
+    }
+
+    gfsh.executeCommand(command + moduleArgs);
+
     CommandResult result;
     try {
       result = gfsh.getResult();

--- a/geode-junit/src/main/java/org/apache/geode/test/process/JavaModuleHelper.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/process/JavaModuleHelper.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.test.process;
+
+import static java.util.stream.Collectors.toList;
+
+import java.lang.management.ManagementFactory;
+import java.util.List;
+
+public class JavaModuleHelper {
+  /**
+   * Returns the list of --add-opens and --add-exports options passed to this JVM.
+   */
+  public static List<String> getJvmModuleOptions() {
+    return ManagementFactory.getRuntimeMXBean().getInputArguments()
+        .stream()
+        .filter(s -> s.startsWith("--add-opens=") || s.startsWith("--add-exports="))
+        .collect(toList());
+  }
+}

--- a/geode-junit/src/test/java/org/apache/geode/test/process/JavaModuleHelperTest.java
+++ b/geode-junit/src/test/java/org/apache/geode/test/process/JavaModuleHelperTest.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.geode.test.process;
+
+import static java.util.Collections.shuffle;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.condition.JRE.JAVA_9;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+
+class JavaModuleHelperTest {
+  @Test
+  void getJvmModuleOptions_returnsEmptyListIfNoAddOpensOrAddExportsOptions() throws IOException {
+    // Options that are not module-related
+    List<String> jvmOptions = Arrays.asList(
+        "-Dsome.system.property=some.value",
+        "-ea",
+        "-XX:+HeapDumpOnOutOfMemoryError",
+        "-Xmx512m");
+
+    Process queryProcess = startQueryProcess(jvmOptions);
+    List<String> queriedModuleOptions = stdOutputFrom(queryProcess);
+
+    assertThat(queriedModuleOptions)
+        .isEmpty();
+  }
+
+  @EnabledForJreRange(min = JAVA_9, disabledReason = "JRE does not recognize module options")
+  @Test
+  void getJvmModuleOptions_returnsAllAddOpensAndAddExportsOptionsInOrder() throws IOException {
+    List<String> moduleOptions = Arrays.asList(
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.text=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+        "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+        "--add-opens=java.base/java.util.concurrent.locks=ALL-UNNAMED",
+        "--add-opens=java.base/javax.net.ssl=ALL-UNNAMED",
+        "--add-opens=java.base/sun.security.ssl=ALL-UNNAMED",
+        "--add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED",
+        "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
+        "--add-exports=java.base/sun.util.locale=ALL-UNNAMED",
+        "--add-exports=java.management/com.sun.jmx.remote.security=ALL-UNNAMED");
+    shuffle(moduleOptions);
+
+    Process queryProcess = startQueryProcess(moduleOptions);
+    List<String> queriedModuleOptions = stdOutputFrom(queryProcess);
+
+    assertThat(queriedModuleOptions)
+        .containsExactlyElementsOf(moduleOptions);
+  }
+
+  @EnabledForJreRange(min = JAVA_9, disabledReason = "JRE does not recognize module options")
+  @Test
+  void getJvmModuleOptions_doesNotIncludeOptionsOtherThanAddOpensAndAddExports()
+      throws IOException {
+    List<String> moduleOptions = Arrays.asList(
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-opens=java.base/java.text=ALL-UNNAMED");
+
+    // Add non-module options in between the module options
+    List<String> jvmOptions = new ArrayList<>(moduleOptions);
+    jvmOptions.add(4, "-Dsome.system.property=some.value");
+    jvmOptions.add(3, "-ea");
+    jvmOptions.add(2, "-XX:+HeapDumpOnOutOfMemoryError");
+    jvmOptions.add(1, "-Xmx512m");
+
+    Process queryProcess = startQueryProcess(jvmOptions);
+    List<String> queriedModuleOptions = stdOutputFrom(queryProcess);
+
+    assertThat(queriedModuleOptions)
+        .containsExactlyElementsOf(moduleOptions);
+  }
+
+  private static List<String> stdOutputFrom(Process process)
+      throws IOException {
+
+    try (InputStream stdOut = process.getInputStream()) {
+      return new BufferedReader(new InputStreamReader(stdOut))
+          .lines()
+          .collect(toList());
+    }
+  }
+
+  // Starts a query process with the given options.
+  private static Process startQueryProcess(List<String> options) throws IOException {
+    String javaHome = System.getProperty("java.home");
+    String javaBin = Paths.get(javaHome, "bin", "java").toString();
+    String classpath = System.getProperty("java.class.path");
+    List<String> commandLine = new ArrayList<>(Arrays.asList(javaBin, "-classpath", classpath));
+    commandLine.addAll(options);
+    commandLine.add(JavaModuleHelperTest.class.getName());
+
+    return new ProcessBuilder(commandLine)
+        .redirectErrorStream(true)
+        .start();
+  }
+
+  // Queries its JVM's module options and writes each to stdout
+  public static void main(String[] args) {
+    JavaModuleHelper.getJvmModuleOptions()
+        .forEach(System.out::println);
+  }
+}

--- a/gradle/test.gradle
+++ b/gradle/test.gradle
@@ -207,6 +207,7 @@ gradle.taskGraph.whenReady({ graph ->
                 "--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED",
 
                 "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+                "--add-exports=java.base/sun.reflect.generics.repository=ALL-UNNAMED",
                 "--add-exports=java.base/sun.security.x509=ALL-UNNAMED",
                 "--add-exports=java.management/com.sun.jmx.remote.security=ALL-UNNAMED",
         ]


### PR DESCRIPTION
Several tests and test framework classes launch child JVMs to run Geode
product and test code. Those tests and classes now forward the test
JVM's `--add-opens` and `--add-exports` options to the child JVMs.
