### PR TITLE
GEODE-10197: fix test for jdk17

### DIFF
--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -15,6 +15,8 @@
 
 package org.apache.geode.redis;
 
+import static org.apache.commons.lang3.JavaVersion.JAVA_13;
+import static org.apache.commons.lang3.SystemUtils.isJavaVersionAtMost;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.management.internal.i18n.CliStrings.START_LOCATOR;
 import static org.apache.geode.management.internal.i18n.CliStrings.START_LOCATOR__DIR;
@@ -143,8 +145,10 @@ public class OutOfMemoryDUnitTest {
         .addOption(START_SERVER__INITIAL_HEAP, "125m")
         .addOption(START_SERVER__MAXHEAP, "125m")
         .addOption(START_SERVER__CRITICAL__HEAP__PERCENTAGE, "50")
-        .addOption(START_SERVER__J, "-XX:CMSInitiatingOccupancyFraction=45")
         .addOption(START_SERVER__CLASSPATH, redisHome.getGeodeForRedisHome() + "/lib/*");
+    if (isJavaVersionAtMost(JAVA_13)) {
+      startServerCommand.addOption(START_SERVER__J, "-XX:CMSInitiatingOccupancyFraction=45");
+    }
     gfsh.executeAndAssertThat(startServerCommand.getCommandString()).statusIsSuccess();
   }
 


### PR DESCRIPTION
OutOfMemoryDUnitTest now only uses CMS on jdk less than 14.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
