### PR TITLE
GEODE-10246: fix OutOfMemoryDUnitTest for jdk17

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/control/HeapMemoryMonitor.java
@@ -175,6 +175,7 @@ public class HeapMemoryMonitor implements NotificationListener, MemoryMonitor {
         || name.equals("Tenured Gen") // Hitachi 1.5 GC
         || name.equals("Java heap") // IBM 1.5, 1.6 GC
         || name.equals("GenPauseless Old Gen") // azul C4/GPGC collector
+        || name.equals("ZHeap") // ZGC
 
         // Allow an unknown pool name to monitor
         || (HEAP_POOL != null && name.equals(HEAP_POOL));

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -150,7 +150,6 @@ public class OutOfMemoryDUnitTest {
       startServerCommand.addOption(START_SERVER__J, "-XX:CMSInitiatingOccupancyFraction=45");
     } else {
       startServerCommand.addOption(START_SERVER__J, "-XX:+UseZGC");
-      // startServerCommand.addOption(START_SERVER__J, "-XX:SoftMaxHeapSize=65m");
     }
     gfsh.executeAndAssertThat(startServerCommand.getCommandString()).statusIsSuccess();
   }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -184,7 +184,7 @@ public class OutOfMemoryDUnitTest {
 
   @After
   public void tearDown() throws Exception {
-    // removeAllKeysAndForceGC();
+    removeAllKeysAndForceGC();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -182,7 +182,7 @@ public class OutOfMemoryDUnitTest {
 
   @After
   public void tearDown() throws Exception {
-    removeAllKeysAndForceGC();
+    // removeAllKeysAndForceGC();
   }
 
   @Test

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -148,6 +148,9 @@ public class OutOfMemoryDUnitTest {
         .addOption(START_SERVER__CLASSPATH, redisHome.getGeodeForRedisHome() + "/lib/*");
     if (isJavaVersionAtMost(JAVA_13)) {
       startServerCommand.addOption(START_SERVER__J, "-XX:CMSInitiatingOccupancyFraction=45");
+    } else {
+      startServerCommand.addOption(START_SERVER__J, "-XX:+UseZGC");
+      startServerCommand.addOption(START_SERVER__J, "-XX:SoftMaxHeapSize=62m");
     }
     gfsh.executeAndAssertThat(startServerCommand.getCommandString()).statusIsSuccess();
   }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -150,7 +150,7 @@ public class OutOfMemoryDUnitTest {
       startServerCommand.addOption(START_SERVER__J, "-XX:CMSInitiatingOccupancyFraction=45");
     } else {
       startServerCommand.addOption(START_SERVER__J, "-XX:+UseZGC");
-      startServerCommand.addOption(START_SERVER__J, "-XX:SoftMaxHeapSize=65m");
+      // startServerCommand.addOption(START_SERVER__J, "-XX:SoftMaxHeapSize=65m");
     }
     gfsh.executeAndAssertThat(startServerCommand.getCommandString()).statusIsSuccess();
   }

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/OutOfMemoryDUnitTest.java
@@ -150,7 +150,7 @@ public class OutOfMemoryDUnitTest {
       startServerCommand.addOption(START_SERVER__J, "-XX:CMSInitiatingOccupancyFraction=45");
     } else {
       startServerCommand.addOption(START_SERVER__J, "-XX:+UseZGC");
-      startServerCommand.addOption(START_SERVER__J, "-XX:SoftMaxHeapSize=62m");
+      startServerCommand.addOption(START_SERVER__J, "-XX:SoftMaxHeapSize=65m");
     }
     gfsh.executeAndAssertThat(startServerCommand.getCommandString()).statusIsSuccess();
   }


### PR DESCRIPTION
Test now configures ZGC for jdk17.
Also changed the product to know about the ZGC memoryMXBean name "ZHeap".

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
