### PR TITLE
GEODE-10245: Upgrade classgraph 4.8.143 -> 4.8.145

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -180,7 +180,7 @@
       <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
-        <version>4.8.143</version>
+        <version>4.8.145</version>
       </dependency>
       <dependency>
         <groupId>io.github.resilience4j</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -117,7 +117,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'commons-modeler', name: 'commons-modeler', version: '2.0.1')
         api(group: 'commons-validator', name: 'commons-validator', version: get('commons-validator.version'))
         // Careful when upgrading this dependency: see GEODE-7370 and GEODE-8150.
-        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.143')
+        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.145')
         api(group: 'io.github.resilience4j', name: 'resilience4j-retry', version: '1.7.1')
         api(group: 'io.lettuce', name: 'lettuce-core', version: '6.1.8.RELEASE')
         api(group: 'io.micrometer', name: 'micrometer-core', version: get('micrometer.version'))

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -966,7 +966,7 @@ lib/HdrHistogram-2.1.12.jar
 lib/HikariCP-4.0.3.jar
 lib/LatencyUtils-2.0.3.jar
 lib/antlr-2.7.7.jar
-lib/classgraph-4.8.143.jar
+lib/classgraph-4.8.145.jar
 lib/commons-beanutils-1.9.4.jar
 lib/commons-codec-1.15.jar
 lib/commons-collections-3.2.2.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -53,7 +53,7 @@ commons-collections-3.2.2.jar
 commons-digester-2.1.jar
 commons-io-2.11.0.jar
 commons-logging-1.2.jar
-classgraph-4.8.143.jar
+classgraph-4.8.145.jar
 micrometer-core-1.8.4.jar
 fastutil-8.5.8.jar
 javax.resource-api-1.7.1.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -7,7 +7,7 @@ commons-digester-2.1.jar
 commons-validator-1.7.jar
 spring-jcl-5.3.18.jar
 commons-codec-1.15.jar
-classgraph-4.8.143.jar
+classgraph-4.8.145.jar
 jackson-databind-2.13.2.2.jar
 commons-logging-1.2.jar
 geode-management-0.0.0.jar


### PR DESCRIPTION
- This fixes an issue discovered with the ordering of 'manifest only'
  jars and classgraph unable to find classes.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
