### PR TITLE
GEODE-10193: Replace openhft compiler with geode-junit compiler

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -278,11 +278,6 @@
         <version>2.4.7</version>
       </dependency>
       <dependency>
-        <groupId>net.openhft</groupId>
-        <artifactId>compiler</artifactId>
-        <version>2.4.1</version>
-      </dependency>
-      <dependency>
         <groupId>net.sf.jopt-simple</groupId>
         <artifactId>jopt-simple</artifactId>
         <version>5.0.4</version>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -137,7 +137,6 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'net.java.dev.jna', name: 'jna', version: '5.11.0')
         api(group: 'net.java.dev.jna', name: 'jna-platform', version: '5.11.0')
         api(group: 'net.minidev', name: 'json-smart', version: '2.4.7')
-        api(group: 'net.openhft', name: 'compiler', version: '2.4.1')
         api(group: 'net.sf.jopt-simple', name: 'jopt-simple', version: '5.0.4')
         api(group: 'net.sourceforge.pmd', name: 'pmd-java', version: '6.42.0')
         api(group: 'net.sourceforge.pmd', name: 'pmd-test', version: '6.42.0')

--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -385,7 +385,6 @@ dependencies {
   }
   distributedTestImplementation('pl.pragmatists:JUnitParams')
   distributedTestImplementation('com.jayway.jsonpath:json-path-assert')
-  distributedTestImplementation('net.openhft:compiler')
 
   distributedTestRuntimeOnly('org.apache.derby:derby')
 

--- a/geode-junit/src/main/java/org/apache/geode/test/compiler/InMemoryClassFileLoader.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/compiler/InMemoryClassFileLoader.java
@@ -11,38 +11,28 @@
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
+ *
  */
+
 package org.apache.geode.test.compiler;
 
-import java.io.ByteArrayOutputStream;
-import java.io.OutputStream;
-import java.net.URI;
+import static java.util.stream.Collectors.toList;
 
-import javax.tools.SimpleJavaFileObject;
+import java.util.List;
 
 /**
- * In-memory representation of the name and bytecode of a Java class.
+ * Loads classes described by in-memory class files.
  */
-public class InMemoryClassFile extends SimpleJavaFileObject {
-  private final String name;
-  private ByteArrayOutputStream out;
-
-  public InMemoryClassFile(String name) {
-    super(URI.create("string:///" + name.replace('.', '/') + Kind.CLASS.extension), Kind.CLASS);
-    this.name = name;
+public class InMemoryClassFileLoader extends ClassLoader {
+  public List<Class<?>> defineClasses(List<InMemoryClassFile> classFiles) {
+    return classFiles.stream()
+        .map(this::defineClass)
+        .collect(toList());
   }
 
-  @Override
-  public String getName() {
-    return name;
-  }
-
-  @Override
-  public OutputStream openOutputStream() {
-    return out = new ByteArrayOutputStream();
-  }
-
-  public byte[] getByteContent() {
-    return out.toByteArray();
+  public Class<?> defineClass(InMemoryClassFile classFile) {
+    String name = classFile.getName();
+    byte[] bytes = classFile.getByteContent();
+    return defineClass(name, bytes, 0, bytes.length);
   }
 }

--- a/geode-junit/src/main/java/org/apache/geode/test/compiler/InMemoryFileManager.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/compiler/InMemoryFileManager.java
@@ -23,6 +23,9 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 
+/**
+ * In-memory file manager used by an {@link InMemoryJavaCompiler}.
+ */
 public class InMemoryFileManager extends ForwardingJavaFileManager<JavaFileManager> {
   List<InMemoryClassFile> compiledClassFiles = new ArrayList<>();
 

--- a/geode-junit/src/main/java/org/apache/geode/test/compiler/InMemoryJavaCompiler.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/compiler/InMemoryJavaCompiler.java
@@ -34,7 +34,6 @@ import javax.tools.ToolProvider;
 import com.google.common.base.Charsets;
 import org.apache.commons.io.FileUtils;
 
-
 public class InMemoryJavaCompiler {
   private String classpath = System.getProperty("java.class.path");
 

--- a/geode-junit/src/main/java/org/apache/geode/test/compiler/InMemorySourceFile.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/compiler/InMemorySourceFile.java
@@ -22,6 +22,9 @@ import javax.tools.SimpleJavaFileObject;
 
 import org.apache.commons.lang3.StringUtils;
 
+/**
+ * In-memory representation of the name and source code of a Java class.
+ */
 public class InMemorySourceFile extends SimpleJavaFileObject {
   private final String name;
   private final String sourceCode;
@@ -44,7 +47,6 @@ public class InMemorySourceFile extends SimpleJavaFileObject {
 
   static InMemorySourceFile fromSourceCode(String sourceCode) {
     String className = new ClassNameExtractor().extractFromSourceCode(sourceCode);
-    System.out.println("DHE: extracted class name: " + className);
     return new InMemorySourceFile(className, sourceCode);
   }
 


### PR DESCRIPTION
PROBLEM

`QueryPdxDataDUnitTest` compiles and loads classes using the
`net.openhft.compiler` library, which attempts to access a field of
`Unsafe` that does not exist on JDK 17.

SOLUTION

Use the compiler system from `geode-junit`'s
`org.apache.geode.test.compiler` package.
