### PR TITLE
GEODE-10229: GII image should fill disk region RVV's exceptions.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
@@ -980,8 +980,8 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     AsyncInvocation async3 = createDistributedRegionAsync(R);
     waitForCallbackStarted(R, GIITestHookType.BeforeSavedReceivedRVV);
 
-    doOneDestroy(P, 4, "key2");
-    doOnePut(P, 5, "key1");
+    doOnePut(P, 4, "key1");
+    doOneDestroy(P, 5, "key2");
     R.invoke(
         () -> InitialImageOperation.resetGIITestHook(GIITestHookType.BeforeSavedReceivedRVV, true));
     waitForCallbackStarted(R, GIITestHookType.AfterSavedReceivedRVV);
@@ -992,6 +992,12 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     changeForceFullGII(R, true, true);
     changeForceFullGII(P, false, true);
     verifyDeltaSizeFromStats(R, 2, 0);
+
+    // Now restart R again to re-do GII
+    closeCache(R);
+    createDistributedRegion(R);
+    waitForToVerifyRVV(R, memberP, 5, null, 0); // P's rvv=r5, gc=0
+    verifyTombstoneExist(R, "key2", true, false);
   }
 
   /**
@@ -1038,8 +1044,8 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     AsyncInvocation async3 = createDistributedRegionAsync(R);
     waitForCallbackStarted(R, GIITestHookType.AfterCalculatedUnfinishedOps);
 
-    doOneDestroy(P, 4, "key2");
-    doOnePut(P, 5, "key1");
+    doOnePut(P, 4, "key1");
+    doOneDestroy(P, 5, "key2");
     R.invoke(() -> InitialImageOperation
         .resetGIITestHook(GIITestHookType.AfterCalculatedUnfinishedOps, true));
     waitForCallbackStarted(R, GIITestHookType.AfterSavedReceivedRVV);
@@ -1050,6 +1056,11 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     verifyDeltaSizeFromStats(R, 2, 1);
     changeForceFullGII(R, false, true);
     changeForceFullGII(P, false, true);
+    // Now restart R again to re-do GII
+    closeCache(R);
+    createDistributedRegion(R);
+    waitForToVerifyRVV(R, memberP, 5, null, 0); // P's rvv=r5, gc=0
+    verifyTombstoneExist(R, "key2", true, false);
   }
 
   /*

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
@@ -1003,10 +1003,14 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     verifyDeltaSizeFromStats(R, 2, 0);
     verifyDiskRegionRVV();
 
-    // Now restart R again to re-do GII
+    // Close cache P then restart R to make sure R will recover from its own
+    // then restart P to re-do GII
+    closeCache(P);
     closeCache(R);
     createDistributedRegion(R);
-    waitForToVerifyRVV(R, memberP, 5, null, 0); // P's rvv=r5, gc=0
+    createDistributedRegion(P);
+    waitForToVerifyRVV(P, memberP, 5, null, 0); // P's rvv=r5, gc=0
+    verifyTombstoneExist(P, "key2", true, false);
     verifyTombstoneExist(R, "key2", true, false);
   }
 
@@ -1068,10 +1072,14 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     changeForceFullGII(P, false, true);
     verifyDiskRegionRVV();
 
-    // Now restart R again to re-do GII
+    // Close cache P then restart R to make sure R will recover from its own
+    // then restart P to re-do GII
+    closeCache(P);
     closeCache(R);
     createDistributedRegion(R);
-    waitForToVerifyRVV(R, memberP, 5, null, 0); // P's rvv=r5, gc=0
+    createDistributedRegion(P);
+    waitForToVerifyRVV(P, memberP, 5, null, 0); // P's rvv=r5, gc=0
+    verifyTombstoneExist(P, "key2", true, false);
     verifyTombstoneExist(R, "key2", true, false);
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
@@ -938,6 +938,15 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
+  private void verifyDiskRegionRVV() {
+    DiskStoreID P_ID = getMemberID(P);
+    R.invoke(() -> {
+      LocalRegion lr = (LocalRegion) getCache().getRegion(REGION_NAME);
+      RegionVersionVector drRVV = lr.getDiskRegion().getRegionVersionVector();
+      assertEquals(0, drRVV.getExceptionCount(P_ID));
+    });
+  }
+
   /**
    * P1, P2, P3 R does GII but wait at BeforeSavedReceivedRVV, so R's RVV=P3R0 P4, P5 R goes on to
    * save received RVV. R's new RVV=P5(3-6)R0
@@ -992,6 +1001,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     changeForceFullGII(R, true, true);
     changeForceFullGII(P, false, true);
     verifyDeltaSizeFromStats(R, 2, 0);
+    verifyDiskRegionRVV();
 
     // Now restart R again to re-do GII
     closeCache(R);
@@ -1056,6 +1066,8 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     verifyDeltaSizeFromStats(R, 2, 1);
     changeForceFullGII(R, false, true);
     changeForceFullGII(P, false, true);
+    verifyDiskRegionRVV();
+
     // Now restart R again to re-do GII
     closeCache(R);
     createDistributedRegion(R);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -791,6 +791,13 @@ public abstract class AbstractRegionMap extends BaseRegionMap
                   boolean isSameTombstone = oldRe.isTombstone() && isTombstone
                       && oldRe.getVersionStamp().asVersionTag().equals(entryVersion);
                   if (isSameTombstone) {
+                    if (owner.getDiskRegion() != null
+                        && owner.getDiskRegion().getRegionVersionVector() != null) {
+                      // it's possible the region without persistence has RVV
+                      RegionVersionVector drRVV = owner.getDiskRegion().getRegionVersionVector();
+                      drRVV.recordVersion(entryVersion.getMemberID(),
+                          entryVersion.getRegionVersion());
+                    }
                     return true;
                   }
                   processVersionTagForGII(oldRe, owner, entryVersion, isTombstone, sender,

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -795,8 +795,7 @@ public abstract class AbstractRegionMap extends BaseRegionMap
                         && owner.getDiskRegion().getRegionVersionVector() != null) {
                       // it's possible the region without persistence has RVV
                       RegionVersionVector drRVV = owner.getDiskRegion().getRegionVersionVector();
-                      drRVV.recordVersion(entryVersion.getMemberID(),
-                          entryVersion.getRegionVersion());
+                      drRVV.recordVersion(entryVersion.getMemberID(), entryVersion);
                     }
                     return true;
                   }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/AbstractRegionMap.java
@@ -787,18 +787,6 @@ public abstract class AbstractRegionMap extends BaseRegionMap
                   Assert.assertTrue(entryVersion.getMemberID() != null,
                       "GII entry versions must have identifiers");
                   boolean isTombstone = (newValue == Token.TOMBSTONE);
-                  // don't reschedule the tombstone if it hasn't changed
-                  boolean isSameTombstone = oldRe.isTombstone() && isTombstone
-                      && oldRe.getVersionStamp().asVersionTag().equals(entryVersion);
-                  if (isSameTombstone) {
-                    if (owner.getDiskRegion() != null
-                        && owner.getDiskRegion().getRegionVersionVector() != null) {
-                      // it's possible the region without persistence has RVV
-                      RegionVersionVector drRVV = owner.getDiskRegion().getRegionVersionVector();
-                      drRVV.recordVersion(entryVersion.getMemberID(), entryVersion);
-                    }
-                    return true;
-                  }
                   processVersionTagForGII(oldRe, owner, entryVersion, isTombstone, sender,
                       !wasRecovered || isSynchronizing);
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/InitialImageOperation.java
@@ -471,8 +471,8 @@ public class InitialImageOperation {
               m.unfinishedKeys = keysOfUnfinishedOps;
               if (isDebugEnabled) {
                 logger.debug(
-                    "Region {} recovered with EndGII flag, rvv is {}. recovered rvv is {}. Do delta GII",
-                    region.getFullPath(), m.versionVector, recoveredRVV);
+                    "Region {} recovered with EndGII flag, rvv is {}. Received rvv is {}. Do delta GII",
+                    region.getFullPath(), m.versionVector, received_rvv);
               }
             }
           }
@@ -503,8 +503,8 @@ public class InitialImageOperation {
         }
 
         // do not remove the following log statement
-        logger.info("Region {} requesting initial image from {}",
-            new Object[] {region.getName(), recipient});
+        logger.info("Region {} requesting initial image from {}, recovered RVV is {}",
+            new Object[] {region.getName(), recipient, recoveredRVV});
 
         dm.putOutgoing(m);
         region.cache.getCancelCriterion().checkCancelInProgress(null);

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionHolder.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/versions/RegionVersionHolder.java
@@ -338,7 +338,7 @@ public class RegionVersionHolder<T> implements Cloneable, DataSerializable {
       this.version = version;
       return;
     }
-    if (this.version > version) {
+    if (this.version >= version) {
       addOlderVersion(version);
     }
     this.version = Math.max(this.version, version);

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/AbstractRegionMapTest.java
@@ -886,7 +886,7 @@ public class AbstractRegionMapTest {
   }
 
   @Test
-  public void initialImagePut_givenPutIfAbsentReturningRegionEntryAndSameTombstoneWillAttemptToRemoveREAndInvokeNothingElse()
+  public void initialImagePut_givenPutIfAbsentReturningRegionEntryAndSameTombstoneWillReprocessTheTombstone()
       throws RegionClearedException {
     ConcurrentMapWithReusableEntries map = mock(ConcurrentMapWithReusableEntries.class);
     RegionEntry entry = mock(RegionEntry.class);
@@ -911,8 +911,8 @@ public class AbstractRegionMapTest {
 
     arm.initialImagePut(KEY, 0, Token.TOMBSTONE, false, false, versionTag, null, false);
 
-    verify(map, times(1)).remove(eq(KEY), eq(createdEntry));
-    verify(entry, never()).initialImagePut(any(), anyLong(), any(), anyBoolean(), anyBoolean());
+    verify(map, times(0)).remove(eq(KEY), eq(createdEntry));
+    verify(entry, times(1)).initialImagePut(any(), anyLong(), any(), anyBoolean(), anyBoolean());
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionHolderJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionHolderJUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache.versions;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -64,45 +65,40 @@ public class RegionVersionHolderJUnitTest {
   }
 
   private void fillSpecialExceptionForRVH(boolean useBitSet) {
-    RegionVersionHolder vh1 = null;
-    RegionVersionHolder vh2 = null;
+    RegionVersionHolder<InternalDistributedMember> vh1;
+    RegionVersionHolder<InternalDistributedMember> vh2;
     if (useBitSet) {
-      vh1 = new RegionVersionHolder(member);
-      vh2 = new RegionVersionHolder(member);
+      vh1 = new RegionVersionHolder<>(member);
+      vh2 = new RegionVersionHolder<>(member);
     } else {
-      vh1 = new RegionVersionHolder(0);
-      vh2 = new RegionVersionHolder(0);
+      vh1 = new RegionVersionHolder<>(0);
+      vh2 = new RegionVersionHolder<>(0);
     }
     for (int i = 1; i <= 3; i++) {
       vh1.recordVersion(i);
     }
-
     for (int i = 1; i <= 5; i++) {
       vh2.recordVersion(i);
     }
 
     // create special exception 5(n=6,p=3)
     vh2.initializeFrom(vh1);
-    System.out.println("vh2=" + vh2);
     List<RVVException> exceptionList = vh2.getExceptionForTest();
-    assertEquals(1, exceptionList.size());
+    assertThat(exceptionList.size()).isEqualTo(1);
     RVVException exception = exceptionList.get(0);
-    assertEquals(3, exception.previousVersion);
-    assertEquals(6, exception.nextVersion);
-    System.out.println("vh2=" + vh2);
+    assertThat(exception.previousVersion).isEqualTo(3);
+    assertThat(exception.nextVersion).isEqualTo(6);
 
     vh2.recordVersion(5);
     exceptionList = vh2.getExceptionForTest();
-    assertEquals(1, exceptionList.size());
+    assertThat(exceptionList.size()).isEqualTo(1);
     exception = exceptionList.get(0);
-    assertEquals(3, exception.previousVersion);
-    assertEquals(5, exception.nextVersion);
-    System.out.println("vh2=" + vh2);
+    assertThat(exception.previousVersion).isEqualTo(3);
+    assertThat(exception.nextVersion).isEqualTo(5);
 
     vh2.recordVersion(4);
     exceptionList = vh2.getExceptionForTest();
-    assertEquals(0, exceptionList.size());
-    System.out.println("vh2=" + vh2);
+    assertThat(exceptionList.size()).isEqualTo(0);
   }
 
   @Test

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionHolderJUnitTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/versions/RegionVersionHolderJUnitTest.java
@@ -54,6 +54,58 @@ public class RegionVersionHolderJUnitTest {
   }
 
   @Test
+  public void fillSpecialExceptionForRVHWithBitSet() {
+    fillSpecialExceptionForRVH(true);
+  }
+
+  @Test
+  public void fillSpecialExceptionForRVHWithoutBitSet() {
+    fillSpecialExceptionForRVH(false);
+  }
+
+  private void fillSpecialExceptionForRVH(boolean useBitSet) {
+    RegionVersionHolder vh1 = null;
+    RegionVersionHolder vh2 = null;
+    if (useBitSet) {
+      vh1 = new RegionVersionHolder(member);
+      vh2 = new RegionVersionHolder(member);
+    } else {
+      vh1 = new RegionVersionHolder(0);
+      vh2 = new RegionVersionHolder(0);
+    }
+    for (int i = 1; i <= 3; i++) {
+      vh1.recordVersion(i);
+    }
+
+    for (int i = 1; i <= 5; i++) {
+      vh2.recordVersion(i);
+    }
+
+    // create special exception 5(n=6,p=3)
+    vh2.initializeFrom(vh1);
+    System.out.println("vh2=" + vh2);
+    List<RVVException> exceptionList = vh2.getExceptionForTest();
+    assertEquals(1, exceptionList.size());
+    RVVException exception = exceptionList.get(0);
+    assertEquals(3, exception.previousVersion);
+    assertEquals(6, exception.nextVersion);
+    System.out.println("vh2=" + vh2);
+
+    vh2.recordVersion(5);
+    exceptionList = vh2.getExceptionForTest();
+    assertEquals(1, exceptionList.size());
+    exception = exceptionList.get(0);
+    assertEquals(3, exception.previousVersion);
+    assertEquals(5, exception.nextVersion);
+    System.out.println("vh2=" + vh2);
+
+    vh2.recordVersion(4);
+    exceptionList = vh2.getExceptionForTest();
+    assertEquals(0, exceptionList.size());
+    System.out.println("vh2=" + vh2);
+  }
+
+  @Test
   public void test48066_1() {
     RegionVersionHolder vh1 = new RegionVersionHolder(member);
     for (int i = 1; i <= 3; i++) {


### PR DESCRIPTION
    There're 2 issues: Tombstone in GII image should save version tag into disk region RVV
    even the tombstone is the same as local one. Disk region RVV holder did not use bitset.
    Only bitset based holder can fill special exception. Should do it for non-bitset holder too.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
