### PR TITLE
GEODE-10119: Handle SSLHandshakeException on JDK17

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionFactoryImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/ConnectionFactoryImpl.java
@@ -132,7 +132,8 @@ public class ConnectionFactoryImpl implements ConnectionFactory {
     } catch (Exception e) {
       String message = e.getMessage();
       if (message != null && (message.contains("Connection refused")
-          || message.contains("Connection reset"))) {
+          || message.contains("Connection reset")
+          || message.contains("Remote host terminated the handshake"))) {
         // this is the most common case, so don't print an exception
         if (logger.isDebugEnabled()) {
           logger.debug("Unable to connect to {}: connection refused", location);

--- a/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/SocketCreator.java
@@ -600,8 +600,11 @@ public class SocketCreator extends TcpSocketCreatorImpl {
           throw ex;
         }
       } catch (SSLHandshakeException ex) {
-        logger.fatal(String.format("Problem forming SSL connection to %s[%s].",
-            socket.getInetAddress(), socket.getPort()), ex);
+        String message = ex.getMessage();
+        if (message != null && !message.contains("Remote host terminated the handshake")) {
+          logger.fatal(String.format("Problem forming SSL connection to %s[%s].",
+              socket.getInetAddress(), socket.getPort()), ex);
+        }
         throw ex;
       } catch (SSLPeerUnverifiedException ex) {
         if (sslConfig.isRequireAuth()) {


### PR DESCRIPTION
 PROBLEM
    
On JDK 17, `SslSocket.startHandshake()` can throw
`SSLHandshakeException` in circumstances where JDK 8 and 11 would throw
`SocketException`.
    
`SocketCreator.configureClientSSLSocket()` catches this exception, logs
it as fatal, and rethrows it.
    
`ConnectionFactoryImpl.createClientToServerConnection()` then catches it
and logs it as a warning.
    
This results in lots of warn/fatal log entries for relatively benign
occurrences that, on JDK 8 and 11, would result in debug entries.
    
Also, `WANSSLDUnitTest.testSenderSSLReceiverNoSSL()` fails when it sees these
unrecognized entries in the log.
    
SOLUTION
    
Change `SocketCreator` and `ConnectionFactoryImpl` to recognize when an
`SSLHandshapeException` describes the kind of problem that would have
thrown a `SocketException` on JDK8/11. If so, treat it the same as a
`SocketException`. If not, treat it as a more serious
`SSLHandshakeException`.