### PR TITLE
GEODE-10106: Handle NPE in QueueManagerImpl

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -853,7 +853,8 @@ public class QueueManagerImpl implements QueueManager {
       return;
     }
     final boolean isDebugEnabled = logger.isDebugEnabled();
-    if (queueConnections.getPrimary() != null && !queueConnections.getPrimary().isDestroyed()) {
+    if (queueConnections != null && queueConnections.getPrimary() != null
+        && !queueConnections.getPrimary().isDestroyed()) {
       if (isDebugEnabled) {
         logger.debug("Primary recovery not needed");
       }

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -422,7 +422,7 @@ public class QueueManagerImpl implements QueueManager {
   private void initializeConnections() {
     final boolean isDebugEnabled = logger.isDebugEnabled();
     if (isDebugEnabled) {
-      logger.debug("SubscriptionManager - intitializing connections");
+      logger.debug("SubscriptionManager - initializing connections");
     }
 
     int queuesNeeded = redundancyLevel == -1 ? -1 : redundancyLevel + 1;
@@ -1048,7 +1048,7 @@ public class QueueManagerImpl implements QueueManager {
           }
         }
 
-        redundancySatisfierTask = new RedundancySatisfierTask(this);
+        redundancySatisfierTask = new RedundancySatisfierTask();
         try {
           ScheduledFuture<?> future =
               recoveryThread.schedule(redundancySatisfierTask, delay, TimeUnit.MILLISECONDS);
@@ -1424,11 +1424,6 @@ public class QueueManagerImpl implements QueueManager {
   protected class RedundancySatisfierTask extends PoolTask {
     private boolean isCancelled;
     private ScheduledFuture<?> future;
-    private QueueManagerImpl queueManager;
-
-    public RedundancySatisfierTask(QueueManagerImpl impl) {
-      queueManager = impl;
-    }
 
     public void setFuture(ScheduledFuture<?> future) {
       this.future = future;
@@ -1454,7 +1449,7 @@ public class QueueManagerImpl implements QueueManager {
             return;
           }
         }
-        Set<ServerLocation> excludedServers = queueManager.queueConnections.getAllLocations();
+        Set<ServerLocation> excludedServers = queueConnections.getAllLocations();
         excludedServers.addAll(denyList.getBadServers());
         excludedServers.addAll(factory.getDenyList().getBadServers());
         recoverPrimary(excludedServers);
@@ -1475,12 +1470,10 @@ public class QueueManagerImpl implements QueueManager {
         SystemFailure.checkFailure();
         synchronized (lock) {
           if (t instanceof GemFireSecurityException) {
-            queueManager.queueConnections =
-                queueManager.queueConnections
-                    .setPrimaryDiscoveryFailed((GemFireSecurityException) t);
+            queueConnections = queueConnections
+                .setPrimaryDiscoveryFailed((GemFireSecurityException) t);
           } else {
-            queueManager.queueConnections =
-                queueManager.queueConnections.setPrimaryDiscoveryFailed(null);
+            queueConnections = queueConnections.setPrimaryDiscoveryFailed(null);
           }
           lock.notifyAll();
           pool.getCancelCriterion().checkCancelInProgress(t);

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/QueueManagerImpl.java
@@ -1422,6 +1422,7 @@ public class QueueManagerImpl implements QueueManager {
    *
    */
   protected class RedundancySatisfierTask extends PoolTask {
+    private ConnectionList queue = queueConnections;
     private boolean isCancelled;
     private ScheduledFuture<?> future;
 
@@ -1449,7 +1450,7 @@ public class QueueManagerImpl implements QueueManager {
             return;
           }
         }
-        Set<ServerLocation> excludedServers = queueConnections.getAllLocations();
+        Set<ServerLocation> excludedServers = queue.getAllLocations();
         excludedServers.addAll(denyList.getBadServers());
         excludedServers.addAll(factory.getDenyList().getBadServers());
         recoverPrimary(excludedServers);
@@ -1470,10 +1471,10 @@ public class QueueManagerImpl implements QueueManager {
         SystemFailure.checkFailure();
         synchronized (lock) {
           if (t instanceof GemFireSecurityException) {
-            queueConnections =
-                queueConnections.setPrimaryDiscoveryFailed((GemFireSecurityException) t);
+            queue =
+                queue.setPrimaryDiscoveryFailed((GemFireSecurityException) t);
           } else {
-            queueConnections = queueConnections.setPrimaryDiscoveryFailed(null);
+            queue = queue.setPrimaryDiscoveryFailed(null);
           }
           lock.notifyAll();
           pool.getCancelCriterion().checkCancelInProgress(t);


### PR DESCRIPTION
CacheClientNotifierDUnitTest failed with an NPE because queuedConnection
is occationally null when trying to recover the primary. This is solved
by checking for null before calling any methods on that object.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
