### PR TITLE
user guide: typo repair in troubleshooting section

### DIFF
--- a/geode-docs/managing/troubleshooting/log_messages_and_solutions.html.md.erb
+++ b/geode-docs/managing/troubleshooting/log_messages_and_solutions.html.md.erb
@@ -244,7 +244,7 @@ it is often possible, by analyzing the “15 seconds have elapsed” messages in
 described more in the [Seconds have elapsed](#secondshaveelapsed) message in this document.
 
 
-## <a id="disconnectingolsdistributedsystem""></a>Disconnecting old DistributedSystem to prepare for a reconnect attempt
+## <a id="disconnectingolsdistributedsystem"></a>Disconnecting old DistributedSystem to prepare for a reconnect attempt
 
 ## <a id="attemptingtoreconnecttothedistributedsystem"></a>Attempting to reconnect to the DistributedSystem.  This is attempt #n
 


### PR DESCRIPTION
Removed a doubled double-quote.