### PR TITLE
GEODE-10243: Fail early if old client auth expires

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/BaseCommand.java
@@ -567,7 +567,8 @@ public abstract class BaseCommand implements Command {
     if (cache != null) {
       OldClientSupportService svc = cache.getService(OldClientSupportService.class);
       if (svc != null) {
-        return svc.getThrowable(e, serverConnection.getClientVersion());
+        return svc.getThrowable(e, serverConnection.getClientVersion(),
+            serverConnection.getProxyID());
       }
     }
     return e;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientReAuthenticateMessage.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientReAuthenticateMessage.java
@@ -28,6 +28,11 @@ import org.apache.geode.internal.serialization.SerializationContext;
 public class ClientReAuthenticateMessage implements ClientMessage {
   @Immutable
   public static final KnownVersion RE_AUTHENTICATION_START_VERSION = KnownVersion.GEODE_1_15_0;
+
+  public static final String OLD_CLIENT_AUTHENTICATION_EXPIRED =
+      "Authorization expired for a client with a version less than Geode 1.15. Cannot re-authenticate an older client "
+          + " that has a server to client queue for CQs or interest registrations. "
+          + "Please upgrade your client to Geode 1.15 or greater to allow re-authentication.";
   /**
    * This {@code ClientMessage}'s {@code EventID}
    */

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OldClientSupportService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/tier/sockets/OldClientSupportService.java
@@ -32,7 +32,8 @@ public interface OldClientSupportService extends CacheService {
    * @param clientVersion the version of the client
    * @return the exception to give the client
    */
-  Throwable getThrowable(Throwable theThrowable, KnownVersion clientVersion);
+  Throwable getThrowable(Throwable theThrowable, KnownVersion clientVersion,
+      ClientProxyMembershipID clientId);
 
   /**
    * Process a class name read from a serialized object of unknown origin

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70Test.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/tier/sockets/command/ExecuteFunction70Test.java
@@ -172,7 +172,8 @@ public class ExecuteFunction70Test {
 
   @Test
   public void nonSecureShouldSucceed() throws Exception {
-    when(oldClientSupportService.getThrowable(any(), any())).thenReturn(mock(Throwable.class));
+    when(oldClientSupportService.getThrowable(any(), any(), null))
+        .thenReturn(mock(Throwable.class));
     when(securityService.isClientSecurityRequired()).thenReturn(false);
 
     executeFunction.cmdExecute(message, serverConnection, securityService, 0);
@@ -183,7 +184,8 @@ public class ExecuteFunction70Test {
 
   @Test
   public void withIntegratedSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(oldClientSupportService.getThrowable(any(), any())).thenReturn(mock(Throwable.class));
+    when(oldClientSupportService.getThrowable(any(), any(), null))
+        .thenReturn(mock(Throwable.class));
     when(securityService.isClientSecurityRequired()).thenReturn(true);
     when(securityService.isIntegratedSecurity()).thenReturn(true);
 
@@ -211,7 +213,8 @@ public class ExecuteFunction70Test {
 
   @Test
   public void withOldSecurityShouldSucceedIfAuthorized() throws Exception {
-    when(oldClientSupportService.getThrowable(any(), any())).thenReturn(mock(Throwable.class));
+    when(oldClientSupportService.getThrowable(any(), any(), null))
+        .thenReturn(mock(Throwable.class));
     when(securityService.isClientSecurityRequired()).thenReturn(true);
     when(securityService.isIntegratedSecurity()).thenReturn(false);
 

--- a/geode-old-client-support/src/distributedTest/java/org/apache/geode/OldClientSupportDistributedTest.java
+++ b/geode-old-client-support/src/distributedTest/java/org/apache/geode/OldClientSupportDistributedTest.java
@@ -161,7 +161,8 @@ public class OldClientSupportDistributedTest implements Serializable {
     Object geodeObject = instantiate(geodeClass);
     if (geodeObject instanceof Throwable) {
       Throwable geodeThrowable = (Throwable) instantiate(geodeClass);
-      Throwable gemfireThrowable = oldClientSupport.getThrowable(geodeThrowable, oldClientVersion);
+      Throwable gemfireThrowable = oldClientSupport.getThrowable(geodeThrowable, oldClientVersion,
+          null);
       assertThat(comGemstoneGemFire)
           .withFailMessage("Failed to convert " + geodeClassName + ". Throwable class is "
               + gemfireThrowable.getClass().getName())


### PR DESCRIPTION
We don't support re-authentication of old clients with server->client queues.
1.15 and greater clients will receive a new message to trigger
reauthentication, but older clients have no reliable way to be notified that
they need to re-authenticate themselves when they have a server->client queue.

To make this clear to users, if an AuthenticationExpiredException is ever
triggered for a client that has a server->client queue and is running a version
less than 1.15, we will return an IllegalStateException to the client. If the
exception happens while processing the queue we will log a warning and
immediately disconnect their queue.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
