### PR TITLE
Revert "GEODE-10097: Avoid Thread.sleep for reauthentication in MessageDispatcher (#7416)"

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationDUnitTest.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import org.junit.After;
-import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -66,12 +65,6 @@ public class AuthExpirationDUnitTest {
 
 
   private ClientVM clientVM;
-
-  @Before
-  public void before() throws Exception {
-    // this is enabled to show how many times authorize call is made with each permission key
-    getSecurityManager().setAllowDuplicate(true);
-  }
 
   @After
   public void after() {
@@ -117,7 +110,7 @@ public class AuthExpirationDUnitTest {
     Map<String, List<String>> authorizedOps = getSecurityManager().getAuthorizedOps();
     assertThat(authorizedOps.keySet().size()).isEqualTo(2);
     assertThat(authorizedOps.get("user1")).asList().containsExactly("DATA:READ:region",
-        "DATA:READ:region", "DATA:READ:region:1");
+        "DATA:READ:region:1");
     assertThat(authorizedOps.get("user2")).asList().containsExactly("DATA:READ:region:2");
 
     Map<String, List<String>> unAuthorizedOps = getSecurityManager().getUnAuthorizedOps();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheClientProxy.java
@@ -723,13 +723,6 @@ public class CacheClientProxy implements ClientSession {
     return _messageDispatcher.isWaitingForReAuthentication();
   }
 
-  public void notifyReAuthentication() {
-    if (_messageDispatcher == null) {
-      return;
-    }
-    _messageDispatcher.notifyReAuthentication();
-  }
-
   /**
    * Returns whether the proxy is paused. It is paused if its message dispatcher is paused. This
    * only applies to durable clients.

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ServerConnection.java
@@ -1231,7 +1231,6 @@ public class ServerConnection implements Runnable {
       secureLogger.debug("update subject on client proxy {} with uniqueId {}", clientProxy,
           uniqueId);
       clientProxy.setSubject(subject);
-      clientProxy.notifyReAuthentication();
     }
     return uniqueId;
   }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/MessageDispatcherTest.java
@@ -137,7 +137,7 @@ public class MessageDispatcherTest {
 
   @Test
   public void newClientWillGetClientReAuthenticateMessage() throws Exception {
-    doReturn(false, false, false, true).when(dispatcher).isStopped();
+    doReturn(false, false, false, false, false, true).when(dispatcher).isStopped();
     doThrow(AuthenticationExpiredException.class).when(dispatcher).dispatchMessage(any());
     when(messageQueue.peek()).thenReturn(message);
     when(proxy.getVersion()).thenReturn(KnownVersion.GEODE_1_15_0);
@@ -145,7 +145,7 @@ public class MessageDispatcherTest {
     doNothing().when(dispatcher).sendMessageDirectly(any());
 
     // make sure wait time is short
-    doReturn(1L).when(dispatcher).getSystemProperty(eq(RE_AUTHENTICATE_WAIT_TIME), anyLong());
+    doReturn(-1L).when(dispatcher).getSystemProperty(eq(RE_AUTHENTICATE_WAIT_TIME), anyLong());
     dispatcher.runDispatcher();
 
     // verify a ReAuthenticate message will be send to the user
@@ -159,9 +159,9 @@ public class MessageDispatcherTest {
 
   @Test
   public void oldClientWillNotGetClientReAuthenticateMessage() throws Exception {
-    doReturn(false, false, false, true).when(dispatcher).isStopped();
+    doReturn(false, false, false, false, false, true).when(dispatcher).isStopped();
     // make sure wait time is short
-    doReturn(1L).when(dispatcher).getSystemProperty(eq(RE_AUTHENTICATE_WAIT_TIME), anyLong());
+    doReturn(-1L).when(dispatcher).getSystemProperty(eq(RE_AUTHENTICATE_WAIT_TIME), anyLong());
 
     doThrow(AuthenticationExpiredException.class).when(dispatcher).dispatchMessage(any());
     when(messageQueue.peek()).thenReturn(message);

--- a/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/security/ExpirableSecurityManager.java
@@ -39,7 +39,6 @@ public class ExpirableSecurityManager extends SimpleSecurityManager implements S
       new ConcurrentHashMap<>();
   private final Map<String, List<String>> unauthorizedOps =
       new ConcurrentHashMap<>();
-  private boolean allowDuplicate = false;
 
   @Override
   public Object authenticate(final Properties credentials) throws AuthenticationFailedException {
@@ -66,10 +65,6 @@ public class ExpirableSecurityManager extends SimpleSecurityManager implements S
     expired_users.add(user);
   }
 
-  public void setAllowDuplicate(boolean allowDuplicate) {
-    this.allowDuplicate = allowDuplicate;
-  }
-
   public Set<String> getExpiredUsers() {
     return expired_users;
   }
@@ -88,7 +83,7 @@ public class ExpirableSecurityManager extends SimpleSecurityManager implements S
     if (list == null) {
       list = new ArrayList<>();
     }
-    if (allowDuplicate || !list.contains(permission.toString())) {
+    if (!list.contains(permission.toString())) {
       list.add(permission.toString());
     }
     maps.put(user.toString(), list);
@@ -98,7 +93,6 @@ public class ExpirableSecurityManager extends SimpleSecurityManager implements S
     expired_users.clear();
     authorizedOps.clear();
     unauthorizedOps.clear();
-    allowDuplicate = false;
   }
 
 }

--- a/geode-junit/src/main/resources/org/apache/geode/test/junit/internal/sanctioned-geode-junit-serializables.txt
+++ b/geode-junit/src/main/resources/org/apache/geode/test/junit/internal/sanctioned-geode-junit-serializables.txt
@@ -69,7 +69,7 @@ org/apache/geode/pdx/Day,false
 org/apache/geode/pdx/DomainObjectPdxAuto$Day,false
 org/apache/geode/pdx/DomainObjectPdxAutoNoDefaultConstructor$Day,false
 org/apache/geode/pdx/SimpleClass$SimpleEnum,false
-org/apache/geode/security/ExpirableSecurityManager,false,allowDuplicate:boolean,authorizedOps:java/util/Map,expired_users:java/util/Set,unauthorizedOps:java/util/Map
+org/apache/geode/security/ExpirableSecurityManager,false,authorizedOps:java/util/Map,expired_users:java/util/Set,unauthorizedOps:java/util/Map
 org/apache/geode/security/query/data/PdxQueryTestObject,false,age:int,id:int,name:java/lang/String,shouldThrowException:boolean
 org/apache/geode/security/query/data/PdxTrade,false,cusip:java/lang/String,id:java/lang/String,price:int,shares:int
 org/apache/geode/security/query/data/QueryTestObject,false,dateField:java/util/Date,id:int,mapField:java/util/Map,name:java/lang/String


### PR DESCRIPTION
This checkin has caused some server connectivity exceptions on. the client. Will investigate further before committing again.