### PR TITLE
GEODE-10225: Gfsh start commands add exports on JDK 11+

### DIFF
--- a/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartServerCommandIntegrationTest.java
+++ b/geode-assembly/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartServerCommandIntegrationTest.java
@@ -36,6 +36,8 @@ import org.apache.geode.test.junit.rules.GfshParserRule;
 
 public class StartServerCommandIntegrationTest {
   private static final String FAKE_HOSTNAME = "someFakeHostname";
+  private static final String SERVER_LAUNCHER_CLASS_NAME =
+      "org.apache.geode.distributed.ServerLauncher";
 
   @Rule
   public GfshParserRule commandRule = new GfshParserRule();
@@ -83,9 +85,12 @@ public class StartServerCommandIntegrationTest {
         .addOption("hostname-for-clients", FAKE_HOSTNAME).toString();
 
     commandRule.executeAndAssertThat(spy, startServerCommand);
-    ArgumentCaptor<String[]> commandLines = ArgumentCaptor.forClass(String[].class);
-    verify(spy).getProcess(any(), commandLines.capture());
-    String[] lines = commandLines.getValue();
-    assertThat(lines).containsOnlyOnce("--hostname-for-clients=" + FAKE_HOSTNAME);
+    ArgumentCaptor<String[]> commandLine = ArgumentCaptor.forClass(String[].class);
+    verify(spy).getProcess(any(), commandLine.capture());
+
+    String expectedHostNameOption = "--hostname-for-clients=" + FAKE_HOSTNAME;
+    assertThat(commandLine.getValue())
+        .containsOnlyOnce(SERVER_LAUNCHER_CLASS_NAME, expectedHostNameOption)
+        .containsSubsequence(SERVER_LAUNCHER_CLASS_NAME, expectedHostNameOption);
   }
 }

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandTest.java
@@ -14,182 +14,254 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.util.stream.Collectors.toSet;
+import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLE_RATE;
+import static org.apache.geode.distributed.LocatorLauncher.Command.START;
+import static org.apache.geode.management.internal.cli.commands.MemberJvmOptions.getMemberJvmOptions;
+import static org.apache.geode.management.internal.cli.commands.VerifyCommandLine.verifyCommandLine;
+import static org.apache.geode.util.internal.GeodeGlossary.GEMFIRE_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.LocatorLauncher;
-import org.apache.geode.util.internal.GeodeGlossary;
 
-public class StartLocatorCommandTest {
+class StartLocatorCommandTest {
+  // JVM options to use with every start command.
+  private static final Set<String> START_COMMAND_UNCONDITIONAL_JVM_OPTIONS = Stream.of(
+      "-Dgemfire.launcher.registerSignalHandlers=true",
+      "-Djava.awt.headless=true",
+      "-Dsun.rmi.dgc.server.gcInterval=9223372036854775806").collect(toSet());
 
-  private StartLocatorCommand startLocatorCommand;
+  private final StartLocatorCommand startLocatorCommand = new StartLocatorCommand();
 
-  @Before
-  public void setUp() {
-    startLocatorCommand = new StartLocatorCommand();
+  @Nested
+  class GetLocatorClasspath {
+    @Test
+    public void addsUserClasspathImmediatelyAfterGemfireJarPath() {
+      final String userClasspath = "/path/to/user/lib/app.jar:/path/to/user/classes";
+
+      String actualClasspath = startLocatorCommand.getLocatorClasspath(true, userClasspath);
+
+      String expectedClasspath = String.join(File.pathSeparator,
+          StartMemberUtils.getGemFireJarPath(),
+          userClasspath,
+          System.getProperty("java.class.path"),
+          StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
+      assertThat(actualClasspath)
+          .isEqualTo(expectedClasspath);
+    }
   }
 
-  @After
-  public void tearDown() {
-    startLocatorCommand = null;
-  }
+  @Nested
+  class CreateStartLocatorCommandLine {
+    private static final String LOCATOR_LAUNCHER_CLASS_NAME =
+        "org.apache.geode.distributed.LocatorLauncher";
 
-  @Test
-  public void testLocatorClasspathOrder() {
-    String userClasspath = "/path/to/user/lib/app.jar:/path/to/user/classes";
-    String expectedClasspath =
-        StartMemberUtils.getGemFireJarPath().concat(File.pathSeparator).concat(userClasspath)
-            .concat(File.pathSeparator).concat(System.getProperty("java.class.path"))
-            .concat(File.pathSeparator).concat(StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
-    String actualClasspath = startLocatorCommand.getLocatorClasspath(true, userClasspath);
-    assertEquals(expectedClasspath, actualClasspath);
-  }
+    private final Set<String> expectedJvmOptions = new HashSet<>();
+    private final List<String> expectedStartCommandSequence = new ArrayList<>();
+    private final Set<String> expectedStartCommandOptions = new HashSet<>();
 
-  @Test
-  public void testLocatorCommandLineWithRestAPI() throws Exception {
-    LocatorLauncher locatorLauncher =
-        new LocatorLauncher.Builder().setCommand(LocatorLauncher.Command.START)
-            .setMemberName("testLocatorCommandLineWithRestAPI").setBindAddress("localhost")
-            .setPort(11111).build();
-
-    Properties gemfireProperties = new Properties();
-    gemfireProperties.setProperty(HTTP_SERVICE_PORT, "8089");
-    gemfireProperties.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
-
-    String[] commandLineElements =
-        startLocatorCommand.createStartLocatorCommandLine(locatorLauncher,
-            null, null, gemfireProperties, null, false, new String[0], null, null);
-
-    assertNotNull(commandLineElements);
-    assertTrue(commandLineElements.length > 0);
-
-    Set<String> expectedCommandLineElements = new HashSet<>(6);
-
-    expectedCommandLineElements.add(locatorLauncher.getCommand().getName());
-    expectedCommandLineElements.add(locatorLauncher.getMemberName().toLowerCase());
-    expectedCommandLineElements.add(String.format("--port=%1$d", locatorLauncher.getPort()));
-    expectedCommandLineElements
-        .add("-d" + GeodeGlossary.GEMFIRE_PREFIX + "" + HTTP_SERVICE_PORT + "=" + "8089");
-    expectedCommandLineElements.add("-d" + GeodeGlossary.GEMFIRE_PREFIX + ""
-        + HTTP_SERVICE_BIND_ADDRESS + "=" + "localhost");
-
-    for (String commandLineElement : commandLineElements) {
-      expectedCommandLineElements.remove(commandLineElement.toLowerCase());
+    @BeforeEach
+    void alwaysExpectUnconditionalOptions() {
+      expectedJvmOptions.addAll(START_COMMAND_UNCONDITIONAL_JVM_OPTIONS);
     }
 
-    assertTrue(String.format("Expected ([]); but was (%1$s)", expectedCommandLineElements),
-        expectedCommandLineElements.isEmpty());
-  }
-
-  @Test
-  public void testCreateStartLocatorCommandLine() throws Exception {
-    LocatorLauncher locatorLauncher = new LocatorLauncher.Builder().setMemberName("defaultLocator")
-        .setCommand(LocatorLauncher.Command.START).build();
-
-    String[] commandLineElements =
-        startLocatorCommand.createStartLocatorCommandLine(locatorLauncher,
-            null, null, new Properties(), null, false, null, null, null);
-
-    Set<String> expectedCommandLineElements = new HashSet<>();
-    expectedCommandLineElements.add(StartMemberUtils.getJavaPath());
-    expectedCommandLineElements.add("-server");
-    expectedCommandLineElements.add("-classpath");
-    expectedCommandLineElements.add(StartMemberUtils.getGemFireJarPath().concat(File.pathSeparator)
-        .concat(StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME));
-    expectedCommandLineElements.add("-Dgemfire.launcher.registerSignalHandlers=true");
-    expectedCommandLineElements.add("-Djava.awt.headless=true");
-    expectedCommandLineElements.add("-Dsun.rmi.dgc.server.gcInterval=9223372036854775806");
-    expectedCommandLineElements.add("org.apache.geode.distributed.LocatorLauncher");
-    expectedCommandLineElements.add("start");
-    expectedCommandLineElements.add("defaultLocator");
-    expectedCommandLineElements.add("--port=10334");
-
-    assertNotNull(commandLineElements);
-    assertTrue(commandLineElements.length > 0);
-    assertEquals(commandLineElements.length, expectedCommandLineElements.size());
-
-    for (String commandLineElement : commandLineElements) {
-      expectedCommandLineElements.remove(commandLineElement);
+    @BeforeEach
+    void alwaysExpectJreSpecificMemberJvmOptions() {
+      expectedJvmOptions.addAll(getMemberJvmOptions());
     }
 
-    assertTrue(String.format("Expected ([]); but was (%1$s)", expectedCommandLineElements),
-        expectedCommandLineElements.isEmpty());
-  }
+    @Test
+    void withTypicalOptions() throws Exception {
+      LocatorLauncher.Builder locatorLauncherBuilder = new LocatorLauncher.Builder();
 
-  @Test
-  public void testCreateStartLocatorCommandLineWithAllOptions() throws Exception {
-    LocatorLauncher locatorLauncher =
-        new LocatorLauncher.Builder().setCommand(LocatorLauncher.Command.START)
-            .setDebug(Boolean.TRUE).setDeletePidFileOnStop(Boolean.TRUE).setForce(Boolean.TRUE)
-            .setHostnameForClients("localhost").setMemberName("customLocator").setPort(10101)
-            .setRedirectOutput(Boolean.TRUE).build();
+      locatorLauncherBuilder.setCommand(START);
+      expectedStartCommandSequence.add(LOCATOR_LAUNCHER_CLASS_NAME);
+      expectedStartCommandSequence.add(START.getName());
 
-    File gemfirePropertiesFile = spy(mock(File.class));
-    when(gemfirePropertiesFile.getAbsolutePath()).thenReturn("/config/customGemfire.properties");
+      final String memberName = "with-typical-options";
+      locatorLauncherBuilder.setMemberName(memberName);
+      expectedStartCommandSequence.add(memberName);
 
-    File gemfireSecurityPropertiesFile = spy(mock(File.class));
-    when(gemfireSecurityPropertiesFile.getAbsolutePath())
-        .thenReturn("/config/customGemfireSecurity.properties");
+      final int defaultPort = 10334;
+      expectedStartCommandOptions.add("--port=" + defaultPort);
 
-    Properties gemfireProperties = new Properties();
-    gemfireProperties.setProperty(ConfigurationProperties.STATISTIC_SAMPLE_RATE, "1500");
-    gemfireProperties.setProperty(ConfigurationProperties.DISABLE_AUTO_RECONNECT, "true");
+      LocatorLauncher locatorLauncher = locatorLauncherBuilder.build();
 
-    String heapSize = "1024m";
-    String customClasspath = "/temp/domain-1.0.0.jar";
-    String[] jvmArguments = new String[] {"-verbose:gc", "-Xloggc:member-gc.log",
-        "-XX:+PrintGCDateStamps", "-XX:+PrintGCDetails"};
+      String expectedClasspath = String.join(
+          File.pathSeparator,
+          StartMemberUtils.getGemFireJarPath(),
+          StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
 
-    String[] commandLineElements =
-        startLocatorCommand.createStartLocatorCommandLine(locatorLauncher,
-            gemfirePropertiesFile, gemfireSecurityPropertiesFile, gemfireProperties,
-            customClasspath,
-            Boolean.FALSE, jvmArguments, heapSize, heapSize);
+      List<String> expectedJavaCommandSequence = Arrays.asList(
+          StartMemberUtils.getJavaPath(),
+          "-server",
+          "-classpath",
+          expectedClasspath);
 
-    Set<String> expectedCommandLineElements = new HashSet<>();
-    expectedCommandLineElements.add(StartMemberUtils.getJavaPath());
-    expectedCommandLineElements.add("-server");
-    expectedCommandLineElements.add("-classpath");
-    expectedCommandLineElements
-        .add(StartMemberUtils.getGemFireJarPath().concat(File.pathSeparator).concat(customClasspath)
-            .concat(File.pathSeparator).concat(StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME));
-    expectedCommandLineElements
-        .add("-DgemfirePropertyFile=".concat(gemfirePropertiesFile.getAbsolutePath()));
-    expectedCommandLineElements.add(
-        "-DgemfireSecurityPropertyFile=".concat(gemfireSecurityPropertiesFile.getAbsolutePath()));
-    expectedCommandLineElements.add("-Dgemfire.statistic-sample-rate=1500");
-    expectedCommandLineElements.add("-Dgemfire.disable-auto-reconnect=true");
-    expectedCommandLineElements.addAll(Arrays.asList(jvmArguments));
-    expectedCommandLineElements.add("org.apache.geode.distributed.LocatorLauncher");
-    expectedCommandLineElements.add("start");
-    expectedCommandLineElements.add("customLocator");
-    expectedCommandLineElements.add("--debug");
-    expectedCommandLineElements.add("--force");
-    expectedCommandLineElements.add("--hostname-for-clients=localhost");
-    expectedCommandLineElements.add("--port=10101");
-    expectedCommandLineElements.add("--redirect-output");
+      String[] commandLine =
+          startLocatorCommand.createStartLocatorCommandLine(locatorLauncher,
+              null, null, new Properties(), null, false, null, null, null);
 
-    assertNotNull(commandLineElements);
-    assertTrue(commandLineElements.length > 0);
+      verifyCommandLine(commandLine, expectedJavaCommandSequence, expectedJvmOptions,
+          expectedStartCommandSequence, expectedStartCommandOptions);
+    }
 
-    assertThat(commandLineElements).containsAll(expectedCommandLineElements);
+    @Test
+    void withRestApiOptions() throws Exception {
+      LocatorLauncher.Builder locatorLauncherBuilder = new LocatorLauncher.Builder();
+
+      locatorLauncherBuilder.setCommand(START);
+      expectedStartCommandSequence.add(LOCATOR_LAUNCHER_CLASS_NAME);
+      expectedStartCommandSequence.add(START.getName());
+
+      final String memberName = "with-rest-api-options";
+      locatorLauncherBuilder.setMemberName(memberName);
+      expectedStartCommandSequence.add(memberName);
+
+      final String bindAddress = "localhost";
+      locatorLauncherBuilder.setBindAddress(bindAddress);
+      expectedStartCommandOptions.add("--bind-address=" + bindAddress);
+
+      final int port = 11111;
+      locatorLauncherBuilder.setPort(port);
+      expectedStartCommandOptions.add("--port=" + port);
+
+      LocatorLauncher locatorLauncher = locatorLauncherBuilder.build();
+      Properties gemfireProperties = new Properties();
+
+      // TODO: Where does the command line get the bind address from? Props or launcher?
+      gemfireProperties.setProperty(HTTP_SERVICE_BIND_ADDRESS, bindAddress);
+      expectedJvmOptions.add("-D" + GEMFIRE_PREFIX + HTTP_SERVICE_BIND_ADDRESS + "=" + bindAddress);
+
+      final String servicePort = "8089";
+      gemfireProperties.setProperty(HTTP_SERVICE_PORT, servicePort);
+      expectedJvmOptions.add("-D" + GEMFIRE_PREFIX + HTTP_SERVICE_PORT + "=" + servicePort);
+
+      String expectedClasspath = String.join(
+          File.pathSeparator,
+          StartMemberUtils.getGemFireJarPath(),
+          StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
+
+      List<String> expectedJavaCommandSequence = Arrays.asList(
+          StartMemberUtils.getJavaPath(),
+          "-server",
+          "-classpath",
+          expectedClasspath);
+
+      String[] commandLine =
+          startLocatorCommand.createStartLocatorCommandLine(locatorLauncher,
+              null, null, gemfireProperties, null, false, new String[0], null, null);
+
+      verifyCommandLine(commandLine, expectedJavaCommandSequence, expectedJvmOptions,
+          expectedStartCommandSequence, expectedStartCommandOptions);
+    }
+
+    @Test
+    void withAllOptions() throws Exception {
+      LocatorLauncher.Builder locatorLauncherBuilder = new LocatorLauncher.Builder();
+
+      final String memberName = "with-all-options";
+      locatorLauncherBuilder.setCommand(START);
+      locatorLauncherBuilder.setMemberName(memberName);
+      expectedStartCommandSequence.add(LOCATOR_LAUNCHER_CLASS_NAME);
+      expectedStartCommandSequence.add(START.getName());
+      expectedStartCommandSequence.add(memberName);
+
+      locatorLauncherBuilder.setDebug(true);
+      expectedStartCommandOptions.add("--debug");
+
+      locatorLauncherBuilder.setForce(true);
+      expectedStartCommandOptions.add("--force");
+
+      final String hostnameForClients = "localhost";
+      locatorLauncherBuilder.setHostnameForClients(hostnameForClients);
+      expectedStartCommandOptions.add("--hostname-for-clients=" + hostnameForClients);
+
+      final int port = 10101;
+      locatorLauncherBuilder.setPort(port);
+      expectedStartCommandOptions.add("--port=" + port);
+
+      locatorLauncherBuilder.setRedirectOutput(true);
+      expectedStartCommandOptions.add("--redirect-output");
+      expectedJvmOptions.add("-Dgemfire.OSProcess.DISABLE_REDIRECTION_CONFIGURATION=true");
+
+      LocatorLauncher locatorLauncher = locatorLauncherBuilder
+          .build();
+
+      Properties gemfireProperties = new Properties();
+
+      final String statisticSampleRate = "1500";
+      gemfireProperties.setProperty(STATISTIC_SAMPLE_RATE, statisticSampleRate);
+      expectedJvmOptions.add("-Dgemfire.statistic-sample-rate=" + statisticSampleRate);
+
+      final String disableAutoReconnect = "true";
+      gemfireProperties.setProperty(DISABLE_AUTO_RECONNECT, disableAutoReconnect);
+      expectedJvmOptions.add("-Dgemfire.disable-auto-reconnect=" + disableAutoReconnect);
+
+      File propertiesFile = mock(File.class);
+      final String propertiesFilePath = "/config/customGemfire.properties";
+      when(propertiesFile.getAbsolutePath())
+          .thenReturn(propertiesFilePath);
+      expectedJvmOptions.add("-DgemfirePropertyFile=" + propertiesFilePath);
+
+      File securityPropertiesFile = mock(File.class);
+      final String securityPropertiesFilePath = "/config/customGemfireSecurity.properties";
+      when(securityPropertiesFile.getAbsolutePath())
+          .thenReturn(securityPropertiesFilePath);
+      expectedJvmOptions.add("-DgemfireSecurityPropertyFile=" + securityPropertiesFilePath);
+
+      String[] customJvmArguments = {
+          "-verbose:gc",
+          "-Xloggc:member-gc.log",
+          "-XX:+PrintGCDateStamps",
+          "-XX:+PrintGCDetails",
+      };
+      expectedJvmOptions.addAll(Arrays.asList(customJvmArguments));
+
+      final String userClasspath = "/temp/domain-1.0.0.jar";
+      String expectedClasspath = String.join(
+          File.pathSeparator,
+          StartMemberUtils.getGemFireJarPath(),
+          userClasspath,
+          StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
+
+      List<String> expectedJavaCommandSequence = Arrays.asList(
+          StartMemberUtils.getJavaPath(),
+          "-server",
+          "-classpath",
+          expectedClasspath);
+
+      final String heapSize = "1024m";
+      expectedJvmOptions.add("-Xms" + heapSize);
+      expectedJvmOptions.add("-Xmx" + heapSize);
+      expectedJvmOptions.add("-XX:+UseConcMarkSweepGC");
+      expectedJvmOptions.add("-XX:CMSInitiatingOccupancyFraction=60");
+
+      String[] commandLine =
+          startLocatorCommand.createStartLocatorCommandLine(locatorLauncher,
+              propertiesFile, securityPropertiesFile, gemfireProperties,
+              userClasspath, false, customJvmArguments, heapSize, heapSize);
+
+      verifyCommandLine(commandLine, expectedJavaCommandSequence, expectedJvmOptions,
+          expectedStartCommandSequence, expectedStartCommandOptions);
+    }
   }
 }

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandTest.java
@@ -15,16 +15,23 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.util.stream.Collectors.toSet;
+import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.START_DEV_REST_API;
+import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLE_RATE;
+import static org.apache.geode.distributed.ServerLauncher.Command.START;
+import static org.apache.geode.internal.lang.SystemUtils.IBM_J9_JVM_NAME;
+import static org.apache.geode.internal.lang.SystemUtils.JAVA_HOTSPOT_JVM_NAME;
+import static org.apache.geode.internal.lang.SystemUtils.ORACLE_JROCKIT_JVM_NAME;
+import static org.apache.geode.management.internal.cli.commands.MemberJvmOptions.getMemberJvmOptions;
 import static org.apache.geode.management.internal.cli.commands.StartServerCommand.addJvmOptionsForOutOfMemoryErrors;
+import static org.apache.geode.management.internal.cli.commands.VerifyCommandLine.verifyCommandLine;
+import static org.apache.geode.util.internal.GeodeGlossary.GEMFIRE_PREFIX;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -34,219 +41,407 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
+import java.util.stream.Stream;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledOnOs;
 
-import org.apache.geode.distributed.ConfigurationProperties;
 import org.apache.geode.distributed.ServerLauncher;
-import org.apache.geode.internal.lang.SystemUtils;
-import org.apache.geode.pdx.PdxSerializer;
-import org.apache.geode.util.internal.GeodeGlossary;
 
-public class StartServerCommandTest {
-  private StartServerCommand serverCommands;
+class StartServerCommandTest {
+  // JVM options to use with every start command.
+  private static final Set<String> START_COMMAND_UNCONDITIONAL_JVM_OPTIONS = Stream.of(
+      "-Dgemfire.launcher.registerSignalHandlers=true",
+      "-Djava.awt.headless=true",
+      "-Dsun.rmi.dgc.server.gcInterval=9223372036854775806")
+      .collect(toSet());
 
-  @Before
-  public void setup() {
-    serverCommands = new StartServerCommand();
-  }
+  @Nested
+  class AddJvmOptionsForOutOfMemoryErrors {
+    private static final String IS_HOTSPOT_VM = ".*" + JAVA_HOTSPOT_JVM_NAME + ".*";
+    private static final String IS_J9_VM = ".*" + IBM_J9_JVM_NAME + ".*";
+    private static final String IS_ROCKIT_VM = ".*" + ORACLE_JROCKIT_JVM_NAME + ".*";
 
-  @After
-  public void tearDown() {
-    serverCommands = null;
-  }
+    @EnabledIfSystemProperty(named = "java.vm.name", matches = IS_HOTSPOT_VM)
+    @EnabledOnOs(WINDOWS)
+    @Test
+    void onWindowsHotSpotVM() {
+      final List<String> jvmOptions = new ArrayList<>();
+      addJvmOptionsForOutOfMemoryErrors(jvmOptions);
+      assertThat(jvmOptions)
+          .containsExactly("-XX:OnOutOfMemoryError=taskkill /F /PID %p");
+    }
 
-  @Test
-  public void testServerClasspathOrder() {
-    String userClasspath = "/path/to/user/lib/app.jar:/path/to/user/classes";
-    String expectedClasspath =
-        StartMemberUtils.getGemFireJarPath().concat(File.pathSeparator).concat(userClasspath)
-            .concat(File.pathSeparator).concat(StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
-    String actualClasspath = serverCommands.getServerClasspath(false, userClasspath);
-    assertEquals(expectedClasspath, actualClasspath);
-  }
+    @Test
+    @EnabledIfSystemProperty(named = "java.vm.name", matches = IS_HOTSPOT_VM)
+    @DisabledOnOs(WINDOWS)
+    void onNonWindowsHotSpotVM() {
+      final List<String> jvmOptions = new ArrayList<>();
+      addJvmOptionsForOutOfMemoryErrors(jvmOptions);
+      assertThat(jvmOptions)
+          .containsExactly("-XX:OnOutOfMemoryError=kill -KILL %p");
+    }
 
-  @Test
-  public void testAddJvmOptionsForOutOfMemoryErrors() {
-    final List<String> jvmOptions = new ArrayList<>(1);
+    @Test
+    @EnabledIfSystemProperty(named = "java.vm.name", matches = IS_J9_VM)
+    void onJ9VM() {
+      final List<String> jvmOptions = new ArrayList<>();
+      addJvmOptionsForOutOfMemoryErrors(jvmOptions);
+      assertThat(jvmOptions)
+          .containsExactly("-Xcheck:memory");
+    }
 
-    addJvmOptionsForOutOfMemoryErrors(jvmOptions);
+    @Test
+    @EnabledIfSystemProperty(named = "java.vm.name", matches = IS_ROCKIT_VM)
+    void onRockitVM() {
+      final List<String> jvmOptions = new ArrayList<>();
+      addJvmOptionsForOutOfMemoryErrors(jvmOptions);
+      assertThat(jvmOptions)
+          .containsExactly("-XXexitOnOutOfMemory");
+    }
 
-    if (SystemUtils.isHotSpotVM()) {
-      if (SystemUtils.isWindows()) {
-        assertTrue(jvmOptions.contains("-XX:OnOutOfMemoryError=taskkill /F /PID %p"));
-      } else {
-        assertTrue(jvmOptions.contains("-XX:OnOutOfMemoryError=kill -KILL %p"));
-      }
-    } else if (SystemUtils.isJ9VM()) {
-      assertEquals(1, jvmOptions.size());
-      assertTrue(jvmOptions.contains("-Xcheck:memory"));
-    } else if (SystemUtils.isJRockitVM()) {
-      assertEquals(1, jvmOptions.size());
-      assertTrue(jvmOptions.contains("-XXexitOnOutOfMemory"));
-    } else {
-      assertTrue(jvmOptions.isEmpty());
+    @Test
+    @DisabledIfSystemProperty(named = "java.vm.name", matches = IS_HOTSPOT_VM)
+    @DisabledIfSystemProperty(named = "java.vm.name", matches = IS_J9_VM)
+    @DisabledIfSystemProperty(named = "java.vm.name", matches = IS_ROCKIT_VM)
+    void otherVM() {
+      final List<String> jvmOptions = new ArrayList<>();
+      addJvmOptionsForOutOfMemoryErrors(jvmOptions);
+      assertThat(jvmOptions)
+          .isEmpty();
     }
   }
 
-  @Test
-  public void testCreateServerCommandLine() throws Exception {
-    ServerLauncher serverLauncher = new ServerLauncher.Builder()
-        .setCommand(ServerLauncher.Command.START).setDisableDefaultServer(true)
-        .setMemberName("testCreateServerCommandLine").setRebalance(true).setServerPort(41214)
-        .setCriticalHeapPercentage(95.5f).setEvictionHeapPercentage(85.0f)
-        .setSocketBufferSize(1024 * 1024).setMessageTimeToLive(93).build();
+  @Nested
+  class GetServerClasspath {
+    private final StartServerCommand serverCommands = new StartServerCommand();
 
-    String[] commandLineElements = serverCommands.createStartServerCommandLine(serverLauncher, null,
-        null, new Properties(), null, false, new String[0], false, null, null);
+    @Test
+    public void addsUserClasspathImmediatelyAfterGemfireJarPath() {
+      String userClasspath = "/path/to/user/lib/app.jar:/path/to/user/classes";
 
-    assertNotNull(commandLineElements);
-    assertTrue(commandLineElements.length > 0);
+      String actualClasspath = serverCommands.getServerClasspath(false, userClasspath);
 
-    Set<String> expectedCommandLineElements = new HashSet<>(6);
-    expectedCommandLineElements.add(serverLauncher.getCommand().getName());
-    expectedCommandLineElements.add("--disable-default-server");
-    expectedCommandLineElements.add(serverLauncher.getMemberName().toLowerCase());
-    expectedCommandLineElements.add("--rebalance");
-    expectedCommandLineElements
-        .add(String.format("--server-port=%1$d", serverLauncher.getServerPort()));
-    expectedCommandLineElements.add(String.format("--critical-heap-percentage=%1$s",
-        serverLauncher.getCriticalHeapPercentage()));
-    expectedCommandLineElements.add(String.format("--eviction-heap-percentage=%1$s",
-        serverLauncher.getEvictionHeapPercentage()));
-    expectedCommandLineElements
-        .add(String.format("--socket-buffer-size=%1$d", serverLauncher.getSocketBufferSize()));
-    expectedCommandLineElements
-        .add(String.format("--message-time-to-live=%1$d", serverLauncher.getMessageTimeToLive()));
-
-    for (String commandLineElement : commandLineElements) {
-      expectedCommandLineElements.remove(commandLineElement.toLowerCase());
+      String expectedClasspath = String.join(
+          File.pathSeparator,
+          StartMemberUtils.getGemFireJarPath(),
+          userClasspath,
+          StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
+      assertThat(actualClasspath)
+          .isEqualTo(expectedClasspath);
     }
-    assertTrue(String.format("Expected ([]); but was (%1$s)", expectedCommandLineElements),
-        expectedCommandLineElements.isEmpty());
   }
 
-  @Test
-  public void testCreateServerCommandLineWithRestAPI() throws Exception {
-    ServerLauncher serverLauncher = new ServerLauncher.Builder()
-        .setCommand(ServerLauncher.Command.START).setDisableDefaultServer(true)
-        .setMemberName("testCreateServerCommandLine").setRebalance(true).setServerPort(41214)
-        .setCriticalHeapPercentage(95.5f).setEvictionHeapPercentage(85.0f).build();
+  @Nested
+  class CreateStartServerCommandLine {
+    private static final String SERVER_LAUNCHER_CLASS_NAME =
+        "org.apache.geode.distributed.ServerLauncher";
 
-    Properties gemfireProperties = new Properties();
-    gemfireProperties.setProperty(START_DEV_REST_API, "true");
-    gemfireProperties.setProperty(HTTP_SERVICE_PORT, "8080");
-    gemfireProperties.setProperty(HTTP_SERVICE_BIND_ADDRESS, "localhost");
+    private final StartServerCommand serverCommands = new StartServerCommand();
+    private final Set<String> expectedJvmOptions = new HashSet<>();
+    private final List<String> expectedStartCommandSequence = new ArrayList<>();
+    private final Set<String> expectedStartCommandOptions = new HashSet<>();
 
-    String[] commandLineElements = serverCommands.createStartServerCommandLine(serverLauncher, null,
-        null, gemfireProperties, null, false, new String[0], false, null, null);
-
-    assertNotNull(commandLineElements);
-    assertTrue(commandLineElements.length > 0);
-
-    Set<String> expectedCommandLineElements = new HashSet<>(6);
-
-    expectedCommandLineElements.add(serverLauncher.getCommand().getName());
-    expectedCommandLineElements.add("--disable-default-server");
-    expectedCommandLineElements.add(serverLauncher.getMemberName().toLowerCase());
-    expectedCommandLineElements.add("--rebalance");
-    expectedCommandLineElements
-        .add(String.format("--server-port=%1$d", serverLauncher.getServerPort()));
-    expectedCommandLineElements.add(String.format("--critical-heap-percentage=%1$s",
-        serverLauncher.getCriticalHeapPercentage()));
-    expectedCommandLineElements.add(String.format("--eviction-heap-percentage=%1$s",
-        serverLauncher.getEvictionHeapPercentage()));
-
-    expectedCommandLineElements
-        .add("-d" + GeodeGlossary.GEMFIRE_PREFIX + "" + START_DEV_REST_API + "=" + "true");
-    expectedCommandLineElements
-        .add("-d" + GeodeGlossary.GEMFIRE_PREFIX + "" + HTTP_SERVICE_PORT + "=" + "8080");
-    expectedCommandLineElements.add("-d" + GeodeGlossary.GEMFIRE_PREFIX + ""
-        + HTTP_SERVICE_BIND_ADDRESS + "=" + "localhost");
-
-    for (String commandLineElement : commandLineElements) {
-      expectedCommandLineElements.remove(commandLineElement.toLowerCase());
+    @BeforeEach
+    void alwaysExpectUnconditionalOptions() {
+      expectedJvmOptions.addAll(START_COMMAND_UNCONDITIONAL_JVM_OPTIONS);
     }
-    assertTrue(String.format("Expected ([]); but was (%1$s)", expectedCommandLineElements),
-        expectedCommandLineElements.isEmpty());
+
+    @BeforeEach
+    void alwaysExpectJreSpecificMemberJvmOptions() {
+      expectedJvmOptions.addAll(getMemberJvmOptions());
+    }
+
+    @Test
+    void withTypicalOptions() throws Exception {
+      ServerLauncher.Builder serverLauncherBuilder = new ServerLauncher.Builder();
+      serverLauncherBuilder.setCommand(START);
+      expectedStartCommandSequence.add(SERVER_LAUNCHER_CLASS_NAME);
+      expectedStartCommandSequence.add(START.getName());
+
+      final String memberName = "with-typical-options";
+      serverLauncherBuilder.setMemberName(memberName);
+      expectedStartCommandSequence.add(memberName);
+
+      serverLauncherBuilder.setDisableDefaultServer(true);
+      expectedStartCommandOptions.add("--disable-default-server");
+
+      serverLauncherBuilder.setRebalance(true);
+      expectedStartCommandOptions.add("--rebalance");
+
+      final int serverPort = 41214;
+      serverLauncherBuilder.setServerPort(serverPort);
+      expectedStartCommandOptions.add("--server-port=" + serverPort);
+
+      final float criticalHeapPercentage = 95.5f;
+      serverLauncherBuilder.setCriticalHeapPercentage(criticalHeapPercentage);
+      expectedStartCommandOptions.add(
+          String.format("--critical-heap-percentage=%s", criticalHeapPercentage));
+
+      final float evictionHeapPercentage = 85.0f;
+      serverLauncherBuilder.setEvictionHeapPercentage(evictionHeapPercentage);
+      expectedStartCommandOptions.add(
+          String.format("--eviction-heap-percentage=%s", evictionHeapPercentage));
+
+      final int socketBufferSize = 1024 * 1024;
+      serverLauncherBuilder.setSocketBufferSize(socketBufferSize);
+      expectedStartCommandOptions.add(String.format("--socket-buffer-size=%d", socketBufferSize));
+
+      final int messageTimeToLive = 93;
+      serverLauncherBuilder.setMessageTimeToLive(messageTimeToLive);
+      expectedStartCommandOptions.add(
+          String.format("--message-time-to-live=%d", messageTimeToLive));
+
+      ServerLauncher serverLauncher = serverLauncherBuilder.build();
+
+      String expectedClasspath = String.join(
+          File.pathSeparator,
+          StartMemberUtils.getGemFireJarPath(),
+          StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
+
+      List<String> expectedJavaCommandSequence = Arrays.asList(
+          StartMemberUtils.getJavaPath(),
+          "-server",
+          "-classpath",
+          expectedClasspath);
+
+      boolean disableExitWhenOutOfMemory = false;
+      expectedJvmOptions.addAll(jdkSpecificOutOfMemoryOptions());
+
+      String[] commandLineElements = serverCommands.createStartServerCommandLine(
+          serverLauncher, null, null, new Properties(), null, false, new String[0],
+          disableExitWhenOutOfMemory, null,
+          null);
+
+      verifyCommandLine(commandLineElements, expectedJavaCommandSequence, expectedJvmOptions,
+          expectedStartCommandSequence, expectedStartCommandOptions);
+    }
+
+    @Test
+    void withRestApiOptions() throws Exception {
+      ServerLauncher.Builder serverLauncherBuilder = new ServerLauncher.Builder();
+
+      expectedStartCommandSequence.add(SERVER_LAUNCHER_CLASS_NAME);
+
+      serverLauncherBuilder.setCommand(START);
+      expectedStartCommandSequence.add(START.getName());
+
+      final String memberName = "with-rest-api-options";
+      serverLauncherBuilder.setMemberName(memberName);
+      expectedStartCommandSequence.add(memberName);
+
+      serverLauncherBuilder.setDisableDefaultServer(true);
+      expectedStartCommandOptions.add("--disable-default-server");
+
+      serverLauncherBuilder.setRebalance(true);
+      expectedStartCommandOptions.add("--rebalance");
+
+      final int serverPort = 41214;
+      serverLauncherBuilder.setServerPort(serverPort);
+      expectedStartCommandOptions.add("--server-port=" + serverPort);
+
+      float criticalHeapPercentage = 95.5f;
+      serverLauncherBuilder.setCriticalHeapPercentage(criticalHeapPercentage);
+      expectedStartCommandOptions.add(
+          String.format("--critical-heap-percentage=%s", criticalHeapPercentage));
+
+      float evictionHeapPercentage = 85.0f;
+      serverLauncherBuilder.setEvictionHeapPercentage(evictionHeapPercentage);
+      expectedStartCommandOptions.add(
+          String.format("--eviction-heap-percentage=%s", evictionHeapPercentage));
+
+      ServerLauncher serverLauncher = serverLauncherBuilder.build();
+
+      Properties gemfireProperties = new Properties();
+
+      final String startDevRestApi = "true";
+      gemfireProperties.setProperty(START_DEV_REST_API, startDevRestApi);
+      expectedJvmOptions.add("-D" + GEMFIRE_PREFIX + START_DEV_REST_API + "=" + startDevRestApi);
+
+      final String httpServicePort = "8080";
+      gemfireProperties.setProperty(HTTP_SERVICE_PORT, httpServicePort);
+      expectedJvmOptions.add("-D" + GEMFIRE_PREFIX + HTTP_SERVICE_PORT + "=" + httpServicePort);
+
+      final String httpServiceBindAddress = "localhost";
+      gemfireProperties.setProperty(HTTP_SERVICE_BIND_ADDRESS, httpServiceBindAddress);
+      expectedJvmOptions.add("-D" + GEMFIRE_PREFIX + HTTP_SERVICE_BIND_ADDRESS
+          + "=" + httpServiceBindAddress);
+
+      final String expectedClasspath = String.join(
+          File.pathSeparator,
+          StartMemberUtils.getGemFireJarPath(),
+          StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
+
+      List<String> expectedJavaCommandSequence = Arrays.asList(
+          StartMemberUtils.getJavaPath(),
+          "-server",
+          "-classpath",
+          expectedClasspath);
+
+      boolean disableExitWhenOutOfMemory = false;
+      expectedJvmOptions.addAll(jdkSpecificOutOfMemoryOptions());
+
+      String[] commandLineElements = serverCommands.createStartServerCommandLine(
+          serverLauncher, null, null, gemfireProperties, null, false, new String[0],
+          disableExitWhenOutOfMemory, null,
+          null);
+
+      verifyCommandLine(commandLineElements, expectedJavaCommandSequence, expectedJvmOptions,
+          expectedStartCommandSequence, expectedStartCommandOptions);
+    }
+
+    @Test
+    void withAllOptions() throws Exception {
+      ServerLauncher.Builder serverLauncherBuilder = new ServerLauncher.Builder();
+      expectedStartCommandSequence.add(SERVER_LAUNCHER_CLASS_NAME);
+
+      serverLauncherBuilder.setCommand(START);
+      expectedStartCommandSequence.add(START.getName());
+
+      final String memberName = "fullServer";
+      serverLauncherBuilder.setMemberName(memberName);
+      expectedStartCommandSequence.add(memberName);
+
+      serverLauncherBuilder.setAssignBuckets(true);
+      expectedStartCommandOptions.add("--assign-buckets");
+
+      final float criticalHeapPercentage = 95.5f;
+      serverLauncherBuilder.setCriticalHeapPercentage(criticalHeapPercentage);
+      expectedStartCommandOptions.add("--critical-heap-percentage=" + criticalHeapPercentage);
+
+      final float criticalOffHeapPercentage = 95.5f;
+      serverLauncherBuilder.setCriticalOffHeapPercentage(criticalOffHeapPercentage);
+      expectedStartCommandOptions.add(
+          "--critical-off-heap-percentage=" + criticalOffHeapPercentage);
+
+      serverLauncherBuilder.setDebug(true);
+      expectedStartCommandOptions.add("--debug");
+
+      serverLauncherBuilder.setDisableDefaultServer(true);
+      expectedStartCommandOptions.add("--disable-default-server");
+
+      final float evictionHeapPercentage = 85.0f;
+      serverLauncherBuilder.setEvictionHeapPercentage(evictionHeapPercentage);
+      expectedStartCommandOptions.add("--eviction-heap-percentage=" + evictionHeapPercentage);
+
+      final float evictionOffHeapPercentage = 85.0f;
+      serverLauncherBuilder.setEvictionOffHeapPercentage(evictionOffHeapPercentage);
+      expectedStartCommandOptions.add(
+          "--eviction-off-heap-percentage=" + evictionOffHeapPercentage);
+
+      serverLauncherBuilder.setForce(true);
+      expectedStartCommandOptions.add("--force");
+
+      final String hostNameForClients = "localhost";
+      serverLauncherBuilder.setHostNameForClients(hostNameForClients);
+      expectedStartCommandOptions.add("--hostname-for-clients=" + hostNameForClients);
+
+      final int maxConnections = 800;
+      serverLauncherBuilder.setMaxConnections(maxConnections);
+      expectedStartCommandOptions.add("--max-connections=" + maxConnections);
+
+      final int maxMessageCount = 500;
+      serverLauncherBuilder.setMaxMessageCount(maxMessageCount);
+      expectedStartCommandOptions.add("--max-message-count=" + maxMessageCount);
+
+      final int maxThreads = 100;
+      serverLauncherBuilder.setMaxThreads(maxThreads);
+      expectedStartCommandOptions.add("--max-threads=" + maxThreads);
+
+      final int messageTimeToLive = 93;
+      serverLauncherBuilder.setMessageTimeToLive(messageTimeToLive);
+      expectedStartCommandOptions.add("--message-time-to-live=" + messageTimeToLive);
+
+      serverLauncherBuilder.setRebalance(true);
+      expectedStartCommandOptions.add("--rebalance");
+
+      serverLauncherBuilder.setRedirectOutput(true);
+      expectedStartCommandOptions.add("--redirect-output");
+      expectedJvmOptions.add("-Dgemfire.OSProcess.DISABLE_REDIRECTION_CONFIGURATION=true");
+
+      final int serverPort = 41214;
+      serverLauncherBuilder.setServerPort(serverPort);
+      expectedStartCommandOptions.add("--server-port=" + serverPort);
+
+      final int socketBufferSize = 1024 * 1024;
+      serverLauncherBuilder.setSocketBufferSize(socketBufferSize);
+      expectedStartCommandOptions.add("--socket-buffer-size=" + socketBufferSize);
+
+      final String springXmlLocation = "/config/spring-server.xml";
+      serverLauncherBuilder.setSpringXmlLocation(springXmlLocation);
+      expectedStartCommandOptions.add("--spring-xml-location=" + springXmlLocation);
+
+      ServerLauncher serverLauncher = serverLauncherBuilder.build();
+
+      Properties gemfireProperties = new Properties();
+
+      final String disableAutoReconnect = "true";
+      gemfireProperties.setProperty(DISABLE_AUTO_RECONNECT, disableAutoReconnect);
+      expectedJvmOptions.add("-Dgemfire.disable-auto-reconnect=" + disableAutoReconnect);
+
+      final String statisticSampleRate = "1500";
+      gemfireProperties.setProperty(STATISTIC_SAMPLE_RATE, statisticSampleRate);
+      expectedJvmOptions.add("-Dgemfire.statistic-sample-rate=" + statisticSampleRate);
+
+      final String propertiesFilePath = "/config/customGemfire.properties";
+      File gemfirePropertiesFile = mock(File.class);
+      when(gemfirePropertiesFile.getAbsolutePath())
+          .thenReturn(propertiesFilePath);
+      expectedJvmOptions.add("-DgemfirePropertyFile=" + propertiesFilePath);
+
+      final String securityPropertiesFilePath = "/config/customGemfireSecurity.properties";
+      File gemfireSecurityPropertiesFile = mock(File.class);
+      when(gemfireSecurityPropertiesFile.getAbsolutePath())
+          .thenReturn(securityPropertiesFilePath);
+      expectedJvmOptions.add("-DgemfireSecurityPropertyFile=" + securityPropertiesFilePath);
+
+      final String heapSize = "1024m";
+      expectedJvmOptions.add("-Xms" + heapSize);
+      expectedJvmOptions.add("-Xmx" + heapSize);
+      expectedJvmOptions.add("-XX:+UseConcMarkSweepGC");
+      expectedJvmOptions.add("-XX:CMSInitiatingOccupancyFraction=60");
+
+      final String[] customJvmOptions = {
+          "-verbose:gc",
+          "-Xloggc:member-gc.log",
+          "-XX:+PrintGCDateStamps",
+          "-XX:+PrintGCDetails",
+      };
+      expectedJvmOptions.addAll(Arrays.asList(customJvmOptions));
+
+      final String customClasspath = "/temp/domain-1.0.0.jar";
+      final String expectedClasspath = String.join(
+          File.pathSeparator,
+          StartMemberUtils.getGemFireJarPath(),
+          customClasspath,
+          StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME);
+
+      List<String> expectedJavaCommandSequence = Arrays.asList(
+          StartMemberUtils.getJavaPath(),
+          "-server",
+          "-classpath",
+          expectedClasspath);
+
+      boolean disableExitWhenOutOfMemory = false;
+      expectedJvmOptions.addAll(jdkSpecificOutOfMemoryOptions());
+
+      String[] commandLineElements = serverCommands.createStartServerCommandLine(
+          serverLauncher, gemfirePropertiesFile, gemfireSecurityPropertiesFile, gemfireProperties,
+          customClasspath, false, customJvmOptions, disableExitWhenOutOfMemory, heapSize, heapSize);
+
+      verifyCommandLine(commandLineElements, expectedJavaCommandSequence, expectedJvmOptions,
+          expectedStartCommandSequence, expectedStartCommandOptions);
+    }
   }
 
-  @Test
-  public void testCreateStartServerCommandLineWithAllOptions() throws Exception {
-    ServerLauncher serverLauncher = new ServerLauncher.Builder().setAssignBuckets(Boolean.TRUE)
-        .setCommand(ServerLauncher.Command.START).setCriticalHeapPercentage(95.5f)
-        .setCriticalOffHeapPercentage(95.5f).setDebug(Boolean.TRUE)
-        .setDisableDefaultServer(Boolean.TRUE).setDeletePidFileOnStop(Boolean.TRUE)
-        .setEvictionHeapPercentage(85.0f).setEvictionOffHeapPercentage(85.0f).setForce(Boolean.TRUE)
-        .setHostNameForClients("localhost").setMaxConnections(800).setMaxMessageCount(500)
-        .setMaxThreads(100).setMemberName("fullServer").setMessageTimeToLive(93)
-        .setPdxDiskStore("pdxDiskStore").setPdxIgnoreUnreadFields(Boolean.TRUE)
-        .setPdxPersistent(Boolean.TRUE).setPdxReadSerialized(Boolean.TRUE)
-        .setPdxSerializer(mock(PdxSerializer.class)).setRebalance(Boolean.TRUE)
-        .setRedirectOutput(Boolean.TRUE).setRebalance(true).setServerPort(41214)
-        .setSocketBufferSize(1024 * 1024).setSpringXmlLocation("/config/spring-server.xml").build();
-
-    File gemfirePropertiesFile = spy(mock(File.class));
-    when(gemfirePropertiesFile.getAbsolutePath()).thenReturn("/config/customGemfire.properties");
-
-    File gemfireSecurityPropertiesFile = spy(mock(File.class));
-    when(gemfireSecurityPropertiesFile.getAbsolutePath())
-        .thenReturn("/config/customGemfireSecurity.properties");
-
-    Properties gemfireProperties = new Properties();
-    gemfireProperties.setProperty(ConfigurationProperties.STATISTIC_SAMPLE_RATE, "1500");
-    gemfireProperties.setProperty(ConfigurationProperties.DISABLE_AUTO_RECONNECT, "true");
-
-    String heapSize = "1024m";
-    String customClasspath = "/temp/domain-1.0.0.jar";
-    String[] jvmArguments = new String[] {"-verbose:gc", "-Xloggc:member-gc.log",
-        "-XX:+PrintGCDateStamps", "-XX:+PrintGCDetails"};
-
-    String[] commandLineElements = serverCommands.createStartServerCommandLine(serverLauncher,
-        gemfirePropertiesFile, gemfireSecurityPropertiesFile, gemfireProperties, customClasspath,
-        Boolean.FALSE, jvmArguments, Boolean.FALSE, heapSize, heapSize);
-
-    Set<String> expectedCommandLineElements = new HashSet<>();
-    expectedCommandLineElements.add(StartMemberUtils.getJavaPath());
-    expectedCommandLineElements.add("-server");
-    expectedCommandLineElements.add("-classpath");
-    expectedCommandLineElements
-        .add(StartMemberUtils.getGemFireJarPath().concat(File.pathSeparator).concat(customClasspath)
-            .concat(File.pathSeparator).concat(StartMemberUtils.CORE_DEPENDENCIES_JAR_PATHNAME));
-    expectedCommandLineElements
-        .add("-DgemfirePropertyFile=".concat(gemfirePropertiesFile.getAbsolutePath()));
-    expectedCommandLineElements.add(
-        "-DgemfireSecurityPropertyFile=".concat(gemfireSecurityPropertiesFile.getAbsolutePath()));
-    expectedCommandLineElements.add("-Dgemfire.statistic-sample-rate=1500");
-    expectedCommandLineElements.add("-Dgemfire.disable-auto-reconnect=true");
-    expectedCommandLineElements.addAll(Arrays.asList(jvmArguments));
-    expectedCommandLineElements.add("org.apache.geode.distributed.ServerLauncher");
-    expectedCommandLineElements.add("start");
-    expectedCommandLineElements.add("fullServer");
-    expectedCommandLineElements.add("--assign-buckets");
-    expectedCommandLineElements.add("--debug");
-    expectedCommandLineElements.add("--disable-default-server");
-    expectedCommandLineElements.add("--force");
-    expectedCommandLineElements.add("--rebalance");
-    expectedCommandLineElements.add("--redirect-output");
-    expectedCommandLineElements.add("--server-port=41214");
-    expectedCommandLineElements.add("--spring-xml-location=/config/spring-server.xml");
-    expectedCommandLineElements.add("--critical-heap-percentage=95.5");
-    expectedCommandLineElements.add("--eviction-heap-percentage=85.0");
-    expectedCommandLineElements.add("--critical-off-heap-percentage=95.5");
-    expectedCommandLineElements.add("--eviction-off-heap-percentage=85.0");
-    expectedCommandLineElements.add("--max-connections=800");
-    expectedCommandLineElements.add("--max-message-count=500");
-    expectedCommandLineElements.add("--max-threads=100");
-    expectedCommandLineElements.add("--message-time-to-live=93");
-    expectedCommandLineElements.add("--socket-buffer-size=1048576");
-    expectedCommandLineElements.add("--hostname-for-clients=localhost");
-
-    assertNotNull(commandLineElements);
-    assertTrue(commandLineElements.length > 0);
-
-    assertThat(commandLineElements).containsAll(expectedCommandLineElements);
+  private static List<String> jdkSpecificOutOfMemoryOptions() {
+    List<String> jdkSpecificOptions = new ArrayList<>();
+    addJvmOptionsForOutOfMemoryErrors(jdkSpecificOptions);
+    return jdkSpecificOptions;
   }
 }

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/VerifyCommandLine.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/VerifyCommandLine.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+class VerifyCommandLine {
+  /**
+   * Asserts that the java command line contains all and only the specified elements, positioned
+   * correctly. The correct positioning is:
+   * <ol>
+   * <li>All expected java command elements, in the expected sequence, followed by</li>
+   * <li>All expected jvm options, in any order, followed by</li>
+   * <li>All expected main class command elements, in the expected sequence, followed by</li>
+   * <li>All expected main class options, in any order</li>
+   * </ol>
+   *
+   * @param javaCommandLine the command line to verify
+   * @param expectedJavaCommandSequence java command and sequence of immediately following options
+   * @param expectedJvmOptions options expected in any order between the java command sequence
+   *        and the main class sequence
+   * @param expectedMainClassSequence main class and sequence of immediately following options
+   * @param expectedMainClassOptions options expected in any order after the main class sequence
+   */
+  static void verifyCommandLine(String[] javaCommandLine, List<String> expectedJavaCommandSequence,
+      Set<String> expectedJvmOptions, List<String> expectedMainClassSequence,
+      Set<String> expectedMainClassOptions) {
+    List<String> commandLine = Arrays.asList(javaCommandLine);
+
+    Set<String> allExpectedElements = new HashSet<>();
+    allExpectedElements.addAll(expectedJavaCommandSequence);
+    allExpectedElements.addAll(expectedJvmOptions);
+    allExpectedElements.addAll(expectedMainClassSequence);
+    allExpectedElements.addAll(expectedMainClassOptions);
+
+    assertThat(commandLine)
+        .startsWith(expectedJavaCommandSequence.toArray(new String[] {}))
+        .containsSequence(expectedMainClassSequence)
+        .containsExactlyInAnyOrderElementsOf(allExpectedElements);
+
+    // All JVM options must be between the java command sequence and the main class sequence.
+    String mainClassName = expectedMainClassSequence.get(0);
+    int mainClassSequenceIndex = commandLine.indexOf(mainClassName);
+    int minJvmOptionIndex = expectedJavaCommandSequence.size();
+    int maxJvmOptionIndex = minJvmOptionIndex + expectedJvmOptions.size() - 1;
+    for (String option : expectedJvmOptions) {
+      assertThat(commandLine.indexOf(option))
+          .as(() -> String.format("position of JVM option %s", option))
+          .isBetween(minJvmOptionIndex, maxJvmOptionIndex);
+    }
+
+    // All main class options must be after the main class sequence.
+    int minMainClassOptionIndex = mainClassSequenceIndex + expectedMainClassSequence.size();
+    int maxMainClassOptionIndex = commandLine.size() - 1;
+    for (String option : expectedMainClassOptions) {
+      assertThat(commandLine.indexOf(option))
+          .as(() -> String.format("position of %s option %s", mainClassName, option))
+          .isBetween(minMainClassOptionIndex, maxMainClassOptionIndex);
+    }
+  }
+}

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/MemberJvmOptions.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/MemberJvmOptions.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.commons.lang3.JavaVersion.JAVA_11;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtLeast;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class MemberJvmOptions {
+  private static final List<String> JAVA_11_OPTIONS = Arrays.asList(
+      "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+      "--add-exports=java.management/com.sun.jmx.remote.security=ALL-UNNAMED");
+
+  public static List<String> getMemberJvmOptions() {
+    if (isJavaVersionAtLeast(JAVA_11)) {
+      return JAVA_11_OPTIONS;
+    }
+    return Collections.emptyList();
+  }
+}

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommand.java
@@ -458,6 +458,7 @@ public class StartLocatorCommand extends OfflineGfshCommand {
     commandLine.add("-classpath");
     commandLine
         .add(getLocatorClasspath(Boolean.TRUE.equals(includeSystemClasspath), userClasspath));
+    commandLine.addAll(MemberJvmOptions.getMemberJvmOptions());
 
     StartMemberUtils.addCurrentLocators(this, commandLine, gemfireProperties);
     StartMemberUtils.addGemFirePropertyFile(commandLine, gemfirePropertiesFile);

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartServerCommand.java
@@ -431,6 +431,7 @@ public class StartServerCommand extends OfflineGfshCommand {
     commandLine.add("-server");
     commandLine.add("-classpath");
     commandLine.add(getServerClasspath(Boolean.TRUE.equals(includeSystemClasspath), userClasspath));
+    commandLine.addAll(MemberJvmOptions.getMemberJvmOptions());
 
     StartMemberUtils.addCurrentLocators(this, commandLine, gemfireProperties);
     StartMemberUtils.addGemFirePropertyFile(commandLine, gemfirePropertiesFile);

--- a/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/MemberJvmOptionsTest.java
+++ b/geode-gfsh/src/test/java/org/apache/geode/management/internal/cli/commands/MemberJvmOptionsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.management.internal.cli.commands;
+
+import static org.apache.geode.management.internal.cli.commands.MemberJvmOptions.getMemberJvmOptions;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
+
+class MemberJvmOptionsTest {
+  @Test
+  @EnabledOnJre(JRE.JAVA_8)
+  void java8Options() {
+    assertThat(getMemberJvmOptions())
+        .isEmpty();
+  }
+
+  @Test
+  @EnabledForJreRange(min = JRE.JAVA_11)
+  void java11Options() {
+    List<String> expectedOptions = Arrays.asList(
+        "--add-exports=java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-exports=java.management/com.sun.jmx.remote.security=ALL-UNNAMED");
+
+    assertThat(getMemberJvmOptions())
+        .containsExactlyElementsOf(expectedOptions);
+  }
+}


### PR DESCRIPTION
PROBLEM

When run on JDK 17, numerous acceptance tests fail because a launched
locator or server requires access to the following packages:
- java.base/sun.nio.ch
- java.management/com.sun.jmx.remote.security

SOLUTION

- Add a `MemberJvmOptions` class that reports the JDK-dependent options
  required to launch a locator or server on the current process's JDK.
- Change `StartLocatorCommand` and `StartServerCommand` to add those
  options to the command line when launching locators and servers.

FUTURE

Future PRs will likely put these opens/exports in an argument file, then
configure these commands to use the argument file. We are deferring that
until we identify additional needs for the argument file, so we can
choose an appropriate location for the argument file.

Co-authored-by: Dale Emery <demery@vmware.com>
Co-authored-by: Kirk Lund <klund@apache.org>
