### PR TITLE
GEODE-10046: Downgrade classgraph from 4.8.143 to 4.8.141

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -180,7 +180,7 @@
       <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
-        <version>4.8.143</version>
+        <version>4.8.141</version>
       </dependency>
       <dependency>
         <groupId>io.github.resilience4j</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -117,7 +117,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'commons-modeler', name: 'commons-modeler', version: '2.0.1')
         api(group: 'commons-validator', name: 'commons-validator', version: get('commons-validator.version'))
         // Careful when upgrading this dependency: see GEODE-7370 and GEODE-8150.
-        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.143')
+        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.141')
         api(group: 'io.github.resilience4j', name: 'resilience4j-retry', version: '1.7.1')
         api(group: 'io.lettuce', name: 'lettuce-core', version: '6.1.8.RELEASE')
         api(group: 'io.micrometer', name: 'micrometer-core', version: get('micrometer.version'))

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -966,7 +966,7 @@ lib/HdrHistogram-2.1.12.jar
 lib/HikariCP-4.0.3.jar
 lib/LatencyUtils-2.0.3.jar
 lib/antlr-2.7.7.jar
-lib/classgraph-4.8.143.jar
+lib/classgraph-4.8.141.jar
 lib/commons-beanutils-1.9.4.jar
 lib/commons-codec-1.15.jar
 lib/commons-collections-3.2.2.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -53,7 +53,7 @@ commons-collections-3.2.2.jar
 commons-digester-2.1.jar
 commons-io-2.11.0.jar
 commons-logging-1.2.jar
-classgraph-4.8.143.jar
+classgraph-4.8.141.jar
 micrometer-core-1.8.4.jar
 fastutil-8.5.8.jar
 javax.resource-api-1.7.1.jar

--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -1064,7 +1064,7 @@ Apache Geode bundles the following files under the MIT License:
 
   - Checker Qual v3.12.0 (https://checkerframework.org), Copyright (c)
     2004-present by the Checker Framework developers
-  - ClassGraph v4.8.143 (https://github.com/classgraph/classgraph), Copyright
+  - ClassGraph v4.8.141 (https://github.com/classgraph/classgraph), Copyright
     (c) 2019 Luke Hutchison
   - HTML5 Shiv vpre3.5 (https://github.com/aFarkas/html5shiv), Copyright
     (c) 2014 Alexander Farkas (aFarkas)

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -7,7 +7,7 @@ commons-digester-2.1.jar
 commons-validator-1.7.jar
 spring-jcl-5.3.18.jar
 commons-codec-1.15.jar
-classgraph-4.8.143.jar
+classgraph-4.8.141.jar
 jackson-databind-2.13.2.2.jar
 commons-logging-1.2.jar
 geode-management-0.0.0.jar


### PR DESCRIPTION
the bump may have negatively impacted Spring Converter autodiscovery