### PR TITLE
GEODE-10242: Generate tail key after all child regions become primary

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
@@ -2766,23 +2766,23 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
 
   boolean checkIfAllColocatedChildBucketsBecomePrimary() {
     List<PartitionedRegion> colocatedChildPRs = getColocateNonShadowChildRegions();
-    if (colocatedChildPRs.size() > 0) {
-      for (PartitionedRegion partitionedRegion : colocatedChildPRs) {
-        Bucket bucket = partitionedRegion.getRegionAdvisor().getBucket(getBucket().getId());
-        if (bucket != null) {
-          BucketAdvisor bucketAdvisor = bucket.getBucketAdvisor();
-          if (!bucketAdvisor.checkIfAllColocatedChildBucketsBecomePrimary()) {
+    if (colocatedChildPRs.isEmpty()) {
+      return checkIfBecomesPrimary();
+    }
+    for (PartitionedRegion partitionedRegion : colocatedChildPRs) {
+      Bucket bucket = partitionedRegion.getRegionAdvisor().getBucket(getBucket().getId());
+      if (bucket != null) {
+        BucketAdvisor bucketAdvisor = bucket.getBucketAdvisor();
+        if (!bucketAdvisor.checkIfAllColocatedChildBucketsBecomePrimary()) {
+          return false;
+        } else {
+          if (!checkIfBecomesPrimary()) {
             return false;
-          } else {
-            if (!checkIfBecomesPrimary()) {
-              return false;
-            }
           }
         }
       }
-      return true;
     }
-    return checkIfBecomesPrimary();
+    return true;
   }
 
   @NotNull
@@ -2802,5 +2802,9 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
         return false;
       }
     }
+  }
+
+  boolean hasParent() {
+    return parentAdvisor != null;
   }
 }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketRegion.java
@@ -237,7 +237,7 @@ public class BucketRegion extends DistributedRegion implements Bucket {
     return eventSeqNum;
   }
 
-  boolean notPrimary = true;
+  volatile boolean notPrimary = true;
   boolean allColocatedBucketsBecomePrimary = false;
   private final Object allColocatedBucketsBecomePrimaryLock = new Object();
   boolean alreadyInWaitForAllColocatedBucketsToBecomePrimary = false;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/ColocationHelper.java
@@ -381,9 +381,8 @@ public class ColocationHelper {
     List<PartitionedRegion> colocatedChildRegions =
         getColocatedChildRegions(partitionedRegion, true, false);
 
-    // Fix for 44484 - Make the list of colocated child regions
-    // is always in the same order on all nodes.
-    Collections.sort(colocatedChildRegions, (o1, o2) -> {
+    // Make the list of colocated child regions is always in the same order on all nodes.
+    colocatedChildRegions.sort((o1, o2) -> {
       if (o1.isShadowPR() == o2.isShadowPR()) {
         return o1.getFullPath().compareTo(o2.getFullPath());
       }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketAdvisorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketAdvisorTest.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -207,7 +206,7 @@ class BucketAdvisorTest {
         mock(BucketAdvisor.VolunteeringDelegate.class);
     advisorSpy.setVolunteeringDelegate(volunteeringDelegate);
     advisorSpy.initializePrimaryElector(missingElectorId);
-    Assertions.assertEquals(missingElectorId, advisorSpy.getPrimaryElector());
+    assertThat(missingElectorId).isEqualTo(advisorSpy.getPrimaryElector());
     advisorSpy.volunteerForPrimary();
     verify(volunteeringDelegate).volunteerForPrimary();
   }
@@ -374,7 +373,7 @@ class BucketAdvisorTest {
   }
 
   @Test
-  void checkIfAllColocatedChildBucketsBecomePrimaryRetrunsTrueIfAllChildBucketsArePrimary() {
+  void checkIfAllColocatedChildBucketsBecomePrimaryReturnsTrueIfAllChildBucketsArePrimary() {
     initSetup();
 
     boolean allChildBucketsBecomesPrimary =

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketRegionTest.java
@@ -812,7 +812,7 @@ public class BucketRegionTest {
   }
 
   @Test
-  public void handleWANEventDoesNotSetNotPrimaryIfWas0NotPrimary() {
+  public void handleWANEventDoesNotSetNotPrimaryIfWasNotPrimary() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
             cache, internalRegionArgs, disabledClock()));
@@ -825,20 +825,15 @@ public class BucketRegionTest {
   }
 
   @Test
-  public void onlyOneThreadWillExecuteCheckIfAllChildBucketsFromLeaderBecomePrimary()
-      throws Exception {
+  public void multipleCallsToWaitForAllColocatedBucketsFromLeaderBecomePrimaryWillOnlyInvokeExecuteCheckIfAllChildBucketsFromLeaderBecomePrimaryOnce() {
     BucketRegion bucketRegion =
         spy(new BucketRegion(regionName, regionAttributes, partitionedRegion,
             cache, internalRegionArgs, disabledClock()));
     doNothing().when(bucketRegion).executeCheckIfAllChildBucketsBecomePrimary();
 
-    Future<?> future =
-        executor.runAsync(bucketRegion::waitForAllColocatedBucketsFromLeaderBecomePrimary);
-    Future<?> future2 =
-        executor.runAsync(bucketRegion::waitForAllColocatedBucketsFromLeaderBecomePrimary);
+    bucketRegion.waitForAllColocatedBucketsFromLeaderBecomePrimary();
+    bucketRegion.waitForAllColocatedBucketsFromLeaderBecomePrimary();
 
-    future.get();
-    future2.get();
     assertThat(bucketRegion.alreadyInWaitForAllColocatedBucketsToBecomePrimary).isTrue();
     verify(bucketRegion).executeCheckIfAllChildBucketsBecomePrimary();
   }


### PR DESCRIPTION
 * When an event occurred on a bucket just become primary, it will not
   generate tail key for the event until all the colocated child buckets
   become primary as well. So that tail key will always be generated on the
   same server.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
