### PR TITLE
GEODE-9568: Update Bookbindery Ruby gem

### DIFF
--- a/geode-book/Gemfile.lock
+++ b/geode-book/Gemfile.lock
@@ -10,7 +10,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
     backports (3.21.0)
-    bookbindery (10.1.17)
+    bookbindery (10.1.18)
       ansi (~> 1.4)
       css_parser
       elasticsearch


### PR DESCRIPTION
https://issues.apache.org/jira/browse/GEODE-9568

The Geode User Guide build script uses this Gemfile.lock file when it runs Docker, but the "bookbindery" gem v10.1.17 was pulled from RubyGems. This results in the script failing.
Updating the version of the gem to 1.10.18 resolves this issue.

