### PR TITLE
GEODE-10232: reformat list for more reliable rendering

### DIFF
--- a/geode-docs/developing/function_exec/how_function_execution_works.html.md.erb
+++ b/geode-docs/developing/function_exec/how_function_execution_works.html.md.erb
@@ -25,13 +25,13 @@ You can execute data-independent functions or data-dependent functions in <%=var
 
 **For Data-independent Functions**
 
--   **On a specific member or members—**Execute the function within a peer-to-peer cluster, specifying the member or members where you want to run the function by using `FunctionService` methods `onMember()` and `onMembers()`.
--   **On a specific server or set of servers—**If you are connected to a cluster as a client, you can execute the function on a server or servers configured for a specific connection pool, or on a server or servers connected to a given cache using the default connection pool. For data-independent functions on client/server architectures, a client invokes `FunctionService` methods `onServer()` or `onServers()`. (See [How Client/Server Connections Work](../../topologies_and_comm/topology_concepts/how_the_pool_manages_connections.html) for details regarding pool connections.)
--   **On member groups or on a single member within each member group—**You can organize members into logical member groups. (See [Configuring and Running a Cluster](../../configuring/chapter_overview.html#concept_lrh_gyq_s4) for more information about using member groups.) You can invoke a data independent function on all members in a specified member group or member groups, or execute the function on only one member of each specified member group.
+-   **On a specific member or members:** Execute the function within a peer-to-peer cluster, specifying the member or members where you want to run the function by using `FunctionService` methods `onMember()` and `onMembers()`.
+-   **On a specific server or set of servers:** If you are connected to a cluster as a client, you can execute the function on a server or servers configured for a specific connection pool, or on a server or servers connected to a given cache using the default connection pool. For data-independent functions on client/server architectures, a client invokes `FunctionService` methods `onServer()` or `onServers()`. (See [How Client/Server Connections Work](../../topologies_and_comm/topology_concepts/how_the_pool_manages_connections.html) for details regarding pool connections.)
+-   **On member groups or on a single member within each member group:** You can organize members into logical member groups. (See [Configuring and Running a Cluster](../../configuring/chapter_overview.html#concept_lrh_gyq_s4) for more information about using member groups.) You can invoke a data independent function on all members in a specified member group or member groups, or execute the function on only one member of each specified member group.
 
 **For Data-dependent Functions**
 
--   **On a region—**If you are executing a data-dependent function, specify a region and, optionally, a set of keys on which to run the function. The method `FunctionService.onRegion()` directs a data-dependent function to execute on a specific region.
+-   **On a region:** If you are executing a data-dependent function, specify a region and, optionally, a set of keys on which to run the function. The method `FunctionService.onRegion()` directs a data-dependent function to execute on a specific region.
 
 See the `org.apache.geode.cache.execute.FunctionService` Java API documentation for more details.
 


### PR DESCRIPTION
The How Function Execution Works page contains a bullet list with bold elements and en-dashes (apparently entered via keyboard shortcuts) that are not always interpreted in the same way by different Markdown interpreters.
Simplified the layout for more reliable output by replacing each en-dash with a colon+space combination.