### PR TITLE
GEODE-10211: Correctly check persistence on accessor

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put70.java
@@ -21,7 +21,6 @@ import org.jetbrains.annotations.NotNull;
 
 import org.apache.geode.InvalidDeltaException;
 import org.apache.geode.annotations.Immutable;
-import org.apache.geode.annotations.VisibleForTesting;
 import org.apache.geode.cache.DynamicRegionFactory;
 import org.apache.geode.cache.Operation;
 import org.apache.geode.cache.RegionDestroyedException;
@@ -464,7 +463,6 @@ public class Put70 extends BaseCommand {
 
   }
 
-  @VisibleForTesting
   boolean shouldSetPossibleDuplicate(LocalRegion region, EventIDHolder clientEvent) {
     boolean shouldSetPossibleDuplicate = true;
     if (region.getAttributes().getConcurrencyChecksEnabled()) {
@@ -480,7 +478,6 @@ public class Put70 extends BaseCommand {
     return shouldSetPossibleDuplicate;
   }
 
-  @VisibleForTesting
   boolean isRegionWithPersistence(LocalRegion region) {
     if (region.getAttributes().getDataPolicy().withPersistence()) {
       return true;
@@ -489,7 +486,7 @@ public class Put70 extends BaseCommand {
       PartitionedRegion partitionedRegion = (PartitionedRegion) region;
       if (!partitionedRegion.isDataStore()) {
         // if is accessor, find if region persist on other members.
-        return partitionedRegion.getRegionAdvisor().advisePersistentMembers() != null;
+        return partitionedRegion.getRegionAdvisor().advisePersistentMembers().size() > 0;
       }
     }
     return false;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put70.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/command/Put70.java
@@ -468,7 +468,7 @@ public class Put70 extends BaseCommand {
     if (region.getAttributes().getConcurrencyChecksEnabled()) {
       // recover the version tag from other servers
       clientEvent.setRegion(region);
-      if (!recoverVersionTagForRetriedOperation(clientEvent) && !isRegionWithPersistence(region)) {
+      if (!isRegionWithPersistence(region) && !recoverVersionTagForRetriedOperation(clientEvent)) {
         // For persistent region, it is possible that all persistent copies went offline.
         // Do not reset possible duplicate in this case, as persistent data
         // can be recovered during the retry after recover of version tag failed.

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put70Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/Put70Test.java
@@ -25,12 +25,13 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
+import java.util.Collections;
+import java.util.HashMap;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -41,12 +42,14 @@ import org.apache.geode.CancelCriterion;
 import org.apache.geode.cache.DataPolicy;
 import org.apache.geode.cache.RegionAttributes;
 import org.apache.geode.cache.operations.PutOperationContext;
+import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.EventIDHolder;
 import org.apache.geode.internal.cache.InternalCache;
 import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.PartitionedRegion;
 import org.apache.geode.internal.cache.TXManagerImpl;
 import org.apache.geode.internal.cache.partitioned.RegionAdvisor;
+import org.apache.geode.internal.cache.persistence.PersistentMemberID;
 import org.apache.geode.internal.cache.tier.CachedRegionHelper;
 import org.apache.geode.internal.cache.tier.sockets.CacheServerStats;
 import org.apache.geode.internal.cache.tier.sockets.Message;
@@ -61,7 +64,7 @@ import org.apache.geode.security.ResourcePermission.Resource;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 
 @Category({ClientServerTest.class})
-public class Put70Test {
+class Put70Test {
 
   private static final String REGION_NAME = "region1";
   private static final String KEY = "key1";
@@ -122,8 +125,8 @@ public class Put70Test {
 
   private AutoCloseable mockitoMocks;
 
-  @Before
-  public void setUp() throws Exception {
+  @BeforeEach
+  void setUp() throws Exception {
     put70 = (Put70) Put70.getCommand();
     mockitoMocks = MockitoAnnotations.openMocks(this);
 
@@ -185,13 +188,13 @@ public class Put70Test {
     when(partitionedRegion.getAttributes()).thenReturn(attributes);
   }
 
-  @After
-  public void after() throws Exception {
+  @AfterEach
+  void after() throws Exception {
     mockitoMocks.close();
   }
 
   @Test
-  public void noSecurityShouldSucceed() throws Exception {
+  void noSecurityShouldSucceed() throws Exception {
     when(securityService.isClientSecurityRequired()).thenReturn(false);
 
     put70.cmdExecute(message, serverConnection, securityService, 0);
@@ -200,7 +203,7 @@ public class Put70Test {
   }
 
   @Test
-  public void noRegionNameShouldFail() throws Exception {
+  void noRegionNameShouldFail() throws Exception {
     when(securityService.isClientSecurityRequired()).thenReturn(false);
     when(regionNamePart.getCachedString()).thenReturn(null);
 
@@ -213,7 +216,7 @@ public class Put70Test {
   }
 
   @Test
-  public void noKeyShouldFail() throws Exception {
+  void noKeyShouldFail() throws Exception {
     when(securityService.isClientSecurityRequired()).thenReturn(false);
     when(keyPart.getStringOrObject()).thenReturn(null);
 
@@ -226,7 +229,7 @@ public class Put70Test {
   }
 
   @Test
-  public void integratedSecurityShouldSucceedIfAuthorized() throws Exception {
+  void integratedSecurityShouldSucceedIfAuthorized() throws Exception {
     when(securityService.isClientSecurityRequired()).thenReturn(true);
     when(securityService.isIntegratedSecurity()).thenReturn(true);
 
@@ -237,7 +240,7 @@ public class Put70Test {
   }
 
   @Test
-  public void integratedSecurityShouldFailIfNotAuthorized() throws Exception {
+  void integratedSecurityShouldFailIfNotAuthorized() throws Exception {
     when(securityService.isClientSecurityRequired()).thenReturn(true);
     when(securityService.isIntegratedSecurity()).thenReturn(true);
     doThrow(new NotAuthorizedException("")).when(securityService).authorize(Resource.DATA,
@@ -250,7 +253,7 @@ public class Put70Test {
   }
 
   @Test
-  public void oldSecurityShouldSucceedIfAuthorized() throws Exception {
+  void oldSecurityShouldSucceedIfAuthorized() throws Exception {
     when(securityService.isClientSecurityRequired()).thenReturn(true);
     when(securityService.isIntegratedSecurity()).thenReturn(false);
 
@@ -267,7 +270,7 @@ public class Put70Test {
   }
 
   @Test
-  public void oldSecurityShouldFailIfNotAuthorized() throws Exception {
+  void oldSecurityShouldFailIfNotAuthorized() throws Exception {
     when(securityService.isClientSecurityRequired()).thenReturn(true);
     when(securityService.isIntegratedSecurity()).thenReturn(false);
     doThrow(new NotAuthorizedException("")).when(authzRequest).putAuthorize(eq(REGION_NAME),
@@ -287,7 +290,7 @@ public class Put70Test {
   }
 
   @Test
-  public void shouldSetPossibleDuplicateReturnsTrueIfConcurrencyChecksNotEnabled() {
+  void shouldSetPossibleDuplicateReturnsTrueIfConcurrencyChecksNotEnabled() {
 
     when(attributes.getConcurrencyChecksEnabled()).thenReturn(false);
 
@@ -295,7 +298,7 @@ public class Put70Test {
   }
 
   @Test
-  public void shouldSetPossibleDuplicateReturnsTrueIfRecoveredVersionTagForRetriedOperation() {
+  void shouldSetPossibleDuplicateReturnsTrueIfRecoveredVersionTagForRetriedOperation() {
     Put70 spy = Mockito.spy(put70);
     when(attributes.getConcurrencyChecksEnabled()).thenReturn(true);
     doReturn(true).when(spy).recoverVersionTagForRetriedOperation(clientEvent);
@@ -304,7 +307,7 @@ public class Put70Test {
   }
 
   @Test
-  public void shouldSetPossibleDuplicateReturnsFalseIfNotRecoveredVersionTagAndNoPersistence() {
+  void shouldSetPossibleDuplicateReturnsFalseIfNotRecoveredVersionTagAndNoPersistence() {
     Put70 spy = Mockito.spy(put70);
     when(attributes.getConcurrencyChecksEnabled()).thenReturn(true);
     doReturn(false).when(spy).recoverVersionTagForRetriedOperation(clientEvent);
@@ -314,7 +317,7 @@ public class Put70Test {
   }
 
   @Test
-  public void shouldSetPossibleDuplicateReturnsTrueIfNotRecoveredVersionTagAndWithPersistence() {
+  void shouldSetPossibleDuplicateReturnsTrueIfNotRecoveredVersionTagAndWithPersistence() {
     Put70 spy = Mockito.spy(put70);
     when(attributes.getConcurrencyChecksEnabled()).thenReturn(true);
     doReturn(false).when(spy).recoverVersionTagForRetriedOperation(clientEvent);
@@ -324,34 +327,36 @@ public class Put70Test {
   }
 
   @Test
-  public void isRegionWithPersistenceReturnsTrueIfDataPolicyWithPersistence() {
+  void isRegionWithPersistenceReturnsTrueIfDataPolicyWithPersistence() {
     when(dataPolicy.withPersistence()).thenReturn(true);
 
     assertThat(put70.isRegionWithPersistence(localRegion)).isTrue();
   }
 
   @Test
-  public void isRegionWithPersistenceReturnsTrueIfIsAccessorAndHavingPersistentMembers() {
+  void isRegionWithPersistenceReturnsTrueIfIsAccessorAndHavingPersistentMembers() {
     when(dataPolicy.withPersistence()).thenReturn(false);
     when(partitionedRegion.isDataStore()).thenReturn(false);
     when(partitionedRegion.getRegionAdvisor()).thenReturn(regionAdvisor);
-    when(regionAdvisor.advisePersistentMembers()).thenReturn(uncheckedCast(mock(Map.class)));
+    HashMap<InternalDistributedMember, PersistentMemberID> persistentMembers = new HashMap<>();
+    persistentMembers.put(mock(InternalDistributedMember.class), mock(PersistentMemberID.class));
+    when(regionAdvisor.advisePersistentMembers()).thenReturn(persistentMembers);
 
     assertThat(put70.isRegionWithPersistence(partitionedRegion)).isTrue();
   }
 
   @Test
-  public void isRegionWithPersistenceReturnsFalseIfIsAccessorAndHavingNoPersistentMembers() {
+  void isRegionWithPersistenceReturnsFalseIfIsAccessorAndHavingNoPersistentMembers() {
     when(dataPolicy.withPersistence()).thenReturn(false);
     when(partitionedRegion.isDataStore()).thenReturn(false);
     when(partitionedRegion.getRegionAdvisor()).thenReturn(regionAdvisor);
-    when(regionAdvisor.advisePersistentMembers()).thenReturn(null);
+    when(regionAdvisor.advisePersistentMembers()).thenReturn(Collections.emptyMap());
 
     assertThat(put70.isRegionWithPersistence(partitionedRegion)).isFalse();
   }
 
   @Test
-  public void isRegionWithPersistenceReturnsFalseIfIsNotAccessor() {
+  void isRegionWithPersistenceReturnsFalseIfIsNotAccessor() {
     when(dataPolicy.withPersistence()).thenReturn(false);
     when(partitionedRegion.isDataStore()).thenReturn(true);
 


### PR DESCRIPTION
 * To set possible duplicate for an event, whether region is persistent
   need to be determined. Allow an accessor to check the setting through
   profiles.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
