### PR TITLE
GEODE-10165: change how doSend handles SocketException

### DIFF
--- a/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/Transport.java
+++ b/geode-membership/src/main/java/org/apache/geode/distributed/internal/membership/gms/messenger/Transport.java
@@ -85,7 +85,9 @@ public class Transport<ID extends MemberIdentifier> extends UDP {
       super.doSend(cluster_name, buf, offset, length, dest);
     } catch (SocketException sock_ex) {
       if (!sock.isClosed() && !stack.getChannel().isClosed()) {
-        log.error("Exception caught while sending message", sock_ex);
+        if (messenger != null) {
+          messenger.handleJGroupsIOException(sock_ex, dest);
+        }
       }
     } catch (IOException e) {
       if (messenger != null


### PR DESCRIPTION
SocketException is now also handled by messenger.handleJGroupsIOException.
This is needed on java 17 because the exception containing "Operation not permitted" is now a SocketException instead of an IOException.
But this change should have been made anyway since handleJGroupsIOException does some good things to suppress noise on shutdown and SocketException is an IOException so it make sense to 
handle it in the same way.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
