### PR TITLE
GEODE‑10179: Bump jackson-databind from 2.13.2.1 to 2.13.2.2

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -490,12 +490,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.13.2.1</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson</groupId>
-        <artifactId>jackson-bom</artifactId>
-        <version>2.13.2.20220324</version>
+        <version>2.13.2.2</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -46,8 +46,7 @@ class DependencyConstraints implements Plugin<Project> {
     deps.put("slf4j-api.version", "1.7.32")
     deps.put("jboss-modules.version", "1.11.0.Final")
     deps.put("jackson.version", "2.13.2")
-    deps.put("jackson.databind.version", "2.13.2.1")
-    deps.put("jackson.bom.version", "2.13.2.20220324")
+    deps.put("jackson.databind.version", "2.13.2.2")
     deps.put("springshell.version", "1.2.0.RELEASE")
     deps.put("springframework.version", "5.3.16")
 
@@ -191,10 +190,6 @@ class DependencyConstraints implements Plugin<Project> {
 
     dependencySet(group: 'com.fasterxml.jackson.core', version: get('jackson.databind.version')) {
       entry('jackson-databind')
-    }
-
-    dependencySet(group: 'com.fasterxml.jackson', version: get('jackson.bom.version')) {
-      entry('jackson-bom')
     }
 
     dependencySet(group: 'com.fasterxml.jackson.datatype', version: get('jackson.version')) {

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1005,7 +1005,7 @@ lib/httpcore-4.4.15.jar
 lib/istack-commons-runtime-4.0.1.jar
 lib/jackson-annotations-2.13.2.jar
 lib/jackson-core-2.13.2.jar
-lib/jackson-databind-2.13.2.1.jar
+lib/jackson-databind-2.13.2.2.jar
 lib/javax.activation-api-1.2.0.jar
 lib/javax.mail-api-1.6.2.jar
 lib/javax.resource-api-1.7.1.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -23,7 +23,7 @@ commons-lang3-3.12.0.jar
 rmiio-2.1.2.jar
 jackson-annotations-2.13.2.jar
 jackson-core-2.13.2.jar
-jackson-databind-2.13.2.1.jar
+jackson-databind-2.13.2.2.jar
 swagger-annotations-1.6.2.jar
 jopt-simple-5.0.4.jar
 log4j-slf4j-impl-2.17.2.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -8,7 +8,7 @@ commons-validator-1.7.jar
 spring-jcl-5.3.16.jar
 commons-codec-1.15.jar
 classgraph-4.8.141.jar
-jackson-databind-2.13.2.1.jar
+jackson-databind-2.13.2.2.jar
 commons-logging-1.2.jar
 geode-management-0.0.0.jar
 geode-core-0.0.0.jar


### PR DESCRIPTION
This just eliminates the need to override the jackson-bom version, which is a little tidier.  No actual new fixes.