### PR TITLE
[1.13] GEODE-10179: Bump jackson-databind from 2.10.5.1 to 2.12.6.1

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -64,13 +64,13 @@
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-joda</artifactId>
-        <version>2.9.8</version>
+        <version>2.12.6</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
-        <version>2.11.2</version>
+        <version>2.12.6</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
@@ -562,19 +562,19 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-annotations</artifactId>
-        <version>2.10.5</version>
+        <version>2.12.6</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-core</artifactId>
-        <version>2.10.5</version>
+        <version>2.12.6</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.10.5.1</version>
+        <version>2.12.6.1</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -87,8 +87,8 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'cglib', name: 'cglib', version: get('cglib.version'))
         api(group: 'com.arakelian', name: 'java-jq', version: '0.10.1')
         api(group: 'com.carrotsearch.randomizedtesting', name: 'randomizedtesting-runner', version: '2.7.7')
-        api(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.9.8')
-        api(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.11.2')
+        api(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-joda', version: '2.12.6')
+        api(group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.12.6')
         api(group: 'com.fasterxml.jackson.module', name: 'jackson-module-scala_2.10', version: '2.10.0')
         api(group: 'com.github.davidmoten', name: 'geo', version: '0.7.7')
         api(group: 'com.github.stefanbirkner', name: 'system-rules', version: '1.19.0')
@@ -174,12 +174,12 @@ class DependencyConstraints implements Plugin<Project> {
       }
     }
 
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.10.5') {
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.12.6') {
       entry('jackson-annotations')
       entry('jackson-core')
     }
 
-    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.10.5.1') {
+    dependencySet(group: 'com.fasterxml.jackson.core', version: '2.12.6.1') {
       entry('jackson-databind')
     }
 

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1020,9 +1020,9 @@ lib/gfsh-dependencies.jar
 lib/httpclient-4.5.13.jar
 lib/httpcore-4.4.13.jar
 lib/istack-commons-runtime-3.0.11.jar
-lib/jackson-annotations-2.10.5.jar
-lib/jackson-core-2.10.5.jar
-lib/jackson-databind-2.10.5.1.jar
+lib/jackson-annotations-2.12.6.jar
+lib/jackson-core-2.12.6.jar
+lib/jackson-databind-2.12.6.1.jar
 lib/javax.activation-1.2.0.jar
 lib/javax.activation-api-1.2.0.jar
 lib/javax.mail-api-1.6.2.jar

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -16,9 +16,9 @@ geode-redis-0.0.0.jar
 geode-serialization-0.0.0.jar
 geode-tcp-server-0.0.0.jar
 geode-wan-0.0.0.jar
-jackson-databind-2.10.5.1.jar
-jackson-annotations-2.10.5.jar
-jackson-core-2.10.5.jar
+jackson-databind-2.12.6.1.jar
+jackson-annotations-2.12.6.jar
+jackson-core-2.12.6.jar
 geode-membership-0.0.0.jar
 geode-http-service-0.0.0.jar
 geode-unsafe-0.0.0.jar

--- a/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/DistributedSystemMBeanIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/management/internal/beans/DistributedSystemMBeanIntegrationTest.java
@@ -40,6 +40,8 @@ import org.apache.geode.test.junit.rules.ServerStarterRule;
 public class DistributedSystemMBeanIntegrationTest {
 
   public static final String SELECT_ALL = "select * from /testRegion r where r.id=1";
+  public static final String SELECT_ALL_BUT_LOCAL_DATE =
+      "select name, address, startDate, endDate, title from /testRegion r where r.id=1";
   public static final String SELECT_FIELDS = "select id, title from /testRegion r where r.id=1";
 
   @ClassRule
@@ -109,22 +111,28 @@ public class DistributedSystemMBeanIntegrationTest {
   }
 
   // this is simply to document the current behavior of gfsh
-  // gfsh doesn't attempt to format the date objects as of now, and it respect the json annotations
-  // when listing out the headers
   @Test
   public void queryAllUsingGfshDoesNotFormatDate() throws Exception {
     gfsh.connectAndVerify(server.getJmxPort(), GfshCommandRule.PortType.jmxManager);
     TabularResultModelAssert tabularAssert =
-        gfsh.executeAndAssertThat("query --query='" + SELECT_ALL + "'")
+        gfsh.executeAndAssertThat("query --query='" + SELECT_ALL_BUT_LOCAL_DATE + "'")
             .statusIsSuccess()
             .hasTableSection();
-    // note gfsh doesn't show id field and shows "title" field as "Job Title" when doing select *
     tabularAssert.hasColumns().asList().containsExactlyInAnyOrder("name", "address", "startDate",
-        "endDate", "birthday", "Job Title");
+        "endDate", "title");
     tabularAssert.hasColumn("startDate").containsExactly(date.getTime() + "");
     tabularAssert.hasColumn("endDate").containsExactly(sqlDate.getTime() + "");
-    tabularAssert.hasColumn("birthday")
-        .asList().asString().contains("\"year\":2020,\"month\":\"JANUARY\"");
+  }
+
+  // this is simply to document the current behavior of gfsh
+  // gfsh refused to format the date objects as of jackson 2.12's fix#2683
+  @Test
+  public void queryAllUsingGfshRefusesToFormatLocalDate() throws Exception {
+    gfsh.connectAndVerify(server.getJmxPort(), GfshCommandRule.PortType.jmxManager);
+    gfsh.executeAndAssertThat("query --query='" + SELECT_ALL + "'")
+        .statusIsError()
+        .containsOutput(
+            "Java 8 date/time type `java.time.LocalDate` not supported by default: add Module \"com.fasterxml.jackson.datatype:jackson-datatype-jsr310\"");
   }
 
   @Test


### PR DESCRIPTION
to fix https://github.com/FasterXML/jackson-databind/issues/2816