### PR TITLE
GEODE-10127: Corrects NullPointerException in hashCode().

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DistributionLocatorId.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DistributionLocatorId.java
@@ -16,6 +16,7 @@
 package org.apache.geode.internal.admin.remote;
 
 import static java.lang.String.format;
+import static java.util.Objects.hash;
 import static org.apache.commons.lang3.ObjectUtils.defaultIfNull;
 import static org.apache.commons.lang3.ObjectUtils.getIfNull;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
@@ -335,14 +336,7 @@ public class DistributionLocatorId implements java.io.Serializable {
 
   @Override
   public int hashCode() {
-    int result = 17;
-    final int mult = 37;
-
-    result = mult * result + host.hashCode();
-    result = mult * result + port;
-    result = mult * result + bindAddress.hashCode();
-
-    return result;
+    return hash(host, port, bindAddress);
   }
 
   /**

--- a/geode-core/src/test/java/org/apache/geode/internal/admin/remote/DistributionLocatorIdTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/admin/remote/DistributionLocatorIdTest.java
@@ -16,6 +16,7 @@
 package org.apache.geode.internal.admin.remote;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -137,5 +138,13 @@ class DistributionLocatorIdTest {
     final DistributionLocatorId locatorId = new DistributionLocatorId(localHost, locator);
 
     assertThat(locatorId.marshalForClients()).isEqualTo("hostname-for-clients.example.com[1234]");
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test
+  void hashCodeDoesNotThrowWhenHostIsNull() {
+    final DistributionLocatorId locatorId =
+        DistributionLocatorId.unmarshal("unknown.invalid[1234]");
+    assertThatNoException().isThrownBy(locatorId::hashCode);
   }
 }


### PR DESCRIPTION
When unmarshalling an instance with a host name that can't be resolved a
NullPointerException is thrown in hashCode(). Use Objects.hash() to
resolve hash code to avoid NullPointerException.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
