### PR TITLE
GEODE-10199: Make retried putIfAbsent work

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
@@ -406,7 +406,6 @@ public class RegionMapPut extends AbstractRegionMapPut {
         EntryEventImpl event = getEvent();
         if (getOwner().getConcurrencyChecksEnabled() &&
             event.getOperation() == Operation.PUT_IF_ABSENT &&
-            !event.hasValidVersionTag() &&
             event.isPossibleDuplicate()) {
           Object retainedValue = getRegionEntry().getValueRetain(getOwner());
           try {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapPutTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapPutTest.java
@@ -145,6 +145,21 @@ public class RegionMapPutTest {
     assertThat(instance.isOverwritePutIfAbsent()).isTrue();
   }
 
+  @Test
+  public void overWritePutIfAbsentIsTrueIfRetriedPutIfAbsentOperationHavingValidVersionTag() {
+    final byte[] bytes = new byte[] {1, 2, 3, 4, 5};
+    givenExistingRegionEntry();
+    when(existingRegionEntry.getValue()).thenReturn(bytes);
+    when(internalRegion.getConcurrencyChecksEnabled()).thenReturn(true);
+    givenPutIfAbsentOperation(bytes); // duplicate operation
+    when(event.hasValidVersionTag()).thenReturn(true);
+
+    doPut();
+
+    verify(event).setOldValue(null, true);
+    assertThat(instance.isOverwritePutIfAbsent()).isTrue();
+  }
+
   private void givenPutIfAbsentOperation(byte[] bytes) {
     when(event.isPossibleDuplicate()).thenReturn(true);
     when(event.basicGetNewValue()).thenReturn(bytes);


### PR DESCRIPTION
 * Allow a retried putIfAbsend operation to proceed futher so that the
   operation can be distributed to other peers in basicPutPart2 and
   dispatch the event to their clients, even if the event has set the
   valid version tag already.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
