### PR TITLE
GEODE-10166: Move tests to correct directory

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/RebalanceCommandAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/cli/commands/RebalanceCommandAcceptanceTest.java
@@ -38,10 +38,11 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.assertions.TabularResultModelAssert;
 import org.apache.geode.test.junit.rules.GfshCommandRule;
+import org.apache.geode.test.junit.rules.GfshCommandRule.PortType;
 import org.apache.geode.test.junit.rules.MemberStarterRule;
 
 @RunWith(Parameterized.class)
-public class RebalanceCommandDistributedTest implements Serializable {
+public class RebalanceCommandAcceptanceTest implements Serializable {
   private static final int ENTRIES_PER_REGION = 200;
   private static final String REGION_ONE_NAME = "region-1";
   private static final String REGION_TWO_NAME = "region-2";
@@ -56,12 +57,12 @@ public class RebalanceCommandDistributedTest implements Serializable {
   protected MemberVM locator, server1, server2;
 
   @Parameterized.Parameters(name = "ConnectionType:{0}")
-  public static GfshCommandRule.PortType[] connectionTypes() {
-    return new GfshCommandRule.PortType[] {http, jmxManager};
+  public static PortType[] connectionTypes() {
+    return new PortType[] {http, jmxManager};
   }
 
   @Parameterized.Parameter
-  public static GfshCommandRule.PortType portType;
+  public static PortType portType;
 
   private void setUpRegions() {
     server1.invoke(() -> {

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/NestedQueryClassCastExceptionFailureDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/NestedQueryClassCastExceptionFailureDistributedTest.java
@@ -12,7 +12,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package org.apache.geode.management.internal.cli.commands;
+package org.apache.geode.cache.query.dunit;
 
 import static org.apache.geode.cache.Region.SEPARATOR;
 import static org.apache.geode.distributed.ConfigurationProperties.SERIALIZABLE_OBJECT_FILTER;
@@ -31,13 +31,14 @@ import org.apache.geode.cache.RegionShortcut;
 import org.apache.geode.cache.query.QueryService;
 import org.apache.geode.cache.query.SelectResults;
 import org.apache.geode.cache.server.CacheServer;
+import org.apache.geode.management.internal.cli.commands.Product;
 import org.apache.geode.pdx.ReflectionBasedAutoSerializer;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.version.VersionManager;
 
-public class NestedQueryClassCastExceptionFailureDUnitTest {
+public class NestedQueryClassCastExceptionFailureDistributedTest {
   @Rule
   public ClusterStartupRule cluster = new ClusterStartupRule();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/InternalCacheForClientAccessDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/InternalCacheForClientAccessDistributedTest.java
@@ -46,7 +46,7 @@ import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 
-public class InternalCacheForClientAccessDUnitTest<tearDown> implements java.io.Serializable {
+public class InternalCacheForClientAccessDistributedTest implements java.io.Serializable {
   public static final long serialVersionUID = 1l;
 
   @Rule

--- a/geode-dunit/src/main/resources/org/apache/geode/test/dunit/internal/sanctioned-geode-dunit-serializables.txt
+++ b/geode-dunit/src/main/resources/org/apache/geode/test/dunit/internal/sanctioned-geode-dunit-serializables.txt
@@ -104,7 +104,6 @@ org/apache/geode/cache30/RegionTestCase$6,false,this$0:org/apache/geode/cache30/
 org/apache/geode/cache30/RegionTestCase$7,false,this$0:org/apache/geode/cache30/RegionTestCase,val$name:java/lang/String
 org/apache/geode/cache30/RegionTestCase$8,false,this$0:org/apache/geode/cache30/RegionTestCase,val$name:java/lang/String
 org/apache/geode/cache30/RegionTestCase$9,false,this$0:org/apache/geode/cache30/RegionTestCase,val$name:java/lang/String
-org/apache/geode/internal/cache/InternalCacheForClientAccessDUnitTest,true,1,clientVM:org/apache/geode/test/dunit/VM,dunitRule:org/apache/geode/test/dunit/rules/DistributedRule,serverVM:org/apache/geode/test/dunit/VM
 org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil,false
 org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase,false,props:java/util/Properties,putRange_1End:int,putRange_1Start:int,putRange_2End:int,putRange_2Start:int,testVersion:java/lang/String
 org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase$1,false,this$0:org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase,val$rName:java/lang/String
@@ -115,7 +114,6 @@ org/apache/geode/management/internal/cli/commands/ExportLogsDistributedTestBase$
 org/apache/geode/management/internal/cli/commands/Product,false,contractSize:java/lang/String,productCodes:java/util/TreeMap,productID:java/lang/Long,status:java/lang/String
 org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase$Address,false,city:java/lang/String,street:java/lang/String
 org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase$Customer,false,address:org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase$Address,name:java/lang/String
-org/apache/geode/management/internal/cli/commands/RebalanceCommandDistributedTest,false,cluster:org/apache/geode/test/dunit/rules/ClusterStartupRule,locator:org/apache/geode/test/dunit/rules/MemberVM,server1:org/apache/geode/test/dunit/rules/MemberVM,server2:org/apache/geode/test/dunit/rules/MemberVM
 org/apache/geode/management/internal/cli/commands/ShowDeadlockDistributedTestBase$LockFunction,false
 org/apache/geode/management/internal/cli/commands/ShowLogCommandDistributedTestBase,false
 org/apache/geode/management/internal/configuration/ClusterConfig,false,groups:java/util/List


### PR DESCRIPTION
 - Rename InternalCacheForClientAccessDUnitTest ->
 InternalCacheForClientAccessDistributedTest
 - Move InternalCacheForClientAccessDistributedTest to geode-core module
 - Remove spurious <tearDown> parameterization from
 InternalCacheForClientAccessDistributedTest
 - Rename NestedQueryClassCastExceptionFailureDUnitTest ->
 NestedQueryClassCastExceptionFailureDistributedTest
 - Move NestedQueryClassCastExceptionFailureDistributedTest to
   geode-core module, change package to cache.query.dunit
 - Rename RebalanceCommandDistributesTest to
  RelanaceCommandAcceptanceTest
 - Move RebalanceCommandAcceptanceTest to geode-assembly module
  acceptanceTest directory as it requires that GEODE_HOME is set
 - Remove files from sanctioned-geode-dunit-serializables.txt

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
