### PR TITLE
GEODE-10101: Replace 1.14.3 with 1.14.4 as old version

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -17,7 +17,7 @@
 
 benchmarks:
   baseline_branch_default: ''
-  baseline_version_default: '1.14.3'
+  baseline_version_default: '1.14.4'
   benchmark_branch: ((geode-build-branch))
   flavors:
   - title: 'base'
@@ -36,8 +36,8 @@ benchmarks:
     max_in_flight: 2
     timeout: 10h
   - title: 'radish'
-    baseline_branch: 'geode-for-redis-benchmark-baseline'
-    baseline_version: ''
+    baseline_branch: ''
+    baseline_version: '1.14.4'
     flag: '-PtestJVM=/usr/lib/jvm/bellsoft-java11-amd64 -Pbenchmark.withRedisCluster=geode -Pbenchmark.withServerCount=2'
     options: '--tests=org.apache.geode.benchmark.redis.tests.*'
     max_in_flight: 2

--- a/settings.gradle
+++ b/settings.gradle
@@ -89,7 +89,7 @@ include 'geode-server-all'
  '1.13.1',
  '1.13.8',
  '1.14.0', // Include for SSL protocol configuration changes in 1.14.0
- '1.14.3'].each {
+ '1.14.4'].each {
   include 'geode-old-versions:'.concat(it)
 }
 


### PR DESCRIPTION
Replace 1.14.3 with 1.14.4 in old versions and set as Benchmarks baseline on develop
to enable rolling upgrade tests from 1.14.4

The serialization version has not changed between 1.14.3 and 1.14.4,
so there should be no need to keep both
