### PR TITLE
GEODE-10202: change test to not depend on InetAddress.toString

### DIFF
--- a/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
+++ b/geode-membership/src/integrationTest/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeaveJUnitTest.java
@@ -1595,8 +1595,10 @@ public class GMSJoinLeaveJUnitTest {
     assertThatThrownBy(gmsJoinLeave::join)
         .isInstanceOf(MembershipConfigurationException.class)
         .hasMessageContaining(
-            "Could not contact any of the locators: [locator1:12345, locator2:54321]")
+            "Could not contact any of the locators: " + gmsJoinLeave.getLocators())
         .hasCauseInstanceOf(IOException.class);
+    assertThat(gmsJoinLeave.getLocators().toString()).contains("locator1", "locator2", "12345",
+        "54321");
   }
 
   private void mockRequestToServer(HostAndPort hostAndPort)

--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/membership/GMSJoinLeave.java
@@ -261,6 +261,10 @@ public class GMSJoinLeave<ID extends MemberIdentifier> implements JoinLeave<ID> 
     this.locatorClient = locatorClient;
   }
 
+  public List<HostAndPort> getLocators() {
+    return locators;
+  }
+
   static class SearchState<ID extends MemberIdentifier> {
     public int joinedMembersContacted;
     Set<ID> alreadyTried = new HashSet<>();


### PR DESCRIPTION
Test now asks the GMSJoinLeave for its locators and validates
that they are in the exception message instead of having a test
expectation of how InetAddress will be formatted in this exception.
This is needed because the toString format has changed in java 17.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
