### PR TITLE
GEODE-10191: Radish RENAME and RESTORE create notification events

### DIFF
--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/eventing/EventDistributorTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/eventing/EventDistributorTest.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import org.junit.Test;
 
 import org.apache.geode.redis.ConcurrentLoopingThreads;
-import org.apache.geode.redis.internal.commands.RedisCommandType;
 import org.apache.geode.redis.internal.data.RedisKey;
 
 public class EventDistributorTest {
@@ -45,7 +44,7 @@ public class EventDistributorTest {
     }
 
     @Override
-    public EventResponse process(RedisCommandType commandType, RedisKey key) {
+    public EventResponse process(NotificationEvent notificationEvent, RedisKey key) {
       fired += 1;
       return EventResponse.REMOVE_AND_STOP;
     }

--- a/geode-for-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
+++ b/geode-for-redis/src/integrationTest/resources/org/apache/geode/codeAnalysis/excludedClasses.txt
@@ -16,6 +16,7 @@ org/apache/geode/redis/internal/data/collections/SizeableByteArrayList
 org/apache/geode/redis/internal/data/collections/SizeableBytes2ObjectOpenCustomHashMapWithCursor
 org/apache/geode/redis/internal/data/collections/SizeableObjectOpenCustomHashSetWithCursor
 org/apache/geode/redis/internal/eventing/EventResponse
+org/apache/geode/redis/internal/eventing/NotificationEvent
 org/apache/geode/redis/internal/pubsub/Publisher$PublishFunction
 org/apache/geode/redis/internal/services/cluster/RedisMemberInfoRetrievalFunction
 org/apache/geode/redis/internal/services/locking/StripedExecutorService$State

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/AbstractRenameExecutor.java
@@ -56,7 +56,7 @@ public abstract class AbstractRenameExecutor implements CommandExecutor {
 
     return context.lockedExecuteInTransaction(oldKey, keysToLock,
         () -> context.getRedisData(oldKey)
-            .rename(context.getRegion(), oldKey, newKey, ifTargetNotExists));
+            .rename(context, oldKey, newKey, ifTargetNotExists));
   }
 
   protected RedisResponse getNoSuchKeyResponse() {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/RestoreExecutor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/commands/executor/key/RestoreExecutor.java
@@ -31,6 +31,7 @@ import org.apache.geode.redis.internal.data.AbstractRedisData;
 import org.apache.geode.redis.internal.data.RedisData;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.data.RedisKeyExistsException;
+import org.apache.geode.redis.internal.eventing.NotificationEvent;
 import org.apache.geode.redis.internal.netty.Coder;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
@@ -103,6 +104,7 @@ public class RestoreExecutor implements CommandExecutor {
       RedisData value = data.restore(dataBytes, options.isReplace());
       ((AbstractRedisData) value).setExpirationTimestampNoDelta(expireAt);
       context.getRegion().put(key, value);
+      context.fireEvent(NotificationEvent.RESTORE, key);
       return null;
     });
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisData.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisData.java
@@ -25,6 +25,7 @@ import org.apache.geode.cache.Region;
 import org.apache.geode.internal.serialization.DeserializationContext;
 import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.SerializationContext;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.services.RegionProvider;
 
 /**
@@ -86,7 +87,7 @@ public class NullRedisData implements RedisData {
   }
 
   @Override
-  public boolean rename(Region<RedisKey, RedisData> region, RedisKey oldKey, RedisKey newKey,
+  public boolean rename(ExecutionHandlerContext context, RedisKey oldKey, RedisKey newKey,
       boolean ifNotExists) {
     return false;
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisList.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/NullRedisList.java
@@ -20,7 +20,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.apache.geode.cache.Region;
-import org.apache.geode.redis.internal.commands.RedisCommandType;
+import org.apache.geode.redis.internal.eventing.NotificationEvent;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 
 class NullRedisList extends RedisList {
@@ -62,7 +62,7 @@ class NullRedisList extends RedisList {
       newList.elementPushHead(element);
     }
     context.getRegion().create(key, newList);
-    context.fireEvent(RedisCommandType.LPUSH, key);
+    context.fireEvent(NotificationEvent.LPUSH, key);
 
     return elementsToAdd.size();
   }
@@ -79,7 +79,7 @@ class NullRedisList extends RedisList {
       newList.elementPushTail(element);
     }
     context.getRegion().create(key, newList);
-    context.fireEvent(RedisCommandType.RPUSH, key);
+    context.fireEvent(NotificationEvent.RPUSH, key);
 
     return elementsToAdd.size();
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisData.java
@@ -34,6 +34,7 @@ import org.apache.geode.internal.serialization.VersionedDataInputStream;
 import org.apache.geode.internal.size.Sizeable;
 import org.apache.geode.logging.internal.log4j.api.LogService;
 import org.apache.geode.redis.internal.RedisException;
+import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.services.RegionProvider;
 
 public interface RedisData extends Delta, DataSerializableFixedID, Sizeable {
@@ -69,7 +70,7 @@ public interface RedisData extends Delta, DataSerializableFixedID, Sizeable {
 
   String type();
 
-  boolean rename(Region<RedisKey, RedisData> region, RedisKey oldKey, RedisKey newKey,
+  boolean rename(ExecutionHandlerContext context, RedisKey oldKey, RedisKey newKey,
       boolean ifTargetNotExists);
 
   default boolean getForceRecalculateSize() {

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisList.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/data/RedisList.java
@@ -37,7 +37,6 @@ import org.apache.geode.internal.serialization.KnownVersion;
 import org.apache.geode.internal.serialization.SerializationContext;
 import org.apache.geode.redis.internal.RedisException;
 import org.apache.geode.redis.internal.commands.Command;
-import org.apache.geode.redis.internal.commands.RedisCommandType;
 import org.apache.geode.redis.internal.data.collections.SizeableByteArrayList;
 import org.apache.geode.redis.internal.data.delta.AddByteArrays;
 import org.apache.geode.redis.internal.data.delta.AddByteArraysTail;
@@ -45,6 +44,7 @@ import org.apache.geode.redis.internal.data.delta.InsertByteArray;
 import org.apache.geode.redis.internal.data.delta.RemoveElementsByIndex;
 import org.apache.geode.redis.internal.data.delta.ReplaceByteArrayAtOffset;
 import org.apache.geode.redis.internal.eventing.BlockingCommandListener;
+import org.apache.geode.redis.internal.eventing.NotificationEvent;
 import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 import org.apache.geode.redis.internal.services.RegionProvider;
 
@@ -163,7 +163,7 @@ public class RedisList extends AbstractRedisData {
       elementsPushHead(elementsToAdd);
     }
     storeChanges(context.getRegion(), key, new AddByteArrays(elementsToAdd, newVersion));
-    context.fireEvent(RedisCommandType.LPUSH, key);
+    context.fireEvent(NotificationEvent.LPUSH, key);
 
     return elementList.size();
   }
@@ -268,7 +268,7 @@ public class RedisList extends AbstractRedisData {
       elementsToAdd.forEach(this::elementPushTail);
     }
     storeChanges(context.getRegion(), key, new AddByteArraysTail(newVersion, elementsToAdd));
-    context.fireEvent(RedisCommandType.RPUSH, key);
+    context.fireEvent(NotificationEvent.RPUSH, key);
 
     return elementList.size();
   }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/eventing/BlockingCommandListener.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/eventing/BlockingCommandListener.java
@@ -23,7 +23,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.redis.internal.commands.Command;
-import org.apache.geode.redis.internal.commands.RedisCommandType;
 import org.apache.geode.redis.internal.commands.executor.RedisResponse;
 import org.apache.geode.redis.internal.data.RedisKey;
 import org.apache.geode.redis.internal.netty.Coder;
@@ -63,7 +62,7 @@ public class BlockingCommandListener implements EventListener {
   }
 
   @Override
-  public EventResponse process(RedisCommandType commandType, RedisKey key) {
+  public EventResponse process(NotificationEvent notificationEvent, RedisKey key) {
     if (!keys.contains(key)) {
       return EventResponse.CONTINUE;
     }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/eventing/EventDistributor.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/eventing/EventDistributor.java
@@ -28,7 +28,6 @@ import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.partition.PartitionListenerAdapter;
 import org.apache.geode.internal.lang.utils.JavaWorkarounds;
 import org.apache.geode.logging.internal.executors.LoggingThreadFactory;
-import org.apache.geode.redis.internal.commands.RedisCommandType;
 import org.apache.geode.redis.internal.data.RedisKey;
 
 public class EventDistributor extends PartitionListenerAdapter {
@@ -52,14 +51,14 @@ public class EventDistributor extends PartitionListenerAdapter {
     listener.scheduleTimeout(timerExecutor, this);
   }
 
-  public void fireEvent(RedisCommandType command, RedisKey key) {
+  public void fireEvent(NotificationEvent notificationEvent, RedisKey key) {
     Queue<EventListener> listenerList = listeners.get(key);
     if (listenerList == null) {
       return;
     }
 
     for (EventListener listener : listenerList) {
-      if (listener.process(command, key) == EventResponse.REMOVE_AND_STOP) {
+      if (listener.process(notificationEvent, key) == EventResponse.REMOVE_AND_STOP) {
         removeListener(listener);
         break;
       }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/eventing/EventListener.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/eventing/EventListener.java
@@ -18,7 +18,6 @@ package org.apache.geode.redis.internal.eventing;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
-import org.apache.geode.redis.internal.commands.RedisCommandType;
 import org.apache.geode.redis.internal.data.RedisKey;
 
 /**
@@ -32,11 +31,11 @@ public interface EventListener {
    * Receive and process an event. This method should execute very quickly. The return value
    * determines additional process steps for the given event.
    *
-   * @param commandType the command triggering the event
+   * @param notificationEvent the event triggered by the command
    * @param key the key triggering the event
    * @return response determining subsequent processing steps
    */
-  EventResponse process(RedisCommandType commandType, RedisKey key);
+  EventResponse process(NotificationEvent notificationEvent, RedisKey key);
 
   /**
    * Return the list of keys this listener is interested in.

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/eventing/NotificationEvent.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/eventing/NotificationEvent.java
@@ -15,19 +15,17 @@
 
 package org.apache.geode.redis.internal.eventing;
 
-import org.apache.geode.redis.internal.data.RedisKey;
-
 /**
- * Response returned by {@link EventListener#process(NotificationEvent, RedisKey)}
+ * These are the notification events used to trigger keyspace events and blocking commands.
+ *
+ * @see <a href="https://redis.io/docs/manual/keyspace-notifications">Redis notifications</a>
  */
-public enum EventResponse {
-  /**
-   * Response indicating that processing should continue.
-   */
-  CONTINUE,
-  /**
-   * Response indicating that processing should stop and the listener should be
-   * removed.
-   */
-  REMOVE_AND_STOP
+public enum NotificationEvent {
+
+  LPUSH,
+  RENAME_FROM,
+  RENAME_TO,
+  RESTORE,
+  RPUSH,
+
 }

--- a/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
+++ b/geode-for-redis/src/main/java/org/apache/geode/redis/internal/netty/ExecutionHandlerContext.java
@@ -62,6 +62,7 @@ import org.apache.geode.redis.internal.data.RedisSortedSet;
 import org.apache.geode.redis.internal.data.RedisString;
 import org.apache.geode.redis.internal.eventing.EventDistributor;
 import org.apache.geode.redis.internal.eventing.EventListener;
+import org.apache.geode.redis.internal.eventing.NotificationEvent;
 import org.apache.geode.redis.internal.pubsub.PubSub;
 import org.apache.geode.redis.internal.services.RegionProvider;
 import org.apache.geode.redis.internal.services.locking.RedisSecurityService;
@@ -423,8 +424,8 @@ public class ExecutionHandlerContext extends ChannelInboundHandlerAdapter {
     eventDistributor.registerListener(listener);
   }
 
-  public void fireEvent(RedisCommandType command, RedisKey key) {
-    eventDistributor.fireEvent(command, key);
+  public void fireEvent(NotificationEvent notificationEvent, RedisKey key) {
+    eventDistributor.fireEvent(notificationEvent, key);
   }
 
   public Region<RedisKey, RedisData> getRegion() {


### PR DESCRIPTION
- Both of these commands have the ability to create events to satisfy
  BLPOP.
- Introduce a NotificationEvent enum which is passed to fireEvent.
- Previously the RedisCommandType was being passed, but this does not
  work for RENAME which creates RENAME_FROM and RENAME_TO events. In the
  future, other commands will need to create multiple events too.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
