### PR TITLE
Fixing bug with geode home determination

### DIFF
--- a/geode-assembly/src/main/dist/bin/gfsh.bat
+++ b/geode-assembly/src/main/dist/bin/gfsh.bat
@@ -27,7 +27,7 @@ REM
 
 setlocal enableextensions
 set scriptdir=%~dp0
-set gf=%scriptdir:\bin\=%
+set gf=%scriptdir:~0,-4%
 REM echo %gf%
 REM echo %scriptdir%
 if exist "%gf%\lib\geode-dependencies.jar" goto gfok


### PR DESCRIPTION
If you place the product_dir in a path with "bin" in, the old method would ruin the path. For example 
`C:\Users\steve\bin\apache-geode-1.14.4\bin\`

would become
`C:\Users\steveapache-geode-1.14.4`

This implementation cuts off the last 4 letters of the bin directory to get to the installation location.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
