### PR TITLE
GEODE-10171: AbstractRedisData version being incremented for no-op operations can lead to corruption

### DIFF
--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/AbstractRedisData.java
@@ -95,6 +95,10 @@ public abstract class AbstractRedisData implements RedisData {
     return ++version;
   }
 
+  public byte getVersion() {
+    return version;
+  }
+
   public void setVersion(byte version) {
     this.version = version;
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisSet.java
@@ -422,14 +422,14 @@ public class RedisSet extends AbstractRedisData {
    * @return the number of members actually added
    */
   public long sadd(List<byte[]> membersToAdd, Region<RedisKey, RedisData> region, RedisKey key) {
-    byte newVersion;
     int membersAdded = 0;
-    AddByteArrays delta;
+    AddByteArrays delta = null;
     synchronized (this) {
-      newVersion = incrementAndGetVersion();
-      delta = new AddByteArrays(newVersion);
       for (byte[] member : membersToAdd) {
         if (membersAdd(member)) {
+          if (delta == null) {
+            delta = new AddByteArrays(incrementAndGetVersion());
+          }
           delta.add(member);
           membersAdded++;
         }

--- a/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/RedisListTest.java
+++ b/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/RedisListTest.java
@@ -132,6 +132,17 @@ public class RedisListTest {
     assertThat(list.hasDelta()).isFalse();
   }
 
+  @Test
+  public void versionDoesNotUpdateWhenReferenceElementNotFound() {
+    Region<RedisKey, RedisData> region = uncheckedCast(mock(PartitionedRegion.class));
+    RedisList list = createRedisList(1, 2);
+
+    byte originalVersion = list.getVersion();
+    list.linsert(new byte[] {(byte) 3}, new byte[] {(byte) 0}, true, region, null);
+
+    assertThat(list.getVersion()).isEqualTo(originalVersion);
+  }
+
   private Object validateDeltaSerialization(InvocationOnMock invocation) throws IOException {
     RedisList value = invocation.getArgument(1, RedisList.class);
     assertThat(value.hasDelta()).isTrue();

--- a/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
+++ b/geode-for-redis/src/test/java/org/apache/geode/redis/internal/data/RedisSetTest.java
@@ -277,6 +277,17 @@ public class RedisSetTest {
     assertThat(set1.hasDelta()).isFalse();
   }
 
+  @Test
+  public void versionDoesNotUpdateForDuplicateAddedMember() {
+    Region<RedisKey, RedisData> region = uncheckedCast(mock(PartitionedRegion.class));
+    RedisSet set = createRedisSet(1, 2);
+
+    byte originalVersion = set.getVersion();
+    set.sadd(Collections.singletonList(new byte[] {(byte) 1}), region, null);
+
+    assertThat(set.getVersion()).isEqualTo(originalVersion);
+  }
+
   /************* test size of bytes in use *************/
 
   /******* constructor *******/


### PR DESCRIPTION

For SADD, which may or may not modify the data in the region depending
on whether the member being added is already present in the set, the
version in AbstractRedisData is updated regardless of whether a Delta is
sent to the secondary. This can lead to the version on the primary
wrapping around to be equal to the version on the secondary, which means
that if a delta is sent, it will not be applied on the secondary,
leading to potential data loss.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
