### PR TITLE
GEODE-10223: Fix BlockingCommandListnerTest to be less flaky.

### DIFF
--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/eventing/BlockingCommandListenerTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/eventing/BlockingCommandListenerTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.redis.internal.eventing;
 
+import static java.lang.Thread.sleep;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -45,20 +46,20 @@ import org.apache.geode.redis.internal.netty.ExecutionHandlerContext;
 public class BlockingCommandListenerTest {
 
   @Test
-  public void testTimeoutIsAdjusted() {
+  public void testTimeoutIsAdjusted() throws InterruptedException {
     ExecutionHandlerContext context = mock(ExecutionHandlerContext.class);
     List<byte[]> commandArgs = Arrays.asList("KEY".getBytes(), "0".getBytes());
     Command command = new Command(RedisCommandType.BLPOP, commandArgs);
     BlockingCommandListener listener =
         new BlockingCommandListener(context, command, Collections.emptyList(), 1.0D);
-
+    sleep(100);
     listener.resubmitCommand();
 
     ArgumentCaptor<Command> argumentCaptor = ArgumentCaptor.forClass(Command.class);
     verify(context, times(1)).resubmitCommand(argumentCaptor.capture());
 
     double timeout = Coder.bytesToDouble(argumentCaptor.getValue().getCommandArguments().get(0));
-    await().untilAsserted(() -> assertThat(timeout).isLessThan(1.0D));
+    assertThat(timeout).isLessThan(1.0D);
   }
 
   @Test

--- a/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/eventing/BlockingCommandListenerTest.java
+++ b/geode-for-redis/src/integrationTest/java/org/apache/geode/redis/internal/eventing/BlockingCommandListenerTest.java
@@ -58,7 +58,7 @@ public class BlockingCommandListenerTest {
     verify(context, times(1)).resubmitCommand(argumentCaptor.capture());
 
     double timeout = Coder.bytesToDouble(argumentCaptor.getValue().getCommandArguments().get(0));
-    assertThat(timeout).isLessThan(1.0D);
+    await().untilAsserted(() -> assertThat(timeout).isLessThan(1.0D));
   }
 
   @Test


### PR DESCRIPTION
testTimeoutIsAdjusted is flaky on windows machines. This will fix it to
be less flaky.

Authored-by: Bala Kaza Venkata <bkazavenkata@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
