### PR TITLE
GEODE-10020: Introduction of option to gradually activate pinging

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
@@ -400,7 +400,7 @@ public class SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest {
     return vm.invoke(() -> {
       AbstractGatewaySender sender =
           (AbstractGatewaySender) CacheFactory.getAnyInstance().getGatewaySender(senderId);
-      assertNotNull(sender);
+      assertThat(sender).isNotNull();
       PoolStats poolStats = sender.getProxy().getStats();
       return poolStats.getDisConnects();
     });
@@ -410,7 +410,7 @@ public class SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest {
     return vm.invoke(() -> {
       AbstractGatewaySender sender =
           (AbstractGatewaySender) CacheFactory.getAnyInstance().getGatewaySender(senderId);
-      assertNotNull(sender);
+      assertThat(sender).isNotNull();
       PoolStats poolStats = sender.getProxy().getStats();
       return poolStats.getConnects();
     });

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
@@ -256,17 +256,9 @@ public class SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest {
 
     await().untilAsserted(() -> assertThat(getQueuedEvents(vm1, senderId)).isEqualTo(0));
 
-
-    // Wait longer than the value set in the receivers for
-    // maximum-time-between-pings: 10000 (see geode-starter-create.gfsh)
-    // to verify that connections are not closed
-    // by the receivers because each has received the pings timely.
-    int maxTimeBetweenPingsInReceiver = 10000;
-    Thread.sleep(maxTimeBetweenPingsInReceiver);
-
     await().untilAsserted(() -> assertThat(getSenderPoolDisconnects(vm1, senderId)).isEqualTo(0));
 
-    await().untilAsserted(() -> assertThat(getSenderPoolConnects(vm1, senderId)).isEqualTo(3));
+    await().untilAsserted(() -> assertThat(getSenderPoolConnects(vm1, senderId)).isEqualTo(4));
   }
 
 

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
@@ -58,6 +58,7 @@ import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.junit.categories.WanTest;
+import org.apache.geode.util.internal.GeodeGlossary;
 
 
 /**
@@ -214,6 +215,62 @@ public class SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest {
 
   }
 
+
+  /**
+   * The aim of this test is verify that when several gateway receivers in a remote site share the
+   * same port and hostname-for-senders, the pings sent from the gateway senders reach the right
+   * gateway receiver and not just any of the receivers. Check that only one additional connection
+   * is used.
+   */
+  @Test
+  public void testPingsToReceiversWithSamePortAndHostnameForSendersUseOnlyOneMoreConnection()
+      throws InterruptedException {
+    String senderId = "ln";
+    String regionName = "region-wan";
+    final int remoteLocPort = docker.getExternalPortForService("haproxy", 20334);
+
+    int locPort = createLocator(VM.getVM(0), 1, remoteLocPort);
+
+    VM vm1 = VM.getVM(1);
+
+    vm1.invoke(() -> {
+      System.setProperty(
+          GeodeGlossary.GEMFIRE_PREFIX + "InitialServerPinger.OFFSET", "500");
+
+      Properties props = new Properties();
+      props.setProperty(LOCATORS, "localhost[" + locPort + "]");
+      CacheFactory cacheFactory = new CacheFactory(props);
+      cache = cacheFactory.create();
+    });
+
+    createGatewaySender(vm1, senderId, 2, true, 5,
+        2, GatewaySender.DEFAULT_ORDER_POLICY);
+
+    createPartitionedRegion(vm1, regionName, senderId, 0, 10);
+
+    int NUM_PUTS = 10;
+
+    putKeyValues(vm1, NUM_PUTS, regionName);
+
+    await().untilAsserted(() -> assertThat(getQueuedEvents(vm1, senderId)).isEqualTo(0));
+
+
+    // Wait longer than the value set in the receivers for
+    // maximum-time-between-pings: 10000 (see geode-starter-create.gfsh)
+    // to verify that connections are not closed
+    // by the receivers because each has received the pings timely.
+    int maxTimeBetweenPingsInReceiver = 10000;
+    Thread.sleep(maxTimeBetweenPingsInReceiver);
+
+    int senderPoolDisconnects = getSenderPoolDisconnects(vm1, senderId);
+    assertEquals(0, senderPoolDisconnects);
+
+    int poolEndPointSize = getSenderPoolConnects(vm1, senderId);
+    assertEquals(3, poolEndPointSize);
+  }
+
+
+
   private boolean allDispatchersConnectedToSameReceiver(int server) {
 
     String gfshOutput = runListGatewayReceiversCommandInServer(server);
@@ -354,6 +411,16 @@ public class SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest {
       assertNotNull(sender);
       PoolStats poolStats = sender.getProxy().getStats();
       return poolStats.getDisConnects();
+    });
+  }
+
+  private static int getSenderPoolConnects(VM vm, String senderId) {
+    return vm.invoke(() -> {
+      AbstractGatewaySender sender =
+          (AbstractGatewaySender) CacheFactory.getAnyInstance().getGatewaySender(senderId);
+      assertNotNull(sender);
+      PoolStats poolStats = sender.getProxy().getStats();
+      return poolStats.getConnects();
     });
   }
 

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
@@ -262,11 +262,9 @@ public class SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest {
     int maxTimeBetweenPingsInReceiver = 10000;
     Thread.sleep(maxTimeBetweenPingsInReceiver);
 
-    int senderPoolDisconnects = getSenderPoolDisconnects(vm1, senderId);
-    assertEquals(0, senderPoolDisconnects);
+    await().untilAsserted(() -> assertThat(getSenderPoolDisconnects(vm1, senderId)).isEqualTo(0));
 
-    int poolEndPointSize = getSenderPoolConnects(vm1, senderId);
-    assertEquals(3, poolEndPointSize);
+    await().untilAsserted(() -> assertThat(getSenderPoolConnects(vm1, senderId)).isEqualTo(3));
   }
 
 

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/cache/wan/SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest.java
@@ -235,7 +235,9 @@ public class SeveralGatewayReceiversWithSamePortAndHostnameForSendersTest {
 
     vm1.invoke(() -> {
       System.setProperty(
-          GeodeGlossary.GEMFIRE_PREFIX + "InitialServerPinger.OFFSET", "500");
+          GeodeGlossary.GEMFIRE_PREFIX
+              + "LiveServerPinger.INITIAL_DELAY_MULTIPLIER_IN_MILLISECONDS",
+          "500");
 
       Properties props = new Properties();
       props.setProperty(LOCATORS, "localhost[" + locPort + "]");

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/LiveServerPinger.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/LiveServerPinger.java
@@ -70,11 +70,13 @@ public class LiveServerPinger extends EndpointListenerAdapter {
     cancelFuture(endpoint);
   }
 
+  /**
+   * At each registration of new endpoint increase counter for calculation of initial delay offset
+   *
+   */
   @Override
   public void endpointNowInUse(Endpoint endpoint) {
     try {
-      // At each registration of new endpoint increase counter for calculation of initial delay
-      // offset
       long initDelay = calculateInitialDelay();
 
       // initDelay - the time to delay first execution

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/LiveServerPinger.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/LiveServerPinger.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.logging.log4j.Logger;
 
@@ -27,6 +28,7 @@ import org.apache.geode.cache.client.internal.PoolImpl.PoolTask;
 import org.apache.geode.internal.cache.GemFireCacheImpl;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.logging.internal.log4j.api.LogService;
+import org.apache.geode.util.internal.GeodeGlossary;
 
 /**
  * Responsible for pinging live servers to make sure they are still alive.
@@ -41,6 +43,15 @@ public class LiveServerPinger extends EndpointListenerAdapter {
   protected final InternalPool pool;
   protected final long pingIntervalNanos;
 
+  /**
+   * Initial delay offset time between LiveServerPinger tasks. Time in milliseconds.
+   */
+  public static final int OFFSET =
+      Integer.getInteger(GeodeGlossary.GEMFIRE_PREFIX + "InitialServerPinger.OFFSET", 0);
+
+  private final AtomicInteger offsetIndex = new AtomicInteger(0);
+
+
   public LiveServerPinger(InternalPool pool) {
     this.pool = pool;
     pingIntervalNanos = ((pool.getPingInterval() + 1) / 2) * NANOS_PER_MS;
@@ -48,19 +59,30 @@ public class LiveServerPinger extends EndpointListenerAdapter {
 
   @Override
   public void endpointCrashed(Endpoint endpoint) {
+    offsetIndex.set(0); // Reset counter
     cancelFuture(endpoint);
   }
 
   @Override
   public void endpointNoLongerInUse(Endpoint endpoint) {
+    offsetIndex.set(0); // Reset counter
     cancelFuture(endpoint);
   }
 
   @Override
   public void endpointNowInUse(Endpoint endpoint) {
     try {
+      // At each registration of new endpoint increase counter for calculation of initial delay
+      // offset
+      long initDelay = offsetIndex.getAndIncrement();
+      initDelay = (initDelay * OFFSET * NANOS_PER_MS) + pingIntervalNanos;
+
+      // initDelay - the time to delay first execution
+      // pingIntervalNanos - the delay between the termination of one execution and the commencement
+      // of the next
+
       Future future = pool.getBackgroundProcessor().scheduleWithFixedDelay(new PingTask(endpoint),
-          pingIntervalNanos, pingIntervalNanos, TimeUnit.NANOSECONDS);
+          initDelay, pingIntervalNanos, TimeUnit.NANOSECONDS);
       taskFutures.put(endpoint, future);
     } catch (RejectedExecutionException e) {
       if (!pool.getCancelCriterion().isCancelInProgress()) {

--- a/geode-core/src/main/java/org/apache/geode/cache/client/internal/LiveServerPinger.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/client/internal/LiveServerPinger.java
@@ -46,15 +46,16 @@ public class LiveServerPinger extends EndpointListenerAdapter {
   /**
    * Initial delay offset time between LiveServerPinger tasks. Time in milliseconds.
    */
-  public static final int OFFSET =
-      Integer.getInteger(GeodeGlossary.GEMFIRE_PREFIX + "InitialServerPinger.OFFSET", 0);
+  public static final int INITIAL_DELAY_MULTIPLYER_IN_MILLISECONDS =
+      Integer.getInteger(GeodeGlossary.GEMFIRE_PREFIX
+          + "LiveServerPinger.INITIAL_DELAY_MULTIPLYER_IN_MILLISECONDS", 0);
 
   private final AtomicInteger offsetIndex = new AtomicInteger(0);
 
 
   public LiveServerPinger(InternalPool pool) {
     this.pool = pool;
-    pingIntervalNanos = ((pool.getPingInterval() + 1) / 2) * NANOS_PER_MS;
+    pingIntervalNanos = TimeUnit.MILLISECONDS.toNanos((pool.getPingInterval() + 1) / 2);
   }
 
   @Override
@@ -75,7 +76,9 @@ public class LiveServerPinger extends EndpointListenerAdapter {
       // At each registration of new endpoint increase counter for calculation of initial delay
       // offset
       long initDelay = offsetIndex.getAndIncrement();
-      initDelay = (initDelay * OFFSET * NANOS_PER_MS) + pingIntervalNanos;
+      initDelay =
+          TimeUnit.MILLISECONDS.toNanos(initDelay * INITIAL_DELAY_MULTIPLYER_IN_MILLISECONDS)
+              + pingIntervalNanos;
 
       // initDelay - the time to delay first execution
       // pingIntervalNanos - the delay between the termination of one execution and the commencement

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/LiveServerPingerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/LiveServerPingerTest.java
@@ -19,14 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.experimental.categories.Category;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.util.internal.GeodeGlossary;
 
-@Category({ClientServerTest.class})
 public class LiveServerPingerTest {
 
   private InternalPool pool;

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/LiveServerPingerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/LiveServerPingerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.cache.client.internal;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.geode.test.junit.categories.ClientServerTest;
+import org.apache.geode.util.internal.GeodeGlossary;
+
+@Category({ClientServerTest.class})
+public class LiveServerPingerTest {
+
+  private InternalPool pool;
+
+  private static long PING_INTERVAL = 10L;
+  private static long DEFAULT_PING_INTERVAL_NANOS = 5000000L;
+
+  private static long CONFIG_PING_INTERVAL_NANOS = 1000000L;
+
+
+  @Before
+  public void before() throws Exception {
+    System.setProperty(
+        GeodeGlossary.GEMFIRE_PREFIX + "LiveServerPinger.INITIAL_DELAY_MULTIPLIER_IN_MILLISECONDS",
+        "1");
+
+    pool = mock(InternalPool.class);
+    when(pool.getPingInterval()).thenReturn(PING_INTERVAL);
+  }
+
+  @Test
+  public void testInitialDelay() throws Exception {
+
+    LiveServerPinger lsp = new LiveServerPinger(pool);
+
+    assertThat(lsp.calculateInitialDelay()).isEqualTo(DEFAULT_PING_INTERVAL_NANOS);
+    assertThat(lsp.calculateInitialDelay())
+        .isEqualTo(DEFAULT_PING_INTERVAL_NANOS + CONFIG_PING_INTERVAL_NANOS);
+    assertThat(lsp.calculateInitialDelay())
+        .isEqualTo(DEFAULT_PING_INTERVAL_NANOS + (2 * CONFIG_PING_INTERVAL_NANOS));
+    assertThat(lsp.calculateInitialDelay())
+        .isEqualTo(DEFAULT_PING_INTERVAL_NANOS + (3 * CONFIG_PING_INTERVAL_NANOS));
+
+  }
+
+  @Test
+  public void testInitialDelayWithReset() throws Exception {
+
+    LiveServerPinger lsp = new LiveServerPinger(pool);
+
+    assertThat(lsp.calculateInitialDelay()).isEqualTo(DEFAULT_PING_INTERVAL_NANOS);
+    assertThat(lsp.calculateInitialDelay())
+        .isEqualTo(DEFAULT_PING_INTERVAL_NANOS + CONFIG_PING_INTERVAL_NANOS);
+    assertThat(lsp.calculateInitialDelay())
+        .isEqualTo(DEFAULT_PING_INTERVAL_NANOS + (2 * CONFIG_PING_INTERVAL_NANOS));
+    lsp.resetInitialDelay();
+    assertThat(lsp.calculateInitialDelay())
+        .isEqualTo(DEFAULT_PING_INTERVAL_NANOS);
+
+  }
+
+}

--- a/geode-core/src/test/java/org/apache/geode/cache/client/internal/LiveServerPingerTest.java
+++ b/geode-core/src/test/java/org/apache/geode/cache/client/internal/LiveServerPingerTest.java
@@ -19,9 +19,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.util.internal.GeodeGlossary;
@@ -31,26 +31,28 @@ public class LiveServerPingerTest {
 
   private InternalPool pool;
 
+  private LiveServerPinger lsp;
+
   private static long PING_INTERVAL = 10L;
   private static long DEFAULT_PING_INTERVAL_NANOS = 5000000L;
 
   private static long CONFIG_PING_INTERVAL_NANOS = 1000000L;
 
 
-  @Before
-  public void before() throws Exception {
+  @BeforeEach
+  public void init() throws Exception {
     System.setProperty(
         GeodeGlossary.GEMFIRE_PREFIX + "LiveServerPinger.INITIAL_DELAY_MULTIPLIER_IN_MILLISECONDS",
         "1");
 
     pool = mock(InternalPool.class);
     when(pool.getPingInterval()).thenReturn(PING_INTERVAL);
+
+    lsp = new LiveServerPinger(pool);
   }
 
   @Test
   public void testInitialDelay() throws Exception {
-
-    LiveServerPinger lsp = new LiveServerPinger(pool);
 
     assertThat(lsp.calculateInitialDelay()).isEqualTo(DEFAULT_PING_INTERVAL_NANOS);
     assertThat(lsp.calculateInitialDelay())
@@ -64,8 +66,6 @@ public class LiveServerPingerTest {
 
   @Test
   public void testInitialDelayWithReset() throws Exception {
-
-    LiveServerPinger lsp = new LiveServerPinger(pool);
 
     assertThat(lsp.calculateInitialDelay()).isEqualTo(DEFAULT_PING_INTERVAL_NANOS);
     assertThat(lsp.calculateInitialDelay())


### PR DESCRIPTION
As described in RFC, when several gateway receivers have the same value for VIP:PORT, since we have same VIP:PORT for all destinations, theoretically only one connection could be used for pinging destinations. But since all ping tasks are triggered  in parallel, generally each task will request same connection at the same time, and we will create new connection for each task.

To solve this problem, proposal is to introduce configurable option to gradually activate pinging toward destination. This can be accomplish by increasing initial delay of each ping task, when endpoint is registering to be in use. So when initially creating ping tasks, we will set initial start of each task at different time.

For example if we have 5 destinations, and we set ping interval of 5 secs, and initial delay of 0.5 secs, result would be:

1st ping task will start after 5 secs
2nd ping task will start after 5.5 secs
3rd ping task will start after 6 secs
4th ping task will start after 6.5 secs
5th ping task will start after 7 secs

After initial delay, existing logic is kept, to trigger new ping after ping interval of 5 secs.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [*] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [*] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [*] Is your initial contribution a single, squashed commit?

- [*] Does `gradlew build` run cleanly?

- [*] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
