### PR TITLE
GEODE-10222: Handle null memberID in GII

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -956,13 +956,12 @@ public class InitialImageOperation {
             // null IDs in a version tag are meant to mean "this member", so
             // we need to change them to refer to the image provider.
             if (tag != null) {
-              try {
+              tag.replaceNullIDs(sender);
+              if (tag.getMemberID() == null) {
                 // It's possible that for persistent regions, a race condition between GII due to
-                // region creation and a region destroy on the remote member can result in
-                // DiskVersionTag.replaceNullIDs() throwing due to null memberID, so in that
-                // situation, return false to allow the GII to be retried.
-                tag.replaceNullIDs(sender);
-              } catch (IllegalStateException ex) {
+                // region creation and a region destroy on the remote member can result in a
+                // DiskVersionTag having a null memberID, so in that situation, return false to
+                // allow the GII to be retried.
                 if (isDebugEnabled) {
                   logger.debug("For Entry = {} with DiskVersionTag = {} from sender = {}, memberID"
                       + " was null; returning false from processChunk()", entry, tag, sender);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/DiskVersionTag.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/DiskVersionTag.java
@@ -44,7 +44,7 @@ public class DiskVersionTag extends VersionTag<DiskStoreID> {
   @Override
   public void replaceNullIDs(VersionSource memberID) {
     if (getMemberID() == null) {
-      throw new AssertionError("Member id should not be null for persistent version tags");
+      throw new IllegalStateException("Member id should not be null for persistent version tags");
     }
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/DiskVersionTag.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/DiskVersionTag.java
@@ -42,11 +42,7 @@ public class DiskVersionTag extends VersionTag<DiskStoreID> {
    * member id in later.
    */
   @Override
-  public void replaceNullIDs(VersionSource memberID) {
-    if (getMemberID() == null) {
-      throw new IllegalStateException("Member id should not be null for persistent version tags");
-    }
-  }
+  public void replaceNullIDs(VersionSource memberID) {}
 
   /*
    * (non-Javadoc)


### PR DESCRIPTION
 - Change the exception thrown by DiskVersionTag.replaceNullIDs() from
 AssertionError to IllegalStateException
 - Catch the IllegalStateException in
 InitialImageOperation.processChunk() and return false, to allow the
 GII to be aborted and retried if appropriate
 - Add debug log to record if this has occurred
 - Add unit test for the new behaviour

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
