### PR TITLE
GEM-3405 update Bookbinder version in Gemfile.lock

### DIFF
--- a/geode-book/Gemfile.lock
+++ b/geode-book/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     backports (3.21.0)
-    bookbindery (10.1.17)
+    bookbindery (10.1.18)
       ansi (~> 1.4)
       css_parser
       elasticsearch


### PR DESCRIPTION
https://jira-pivotal.atlassian.net/browse/GEM-3405

Bookbindery v10.1.17 was pulled from Rubygems, so updating Gemfile.lock to use v10.1.18

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [y] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [y] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [y] Is your initial contribution a single, squashed commit?

- [n/a - README file change] Does `gradlew build` run cleanly?

- [n/a - README file change] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
