### PR TITLE
GEODE-10145: java tools such as javac should be on PATH

### DIFF
--- a/ci/images/alpine-tools/Dockerfile
+++ b/ci/images/alpine-tools/Dockerfile
@@ -56,3 +56,4 @@ RUN apk --no-cache add \
   && pip3 install awscli
 
 ENV JAVA_HOME /usr/lib/jvm/default-jvm
+ENV PATH="$PATH:$JAVA_HOME/bin"


### PR DESCRIPTION
they were accidentally removed by prior PR for GEODE-10145
