### PR TITLE
GEODE-10146: Make GradleBuildWithGeodeCoreAcceptanceTest run on JDK 17

### DIFF
--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/rest/GradleBuildWithGeodeCoreAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/rest/GradleBuildWithGeodeCoreAcceptanceTest.java
@@ -46,8 +46,19 @@ public class GradleBuildWithGeodeCoreAcceptanceTest {
     assertThat(projectDir).isNotNull();
 
     String projectGroup = System.getProperty("projectGroup");
-    assertThat(projectGroup).as("'projectGroup' is not available as a system property")
+    assertThat(projectGroup)
+        .as("'projectGroup' system property")
         .isNotBlank();
+
+    String gradleJvm = System.getenv("GRADLE_JVM");
+    assertThat(gradleJvm)
+        .as("'GRADLE_JVM' environment variable")
+        .isNotBlank();
+
+    File gradleJvmFile = new File(gradleJvm);
+    assertThat(gradleJvmFile)
+        .as("'GRADLE_JVM' directory")
+        .isDirectory();
 
     String geodeVersion = GemFireVersion.getGemFireVersion();
 
@@ -60,6 +71,7 @@ public class GradleBuildWithGeodeCoreAcceptanceTest {
 
     ProjectConnection connection = connector.connect();
     BuildLauncher build = connection.newBuild();
+    build.setJavaHome(gradleJvmFile);
 
     build.setStandardError(System.err);
     build.setStandardOutput(System.out);


### PR DESCRIPTION
PROBLEM

GradleBuildWithGeodeCoreAcceptanceTest attempts to run Gradle v5.1.1
using the test JVM. This fails when the test is run in JDK 17, because
Gradle 5.1.1 does not support JDK 17.

SOLUTION

Configure the test's "inner" build to use the value of the GRADLE_JVM
environment variable as its JVM. This makes it use the same JVM that we
use to build Geode.
