### PR TITLE
GEODE-10150: alter runtime command and change loglevel command docs

### DIFF
--- a/geode-docs/tools_modules/gfsh/command-pages/alter.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/alter.html.md.erb
@@ -542,7 +542,11 @@ server1 | Region "/customer" altered on "server1"
 
 ## <a id="topic_7E6B7E1B972D4F418CB45354D1089C2B" class="no-quick-link"></a>alter runtime
 
-Alters configuration properties for all members or a subset of members while the member or members are running.
+Alters configuration properties for all servers or a subset of servers while the member or members are running.
+Alter runtime is a cluster configuration command that affects the configuration for newly joining servers.
+In order for running members to adopt the alteration, they must be stopped and restarted.
+
+The alter runtime command does not apply to locators.
 
 For more information on these configuration properties, see [cache.xml](../../../reference/topics/chapter_overview_cache_xml.html#cache_xml) and configuration parameter reference.
 
@@ -606,7 +610,7 @@ alter runtime [--members=value(,value)*] [--groups=value(,value)*]
 <td>0</td>
 </tr>
 <tr>
-<td><span class="keyword parmname">\-\-loglevel </span></td>
+<td><span class="keyword parmname">\-\-log-level </span></td>
 <td>The new log level. This option is required and you must specify a value.
 Valid values are: `ALL`, `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`, `OFF`. 
 <td>INFO</td>
@@ -657,13 +661,13 @@ Valid values are: `ALL`, `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`, `OF
 **Example Commands:**
 
 ``` pre
-alter runtime --members=server1 --loglevel=WARN --enable-statistics=true
+alter runtime --members=server1 --log-level=WARN --enable-statistics=true
 ```
 
 **Sample Output:**
 
 ``` pre
-gfsh>alter runtime --members=server1 --loglevel=WARN --enable-statistics=true
+gfsh>alter runtime --members=server1 --log-level=WARN --enable-statistics=true
 Runtime configuration altered successfully for the following member(s)
 192.0.2.0(server1:240)<v1>:64871
 ```

--- a/geode-docs/tools_modules/gfsh/command-pages/change.html.md.erb
+++ b/geode-docs/tools_modules/gfsh/command-pages/change.html.md.erb
@@ -24,12 +24,14 @@ Changes the logging level on specified members. This command takes effect if the
 
 When using a custom `Log4J` configuration, this command takes effect only if the member whose logging level you want to change was started using the `--J=-Dgeode.LOG_LEVEL_UPDATE_OCCURS=ALWAYS` system property.
 
+The `change loglevel` command applies only to the members specified, whether they are servers or locators. The change does not apply to unspecified or subsequently-added members.
+
 **Availability:** Online. You must be connected in `gfsh` to a JMX Manager member to use this command.
 
 **Syntax:**
 
 ``` pre
-change loglevel --loglevel=value [--members=value(,value)*] [--groups=value(,value)*]
+change loglevel --log-level=value [--members=value(,value)*] [--groups=value(,value)*]
 ```
 
 <a id="topic_E74ED23CB60342538B2175C326E7D758__table_2277A2CE8F6E4731B45FEFA2B1366DB6"></a>
@@ -60,7 +62,7 @@ change loglevel --loglevel=value [--members=value(,value)*] [--groups=value(,val
 <td> </td>
 </tr>
 <tr>
-<td><span class="keyword parmname">\-\-loglevel</span></td>
+<td><span class="keyword parmname">\-\-log-level</span></td>
 <td><em>Required.</em> Log level to change. Valid options are:
  <code>ALL</code>, <code>TRACE</code>, <code>DEBUG</code>, <code>INFO</code>, <code>WARN</code>, <code>ERROR</code>, <code>FATAL</code>, <code>OFF</code>. 
 </td>
@@ -74,13 +76,13 @@ change loglevel --loglevel=value [--members=value(,value)*] [--groups=value(,val
 **Example Commands:**
 
 ``` pre
-gfsh>change loglevel --loglevel=DEBUG --members=server1
+gfsh>change loglevel --log-level=DEBUG --members=server1
 ```
 
 **Sample Output:**
 
 ``` pre
-gfsh>change loglevel --loglevel=DEBUG --members=server1
+gfsh>change loglevel --log-level=DEBUG --members=server1
 
 Summary
 


### PR DESCRIPTION
Release blocker reported by @dkhopade. Two fixes:

- The --log-level parameter was incorrectly shown as --loglevel. (Note: the `change loglevel` command itself is not hyphenated, but its `--log-level` option is.
- The `alter runtime` command is a cluster config command, so affects new and restarted servers, but not locators.
- The `change loglevel` command is not a cluster config command, so it applies to both servers and locators, but only those specified in the command line, not subsequently-added members.
