### PR TITLE
GEODE-10137: allow PRs to opt-in to JDK17 via jdk17 label

### DIFF
--- a/ci/images/google-geode-builder/scripts/setup.sh
+++ b/ci/images/google-geode-builder/scripts/setup.sh
@@ -60,6 +60,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
 cp -R /etc/alternatives /etc/keep-alternatives
 apt-get install -y --no-install-recommends \
     bellsoft-java11 \
+    bellsoft-java17 \
     bellsoft-java8
 rm -rf /etc/alternatives
 mv /etc/keep-alternatives /etc/alternatives

--- a/ci/images/google-windows-geode-builder/packer.json
+++ b/ci/images/google-windows-geode-builder/packer.json
@@ -78,6 +78,8 @@
         "Set-ExecutionPolicy Bypass -Scope Process -Force",
         "choco install -y git cygwin cyg-get liberica11jdk",
         "Move-Item \"C:\\Program Files\\BellSoft\\LibericaJDK-11*\" c:\\java11",
+        "choco install -y liberica17jdk",
+        "Move-Item \"C:\\Program Files\\BellSoft\\LibericaJDK-17*\" c:\\java17",
         "choco install -y liberica8jdk",
         "Move-Item \"C:\\Program Files\\BellSoft\\LibericaJDK-8*\" c:\\java8",
         "choco install openssh -params '/SSHServerFeature' -confirm",

--- a/ci/pipelines/geode-build/jinja.template.yml
+++ b/ci/pipelines/geode-build/jinja.template.yml
@@ -91,7 +91,7 @@ GRADLE_GLOBAL_ARGS: ((gradle-global-args))
 
 {% macro all_gating_jobs() %}
   {%- for test in (tests) if not test.name=="stress-new" -%}
-  {%- for java_test_version in (java_test_versions) if ((not test.ONLY_JDK is defined) or test.ONLY_JDK==java_test_version.version) %}
+  {%- for java_test_version in (java_test_versions) if ((not test.ONLY_JDK is defined) or test.ONLY_JDK==java_test_version.version) and java_test_version.version!=17 %}
 - {{test.name}}-test-{{java_test_version.name}}
   {%- endfor -%}
   {%- endfor -%}

--- a/ci/pipelines/pull-request/jinja.template.yml
+++ b/ci/pipelines/pull-request/jinja.template.yml
@@ -23,7 +23,7 @@ groups:
   jobs:
   - {{ build_test.name }}
 {%- for test in tests %}
-  {%- for java_test_version in (java_test_versions) if (java_test_version.name.endswith("jdk11") or (java_test_version.name.endswith("jdk8") and test.PLATFORM == "linux")) and ((not test.ONLY_JDK is defined) or test.ONLY_JDK == java_test_version.version) %}
+  {%- for java_test_version in (java_test_versions) if (java_test_version.version == 11 or (java_test_version.version == 8 and test.PLATFORM == "linux") or (java_test_version.version == 17 and test.PLATFORM == "linux")) and ((not test.ONLY_JDK is defined) or test.ONLY_JDK == java_test_version.version) %}
   - {{test.name}}-test-{{java_test_version.name}}
   {%- endfor %}
 {%- endfor %}
@@ -51,6 +51,14 @@ resources:
     disable_ci_skip: false
     skip_ssl_verification: false
     labels: [jdk8]
+- name: geode-jdk17
+  type: pull-request
+  source:
+    access_token: ((github-apachegeode-ci-read-only-token))
+    repository: {{repository.fork}}/geode
+    disable_ci_skip: false
+    skip_ssl_verification: false
+    labels: [jdk17]
 - name: geode-status
   type: pull-request
   source:
@@ -287,15 +295,18 @@ jobs:
 
 
 {% for test in tests %}
-  {%- for java_test_version in (java_test_versions) if (java_test_version.name.endswith("jdk11") or (java_test_version.name.endswith("jdk8") and test.PLATFORM == "linux")) and ((not test.ONLY_JDK is defined) or test.ONLY_JDK == java_test_version.version) %}
+  {%- for java_test_version in (java_test_versions) if (java_test_version.version == 11 or (java_test_version.version == 8 and test.PLATFORM == "linux") or (java_test_version.version == 17 and test.PLATFORM == "linux")) and ((not test.ONLY_JDK is defined) or test.ONLY_JDK == java_test_version.version) %}
 - name: {{test.name}}-test-{{java_test_version.name}}
   public: true
   plan:
   - do:
     - in_parallel:
       - get: alpine-tools-image
-{%- if test.PLATFORM == "linux" and (java_test_version.name.endswith("jdk11") or test.name == "unit" or test.name == "stress-new" or test.name == "distributed") %}
+{%- if test.PLATFORM == "linux" and (java_test_version.version == 11 or (java_test_version.version == 8 and (test.name == "unit" or test.name == "stress-new" or test.name == "distributed"))) %}
       - get: geode
+{%- elif test.PLATFORM == "linux" and java_test_version.version == 17 %}
+      - get: geode
+        resource: geode-jdk17
 {%- elif test.PLATFORM == "linux" %}
       - get: geode
         resource: geode-jdk8

--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -79,6 +79,8 @@ java_test_versions:
   version: 8
 - name: openjdk11
   version: 11
+- name: openjdk17
+  version: 17
 
 metadata:
   initial_version: 1.15.0-((semver-prerelease-token)).0


### PR DESCRIPTION
Adds JDK17 to Windows and Linux images.

Adds JDK17 Windows and Linux jobs to main pipeline, but not as gating jobs _for now_, so they can be paused if needed.

Note: adding the jdk17 label to a PR only adds linux, not windows jdk17 jobs to the PR (consistent with how jdk8 label works)

