### PR TITLE
GEODE-10230: PDX UPDATE/DELETE in Mgmt REST API

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/DeploymentValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/DeploymentValidator.java
@@ -19,6 +19,8 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.NotImplementedException;
+
 import org.apache.geode.management.configuration.Deployment;
 import org.apache.geode.management.internal.CacheElementOperation;
 import org.apache.geode.management.internal.utils.JarFileUtils;
@@ -28,11 +30,12 @@ public class DeploymentValidator implements ConfigurationValidator<Deployment> {
   public void validate(CacheElementOperation operation, Deployment config)
       throws IllegalArgumentException {
     switch (operation) {
+      case UPDATE:
+        throw new NotImplementedException("Not implemented");
       case CREATE:
         validateCreate(config);
         break;
       case DELETE:
-      case UPDATE:
       default:
     }
   }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/DiskStoreValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/DiskStoreValidator.java
@@ -24,6 +24,7 @@ import static org.apache.geode.internal.cache.DiskStoreAttributes.checkQueueSize
 import static org.apache.geode.internal.cache.DiskStoreAttributes.checkWriteBufferSize;
 import static org.apache.geode.internal.cache.DiskStoreAttributes.verifyNonNegativeDirSize;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.internal.cache.DiskStoreMonitor;
@@ -36,8 +37,9 @@ public class DiskStoreValidator implements ConfigurationValidator<DiskStore> {
   public void validate(CacheElementOperation operation, DiskStore config)
       throws IllegalArgumentException {
     switch (operation) {
-      case CREATE:
       case UPDATE:
+        throw new NotImplementedException("Not implemented");
+      case CREATE:
         checkRequiredItems(config);
         checkValueRanges(config);
         break;

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/GatewayReceiverConfigValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/GatewayReceiverConfigValidator.java
@@ -18,6 +18,8 @@ package org.apache.geode.management.internal.configuration.validators;
 import static org.apache.geode.cache.wan.GatewayReceiver.DEFAULT_END_PORT;
 import static org.apache.geode.cache.wan.GatewayReceiver.DEFAULT_START_PORT;
 
+import org.apache.commons.lang3.NotImplementedException;
+
 import org.apache.geode.management.configuration.GatewayReceiver;
 import org.apache.geode.management.internal.CacheElementOperation;
 
@@ -27,19 +29,25 @@ public class GatewayReceiverConfigValidator
   public void validate(CacheElementOperation operation, GatewayReceiver config)
       throws IllegalArgumentException {
 
-    if (operation == CacheElementOperation.CREATE) {
-      if (config.getStartPort() == null) {
-        config.setStartPort(DEFAULT_START_PORT);
-      }
+    switch (operation) {
+      case CREATE:
+        if (config.getStartPort() == null) {
+          config.setStartPort(DEFAULT_START_PORT);
+        }
 
-      if (config.getEndPort() == null) {
-        config.setEndPort(DEFAULT_END_PORT);
-      }
+        if (config.getEndPort() == null) {
+          config.setEndPort(DEFAULT_END_PORT);
+        }
 
-      if (config.getStartPort() > config.getEndPort()) {
-        throw new IllegalArgumentException("Start port " + config.getStartPort()
-            + " must be less than the end port " + config.getEndPort() + ".");
-      }
+        if (config.getStartPort() > config.getEndPort()) {
+          throw new IllegalArgumentException("Start port " + config.getStartPort()
+              + " must be less than the end port " + config.getEndPort() + ".");
+        }
+        break;
+      case UPDATE:
+        throw new NotImplementedException("Not implemented");
+      case DELETE:
+      default:
     }
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/IndexValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/IndexValidator.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.management.internal.configuration.validators;
 
+import org.apache.commons.lang3.NotImplementedException;
+
 import org.apache.geode.management.configuration.Index;
 import org.apache.geode.management.configuration.IndexType;
 import org.apache.geode.management.internal.CacheElementOperation;
@@ -24,6 +26,8 @@ public class IndexValidator implements ConfigurationValidator<Index> {
   public void validate(CacheElementOperation operation, Index config)
       throws IllegalArgumentException {
     switch (operation) {
+      case UPDATE:
+        throw new NotImplementedException("Not implemented");
       case CREATE:
         if (config.getName() == null) {
           throw new IllegalArgumentException("Name is required.");

--- a/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidator.java
+++ b/geode-core/src/main/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidator.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.StringUtils;
 
 import org.apache.geode.internal.cache.InternalCache;
@@ -42,6 +43,7 @@ public class RegionConfigValidator implements ConfigurationValidator<Region> {
       throws IllegalArgumentException {
     switch (operation) {
       case UPDATE:
+        throw new NotImplementedException("Not implemented");
       case CREATE:
         validateCreate(config);
         break;

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/DeploymentValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/DeploymentValidatorTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.io.IOException;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -73,9 +74,10 @@ public class DeploymentValidatorTest {
   }
 
   @Test
-  public void validateUpdateIsNotImplemented() {
-    assertThatCode(() -> deploymentValidator.validate(UPDATE, deployment))
-        .doesNotThrowAnyException();
+  public void validateUpdateThrowsNotImplementedException() {
+    assertThatThrownBy(() -> deploymentValidator.validate(UPDATE, deployment))
+        .isInstanceOf(NotImplementedException.class)
+        .hasMessageContaining("Not implemented");
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/DiskStoreValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/DiskStoreValidatorTest.java
@@ -19,10 +19,12 @@
 
 package org.apache.geode.management.internal.configuration.validators;
 
+import static org.apache.geode.management.internal.CacheElementOperation.UPDATE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -163,5 +165,12 @@ public class DiskStoreValidatorTest {
     assertThatThrownBy(() -> diskStoreValidator.validate(CacheElementOperation.CREATE, diskStore))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Dir size cannot be negative :");
+  }
+
+  @Test
+  public void validateUpdateThrowsNotImplementedException() {
+    assertThatThrownBy(() -> diskStoreValidator.validate(UPDATE, diskStore))
+        .isInstanceOf(NotImplementedException.class)
+        .hasMessageContaining("Not implemented");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/GatewayReceiverConfigValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/GatewayReceiverConfigValidatorTest.java
@@ -15,8 +15,10 @@
 
 package org.apache.geode.management.internal.configuration.validators;
 
+import static org.apache.geode.management.internal.CacheElementOperation.UPDATE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -35,7 +37,7 @@ public class GatewayReceiverConfigValidatorTest {
   }
 
   @Test
-  public void startPort() throws Exception {
+  public void startPort() {
     receiver.setStartPort(6000);
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, receiver))
         .isInstanceOf(IllegalArgumentException.class)
@@ -43,7 +45,7 @@ public class GatewayReceiverConfigValidatorTest {
   }
 
   @Test
-  public void endPort() throws Exception {
+  public void endPort() {
     receiver.setEndPort(4000);
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, receiver))
         .isInstanceOf(IllegalArgumentException.class)
@@ -51,11 +53,18 @@ public class GatewayReceiverConfigValidatorTest {
   }
 
   @Test
-  public void startPortEndPort() throws Exception {
+  public void startPortEndPort() {
     receiver.setStartPort(2000);
     receiver.setEndPort(1900);
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, receiver))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Start port 2000 must be less than the end port 1900");
+  }
+
+  @Test
+  public void validateUpdateThrowsNotImplementedException() {
+    assertThatThrownBy(() -> validator.validate(UPDATE, receiver))
+        .isInstanceOf(NotImplementedException.class)
+        .hasMessageContaining("Not implemented");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/IndexValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/IndexValidatorTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.configuration.validators;
 
+import static org.apache.geode.management.internal.CacheElementOperation.UPDATE;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -103,6 +105,12 @@ public class IndexValidatorTest {
       softly.assertThatThrownBy(() -> indexValidator.validate(CacheElementOperation.DELETE, index))
           .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("Name is required");
     });
+  }
 
+  @Test
+  public void validateUpdateThrowsNotImplementedException() {
+    assertThatThrownBy(() -> indexValidator.validate(UPDATE, index))
+        .isInstanceOf(NotImplementedException.class)
+        .hasMessageContaining("Not implemented");
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidatorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/configuration/validators/RegionConfigValidatorTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.geode.management.internal.configuration.validators;
 
+import static org.apache.geode.management.internal.CacheElementOperation.UPDATE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -25,6 +26,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -284,5 +286,12 @@ public class RegionConfigValidatorTest {
     assertThatThrownBy(() -> validator.validate(CacheElementOperation.CREATE, config))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("ObjectSizer must not be set for: ENTRY_COUNT");
+  }
+
+  @Test
+  public void validateUpdateThrowsNotImplementedException() {
+    assertThatThrownBy(() -> validator.validate(UPDATE, config))
+        .isInstanceOf(NotImplementedException.class)
+        .hasMessageContaining("Not implemented");
   }
 }

--- a/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/ClusterManagementSecurityRestIntegrationTest.java
+++ b/geode-web-management/src/integrationTest/java/org/apache/geode/management/internal/rest/ClusterManagementSecurityRestIntegrationTest.java
@@ -20,6 +20,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -107,6 +108,10 @@ public class ClusterManagementSecurityRestIntegrationTest {
     testContexts.add(new TestContext(get("/v1/members/server1"), "CLUSTER:READ"));
 
     testContexts.add(new TestContext(post("/v1/configurations/pdx"), "CLUSTER:MANAGE")
+        .setContent(mapper.writeValueAsString(new PdxType())));
+    testContexts.add(new TestContext(put("/v1/configurations/pdx"), "CLUSTER:MANAGE")
+        .setContent(mapper.writeValueAsString(new PdxType())));
+    testContexts.add(new TestContext(delete("/v1/configurations/pdx"), "CLUSTER:MANAGE")
         .setContent(mapper.writeValueAsString(new PdxType())));
     testContexts.add(new TestContext(get("/v1/configurations/pdx"), "CLUSTER:READ"));
 

--- a/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/PdxManagementController.java
+++ b/geode-web-management/src/main/java/org/apache/geode/management/internal/rest/controllers/PdxManagementController.java
@@ -24,8 +24,10 @@ import io.swagger.annotations.ApiResponses;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -57,5 +59,24 @@ public class PdxManagementController extends AbstractManagementController {
   @GetMapping(PDX_ENDPOINT)
   public ClusterManagementGetResult<Pdx, PdxInfo> getPDX() {
     return clusterManagementService.get(new Pdx());
+  }
+
+  @ApiOperation(value = "update pdx")
+  @ApiResponses({
+      @ApiResponse(code = 400, message = "Bad request."),
+      @ApiResponse(code = 500, message = "Internal error.")})
+  @PreAuthorize("@securityService.authorize('CLUSTER', 'MANAGE')")
+  @PutMapping(PDX_ENDPOINT)
+  public ResponseEntity<ClusterManagementResult> updatePdx(@RequestBody Pdx pdxType) {
+    ClusterManagementResult result = clusterManagementService.update(pdxType);
+
+    return new ResponseEntity<>(result, HttpStatus.CREATED);
+  }
+
+  @ApiOperation(value = "delete pdx")
+  @PreAuthorize("@securityService.authorize('CLUSTER', 'MANAGE')")
+  @DeleteMapping(PDX_ENDPOINT)
+  public ClusterManagementResult deletePDX() {
+    return clusterManagementService.delete(new Pdx());
   }
 }


### PR DESCRIPTION
Add update (HTTP put) and delete (HTTP DELETE) operations support for
PDX in the cluster management REST API service.

- Add and update unit and integration tests.
- Keep old update behaviour (NotImplementedException thrown) for cache
  configurations other than PDX.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [X] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
