### PR TITLE
GEODE-10216: Add test for existence of VM stats

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/statistics/StatisticsDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/statistics/StatisticsDistributedTest.java
@@ -25,6 +25,7 @@ import static org.apache.geode.test.dunit.Assert.assertTrue;
 import static org.apache.geode.test.dunit.Assert.fail;
 import static org.apache.geode.test.dunit.Host.getHost;
 import static org.apache.geode.test.dunit.Invoke.invokeInEveryVM;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -516,24 +517,20 @@ public class StatisticsDistributedTest extends JUnit4CacheTestCase {
       StatisticsType VMStatsType = getSystem().findType("VMStats");
       Statistics vmStats = getSystem().findStatisticsByType(VMStatsType)[0];
 
-      try {
-        vmStats.get("pendingFinalization");
-        vmStats.get("loadedClasses");
-        vmStats.get("unloadedClasses");
-        vmStats.get("daemonThreads");
-        vmStats.get("peakThreads");
-        vmStats.get("threads");
-        vmStats.get("threadStarts");
-        vmStats.get("cpus");
-        vmStats.get("freeMemory");
-        vmStats.get("totalMemory");
-        vmStats.get("maxMemory");
-        vmStats.get("processCpuTime");
-        vmStats.get("fdsOpen");
-        vmStats.get("fdLimit");
-      } catch (IllegalArgumentException e) {
-        fail("Stats do not exist: " + e.getMessage());
-      }
+      assertThatNoException().isThrownBy(() -> vmStats.get("pendingFinalization"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("loadedClasses"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("unloadedClasses"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("daemonThreads"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("peakThreads"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("threads"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("threadStarts"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("cpus"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("freeMemory"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("totalMemory"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("maxMemory"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("processCpuTime"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("fdsOpen"));
+      assertThatNoException().isThrownBy(() -> vmStats.get("fdLimit"));
     });
   }
 


### PR DESCRIPTION
When we started running with JDK 11, some users noticed that a few stats
had gone missing. There was a one line fix in test.gradle, but the
change was not tested. This adds a test for the existence of the VM
stats so that none of the stats go missing in the future.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
