### PR TITLE
GEODE-10158: fix critiical-offheap-threshold interaction with QueryMonitor

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCache.java
@@ -464,8 +464,6 @@ public interface InternalCache extends Cache, Extensible<Cache>, CacheTime, Inte
 
   DistributionAdvisor getDistributionAdvisor();
 
-  void setQueryMonitorRequiredForResourceManager(boolean required);
-
   boolean isQueryMonitorDisabledForLowMemory();
 
   boolean isRESTServiceRunning();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InternalCacheForClientAccess.java
@@ -1071,11 +1071,6 @@ public class InternalCacheForClientAccess implements InternalCache {
   }
 
   @Override
-  public void setQueryMonitorRequiredForResourceManager(boolean required) {
-    delegate.setQueryMonitorRequiredForResourceManager(required);
-  }
-
-  @Override
   public boolean isQueryMonitorDisabledForLowMemory() {
     return delegate.isQueryMonitorDisabledForLowMemory();
   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -376,8 +376,6 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
             "Critical percentage must be greater than the eviction percentage.");
       }
 
-      cache.setQueryMonitorRequiredForResourceManager(criticalThreshold != 0);
-
       thresholds = new MemoryThresholds(thresholds.getMaxMemoryBytes(), criticalThreshold,
           thresholds.getEvictionThreshold());
 
@@ -535,10 +533,9 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
 
   @Override
   public MemoryThresholds getThresholds() {
-    MemoryThresholds saveThresholds = thresholds;
-
-    return new MemoryThresholds(saveThresholds.getMaxMemoryBytes(),
-        saveThresholds.getCriticalThreshold(), saveThresholds.getEvictionThreshold());
+    // MemoryThresholds is immutable so we
+    // can just return it instead of making a copy.
+    return thresholds;
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/OffHeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/OffHeapMemoryMonitor.java
@@ -202,8 +202,6 @@ public class OffHeapMemoryMonitor implements MemoryMonitor, MemoryUsageListener 
             "Critical percentage must be greater than the eviction percentage.");
       }
 
-      cache.setQueryMonitorRequiredForResourceManager(criticalThreshold != 0);
-
       thresholds = new MemoryThresholds(thresholds.getMaxMemoryBytes(), criticalThreshold,
           thresholds.getEvictionThreshold());
 
@@ -402,10 +400,9 @@ public class OffHeapMemoryMonitor implements MemoryMonitor, MemoryUsageListener 
 
   @Override
   public MemoryThresholds getThresholds() {
-    MemoryThresholds saveThresholds = thresholds;
-
-    return new MemoryThresholds(saveThresholds.getMaxMemoryBytes(),
-        saveThresholds.getCriticalThreshold(), saveThresholds.getEvictionThreshold());
+    // MemoryThresholds is immutable so we
+    // can just return it instead of making a copy.
+    return thresholds;
   }
 
   /**

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/xmlcache/CacheCreation.java
@@ -1352,11 +1352,6 @@ public class CacheCreation implements InternalCache {
   }
 
   @Override
-  public void setQueryMonitorRequiredForResourceManager(final boolean required) {
-    throw new UnsupportedOperationException("Should not be invoked");
-  }
-
-  @Override
   public boolean isQueryMonitorDisabledForLowMemory() {
     throw new UnsupportedOperationException("Should not be invoked");
   }


### PR DESCRIPTION
Removed setQueryMonitorRequiredForResourceManager from InternalCache.
Now when we are considering creating a QueryMonitor, the cache will
ask the resource manager for its critical heap percentage. If it is 0
then it the resource manager does not need a QueryMonitor for low mem monitoring.
Also optimized MemoryMonitor.getThresholds to not make a copy of the result
since MemoryThresholds is immutable.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
