### PR TITLE
GEODE-10179: Bump jackson-databind to 2.13.2.1

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -490,7 +490,12 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.2</version>
+        <version>2.13.2.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
+        <version>2.13.2.20220324</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -46,6 +46,8 @@ class DependencyConstraints implements Plugin<Project> {
     deps.put("slf4j-api.version", "1.7.32")
     deps.put("jboss-modules.version", "1.11.0.Final")
     deps.put("jackson.version", "2.13.2")
+    deps.put("jackson.databind.version", "2.13.2.1")
+    deps.put("jackson.bom.version", "2.13.2.20220324")
     deps.put("springshell.version", "1.2.0.RELEASE")
     deps.put("springframework.version", "5.3.16")
 
@@ -185,7 +187,14 @@ class DependencyConstraints implements Plugin<Project> {
     dependencySet(group: 'com.fasterxml.jackson.core', version: get('jackson.version')) {
       entry('jackson-annotations')
       entry('jackson-core')
+    }
+
+    dependencySet(group: 'com.fasterxml.jackson.core', version: get('jackson.databind.version')) {
       entry('jackson-databind')
+    }
+
+    dependencySet(group: 'com.fasterxml.jackson', version: get('jackson.bom.version')) {
+      entry('jackson-bom')
     }
 
     dependencySet(group: 'com.fasterxml.jackson.datatype', version: get('jackson.version')) {

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1007,7 +1007,7 @@ lib/httpcore-4.4.15.jar
 lib/istack-commons-runtime-4.0.1.jar
 lib/jackson-annotations-2.13.2.jar
 lib/jackson-core-2.13.2.jar
-lib/jackson-databind-2.13.2.jar
+lib/jackson-databind-2.13.2.1.jar
 lib/javax.activation-api-1.2.0.jar
 lib/javax.mail-api-1.6.2.jar
 lib/javax.resource-api-1.7.1.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -38,7 +38,7 @@ httpcore-4.4.15.jar
 istack-commons-runtime-4.0.1.jar
 jackson-annotations-2.13.2.jar
 jackson-core-2.13.2.jar
-jackson-databind-2.13.2.jar
+jackson-databind-2.13.2.1.jar
 javax.activation-api-1.2.0.jar
 javax.resource-api-1.7.1.jar
 javax.servlet-api-3.1.0.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -38,7 +38,7 @@ httpcore-4.4.15.jar
 istack-commons-runtime-4.0.1.jar
 jackson-annotations-2.13.2.jar
 jackson-core-2.13.2.jar
-jackson-databind-2.13.2.jar
+jackson-databind-2.13.2.1.jar
 javax.activation-api-1.2.0.jar
 javax.resource-api-1.7.1.jar
 javax.servlet-api-3.1.0.jar


### PR DESCRIPTION
Geode endeavors to update to the latest version of 3rd-party
dependencies on develop wherever possible.  Doing so increases the
shelf life of releases and increases security and reliability; doing so
regularly makes any hiccups easier to identify.

This bump of jackson-databind from 2.13.2 to micropatch 2.13.2.1 is
a little clunkly and once 2.13.3 or 2.14.0 is available, this should
first be reverted...