### PR TITLE
GEODE-10190: Improve runtime of MSetIntegrationTest and RenameIntegrationTest

### DIFF
--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameIntegrationTest.java
@@ -150,8 +150,8 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
   @Test
   public void shouldRenameAtomically() {
     int numIterations = 100;
-    int numStringsFirstKey = 500000;
-    int numStringsSecondKey = 30000;
+    int numStringsFirstKey = 10000;
+    int numStringsSecondKey = 1000;
 
     String k1 = "{tag1}k1";
     String k2 = "{tag1}k2";
@@ -171,7 +171,7 @@ public abstract class AbstractRenameIntegrationTest implements RedisIntegrationT
         i -> {
           // introduce more variability as to when the rename happens
           try {
-            Thread.sleep(rand.nextInt(1000));
+            Thread.sleep(rand.nextInt(100));
           } catch (InterruptedException ignored) {
           }
           jedis.rename(k1, k2);

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetIntegrationTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/commands/executor/string/AbstractMSetIntegrationTest.java
@@ -124,7 +124,7 @@ public abstract class AbstractMSetIntegrationTest implements RedisIntegrationTes
 
   @Test
   public void testMSet_concurrentInstances_mustBeAtomic() {
-    int KEY_COUNT = 5000;
+    int KEY_COUNT = 500;
     String[] keys = new String[KEY_COUNT];
 
     for (int i = 0; i < keys.length; i++) {


### PR DESCRIPTION


- Reduce the iterations and/or elements used by these tests reducing the
  runtimes significantly (down to seconds instead of minutes).

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
