### PR TITLE
GEODE-10023: do not @link to type params

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/services/result/Result.java
+++ b/geode-core/src/main/java/org/apache/geode/services/result/Result.java
@@ -30,27 +30,27 @@ import org.apache.geode.annotations.Experimental;
 @Experimental
 public interface Result<SuccessType, FailureType> {
   /**
-   * A mapping function that maps to either {@link SuccessType} or {@link FailureType} depending on
+   * A mapping function that maps to either {@code SuccessType} or {@code FailureType} depending on
    * success or
    * failure of the operation.
    *
    * @param successFunction the mapping function to map the SuccessType to the resultant type
    * @param errorFunction the mapping function to map the FailureType to the resultant error type
    * @param <T> the resultant type
-   * @return result of type {@link T}
+   * @return result of type {@code T}
    */
   <T> T map(Function<SuccessType, T> successFunction,
       Function<FailureType, T> errorFunction);
 
   /**
-   * The return message of a successful operation. The return type is of type {@link SuccessType}
+   * The return message of a successful operation. The return type is of type {@code SuccessType}
    *
    * @return the result of the operation
    */
   SuccessType getMessage();
 
   /**
-   * The return message of a failed operation. The return type is of type {@link FailureType}
+   * The return message of a failed operation. The return type is of type {@code FailureType}
    *
    * @return the failure message of why the operation did not succeed.
    */

--- a/geode-core/src/main/java/org/apache/geode/services/result/impl/Success.java
+++ b/geode-core/src/main/java/org/apache/geode/services/result/impl/Success.java
@@ -23,7 +23,7 @@ import org.apache.geode.services.result.ServiceResult;
 
 /**
  * This type of {@link ServiceResult} represents a successful operation. It contains the
- * return value of type {@link SuccessType}
+ * return value of type {@code SuccessType}
  *
  * @param <SuccessType> the result type for a successful operation.
  *

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementOperationResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementOperationResult.java
@@ -52,7 +52,7 @@ public class ClusterManagementOperationResult<A extends ClusterManagementOperati
   /**
    * normally called by {@link ClusterManagementService#start(ClusterManagementOperation)}
    *
-   * @param statusCode the {@link StatusCode} of the result
+   * @param statusCode the {@code StatusCode} of the result
    * @param message the status message to set
    * @param operationStart a {@link Date} representing the time the operation started
    * @param operationEnd a {@link Date} representing the time the operation ended

--- a/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementRealizationResult.java
+++ b/geode-management/src/main/java/org/apache/geode/management/api/ClusterManagementRealizationResult.java
@@ -35,7 +35,7 @@ public class ClusterManagementRealizationResult extends ClusterManagementResult 
   /**
    * for internal use only
    *
-   * @param statusCode the {@link StatusCode} to set
+   * @param statusCode the {@code StatusCode} to set
    * @param message the status message to set
    */
   public ClusterManagementRealizationResult(StatusCode statusCode, String message) {


### PR DESCRIPTION
Some javadocs contained @link tags pointing to type parameters. These
should have been @code tags, as type parameters cannot be linked to

Authored-by: Donal Evans <doevans@vmware.com>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
