### PR TITLE
GEODE-10235: fix --maxHeap for java 17

### DIFF
--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartLocatorCommandTest.java
@@ -14,12 +14,14 @@
  */
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_PORT;
 import static org.apache.geode.distributed.ConfigurationProperties.STATISTIC_SAMPLE_RATE;
 import static org.apache.geode.distributed.LocatorLauncher.Command.START;
+import static org.apache.geode.management.internal.cli.commands.MemberJvmOptions.getGcJvmOptions;
 import static org.apache.geode.management.internal.cli.commands.MemberJvmOptions.getMemberJvmOptions;
 import static org.apache.geode.management.internal.cli.commands.VerifyCommandLine.verifyCommandLine;
 import static org.apache.geode.util.internal.GeodeGlossary.GEMFIRE_PREFIX;
@@ -252,8 +254,7 @@ class StartLocatorCommandTest {
       final String heapSize = "1024m";
       expectedJvmOptions.add("-Xms" + heapSize);
       expectedJvmOptions.add("-Xmx" + heapSize);
-      expectedJvmOptions.add("-XX:+UseConcMarkSweepGC");
-      expectedJvmOptions.add("-XX:CMSInitiatingOccupancyFraction=60");
+      expectedJvmOptions.addAll(getGcJvmOptions(emptyList()));
 
       String[] commandLine =
           startLocatorCommand.createStartLocatorCommandLine(locatorLauncher,

--- a/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandTest.java
+++ b/geode-assembly/src/test/java/org/apache/geode/management/internal/cli/commands/StartServerCommandTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.management.internal.cli.commands;
 
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toSet;
 import static org.apache.geode.distributed.ConfigurationProperties.DISABLE_AUTO_RECONNECT;
 import static org.apache.geode.distributed.ConfigurationProperties.HTTP_SERVICE_BIND_ADDRESS;
@@ -25,6 +26,7 @@ import static org.apache.geode.distributed.ServerLauncher.Command.START;
 import static org.apache.geode.internal.lang.SystemUtils.IBM_J9_JVM_NAME;
 import static org.apache.geode.internal.lang.SystemUtils.JAVA_HOTSPOT_JVM_NAME;
 import static org.apache.geode.internal.lang.SystemUtils.ORACLE_JROCKIT_JVM_NAME;
+import static org.apache.geode.management.internal.cli.commands.MemberJvmOptions.getGcJvmOptions;
 import static org.apache.geode.management.internal.cli.commands.MemberJvmOptions.getMemberJvmOptions;
 import static org.apache.geode.management.internal.cli.commands.StartServerCommand.addJvmOptionsForOutOfMemoryErrors;
 import static org.apache.geode.management.internal.cli.commands.VerifyCommandLine.verifyCommandLine;
@@ -403,8 +405,7 @@ class StartServerCommandTest {
       final String heapSize = "1024m";
       expectedJvmOptions.add("-Xms" + heapSize);
       expectedJvmOptions.add("-Xmx" + heapSize);
-      expectedJvmOptions.add("-XX:+UseConcMarkSweepGC");
-      expectedJvmOptions.add("-XX:CMSInitiatingOccupancyFraction=60");
+      expectedJvmOptions.addAll(getGcJvmOptions(emptyList()));
 
       final String[] customJvmOptions = {
           "-verbose:gc",

--- a/geode-gfsh/build.gradle
+++ b/geode-gfsh/build.gradle
@@ -48,6 +48,7 @@ dependencies {
   integrationTestImplementation(project(':geode-dunit'))
   integrationTestImplementation('pl.pragmatists:JUnitParams')
   integrationTestRuntimeOnly('org.apache.derby:derby')
+  integrationTestImplementation('org.junit.jupiter:junit-jupiter-migrationsupport')
 
   distributedTestImplementation(project(':geode-dunit'))
   distributedTestImplementation('pl.pragmatists:JUnitParams')

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartMemberUtilsTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/StartMemberUtilsTest.java
@@ -159,6 +159,11 @@ public class StartMemberUtilsTest {
 
   }
 
+  private static int getJavaMajorVersion() {
+    String version = System.getProperty("java.specification.version");
+    return Integer.parseInt(version.substring(version.indexOf('.') + 1));
+  }
+
   @Test
   public void testAddMaxHeap() {
     List<String> baseCommandLine = new ArrayList<>();
@@ -172,9 +177,14 @@ public class StartMemberUtilsTest {
 
     // Only Max Heap Option Set
     StartMemberUtils.addMaxHeap(baseCommandLine, "32g");
-    assertThat(baseCommandLine.size()).isEqualTo(3);
-    assertThat(baseCommandLine).containsExactly("-Xmx32g", "-XX:+UseConcMarkSweepGC",
-        "-XX:CMSInitiatingOccupancyFraction=" + StartMemberUtils.CMS_INITIAL_OCCUPANCY_FRACTION);
+    if (getJavaMajorVersion() < 14) {
+      assertThat(baseCommandLine.size()).isEqualTo(3);
+      assertThat(baseCommandLine).containsExactly("-Xmx32g", "-XX:+UseConcMarkSweepGC",
+          "-XX:CMSInitiatingOccupancyFraction=" + StartMemberUtils.CMS_INITIAL_OCCUPANCY_FRACTION);
+    } else {
+      assertThat(baseCommandLine.size()).isEqualTo(1);
+      assertThat(baseCommandLine).containsExactly("-Xmx32g");
+    }
 
     // All Options Set
     List<String> customCommandLine = new ArrayList<>(

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
@@ -135,18 +135,27 @@ class StartMemberUtils {
     }
   }
 
+  private static int getJavaMajorVersion() {
+    String version = System.getProperty("java.specification.version");
+    return Integer.parseInt(version.substring(version.indexOf('.') + 1));
+  }
+
   static void addMaxHeap(final List<String> commandLine, final String maxHeap) {
     if (StringUtils.isNotBlank(maxHeap)) {
       commandLine.add("-Xmx" + maxHeap);
 
-      String collectorKey = "-XX:+UseConcMarkSweepGC";
-      if (!commandLine.contains(collectorKey)) {
-        commandLine.add(collectorKey);
-      }
+      if (getJavaMajorVersion() < 14) {
+        String collectorKey = "-XX:+UseConcMarkSweepGC";
+        if (!commandLine.contains(collectorKey)) {
+          commandLine.add(collectorKey);
+        }
 
-      String occupancyFractionKey = "-XX:CMSInitiatingOccupancyFraction=";
-      if (commandLine.stream().noneMatch(s -> s.contains(occupancyFractionKey))) {
-        commandLine.add(occupancyFractionKey + CMS_INITIAL_OCCUPANCY_FRACTION);
+        String occupancyFractionKey = "-XX:CMSInitiatingOccupancyFraction=";
+        if (commandLine.stream().noneMatch(s -> s.contains(occupancyFractionKey))) {
+          commandLine.add(occupancyFractionKey + CMS_INITIAL_OCCUPANCY_FRACTION);
+        }
+      } else {
+        // TODO: configure ZGC?
       }
     }
   }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/StartMemberUtils.java
@@ -50,7 +50,6 @@ class StartMemberUtils {
   static final String GEODE_HOME = System.getenv("GEODE_HOME");
 
   private static final String JAVA_HOME = System.getProperty("java.home");
-  static final int CMS_INITIAL_OCCUPANCY_FRACTION = 60;
   @Immutable
   private static final ThreePhraseGenerator nameGenerator = new ThreePhraseGenerator();
 
@@ -135,28 +134,10 @@ class StartMemberUtils {
     }
   }
 
-  private static int getJavaMajorVersion() {
-    String version = System.getProperty("java.specification.version");
-    return Integer.parseInt(version.substring(version.indexOf('.') + 1));
-  }
-
   static void addMaxHeap(final List<String> commandLine, final String maxHeap) {
     if (StringUtils.isNotBlank(maxHeap)) {
       commandLine.add("-Xmx" + maxHeap);
-
-      if (getJavaMajorVersion() < 14) {
-        String collectorKey = "-XX:+UseConcMarkSweepGC";
-        if (!commandLine.contains(collectorKey)) {
-          commandLine.add(collectorKey);
-        }
-
-        String occupancyFractionKey = "-XX:CMSInitiatingOccupancyFraction=";
-        if (commandLine.stream().noneMatch(s -> s.contains(occupancyFractionKey))) {
-          commandLine.add(occupancyFractionKey + CMS_INITIAL_OCCUPANCY_FRACTION);
-        }
-      } else {
-        // TODO: configure ZGC?
-      }
+      commandLine.addAll(MemberJvmOptions.getGcJvmOptions(commandLine));
     }
   }
 


### PR DESCRIPTION
The product code will no longer add CMS args for java versions that do not support CMS.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
