### PR TITLE
GEODE-10149: don't roll radish baseline except on new minor

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -36,8 +36,8 @@ benchmarks:
     max_in_flight: 2
     timeout: 10h
   - title: 'radish'
-    baseline_branch: ''
-    baseline_version: '1.14.4'
+    baseline_branch: 'geode-for-redis-benchmark-baseline'
+    baseline_version: ''
     flag: '-PtestJVM=/usr/lib/jvm/bellsoft-java11-amd64 -Pbenchmark.withRedisCluster=geode -Pbenchmark.withServerCount=2'
     options: '--tests=org.apache.geode.benchmark.redis.tests.*'
     max_in_flight: 2

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -505,13 +505,21 @@ fi
 if [ -z "$LATER" ] ; then
   #also update benchmark baseline for develop to this new minor
   sed \
-    -e "s/^    baseline_version:.*/    baseline_version: '${VERSION}'/" \
     -e "s/^  baseline_version_default:.*/  baseline_version_default: '${VERSION}'/" \
-    -e "s/^    baseline_branch:.*/    baseline_branch: ''/" \
     -e "s/^  baseline_branch_default:.*/  baseline_branch_default: ''/" \
     -i.bak ci/pipelines/shared/jinja.variables.yml
   rm ci/pipelines/shared/jinja.variables.yml.bak
-  BENCHMSG=" and set as Benchmarks baseline"
+  BENCHMSG=" and set as default Benchmarks baseline"
+  #if custom baseline on develop is newer [than release branch cut date], resetting might
+  #be the wrong choice.  but, assuming it's older, a new minor is the time to un-custom it
+  if [ $PATCH = 0 ] ; then
+    sed \
+      -e "s/^    baseline_version:.*/    baseline_version: '${VERSION}'/" \
+      -e "s/^    baseline_branch:.*/    baseline_branch: ''/" \
+      -i.bak ci/pipelines/shared/jinja.variables.yml
+    rm ci/pipelines/shared/jinja.variables.yml.bak
+    BENCHMSG=" and set as Benchmarks baseline"
+  fi
   set -x
   git add ci/pipelines/shared/jinja.variables.yml
 fi


### PR DESCRIPTION
radish benchmarks use a custom branch/tag
on a new minor, the release scripts should reset that to the new minor release
however, the scripts are incorrectly resetting it on every patch, oops

even resetting it on a new minor _could_ be the wrong thing, if the custom baseline on develop is already newer than the point where the release branch was cut, but hopefully that can be caught in PR review if ever a problem; I feel there is bigger concern of forgetting to reset the custom branch when a new minor happens, so best for the script to still do it.