### PR TITLE
GEODE-10035: fix BufferPool sys prop logic

### DIFF
--- a/geode-core/build.gradle
+++ b/geode-core/build.gradle
@@ -336,6 +336,7 @@ dependencies {
   testImplementation(project(path: ':geode-core', configuration: 'raOutput'))
   testImplementation('org.springframework:spring-web')
   testImplementation(files("${System.getProperty('java.home')}/../lib/tools.jar"))
+  testImplementation('org.junit-pioneer:junit-pioneer')
 
   testCompileOnly('org.jetbrains:annotations')
 

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
@@ -76,8 +76,17 @@ public class BufferPool {
   /**
    * use direct ByteBuffers instead of heap ByteBuffers for NIO operations
    */
-  public static final boolean useDirectBuffers = !Boolean.getBoolean("p2p.nodirectBuffers")
-      || Boolean.getBoolean(GeodeGlossary.GEMFIRE_PREFIX + "BufferPool.useHeapBuffers");
+  public static final boolean useDirectBuffers = computeUseDirectBuffers();
+
+  static boolean computeUseDirectBuffers() {
+    if (Boolean.getBoolean("p2p.nodirectBuffers")) {
+      return false;
+    }
+    if (Boolean.getBoolean(GeodeGlossary.GEMFIRE_PREFIX + "BufferPool.useHeapBuffers")) {
+      return false;
+    }
+    return true;
+  }
 
   /**
    * Should only be called by threads that have currently acquired send permission.

--- a/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/net/BufferPool.java
@@ -82,10 +82,7 @@ public class BufferPool {
     if (Boolean.getBoolean("p2p.nodirectBuffers")) {
       return false;
     }
-    if (Boolean.getBoolean(GeodeGlossary.GEMFIRE_PREFIX + "BufferPool.useHeapBuffers")) {
-      return false;
-    }
-    return true;
+    return !Boolean.getBoolean(GeodeGlossary.GEMFIRE_PREFIX + "BufferPool.useHeapBuffers");
   }
 
   /**


### PR DESCRIPTION
Now if either system property is set to true that takes precedence
and heap buffers will be used. Otherwise, direct buffers will be used.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
