### PR TITLE
GEODE-9983: Implement RPOPLPUSH command

### DIFF
--- a/geode-docs/tools_modules/geode_for_redis.html.md.erb
+++ b/geode-docs/tools_modules/geode_for_redis.html.md.erb
@@ -194,18 +194,19 @@ Could not connect to Redis at 127.0.0.1:6379: Connection refused
 | PING               | PSETEX             | PSUBSCRIBE         | PTTL               |
 | PUBLISH            | PUBSUB             | PUNSUBSCRIBE       | RENAME             |
 | RENAMENX           | RESTORE            | RPUSH              | RPOP               |
-| SADD               | SCARD              | SDIFF              | SDIFFSTORE         |
-| SET                | SETEX              | SETNX              | SETRANGE           |
-| SINTER             | SINTERSTORE        | SISMEMBER          | SMEMBERS           |
-| SMOVE              | SPOP               | SRANDMEMBER        | SREM               |
-| SSCAN **[3]**      | STRLEN             | SUBSCRIBE          | SUNION             |
-| SUNIONSTORE        | TTL                | TYPE               | UNSUBSCRIBE        |
-| QUIT               | ZADD               | ZCARD              | ZCOUNT             |
-| ZINCRBY            | ZINTERSTORE        | ZLEXCOUNT          | ZPOPMAX            |
-| ZPOPMIN            | ZRANGE             | ZRANGEBYLEX        | ZRANGEBYSCORE      |
-| ZRANK              | ZREM               | ZREMRANGEBYLEX     | ZREMRANGEBYRANK    |
-| ZREMRANGEBYSCORE   | ZREVRANGE          | ZREVRANGEBYLEX     | ZREVRANGEBYSCORE   |
-| ZREVRANK           | ZSCAN **[3]**      | ZSCORE             | ZUNIONSTORE        |
+| RPOPLPUSH          | SADD               | SCARD              | SDIFF              |
+| SDIFFSTORE         | SET                | SETEX              | SETNX              |
+| SETRANGE           | SINTER             | SINTERSTORE        | SISMEMBER          |
+| SMEMBERS           | SMOVE              | SPOP               | SRANDMEMBER        |
+| SREM               | SSCAN **[3]**      | STRLEN             | SUBSCRIBE          |
+| SUNION             | SUNIONSTORE        | TTL                | TYPE               |
+| UNSUBSCRIBE        | QUIT               | ZADD               | ZCARD              |
+| ZCOUNT             | ZINCRBY            | ZINTERSTORE        | ZLEXCOUNT          |
+| ZPOPMAX            | ZPOPMIN            | ZRANGE             | ZRANGEBYLEX        |
+| ZRANGEBYSCORE      | ZRANK              | ZREM               | ZREMRANGEBYLEX     |
+| ZREMRANGEBYRANK    | ZREMRANGEBYSCORE   | ZREVRANGE          | ZREVRANGEBYLEX     |
+| ZREVRANGEBYSCORE   | ZREVRANK           | ZSCAN **[3]**      | ZSCORE             |
+| ZUNIONSTORE        |                    |                    |                    |
 
 Commands not listed above are **not implemented**.
 

--- a/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/list/RPopLPushNativeRedisAcceptanceTest.java
+++ b/geode-for-redis/src/acceptanceTest/java/org/apache/geode/redis/internal/commands/executor/list/RPopLPushNativeRedisAcceptanceTest.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.commands.executor.list;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.NativeRedisClusterTestRule;
+
+public class RPopLPushNativeRedisAcceptanceTest extends AbstractRPopLPushIntegrationTest {
+  @ClassRule
+  public static NativeRedisClusterTestRule server = new NativeRedisClusterTestRule();
+
+  @Override
+  public int getPort() {
+    return server.getExposedPorts().get(0);
+  }
+
+  @Override
+  public void flushAll() {
+    server.flushAll();
+  }
+}

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/list/RPopLPushDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/list/RPopLPushDUnitTest.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.commands.executor.list;
+
+import static org.apache.geode.redis.internal.RedisConstants.SERVER_ERROR_MESSAGE;
+import static org.apache.geode.redis.internal.services.RegionProvider.DEFAULT_REDIS_REGION_NAME;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+
+import org.apache.geode.cache.Region;
+import org.apache.geode.redis.internal.data.RedisData;
+import org.apache.geode.redis.internal.data.RedisKey;
+import org.apache.geode.redis.internal.data.RedisList;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
+import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.dunit.rules.RedisClusterStartupRule;
+import org.apache.geode.test.junit.rules.ExecutorServiceRule;
+
+public class RPopLPushDUnitTest {
+  public static final String KEY_1 = "key1";
+  public static final String KEY_2 = "key2";
+  public static final String THROWING_REDIS_LIST_EXCEPTION = "to be ignored";
+
+  @Rule
+  public RedisClusterStartupRule clusterStartUp = new RedisClusterStartupRule();
+
+  @Rule
+  public ExecutorServiceRule executor = new ExecutorServiceRule();
+
+  private static JedisCluster jedis;
+
+  @Before
+  public void testSetup() {
+    MemberVM locator = clusterStartUp.startLocatorVM(0);
+    clusterStartUp.startRedisVM(1, locator.getPort());
+    clusterStartUp.startRedisVM(2, locator.getPort());
+    clusterStartUp.startRedisVM(3, locator.getPort());
+    int redisServerPort = clusterStartUp.getRedisPort(1);
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, redisServerPort), 20_000);
+    clusterStartUp.flushAll();
+  }
+
+  @After
+  public void tearDown() {
+    jedis.close();
+  }
+
+  @Test
+  public void shouldDistributeDataAmongCluster_andRetainDataAfterServerCrash() {
+    int primaryVMIndex = 1;
+    final String tag = "{" + clusterStartUp.getKeyOnServer("tag", primaryVMIndex) + "}";
+    final String sourceKey = tag + KEY_1;
+    final String destinationKey = tag + KEY_2;
+
+    final int elementsToMove = 5;
+    final int initialElementCount = elementsToMove * 2;
+
+    List<String> initialElements = makeInitialElementsList(initialElementCount);
+
+    jedis.lpush(sourceKey, initialElements.toArray(new String[0]));
+
+    // Move half the elements from the source list to the destination
+    for (int i = 0; i < elementsToMove; ++i) {
+      assertThat(jedis.rpoplpush(sourceKey, destinationKey)).isEqualTo(initialElements.get(i));
+    }
+
+    clusterStartUp.crashVM(primaryVMIndex); // kill primary server
+
+    // For easier validation
+    List<String> reversedInitialElements = new ArrayList<>(initialElements);
+    Collections.reverse(reversedInitialElements);
+
+    assertThat(jedis.lrange(sourceKey, 0, -1))
+        .containsExactlyElementsOf(reversedInitialElements.subList(0, elementsToMove));
+    assertThat(jedis.lrange(destinationKey, 0, -1)).containsExactlyElementsOf(
+        reversedInitialElements.subList(elementsToMove, initialElementCount));
+  }
+
+  @Test
+  public void givenBucketsMovedDuringRPopLPush_thenOperationsAreNotLostOrDuplicated()
+      throws InterruptedException, ExecutionException {
+    final AtomicBoolean continueRunning = new AtomicBoolean(true);
+    final List<String> hashTags = getHashTagsForEachServer();
+    final int initialElementCount = 1000;
+
+    List<String> initialElements = makeInitialElementsList(initialElementCount);
+
+    for (String hashTag : hashTags) {
+      jedis.lpush(hashTag + KEY_1, initialElements.toArray(new String[0]));
+    }
+
+    Future<Void> future1 = executor.runAsync(() -> repeatRPopLPush(hashTags.get(0),
+        initialElements, continueRunning));
+    Future<Void> future2 = executor.runAsync(() -> repeatRPopLPush(hashTags.get(1),
+        initialElements, continueRunning));
+    Future<Void> future3 =
+        executor.runAsync(() -> repeatRPopLPushWithSameSourceAndDest(hashTags.get(2),
+            initialElements, continueRunning));
+
+    for (int i = 0; i < 25 && continueRunning.get(); i++) {
+      clusterStartUp.moveBucketForKey(hashTags.get(i % hashTags.size()));
+      Thread.sleep(200);
+    }
+
+    continueRunning.set(false);
+
+    future1.get();
+    future2.get();
+    future3.get();
+  }
+
+  @Ignore("GEODE-10121")
+  @Test
+  public void rpoplpush_isTransactional() {
+    String hashTag = "{" + clusterStartUp.getKeyOnServer("tag", 1) + "}";
+
+    // Create two real RedisList entries
+    String sourceKey = hashTag + KEY_1;
+    String[] sourceElements = {"sourceElement1", "sourceElement2"};
+    jedis.lpush(sourceKey, sourceElements);
+    String destinationKey = hashTag + KEY_2;
+    String destinationElement = "destinationElement";
+    jedis.lpush(destinationKey, destinationElement);
+
+    String throwingRedisListKey = hashTag + "ThrowingRedisList";
+    String throwingListElement = "shouldNotMove";
+
+    // Put a test version of RedisList directly into the region that throws if rpop() or lpush() are
+    // called on it
+    clusterStartUp.getMember(1).invoke(() -> {
+      RedisKey throwingKey = new RedisKey(throwingRedisListKey.getBytes(StandardCharsets.UTF_8));
+      ThrowingRedisList throwingRedisList = new ThrowingRedisList();
+      throwingRedisList.elementInsert(throwingListElement.getBytes(StandardCharsets.UTF_8), 0);
+      ClusterStartupRule.getCache().getRegion(DEFAULT_REDIS_REGION_NAME).put(throwingKey,
+          throwingRedisList);
+    });
+
+    IgnoredException.addIgnoredException(THROWING_REDIS_LIST_EXCEPTION);
+
+    // Test with an exception being thrown from the source RedisList
+    assertThatThrownBy(() -> jedis.rpoplpush(throwingRedisListKey, destinationKey))
+        .hasMessage(SERVER_ERROR_MESSAGE);
+
+    assertThat(jedis.lrange(throwingRedisListKey, 0, -1)).containsExactly(throwingListElement);
+    assertThat(jedis.lrange(destinationKey, 0, -1)).containsExactly(destinationElement);
+
+    // Test with an exception being thrown from the destination RedisList
+    assertThatThrownBy(() -> jedis.rpoplpush(sourceKey, throwingRedisListKey))
+        .hasMessage(SERVER_ERROR_MESSAGE);
+
+    assertThat(jedis.lrange(sourceKey, 0, -1)).containsExactlyInAnyOrder(sourceElements);
+    assertThat(jedis.lrange(throwingRedisListKey, 0, -1)).containsExactly(throwingRedisListKey);
+
+    IgnoredException.removeAllExpectedExceptions();
+  }
+
+  private List<String> getHashTagsForEachServer() {
+    List<String> hashTags = new ArrayList<>();
+    hashTags.add("{" + clusterStartUp.getKeyOnServer("tag", 1) + "}");
+    hashTags.add("{" + clusterStartUp.getKeyOnServer("tag", 2) + "}");
+    hashTags.add("{" + clusterStartUp.getKeyOnServer("tag", 3) + "}");
+    return hashTags;
+  }
+
+  private List<String> makeInitialElementsList(int size) {
+    return IntStream.range(0, size)
+        .mapToObj(String::valueOf)
+        .collect(Collectors.toList());
+  }
+
+  private void repeatRPopLPush(String hashTag, List<String> initialElements,
+      AtomicBoolean continueRunning) {
+    String source = hashTag + KEY_1;
+    String destination = hashTag + KEY_2;
+
+    // For easier validation
+    List<String> reversedInitialElements = new ArrayList<>(initialElements);
+    Collections.reverse(reversedInitialElements);
+
+    while (continueRunning.get()) {
+      for (int i = 0; i < initialElements.size(); i++) {
+        assertThat(jedis.rpoplpush(source, destination)).isEqualTo(initialElements.get(i));
+
+        int movedIndex = (reversedInitialElements.size() - 1) - i;
+        // Confirm we moved the correct element
+        assertThat(jedis.lrange(destination, 0, -1)).containsExactlyElementsOf(
+            reversedInitialElements.subList(movedIndex, reversedInitialElements.size()));
+        assertThat(jedis.lrange(source, 0, -1)).containsExactlyElementsOf(
+            reversedInitialElements.subList(0, movedIndex));
+      }
+
+      // All elements have been moved
+      assertThat(jedis.exists(source)).isFalse();
+
+      // Swap the source and destination keys
+      String tmp = source;
+      source = destination;
+      destination = tmp;
+    }
+  }
+
+  private void repeatRPopLPushWithSameSourceAndDest(String hashTag, List<String> initialElements,
+      AtomicBoolean continueRunning) {
+    String key = hashTag + KEY_1;
+
+    // For easier validation
+    List<String> expectedElements = new ArrayList<>(initialElements);
+    Collections.reverse(expectedElements);
+
+    while (continueRunning.get()) {
+      for (String element : initialElements) {
+        assertThat(jedis.rpoplpush(key, key)).isEqualTo(element);
+        Collections.rotate(expectedElements, 1);
+        assertThat(jedis.lrange(key, 0, -1)).containsExactlyElementsOf(expectedElements);
+      }
+    }
+  }
+
+  static class ThrowingRedisList extends RedisList {
+    @Override
+    public long lpush(ExecutionHandlerContext context, List<byte[]> elementsToAdd, RedisKey key,
+        boolean onlyIfExists) {
+      throw new RuntimeException(THROWING_REDIS_LIST_EXCEPTION);
+    }
+
+    @Override
+    public byte[] rpop(Region<RedisKey, RedisData> region, RedisKey key) {
+      throw new RuntimeException(THROWING_REDIS_LIST_EXCEPTION);
+    }
+  }
+}

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractRPopLPushIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/AbstractRPopLPushIntegrationTest.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.commands.executor.list;
+
+import static org.apache.geode.redis.RedisCommandArgumentsTestHelper.assertExactNumberOfArgs;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_SLOT;
+import static org.apache.geode.redis.internal.RedisConstants.ERROR_WRONG_TYPE;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.BIND_ADDRESS;
+import static org.apache.geode.test.dunit.rules.RedisClusterStartupRule.REDIS_CLIENT_TIMEOUT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static redis.clients.jedis.Protocol.Command.RPOPLPUSH;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import redis.clients.jedis.HostAndPort;
+import redis.clients.jedis.JedisCluster;
+
+import org.apache.geode.redis.ConcurrentLoopingThreads;
+import org.apache.geode.redis.RedisIntegrationTest;
+
+public abstract class AbstractRPopLPushIntegrationTest implements RedisIntegrationTest {
+  private static final String SOURCE_KEY = "{tag}source";
+  private static final String DESTINATION_KEY = "{tag}destination";
+  private JedisCluster jedis;
+
+  @Before
+  public void setUp() {
+    jedis = new JedisCluster(new HostAndPort(BIND_ADDRESS, getPort()), REDIS_CLIENT_TIMEOUT);
+  }
+
+  @After
+  public void tearDown() {
+    flushAll();
+    jedis.close();
+  }
+
+  @Test
+  public void rPopLPush_withWrongNumberOfArguments_returnsError() {
+    assertExactNumberOfArgs(jedis, RPOPLPUSH, 2);
+  }
+
+  @Test
+  public void rPopLPush_withKeysInDifferentSlots_returnsCrossSlotError() {
+    final String key1 = "{1}key1";
+    final String key2 = "{2}key2";
+
+    // Neither key exists
+    assertThatThrownBy(() -> jedis.sendCommand(RPOPLPUSH, key1, key2)).hasMessage(ERROR_WRONG_SLOT);
+
+    jedis.lpush(key1, "1", "2", "3");
+
+    // Source key exists
+    assertThatThrownBy(() -> jedis.sendCommand(RPOPLPUSH, key1, key2)).hasMessage(ERROR_WRONG_SLOT);
+
+    // Destination key exists
+    assertThatThrownBy(() -> jedis.sendCommand(RPOPLPUSH, key2, key1)).hasMessage(ERROR_WRONG_SLOT);
+
+    jedis.lpush(key2, "a", "b", "c");
+
+    // Both keys exist
+    assertThatThrownBy(() -> jedis.sendCommand(RPOPLPUSH, key1, key2)).hasMessage(ERROR_WRONG_SLOT);
+  }
+
+  @Test
+  public void rPopLPush_withNonListSourceKey_returnsWrongTypeError() {
+    jedis.set(SOURCE_KEY, "not_a_list");
+
+    assertThatThrownBy(() -> jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY))
+        .hasMessage(ERROR_WRONG_TYPE);
+  }
+
+  @Test
+  public void rPopLPush_withNonListDestinationKey_returnsWrongTypeError() {
+    jedis.lpush(SOURCE_KEY, "1", "2", "3");
+    jedis.set(DESTINATION_KEY, "not_a_list");
+
+    assertThatThrownBy(() -> jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY))
+        .hasMessage(ERROR_WRONG_TYPE);
+  }
+
+  @Test
+  public void rPopLPush_withNonexistentSourceKey_returnsNull() {
+    assertThat(jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY)).isNull();
+  }
+
+  @Test
+  public void rPopLPush_withNonexistentSourceKey_doesNotCreateListAtDestination() {
+    jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY);
+    assertThat(jedis.exists(DESTINATION_KEY)).isFalse();
+  }
+
+  @Test
+  public void rPopLPush_withNonexistentSourceKey_doesNotModifyListAtDestination() {
+    jedis.lpush(DESTINATION_KEY, "a", "b", "c");
+    jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY);
+    assertThat(jedis.lrange(DESTINATION_KEY, 0, -1)).containsExactly("c", "b", "a");
+  }
+
+  @Test
+  public void rPopLPush_returnsPoppedElement() {
+    jedis.lpush(SOURCE_KEY, "1", "2", "3");
+    assertThat(jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY)).isEqualTo("1");
+  }
+
+  @Test
+  public void rPopLPush_removesRightmostElementFromSource_andAddsToLeftOfDestination() {
+    jedis.lpush(SOURCE_KEY, "1", "2", "3");
+    jedis.lpush(DESTINATION_KEY, "a", "b", "c");
+    jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY);
+
+    assertThat(jedis.lrange(SOURCE_KEY, 0, -1)).containsExactly("3", "2");
+    assertThat(jedis.lrange(DESTINATION_KEY, 0, -1)).containsExactly("1", "c", "b", "a");
+  }
+
+  @Test
+  public void rPopLPush_createsListAtDestination_whenDestinationKeyIsEmpty() {
+    jedis.lpush(SOURCE_KEY, "1", "2", "3");
+    jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY);
+
+    assertThat(jedis.lrange(DESTINATION_KEY, 0, -1)).containsExactly("1");
+  }
+
+  @Test
+  public void rPopLPush_removesSourceList_whenLastElementIsPopped() {
+    jedis.lpush(SOURCE_KEY, "1");
+    jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY);
+
+    assertThat(jedis.exists(SOURCE_KEY)).isFalse();
+    assertThat(jedis.lrange(DESTINATION_KEY, 0, -1)).containsExactly("1");
+  }
+
+  @Test
+  public void rPopLPush_rotatesList_whenSourceAndDestinationKeyAreTheSame() {
+    jedis.lpush(SOURCE_KEY, "1", "2", "3");
+    jedis.rpoplpush(SOURCE_KEY, SOURCE_KEY);
+
+    assertThat(jedis.lrange(SOURCE_KEY, 0, -1)).containsExactly("1", "3", "2");
+  }
+
+  @Test
+  public void rPopLPush_withConcurrentRPush_popsCorrectValue() {
+    String[] initialElements = new String[] {"a", "b", "c"};
+    String[] valuesToAdd = new String[] {"1", "2", "3"};
+    jedis.rpush(SOURCE_KEY, initialElements);
+
+    final AtomicReference<String> rPopLPushReference = new AtomicReference<>();
+    new ConcurrentLoopingThreads(1000,
+        i -> jedis.rpush(SOURCE_KEY, valuesToAdd),
+        i -> rPopLPushReference.set(jedis.rpoplpush(SOURCE_KEY, DESTINATION_KEY)))
+            .runWithAction(() -> {
+              assertThat(rPopLPushReference.get()).satisfiesAnyOf(
+                  // RPOPLPUSH was first
+                  rpopResult -> {
+                    assertThat(rpopResult).isEqualTo("c");
+                    assertThat(jedis.lrange(DESTINATION_KEY, 0, -1)).containsExactly("c");
+                    assertThat(jedis.lrange(SOURCE_KEY, 0, -1))
+                        .containsExactly("a", "b", "1", "2", "3");
+                  },
+                  // RPOP was first
+                  rpopResult -> {
+                    assertThat(rpopResult).isEqualTo("3");
+                    assertThat(jedis.lrange(DESTINATION_KEY, 0, -1)).containsExactly("3");
+                    assertThat(jedis.lrange(SOURCE_KEY, 0, -1))
+                        .containsExactly("a", "b", "c", "1", "2");
+                  });
+              jedis.del(SOURCE_KEY);
+              jedis.del(DESTINATION_KEY);
+              jedis.rpush(SOURCE_KEY, initialElements);
+            });
+  }
+}

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/RPopLPushIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/list/RPopLPushIntegrationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.redis.internal.commands.executor.list;
+
+import org.junit.ClassRule;
+
+import org.apache.geode.redis.GeodeRedisServerRule;
+
+public class RPopLPushIntegrationTest extends AbstractRPopLPushIntegrationTest {
+
+  @ClassRule
+  public static GeodeRedisServerRule server = new GeodeRedisServerRule();
+
+  @Override
+  public int getPort() {
+    return server.getPort();
+  }
+}

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/server/AbstractHitsMissesIntegrationTest.java
@@ -636,6 +636,11 @@ public abstract class AbstractHitsMissesIntegrationTest implements RedisIntegrat
     runCommandAndAssertNoStatUpdates(LIST_KEY, k -> jedis.rpop(k));
   }
 
+  @Test
+  public void testRpopLpush() {
+    runMultiKeyCommandAndAssertNoStatUpdates(LIST_KEY, (k1, k2) -> jedis.rpoplpush(k1, k2));
+  }
+
   /************* Helper Methods *************/
   private void runCommandAndAssertHitsAndMisses(String key, Consumer<String> command) {
     Map<String, String> info = RedisTestHelper.getInfo(jedis);

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/Command.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/Command.java
@@ -109,12 +109,12 @@ public class Command {
   }
 
   /**
-   * Used to get the command element list when every argument is also a key
+   * Used to get the command argument list when every argument is also a key
    *
-   * @return List of command elements in form of {@link List}
+   * @return List of command arguments in form of {@link RedisKey}
    */
   public List<RedisKey> getProcessedCommandKeys() {
-    return commandElems.stream().map(RedisKey::new).collect(Collectors.toList());
+    return commandElems.stream().skip(1).map(RedisKey::new).collect(Collectors.toList());
   }
 
   /**

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/RedisCommandType.java
@@ -89,6 +89,7 @@ import org.apache.geode.redis.internal.commands.executor.list.LRangeExecutor;
 import org.apache.geode.redis.internal.commands.executor.list.LRemExecutor;
 import org.apache.geode.redis.internal.commands.executor.list.LSetExecutor;
 import org.apache.geode.redis.internal.commands.executor.list.RPopExecutor;
+import org.apache.geode.redis.internal.commands.executor.list.RPopLPushExecutor;
 import org.apache.geode.redis.internal.commands.executor.list.RPushExecutor;
 import org.apache.geode.redis.internal.commands.executor.pubsub.PsubscribeExecutor;
 import org.apache.geode.redis.internal.commands.executor.pubsub.PubSubExecutor;
@@ -409,6 +410,8 @@ public enum RedisCommandType {
   RPUSH(new RPushExecutor(), Category.LIST, SUPPORTED,
       new Parameter().min(3).flags(WRITE, DENYOOM, FAST)),
   RPOP(new RPopExecutor(), Category.LIST, SUPPORTED, new Parameter().exact(2).flags(WRITE, FAST)),
+  RPOPLPUSH(new RPopLPushExecutor(), Category.LIST, SUPPORTED,
+      new Parameter().exact(3).lastKey(2).flags(WRITE, DENYOOM)),
 
   /********** Publish Subscribe **********/
 

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameExecutor.java
@@ -30,11 +30,10 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 public abstract class AbstractRenameExecutor implements CommandExecutor {
 
   @Override
-  public RedisResponse executeCommand(Command command,
-      ExecutionHandlerContext context) {
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<RedisKey> commandElems = command.getProcessedCommandKeys();
-    RedisKey key = command.getKey();
-    RedisKey newKey = commandElems.get(2);
+    RedisKey key = commandElems.get(0);
+    RedisKey newKey = commandElems.get(1);
 
     if (key.equals(newKey)) {
       return getTargetSameAsSourceResponse();

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/DumpExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/DumpExecutor.java
@@ -29,7 +29,7 @@ public class DumpExecutor implements CommandExecutor {
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<RedisKey> commandElems = command.getProcessedCommandKeys();
 
-    byte[] rawData = dump(context, commandElems.get(1));
+    byte[] rawData = dump(context, commandElems.get(0));
 
     return RedisResponse.bulkString(rawData);
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/ExistsExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/ExistsExecutor.java
@@ -27,12 +27,10 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 public class ExistsExecutor implements CommandExecutor {
 
   @Override
-  public RedisResponse executeCommand(Command command,
-      ExecutionHandlerContext context) {
+  public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     List<RedisKey> commandElems = command.getProcessedCommandKeys();
 
     long existsCount = commandElems
-        .subList(1, commandElems.size())
         .stream()
         .filter(key -> exists(context, key))
         .count();

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/set/SetOpExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/set/SetOpExecutor.java
@@ -31,8 +31,7 @@ public abstract class SetOpExecutor implements CommandExecutor {
   @Override
   public RedisResponse executeCommand(Command command, ExecutionHandlerContext context) {
     RegionProvider regionProvider = context.getRegionProvider();
-    List<RedisKey> commandElements = command.getProcessedCommandKeys();
-    List<RedisKey> setKeys = commandElements.subList(1, commandElements.size());
+    List<RedisKey> setKeys = command.getProcessedCommandKeys();
 
     return context.lockedExecute(setKeys.get(0), new ArrayList<>(setKeys),
         () -> performCommand(regionProvider, setKeys));

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisList.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisList.java
@@ -58,30 +58,114 @@ public class RedisList extends AbstractRedisData {
     this.elementList = new SizeableByteArrayList();
   }
 
+  public static List<byte[]> blpop(ExecutionHandlerContext context, Command command,
+      List<RedisKey> keys, double timeoutSeconds) {
+    RegionProvider regionProvider = context.getRegionProvider();
+    for (RedisKey key : keys) {
+      RedisList list = regionProvider.getTypedRedisData(REDIS_LIST, key, false);
+      if (!list.isNull()) {
+        byte[] poppedValue = list.lpop(context.getRegion(), key);
+
+        // return the key and value
+        List<byte[]> result = new ArrayList<>(2);
+        result.add(key.toBytes());
+        result.add(poppedValue);
+        return result;
+      }
+    }
+
+    context.registerListener(new BlockingCommandListener(context, command, keys, timeoutSeconds));
+
+    return null;
+  }
+
   /**
-   * @param count number of elements to remove.
-   *        A count that is 0 removes all matching elements in the list.
-   *        Positive count starts from the head and moves to the tail.
-   *        Negative count starts from the tail and moves to the head.
-   * @param element element to remove
-   * @param region the region this instance is stored in
-   * @param key the name of the set to add
-   * @return amount of elements that were actually removed
+   * @param index index of desired element.
+   *        Positive index starts at the head.
+   *        Negative index starts at the tail.
+   * @return element at index. Null if index is out of range.
    */
-  public int lrem(int count, byte[] element, Region<RedisKey, RedisData> region, RedisKey key) {
-    List<Integer> removedIndexes;
-    byte version;
+  public byte[] lindex(int index) {
+    index = getArrayIndex(index);
+
+    if (index == INVALID_INDEX || elementList.size() <= index) {
+      return null;
+    } else {
+      return elementList.get(index);
+    }
+  }
+
+  /**
+   * @param elementToInsert element to insert into the list
+   * @param referenceElement element to insert next to
+   * @param before true if inserting before reference element, false if it is after
+   * @param region the region this instance is store in
+   * @param key the name of the list to add to
+   * @return the number of elements in the list after the element is inserted,
+   *         or -1 if the pivot is not found.
+   */
+  public int linsert(byte[] elementToInsert, byte[] referenceElement, boolean before,
+      Region<RedisKey, RedisData> region, RedisKey key) {
+    byte newVersion;
+    int index;
+
     synchronized (this) {
-      removedIndexes = elementList.remove(element, count);
-      version = incrementAndGetVersion();
+      index = elementInsert(elementToInsert, referenceElement, before);
+      if (index == -1) {
+        return index;
+      }
+      newVersion = incrementAndGetVersion();
     }
+    storeChanges(region, key, new InsertByteArray(newVersion, elementToInsert, index));
 
-    if (!removedIndexes.isEmpty()) {
-      storeChanges(region, key,
-          new RemoveElementsByIndex(version, removedIndexes));
+    return elementList.size();
+  }
+
+  /**
+   * @return the number of elements in the list
+   */
+  public int llen() {
+    return elementList.size();
+  }
+
+  /**
+   * @param region the region this instance is stored in
+   * @param key the name of the list to add to
+   * @return the element actually popped
+   */
+  public byte[] lpop(Region<RedisKey, RedisData> region, RedisKey key) {
+    byte newVersion;
+    byte[] popped;
+    RemoveElementsByIndex removed;
+    synchronized (this) {
+      newVersion = incrementAndGetVersion();
+      popped = removeElement(0);
     }
+    removed = new RemoveElementsByIndex(newVersion);
+    removed.add(0);
+    storeChanges(region, key, removed);
+    return popped;
+  }
 
-    return removedIndexes.size();
+  /**
+   * @param context the context of the executing command
+   * @param elementsToAdd elements to add to this list
+   * @param key the name of the set to add to
+   * @param onlyIfExists if true then the elements should only be added if the key already exists
+   *        and holds a list, otherwise no operation is performed.
+   * @return the length of the list after the operation
+   */
+  public long lpush(ExecutionHandlerContext context, List<byte[]> elementsToAdd,
+      RedisKey key, boolean onlyIfExists) {
+    byte newVersion;
+    synchronized (this) {
+      newVersion = incrementAndGetVersion();
+      elementsPushHead(elementsToAdd);
+    }
+    storeChanges(context.getRegion(), key, new AddByteArrays(elementsToAdd, newVersion));
+    context.fireEvent(RedisCommandType.LPUSH, key);
+
+    return elementList.size();
   }
 
   /**
@@ -126,88 +210,46 @@ public class RedisList extends AbstractRedisData {
   }
 
   /**
-   * @param index index of desired element.
-   *        Positive index starts at the head.
-   *        Negative index starts at the tail.
-   * @return element at index. Null if index is out of range.
+   * @param count number of elements to remove.
+   *        A count that is 0 removes all matching elements in the list.
+   *        Positive count starts from the head and moves to the tail.
+   *        Negative count starts from the tail and moves to the head.
+   * @param element element to remove
+   * @param region the region this instance is stored in
+   * @param key the name of the set to add
+   * @return amount of elements that were actually removed
    */
-  public byte[] lindex(int index) {
-    index = getArrayIndex(index);
-
-    if (index == INVALID_INDEX || elementList.size() <= index) {
-      return null;
-    } else {
-      return elementList.get(index);
-    }
-  }
-
-  private int normalizeStartIndex(int startIndex) {
-    return Math.max(0, getArrayIndex(startIndex));
-  }
-
-  private int normalizeStopIndex(int stopIndex) {
-    return Math.min(elementList.size() - 1, getArrayIndex(stopIndex));
-  }
-
-  /**
-   * Changes negative index to corresponding positive index.
-   * If there is no corresponding positive index, returns INVALID_INDEX.
-   */
-  private int getArrayIndex(int listIndex) {
-    if (listIndex < 0) {
-      listIndex = elementList.size() + listIndex;
-      if (listIndex < 0) {
-        return INVALID_INDEX;
-      }
-    }
-    return listIndex;
-  }
-
-  /**
-   * @param elementToInsert element to insert into the list
-   * @param referenceElement element to insert next to
-   * @param before true if inserting before reference element, false if it is after
-   * @param region the region this instance is store in
-   * @param key the name of the list to add to
-   * @return the number of elements in the list after the element is inserted,
-   *         or -1 if the pivot is not found.
-   */
-  public int linsert(byte[] elementToInsert, byte[] referenceElement, boolean before,
-      Region<RedisKey, RedisData> region, RedisKey key) {
-    byte newVersion;
-    int index;
-
+  public int lrem(int count, byte[] element, Region<RedisKey, RedisData> region, RedisKey key) {
+    List<Integer> removedIndexes;
+    byte version;
     synchronized (this) {
-      index = elementInsert(elementToInsert, referenceElement, before);
-      if (index == -1) {
-        return index;
-      }
-      newVersion = incrementAndGetVersion();
+      removedIndexes = elementList.remove(element, count);
+      version = incrementAndGetVersion();
     }
-    storeChanges(region, key, new InsertByteArray(newVersion, elementToInsert, index));
 
-    return elementList.size();
+    if (!removedIndexes.isEmpty()) {
+      storeChanges(region, key,
+          new RemoveElementsByIndex(version, removedIndexes));
+    }
+
+    return removedIndexes.size();
   }
 
   /**
-   * @param context the context of the executing command
-   * @param elementsToAdd elements to add to this list
-   * @param key the name of the set to add to
-   * @param onlyIfExists if true then the elements should only be added if the key already exists
-   *        and holds a list, otherwise no operation is performed.
-   * @return the length of the list after the operation
+   * @param region the region to set on
+   * @param key the key to set on
+   * @param index the index specified by the user
+   * @param value the value to set
    */
-  public long lpush(ExecutionHandlerContext context, List<byte[]> elementsToAdd,
-      RedisKey key, boolean onlyIfExists) {
-    byte newVersion;
-    synchronized (this) {
-      newVersion = incrementAndGetVersion();
-      elementsPushHead(elementsToAdd);
+  public void lset(Region<RedisKey, RedisData> region, RedisKey key, int index, byte[] value) {
+    int listSize = elementList.size();
+    int adjustedIndex = index >= 0 ? index : listSize + index;
+    if (adjustedIndex > listSize - 1 || adjustedIndex < 0) {
+      throw new RedisException(ERROR_INDEX_OUT_OF_RANGE);
     }
-    storeChanges(context.getRegion(), key, new AddByteArrays(elementsToAdd, newVersion));
-    context.fireEvent(RedisCommandType.LPUSH, key);
 
-    return elementList.size();
+    elementReplace(adjustedIndex, value);
+    storeChanges(region, key, new ReplaceByteArrayAtOffset(index, value));
   }
 
   /**
@@ -236,70 +278,6 @@ public class RedisList extends AbstractRedisData {
    * @param key the name of the list to add to
    * @return the element actually popped
    */
-  public byte[] lpop(Region<RedisKey, RedisData> region, RedisKey key) {
-    byte newVersion;
-    byte[] popped;
-    RemoveElementsByIndex removed;
-    synchronized (this) {
-      newVersion = incrementAndGetVersion();
-      popped = removeElement(0);
-    }
-    removed = new RemoveElementsByIndex(newVersion);
-    removed.add(0);
-    storeChanges(region, key, removed);
-    return popped;
-  }
-
-  public static List<byte[]> blpop(ExecutionHandlerContext context, Command command,
-      List<RedisKey> keys, double timeoutSeconds) {
-    RegionProvider regionProvider = context.getRegionProvider();
-    for (RedisKey key : keys) {
-      RedisList list = regionProvider.getTypedRedisData(REDIS_LIST, key, false);
-      if (!list.isNull()) {
-        byte[] poppedValue = list.lpop(context.getRegion(), key);
-
-        // return the key and value
-        List<byte[]> result = new ArrayList<>(2);
-        result.add(key.toBytes());
-        result.add(poppedValue);
-        return result;
-      }
-    }
-
-    context.registerListener(new BlockingCommandListener(context, command, keys, timeoutSeconds));
-
-    return null;
-  }
-
-  /**
-   * @return the number of elements in the list
-   */
-  public int llen() {
-    return elementList.size();
-  }
-
-  /**
-   * @param region the region to set on
-   * @param key the key to set on
-   * @param index the index specified by the user
-   * @param value the value to set
-   */
-  public void lset(Region<RedisKey, RedisData> region, RedisKey key, int index, byte[] value) {
-    int listSize = elementList.size();
-    int adjustedIndex = index >= 0 ? index : listSize + index;
-    if (adjustedIndex > listSize - 1 || adjustedIndex < 0) {
-      throw new RedisException(ERROR_INDEX_OUT_OF_RANGE);
-    }
-
-    elementReplace(adjustedIndex, value);
-    storeChanges(region, key, new ReplaceByteArrayAtOffset(index, value));
-  }
-
-  /**
-   * @param region the region this instance is stored in
-   * @param key the name of the list to add to
-   * @return the element actually popped
-   */
   public byte[] rpop(Region<RedisKey, RedisData> region, RedisKey key) {
     byte newVersion;
     int index = elementList.size() - 1;
@@ -313,6 +291,49 @@ public class RedisList extends AbstractRedisData {
     removed.add(index);
     storeChanges(region, key, removed);
     return popped;
+  }
+
+  /**
+   *
+   * @param context The {@link ExecutionHandlerContext} for this operation, passed to allow events
+   *        to be triggered
+   * @param source The {@link RedisKey} associated with the source RedisList
+   * @param destination The {@link RedisKey} associated with the destination RedisList
+   * @return The list element moved from source to destination, as a byte array
+   */
+  public static byte[] rpoplpush(ExecutionHandlerContext context, RedisKey source,
+      RedisKey destination) {
+    RegionProvider regionProvider = context.getRegionProvider();
+    RedisList sourceList = regionProvider.getTypedRedisData(REDIS_LIST, source, false);
+    RedisList destinationList = regionProvider.getTypedRedisData(REDIS_LIST, destination, false);
+    Region<RedisKey, RedisData> region = regionProvider.getDataRegion();
+    byte[] moved = sourceList.rpop(region, source);
+    if (moved != null) {
+      destinationList.lpush(context, Collections.singletonList(moved), destination, false);
+    }
+    return moved;
+  }
+
+  private int normalizeStartIndex(int startIndex) {
+    return Math.max(0, getArrayIndex(startIndex));
+  }
+
+  private int normalizeStopIndex(int stopIndex) {
+    return Math.min(elementList.size() - 1, getArrayIndex(stopIndex));
+  }
+
+  /**
+   * Changes negative index to corresponding positive index.
+   * If there is no corresponding positive index, returns INVALID_INDEX.
+   */
+  private int getArrayIndex(int listIndex) {
+    if (listIndex < 0) {
+      listIndex = elementList.size() + listIndex;
+      if (listIndex < 0) {
+        return INVALID_INDEX;
+      }
+    }
+    return listIndex;
   }
 
   @Override


### PR DESCRIPTION
 - Implement RPOPLPUSH command and add associated tests
 - Alphabetize command-related methods in RedisList
 - Change Command.getProcessedCommandKeys() to not convert the command
 name into a RedisKey, because there's no situation in which we'd want
 to do that
 - Add ignored test for transactional behaviour, blocked by GEODE-10121

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
