### PR TITLE
GEODE-10162: Try to find and set version tag if needed

### DIFF
--- a/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/DistributedRegionTest.java
@@ -268,7 +268,7 @@ public class DistributedRegionTest {
   }
 
   @Test
-  public void hasSeenEventDoseNotFindAndSetVersionTagIfFoundInEventTrackerAndVersionTagIsSet() {
+  public void hasSeenEventDoesNotFindAndSetVersionTagIfFoundInEventTrackerAndVersionTagIsSet() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class);
     doCallRealMethod().when(distributedRegion).hasSeenEvent(event);
     when(distributedRegion.getEventTracker()).thenReturn(eventTracker);
@@ -281,7 +281,7 @@ public class DistributedRegionTest {
   }
 
   @Test
-  public void hasSeenEventDoseNotFindAndSetVersionTagIfFoundInEventTrackerAndConcurrencyChecksNotEnabled() {
+  public void hasSeenEventDoesNotFindAndSetVersionTagIfFoundInEventTrackerAndConcurrencyChecksNotEnabled() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class);
     doCallRealMethod().when(distributedRegion).hasSeenEvent(event);
     when(distributedRegion.getEventTracker()).thenReturn(eventTracker);
@@ -295,7 +295,7 @@ public class DistributedRegionTest {
   }
 
   @Test
-  public void hasSeenEventDoseNotFindAndSetVersionTagIfFoundInEventTrackerAndEventIdIsNotSet() {
+  public void hasSeenEventDoesNotFindAndSetVersionTagIfFoundInEventTrackerAndEventIdIsNotSet() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class);
     doCallRealMethod().when(distributedRegion).hasSeenEvent(event);
     when(distributedRegion.getEventTracker()).thenReturn(eventTracker);
@@ -325,7 +325,7 @@ public class DistributedRegionTest {
   }
 
   @Test
-  public void hasSeenEventDoseNotFindAndSetVersionTagIfNotFoundEventInEventTrackerAndNotADuplicateEvent() {
+  public void hasSeenEventDoesNotFindAndSetVersionTagIfNotFoundEventInEventTrackerAndNotADuplicateEvent() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class);
     doCallRealMethod().when(distributedRegion).hasSeenEvent(event);
     when(distributedRegion.getEventTracker()).thenReturn(eventTracker);
@@ -337,7 +337,7 @@ public class DistributedRegionTest {
   }
 
   @Test
-  public void hasSeenEventDoseNotFindAndSetVersionTagIfNotFoundInEventTrackerAndConcurrencyChecksNotEnabled() {
+  public void hasSeenEventDoesNotFindAndSetVersionTagIfNotFoundInEventTrackerAndConcurrencyChecksNotEnabled() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class);
     doCallRealMethod().when(distributedRegion).hasSeenEvent(event);
     when(distributedRegion.getEventTracker()).thenReturn(eventTracker);
@@ -351,7 +351,7 @@ public class DistributedRegionTest {
   }
 
   @Test
-  public void hasSeenEventDoseNotFindAndSetVersionTagIfNotFoundInEventTrackerAndVersionTagIsSet() {
+  public void hasSeenEventDoesNotFindAndSetVersionTagIfNotFoundInEventTrackerAndVersionTagIsSet() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class);
     doCallRealMethod().when(distributedRegion).hasSeenEvent(event);
     when(distributedRegion.getEventTracker()).thenReturn(eventTracker);
@@ -366,7 +366,7 @@ public class DistributedRegionTest {
   }
 
   @Test
-  public void hasSeenEventDoseNotFindAndSetVersionTagIfNotFoundInEventTrackerAndNoEventId() {
+  public void hasSeenEventDoesNotFindAndSetVersionTagIfNotFoundInEventTrackerAndNoEventId() {
     DistributedRegion distributedRegion = mock(DistributedRegion.class);
     doCallRealMethod().when(distributedRegion).hasSeenEvent(event);
     when(distributedRegion.getEventTracker()).thenReturn(eventTracker);


### PR DESCRIPTION
* In geode, version tags are not sent to receiver during GII. When an
  operation is retried on the receiver, a valid tag is needed so that the
  operation can be distributed to other peers. Valid version tage will
  be searched in the cluster and set in the event to make sure the
  operation is distributed.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
