### PR TITLE
GEODE-10139: add -f to curl

### DIFF
--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -37,8 +37,8 @@ RUN chmod +x /usr/local/bin/tini \
   && echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
   && echo "deb http://packages.cloud.google.com/apt cloud-sdk-$(lsb_release -c -s) main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
   && echo "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
-  && curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+  && curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
+  && curl -f https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
   && curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - \
   && apt-get update \
   && apt-get purge lxc-docker \
@@ -66,7 +66,7 @@ RUN chmod +x /usr/local/bin/tini \
   && gcloud config set component_manager/disable_update_check true \
   && gcloud config set metrics/environment github_docker_image \
   && go build -o /usr/local/bin/tini-wrapper ./tini-wrapper.go \
-  && curl -Lo /usr/local/bin/dunit-progress https://github.com/jdeppe-pivotal/progress-util/releases/download/0.2/progress.linux \
+  && curl -fLo /usr/local/bin/dunit-progress https://github.com/jdeppe-pivotal/progress-util/releases/download/0.2/progress.linux \
   && chmod +x /usr/local/bin/dunit-progress \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \

--- a/ci/images/google-geode-builder/scripts/setup.sh
+++ b/ci/images/google-geode-builder/scripts/setup.sh
@@ -30,7 +30,7 @@ apt-get install -y --no-install-recommends \
 echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
 echo "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 echo "deb [arch=amd64] https://apt.bell-sw.com/ stable main" | sudo tee /etc/apt/sources.list.d/bellsoft.list
-curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 curl -fsSL https://download.bell-sw.com/pki/GPG-KEY-bellsoft | apt-key add -
 apt-get update
@@ -70,10 +70,10 @@ pip3 install setuptools
 pip3 install docker-compose
 
 pushd /tmp
-  curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
+  curl -fO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
   tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz -C /
   rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
-  curl -sSO https://dl.google.com/cloudagents/install-monitoring-agent.sh
+  curl -fsSO https://dl.google.com/cloudagents/install-monitoring-agent.sh
   bash install-monitoring-agent.sh
   rm install-monitoring-agent.sh
 popd
@@ -83,7 +83,7 @@ gcloud config set component_manager/disable_update_check true
 gcloud config set metrics/environment github_docker_image
 gcloud components install docker-credential-gcr --quiet
 gcloud auth configure-docker --quiet
-curl -Lo /usr/local/bin/dunit-progress https://github.com/jdeppe-pivotal/progress-util/releases/download/0.2/progress.linux
+curl -fLo /usr/local/bin/dunit-progress https://github.com/jdeppe-pivotal/progress-util/releases/download/0.2/progress.linux
 chmod +x /usr/local/bin/dunit-progress
 wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/${CHROME_DRIVER_VERSION}/chromedriver_linux64.zip
 rm -rf /opt/selenium/chromedriver

--- a/ci/pipelines/mass-test-run/jinja.template.yml
+++ b/ci/pipelines/mass-test-run/jinja.template.yml
@@ -205,7 +205,7 @@ jobs:
         - -ec
         - |
           BASE_DIR=$(pwd)
-          curl "${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=linux" --output fly
+          curl -f "${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=linux" --output fly
           chmod +x fly
           TARGET_NAME=concourse
           ./fly -t ${TARGET_NAME} login -c "${CONCOURSE_URL}" -n "${CONCOURSE_TEAM}" -u "${CONCOURSE_USERNAME}" -p "${CONCOURSE_PASSWORD}"
@@ -375,7 +375,7 @@ jobs:
         - -ec
         - |
           . concourse-metadata-resource/concourse_metadata
-          curl -L -k -o fly "((concourse-url))/api/v1/cli?arch=amd64&platform=linux"
+          curl -fLko fly "((concourse-url))/api/v1/cli?arch=amd64&platform=linux"
           chmod +x fly
           job="{{test.name}}-test-{{java_test_version.name}}"
           ./fly -t cc login \
@@ -432,7 +432,7 @@ jobs:
         - -ec
         - |
           . concourse-metadata-resource/concourse_metadata
-          curl -L -k -o fly "((concourse-url))/api/v1/cli?arch=amd64&platform=linux"
+          curl -fLko fly "((concourse-url))/api/v1/cli?arch=amd64&platform=linux"
           chmod +x fly
           job="{{test.name}}-test-{{java_test_version.name}}"
           ./fly -t cc login \

--- a/ci/pipelines/meta/deploy_meta.sh
+++ b/ci/pipelines/meta/deploy_meta.sh
@@ -117,7 +117,7 @@ YML
   FLY_URL="${CONCOURSE_URL}/api/v1/cli?arch=amd64&platform=${platform}"
   FLY="${SCRIPTDIR}/fly"
   if [[ ! -e "${FLY}" ]]; then
-    curl -so ${FLY} ${FLY_URL}
+    curl -fso ${FLY} ${FLY_URL}
   fi
   chmod +x ${FLY}
   set +e

--- a/ci/pipelines/pull-request/deploy_pr_pipeline.sh
+++ b/ci/pipelines/pull-request/deploy_pr_pipeline.sh
@@ -57,7 +57,7 @@ OUTPUT_DIRECTORY=${OUTPUT_DIRECTORY:-$SCRIPTDIR}
 BIN_DIR=${OUTPUT_DIRECTORY}/bin
 TMP_DIR=${OUTPUT_DIRECTORY}/tmp
 mkdir -p ${BIN_DIR} ${TMP_DIR}
-curl -o ${BIN_DIR}/fly "https://concourse.apachegeode-ci.info/api/v1/cli?arch=amd64&platform=linux"
+curl -fo ${BIN_DIR}/fly "https://concourse.apachegeode-ci.info/api/v1/cli?arch=amd64&platform=linux"
 chmod +x ${BIN_DIR}/fly
 
 PATH=${PATH}:${BIN_DIR}

--- a/dev-tools/docker/base/Dockerfile
+++ b/dev-tools/docker/base/Dockerfile
@@ -22,7 +22,7 @@ LABEL maintainer=dev@geode.apache.org
 
 ENV PATH $PATH:$JAVA_HOME/bin
 
-RUN curl -L -o /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64
+RUN curl -fLo /usr/local/bin/gosu https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64
 RUN chmod +x /usr/local/bin/gosu
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/dev-tools/release/commit_rc.sh
+++ b/dev-tools/release/commit_rc.sh
@@ -153,7 +153,7 @@ echo "1. In a separate terminal window, ${0%/*}/deploy_rc_pipeline.sh -v ${VERSI
 echo "2. Monitor https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-support-${VERSION_MM//./-}-rc until all green"
 echo "3. If you haven't already, add a ${VERSION} section to https://cwiki.apache.org/confluence/display/GEODE/Release+Notes"
 JIRABASE=https://issues.apache.org/jira/secure
-jiraverid=$(curl -s $JIRABASE'/ConfigureReleaseNote.jspa?projectId=12318420' | tr -d ' \n' | tr '<' '\n'| awk '/optionvalue.*'$VERSION'$/{sub(/optionvalue="/,"");sub(/">.*/,"");print}')
+jiraverid=$(curl -fs $JIRABASE'/ConfigureReleaseNote.jspa?projectId=12318420' | tr -d ' \n' | tr '<' '\n'| awk '/optionvalue.*'$VERSION'$/{sub(/optionvalue="/,"");sub(/">.*/,"");print}')
 echo "   The 'full list' link will be $JIRABASE/ReleaseNote.jspa?projectId=12318420&version=$jiraverid"
 echo "4. Send the following email to announce the RC:"
 echo "To: dev@geode.apache.org"

--- a/dev-tools/release/deploy_rc_pipeline.sh
+++ b/dev-tools/release/deploy_rc_pipeline.sh
@@ -158,7 +158,7 @@ jobs:
               FULL_VERSION=$(cd geode && git fetch && git describe --tags | sed -e 's#^rel/v##')
               VERSION=$(echo $FULL_VERSION|sed -e 's/\.RC.*//')
               SHA=$(cd geode && git rev-parse HEAD)
-              curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-${VERSION}-src.tgz > src.tgz
+              curl -fLs https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-${VERSION}-src.tgz > src.tgz
               tar xzf src.tgz
               cd apache-geode-${VERSION}-src
               java -version
@@ -196,7 +196,7 @@ jobs:
               FULL_VERSION=$(cd geode && git fetch && git describe --tags | sed -e 's#^rel/v##')
               VERSION=$(echo $FULL_VERSION|sed -e 's/\.RC.*//')
               SHA=$(cd geode && git rev-parse HEAD)
-              curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-${VERSION}.tgz > bin.tgz
+              curl -fLs https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-${VERSION}.tgz > bin.tgz
               tar xzf bin.tgz
               cd apache-geode-${VERSION}
               java -version
@@ -261,11 +261,11 @@ jobs:
               VERSION=$(echo $FULL_VERSION|sed -e 's/\.RC.*//')
               if [ "${FULL_VERSION}" = "${VERSION}" ] ; then
                 GRADLE_ARGS=""
-                curl -L -s https://downloads.apache.org/geode/${VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
+                curl -fLs https://downloads.apache.org/geode/${VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
               else
                 STAGING_MAVEN=$(cat geode-examples/gradle.properties | grep geodeRepositoryUrl | awk '{print $3}')
                 GRADLE_ARGS="-PgeodeReleaseUrl=https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION} -PgeodeRepositoryUrl=${STAGING_MAVEN}"
-                curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
+                curl -fLs https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-examples-${VERSION}-src.tgz > src.tgz
               fi
               tar xzf src.tgz
               cd apache-geode-examples-${VERSION}-src
@@ -299,13 +299,13 @@ jobs:
               FULL_VERSION=$(cd geode-native && git fetch && git describe --tags | sed -e 's#^rel/v##')
               VERSION=$(echo $FULL_VERSION|sed -e 's/\.RC.*//')
               #use geode from binary dist
-              curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-${VERSION}.tgz > geode-bin.tgz
+              curl -fLs https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-${VERSION}.tgz > geode-bin.tgz
               tar xzf geode-bin.tgz
               apt-get update || true
               DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev zlib1g-dev
 
               echo skipping latest cmake tmp=`mktemp`
-              echo skipping latest cmake curl -o ${tmp} -v -L https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.sh
+              echo skipping latest cmake curl -fo ${tmp} -v -L https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.sh
               echo skipping latest cmake bash ${tmp} --skip-license --prefix=/usr/local
               echo skipping latest cmake rm -f ${tmp}
 
@@ -357,14 +357,14 @@ jobs:
               DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y cmake openssl doxygen build-essential libssl-dev zlib1g-dev
 
               echo skipping latest cmake tmp=`mktemp`
-              echo skipping latest cmake curl -o ${tmp} -v -L https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.sh
+              echo skipping latest cmake curl -fo ${tmp} -v -L https://github.com/Kitware/CMake/releases/download/v3.21.2/cmake-3.21.2-linux-x86_64.sh
               echo skipping latest cmake bash ${tmp} --skip-license --prefix=/usr/local
               echo skipping latest cmake rm -f ${tmp}
 
               #cmake wrongly assumes javah wasn't removed until JDK10, but adoptopenjdk removed it in JDK8
               echo '/opt/java/openjdk/bin/javac -h "$@"' > /opt/java/openjdk/bin/javah
               chmod +x /opt/java/openjdk/bin/javah
-              curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-native-${VERSION}-src.tgz > src.tgz
+              curl -fLs https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-native-${VERSION}-src.tgz > src.tgz
               tar xzf src.tgz
               cd apache-geode-native-${VERSION}-src
               mkdir build
@@ -407,7 +407,7 @@ jobs:
               VERSION=$(echo $FULL_VERSION|sed -e 's/\.RC.*//')
               STAGING_MAVEN=$(cat geode-examples/gradle.properties | grep geodeRepositoryUrl | awk '{print $3}')
               cd upthewaterspout-tests
-              curl -L -s https://dist.apache.org/repos/dist/dev/geode/KEYS > KEYS
+              curl -fLs https://dist.apache.org/repos/dist/dev/geode/KEYS > KEYS
               gpg --import KEYS
               java -version
               ./gradlew build -PmavenURL=${STAGING_MAVEN} -PdownloadURL=https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/ -Pversion=${FULL_VERSION}
@@ -437,7 +437,7 @@ jobs:
               apt install -qq -y --no-install-recommends unzip git keychain
               FULL_VERSION=$(cd geode-benchmarks && git fetch && git describe --tags | sed -e 's#^rel/v##')
               VERSION=$(echo $FULL_VERSION|sed -e 's/\.RC.*//')
-              curl -L -s https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-benchmarks-${VERSION}-src.tgz > src.tgz
+              curl -fLs https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}/apache-geode-benchmarks-${VERSION}-src.tgz > src.tgz
               tar xzf src.tgz
               cd apache-geode-benchmarks-${VERSION}-src
               java -version
@@ -477,7 +477,7 @@ jobs:
               apt install -qq -y --no-install-recommends git gpg gpg-agent
               FULL_VERSION=$(cd geode && git fetch && git describe --tags | sed -e 's#^rel/v##')
               VERSION=$(echo $FULL_VERSION|sed -e 's/\.RC.*//')
-              curl -L -s https://dist.apache.org/repos/dist/dev/geode/KEYS > KEYS
+              curl -fLs https://dist.apache.org/repos/dist/dev/geode/KEYS > KEYS
               gpg --import KEYS
               url=https://dist.apache.org/repos/dist/dev/geode/${FULL_VERSION}
               function verifyArtifactSizeSignatureLicenseNoticeAndCopyright {
@@ -489,7 +489,7 @@ jobs:
                 asc=${file}.asc
                 sha=${file}.sha256
                 sum=sha256sum
-                curl -L -s $url/$file > $file
+                curl -fLs $url/$file > $file
                 actualfilesize=$(wc -c < $file)
                 if [ $actualfilesize -lt $minfilesize ] ; then
                   echo "File size of $file is only $actualfilesize bytes, expected at least $minfilesize"
@@ -499,8 +499,8 @@ jobs:
                   echo "File size of $file is $actualfilesize, expected no more than $maxfilesize bytes"
                   return 1
                 fi
-                curl -L -s $url/$asc > $asc
-                curl -L -s $url/$sha > $sha
+                curl -fLs $url/$asc > $asc
+                curl -fLs $url/$sha > $sha
                 gpg --verify $asc
                 $sum -c $sha
                 echo $file >> exp
@@ -525,7 +525,7 @@ jobs:
               verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-examples-${VERSION}-src   840000    900000
               verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-native-${VERSION}-src    2400000   3200000
               verifyArtifactSizeSignatureLicenseNoticeAndCopyright apache-geode-benchmarks-${VERSION}-src  85000    125000
-              curl -L -s ${url}/ | awk '/>..</{next}/<li>/{gsub(/ *<[^>]*>/,"");print}' | sort > actual-file-list
+              curl -fLs ${url}/ | awk '/>..</{next}/<li>/{gsub(/ *<[^>]*>/,"");print}' | sort > actual-file-list
               sort < exp > expected-file-list
               set +x
               echo ""
@@ -578,7 +578,7 @@ jobs:
                 file=$1
                 echo ""
                 echo Checking $file...
-                curl -L -s $url/$file | tar tvzf - | egrep '\.('"${BINARY_EXTENSIONS}"')$' | tee -a bins
+                curl -fLs $url/$file | tar tvzf - | egrep '\.('"${BINARY_EXTENSIONS}"')$' | tee -a bins
               }
               verifyNoBinaries apache-geode-${VERSION}-src.tgz
               verifyNoBinaries apache-geode-examples-${VERSION}-src.tgz

--- a/dev-tools/release/license_review.sh
+++ b/dev-tools/release/license_review.sh
@@ -98,7 +98,7 @@ function resolve() {
   #download if url (and not already downloaded)
   if echo "$spec" | grep -q '^http.*tgz$' ; then
     filename=$(echo $spec | sed 's#.*/##')
-    [ -r ${DOWNLOAD}/$filename ] || curl -L "$spec" > ${DOWNLOAD}/$filename
+    [ -r ${DOWNLOAD}/$filename ] || curl -fL "$spec" > ${DOWNLOAD}/$filename
     spec=${DOWNLOAD}/$filename
   fi
 

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -212,7 +212,7 @@ function waitforserver {
         echo -n .
         sleep 12
       done
-      actualsize=$(curl -sk --head "$url" | grep -i "Content-Length" | awk '{print $2}' | tr -d '\r')
+      actualsize=$(curl -fsk --head "$url" | grep -i "Content-Length" | awk '{print $2}' | tr -d '\r')
     done
     echo "$url exists and is correct size"
   done

--- a/geode-assembly/src/src/dist/gradlew
+++ b/geode-assembly/src/src/dist/gradlew
@@ -173,7 +173,7 @@ download() {
 
   # download dist. curl on mac doesn't like the cert provided...
   local zip_path=$(zip_path)
-  curl --insecure -L -o "$zip_path/$file_name" "$distributionUrl"
+  curl --insecure -fLo "$zip_path/$file_name" "$distributionUrl"
 
   pushd "$base_path"
     touch "$file_name.lck"

--- a/geode-management/src/test/script/update-management-wiki.sh
+++ b/geode-management/src/test/script/update-management-wiki.sh
@@ -143,7 +143,7 @@ echo "============================================================"
 echo "Download swagger JSON"
 echo "============================================================"
 set -x
-curl http://localhost:7070/management${URI_VERSION}/api-docs | jq . > static/swagger.json
+curl -f http://localhost:7070/management${URI_VERSION}/api-docs | jq . > static/swagger.json
 set +x
 
 echo ""
@@ -258,7 +258,7 @@ echo "============================================================"
 echo "Uploading to wiki"
 echo "============================================================"
 # get the current page version and ADD 1
-PAGE_VERSION=$(curl -s -u $APACHE_CREDS https://cwiki.apache.org/confluence/rest/api/content/${PAGE_ID} | jq .version.number)
+PAGE_VERSION=$(curl -fsu $APACHE_CREDS https://cwiki.apache.org/confluence/rest/api/content/${PAGE_ID} | jq .version.number)
 NEW_PAGE_VERSION=$(( PAGE_VERSION + 1 ))
 # insert page content as the value of the "value" attribute in json update message
 TITLE="${GEODE_VERSION} Management REST API - ${URI_VERSION#/}"
@@ -285,8 +285,8 @@ cat << EOF > static/body.json
 EOF
 # upload
 set -x
-curl -u "$APACHE_CREDS" -X PUT -H 'Content-Type: application/json' -d @static/body.json https://cwiki.apache.org/confluence/rest/api/content/${PAGE_ID}
-curl -v -S -u "$APACHE_CREDS" -X POST -H "X-Atlassian-Token: no-check" -F "file=@static/swagger.json" -F "comment=raw swagger json" "https://cwiki.apache.org/confluence/rest/api/content/${PAGE_ID}/child/attachment"
+curl -fu "$APACHE_CREDS" -X PUT -H 'Content-Type: application/json' -d @static/body.json https://cwiki.apache.org/confluence/rest/api/content/${PAGE_ID}
+curl -fvSu "$APACHE_CREDS" -X POST -H "X-Atlassian-Token: no-check" -F "file=@static/swagger.json" -F "comment=raw swagger json" "https://cwiki.apache.org/confluence/rest/api/content/${PAGE_ID}/child/attachment"
 set +x
 
 echo ""


### PR DESCRIPTION
Without -f, curl will succeed (exitcode 0) even if the response is a 404 error, etc.
This is almost never the desired behavior, especially in scripts that rely on `set -e` to fail fast if there is a problem

particular dangerous is `curl http://someurl > file.tgz` ... the only clue that the file has an error page inside instead of a valid tar archive might be a subsequent failure to untar it ... or it might go unnoticed and upload a junk release artifact (not that this happened or anything, just hypothetically ;)