### PR TITLE
GEODE-10134: Add JDK 17 proxy classes to serialization accept list

### DIFF
--- a/geode-serialization/src/main/java/org/apache/geode/internal/serialization/filter/SanctionedSerializablesFilterPattern.java
+++ b/geode-serialization/src/main/java/org/apache/geode/internal/serialization/filter/SanctionedSerializablesFilterPattern.java
@@ -98,6 +98,7 @@ public class SanctionedSerializablesFilterPattern implements FilterPattern {
 
         // jar deployment
         .add("com.sun.proxy.$Proxy*")
+        .add("jdk.proxy*")
         .add("com.healthmarketscience.rmiio.RemoteInputStream")
         .add("javax.rmi.ssl.SslRMIClientSocketFactory")
         .add("javax.net.ssl.SSLHandshakeException")


### PR DESCRIPTION
Jar deployment serializes proxies. JDK 17 creates proxy classes in
dynamically created packages with names like `jdk.proxy2` and
`jdk.proxy3`.
