### PR TITLE
GEODE-10203: SerialVersionUID added.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/functions/GetClusterConfigurationFunction.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/functions/GetClusterConfigurationFunction.java
@@ -27,6 +27,7 @@ import org.apache.geode.management.internal.configuration.messages.Configuration
 
 public class GetClusterConfigurationFunction implements InternalFunction {
   private static final Logger logger = LogService.getLogger();
+  private static final long serialVersionUID = 6332908511113951823L;
 
   @Override
   public void execute(FunctionContext context) {

--- a/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
+++ b/geode-core/src/main/resources/org/apache/geode/internal/sanctioned-geode-core-serializables.txt
@@ -448,7 +448,7 @@ org/apache/geode/management/internal/cli/functions/CacheRealizationFunction,true
 org/apache/geode/management/internal/cli/functions/RebalanceFunction,true,1
 org/apache/geode/management/internal/configuration/domain/SharedConfigurationStatus,false
 org/apache/geode/management/internal/configuration/functions/DownloadJarFunction,true,1
-org/apache/geode/management/internal/configuration/functions/GetClusterConfigurationFunction,false
+org/apache/geode/management/internal/configuration/functions/GetClusterConfigurationFunction,true,6332908511113951823
 org/apache/geode/management/internal/configuration/functions/GetRegionNamesFunction,false
 org/apache/geode/management/internal/configuration/functions/RecreateCacheFunction,false
 org/apache/geode/management/internal/configuration/messages/ClusterManagementServiceInfo,false,hostName:java/lang/String,httpPort:int,isSSL:boolean,isSecured:boolean

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/GetClusterConfigurationFunctionCompatibilityTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/GetClusterConfigurationFunctionCompatibilityTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import org.apache.geode.cache.execute.FunctionService;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
+import org.apache.geode.internal.AvailablePortHelper;
+import org.apache.geode.management.internal.configuration.functions.GetClusterConfigurationFunction;
+import org.apache.geode.test.dunit.rules.ClusterStartupRule;
+import org.apache.geode.test.dunit.rules.MemberVM;
+import org.apache.geode.test.version.TestVersion;
+import org.apache.geode.test.version.VersionManager;
+
+@RunWith(Parameterized.class)
+public class GetClusterConfigurationFunctionCompatibilityTest {
+
+  private final String oldVersion;
+
+  @Parameterized.Parameters(name = "Version: {0}")
+  public static Collection<String> data() {
+    final TestVersion OLDEST_VERSION_SUPPORTING_GET_CLUSTER_CONFIGURATION_FUNCTION =
+        TestVersion.valueOf("1.12.0");
+    List<String> result = VersionManager.getInstance().getVersionsWithoutCurrent();
+    result.removeIf(s -> TestVersion.valueOf(s)
+        .lessThan(OLDEST_VERSION_SUPPORTING_GET_CLUSTER_CONFIGURATION_FUNCTION));
+    return result;
+  }
+
+  public GetClusterConfigurationFunctionCompatibilityTest(String oldVersion) {
+    this.oldVersion = oldVersion;
+  }
+
+  @Rule
+  public ClusterStartupRule clusterStartupRule = new ClusterStartupRule();
+
+  /*
+   * The goal of the test is that GetClusterConfigurationFunction can be
+   * deserialized in the old versions members
+   * Changes to the class can cause the serialVersionUUID to change which
+   * can cause the serialization to fail in old members.
+   */
+  @Test
+  public void newLocatorCanGetClusterConfigurationFromOldLocator() {
+    // Start locators in old version
+    MemberVM locator1 = clusterStartupRule.startLocatorVM(0, oldVersion);
+    int locator1Port = locator1.getPort();
+    MemberVM locator2 =
+        clusterStartupRule.startLocatorVM(1, AvailablePortHelper.getRandomAvailableTCPPort(),
+            oldVersion, l -> l.withConnectionToLocator(locator1Port));
+    // Roll one locator to the new version
+    locator2.stop(false);
+    locator2 = clusterStartupRule.startLocatorVM(1, l -> l.withConnectionToLocator(locator1Port));
+    // Execute the function from the new locator
+    locator2.invoke(() -> {
+      Set<InternalDistributedMember> locators =
+          ClusterStartupRule.getCache().getDistributionManager().getLocatorDistributionManagerIds();
+      locators.forEach(locator -> {
+        FunctionService.onMember(locator).setArguments(new HashSet<>())
+            .execute(new GetClusterConfigurationFunction());
+      });
+    });
+    /*
+     * LogCheckers will detect the deserialization error in the logs and fail the
+     * test if it occurs.
+     */
+
+  }
+
+
+
+}


### PR DESCRIPTION
* SerialVersionUID added to GetClusterConfigurationFunction.
* Changes to this class will prevent breaking backward compatibility.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
