### PR TITLE
Bugfix/GEODE-10228 DurableClientTestCase.testDurableHAFailover is failing

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/ClientServerRegisterInterestsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/ClientServerRegisterInterestsDUnitTest.java
@@ -20,6 +20,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -207,9 +208,7 @@ public class ClientServerRegisterInterestsDUnitTest extends JUnit4DistributedTes
 
       assertThat(example).describedAs("'Example' Region in Client Cache was not found!")
           .isNotNull();
-      assertThat(example).hasSize(1);
-      assertThat(example).containsKey("1");
-      assertThat(example.get("1")).isEqualTo("ONE");
+      assertThat(example).containsOnly(entry("1", "ONE"));
       assertThat(entryEvents).isEmpty();
 
       String value = put();
@@ -226,8 +225,7 @@ public class ClientServerRegisterInterestsDUnitTest extends JUnit4DistributedTes
       assertThat(entryEvent.getNewValue()).isEqualTo("TWO");
       assertThat(entryEvent.getOldValue()).isNull();
       assertThat(example).hasSize(2);
-      assertThat(example).containsKey("2");
-      assertThat(example.get("2")).isEqualTo("TWO");
+      assertThat(example).contains(entry("2", "TWO"));
     }
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/ClientServerRegisterInterestsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/ClientServerRegisterInterestsDUnitTest.java
@@ -27,8 +27,8 @@ import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -44,7 +44,6 @@ import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
-import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
 /**
  * The ClientServerRegisterInterestsDUnitTest class is a test suite of test cases testing the
@@ -52,7 +51,7 @@ import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
  *
  * @since GemFire 8.0
  */
-@Category({ClientSubscriptionTest.class})
+@Tag("ClientSubscriptionTest")
 public class ClientServerRegisterInterestsDUnitTest extends JUnit4DistributedTestCase {
 
   protected static final long WAIT_TIME_MILLISECONDS = TimeUnit.SECONDS.toMillis(5);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/ClientServerRegisterInterestsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/ClientServerRegisterInterestsDUnitTest.java
@@ -27,8 +27,8 @@ import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheFactory;
@@ -44,6 +44,7 @@ import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
 /**
  * The ClientServerRegisterInterestsDUnitTest class is a test suite of test cases testing the
@@ -51,7 +52,7 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
  *
  * @since GemFire 8.0
  */
-@Tag("ClientSubscriptionTest")
+@Category({ClientSubscriptionTest.class})
 public class ClientServerRegisterInterestsDUnitTest extends JUnit4DistributedTestCase {
 
   protected static final long WAIT_TIME_MILLISECONDS = TimeUnit.SECONDS.toMillis(5);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/ClientServerRegisterInterestsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/ClientServerRegisterInterestsDUnitTest.java
@@ -176,7 +176,7 @@ public class ClientServerRegisterInterestsDUnitTest extends JUnit4DistributedTes
     return clientCache;
   }
 
-  protected <K, V> V put() {
+  protected <V> V put() {
     return (V) gemfireServerVm.invoke(() -> {
       Cache cache = CacheFactory.getAnyInstance();
       cache.getRegion("/Example").put("2", "TWO");

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientBug39997DUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientBug39997DUnitTest.java
@@ -74,8 +74,6 @@ public class DurableClientBug39997DUnitTest extends JUnit4CacheTestCase {
       } catch (NoSubscriptionServersAvailableException expected) {
         // this is expected
       }
-      cache.readyForEvents();
-
     });
 
     vm1.invoke(() -> {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientNoServerAvailabileDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientNoServerAvailabileDUnitTest.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Properties;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.NoSubscriptionServersAvailableException;
@@ -38,8 +38,9 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
-@Tag("ClientSubscriptionTest")
+@Category({ClientSubscriptionTest.class})
 public class DurableClientNoServerAvailabileDUnitTest extends JUnit4CacheTestCase {
 
   @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientNoServerAvailabileDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientNoServerAvailabileDUnitTest.java
@@ -22,8 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Properties;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.NoSubscriptionServersAvailableException;
@@ -38,10 +38,9 @@ import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
-import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
-@Category({ClientSubscriptionTest.class})
-public class DurableClientBug39997DUnitTest extends JUnit4CacheTestCase {
+@Tag("ClientSubscriptionTest")
+public class DurableClientNoServerAvailabileDUnitTest extends JUnit4CacheTestCase {
 
   @Override
   public final void postTearDownCacheTestCase() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientNoServerAvailabileDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientNoServerAvailabileDistributedTest.java
@@ -41,7 +41,7 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
 @Category({ClientSubscriptionTest.class})
-public class DurableClientNoServerAvailabileDUnitTest extends JUnit4CacheTestCase {
+public class DurableClientNoServerAvailabileDistributedTest extends JUnit4CacheTestCase {
 
   @Override
   public final void postTearDownCacheTestCase() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientStatsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientStatsDUnitTest.java
@@ -32,8 +32,8 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.concurrent.RejectedExecutionException;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheException;
@@ -47,9 +47,11 @@ import org.apache.geode.cache30.CacheSerializableRunnable;
 import org.apache.geode.internal.cache.CacheServerImpl;
 import org.apache.geode.internal.cache.PoolFactoryImpl;
 import org.apache.geode.internal.cache.tier.Acceptor;
+import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
 /**
  * The DUnitTest checks whether the following Three counts are incremented correctly or not: 1)
@@ -61,7 +63,7 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
  * In the given test DurableClient comes up and goes down discreetly with different
  * DurableClientTimeouts so as to increment the counts
  */
-@Tag("ClientSubscriptionTest")
+@Category({ClientSubscriptionTest.class})
 public class DurableClientStatsDUnitTest extends JUnit4DistributedTestCase {
 
   private VM server1VM;
@@ -131,6 +133,7 @@ public class DurableClientStatsDUnitTest extends JUnit4DistributedTestCase {
   @Test
   public void testDurableClientStatistics() {
 
+    assertThat(server1VM).isNotNull();
     // Step 1: Starting the servers
     PORT1 = server1VM
         .invoke(() -> createCacheServer(regionName, true));
@@ -176,7 +179,7 @@ public class DurableClientStatsDUnitTest extends JUnit4DistributedTestCase {
     final String durableClientId = getName() + "_client";
 
     durableClientVM.invoke(() -> createCacheClient(
-        getClientPool(VM.getHostName(), PORT1), regionName,
+        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), PORT1), regionName,
         getDurableClientDistributedSystemProperties(durableClientId, durableClientTimeout),
         true));
 
@@ -196,7 +199,9 @@ public class DurableClientStatsDUnitTest extends JUnit4DistributedTestCase {
   public void startRegisterAndCloseNonDurableClientCache() {
 
     durableClientVM
-        .invoke(() -> createCacheClient(getClientPool(VM.getHostName(), PORT1), regionName,
+        .invoke(() -> createCacheClient(
+            getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), PORT1),
+            regionName,
             getNonDurableClientDistributedSystemProperties(), true));
 
     durableClientVM.invoke(() -> DurableClientStatsDUnitTest.registerKey(false));
@@ -209,7 +214,9 @@ public class DurableClientStatsDUnitTest extends JUnit4DistributedTestCase {
     final String durableClientId = getName() + "_client";
 
     durableClientVM
-        .invoke(() -> createCacheClient(getClientPool(VM.getHostName(), PORT1), regionName,
+        .invoke(() -> createCacheClient(
+            getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), PORT1),
+            regionName,
             getDurableClientDistributedSystemProperties(durableClientId, durableClientTimeout),
             true));
 
@@ -228,7 +235,7 @@ public class DurableClientStatsDUnitTest extends JUnit4DistributedTestCase {
   public void startAndCloseNonDurableClientCache() {
 
     durableClientVM.invoke(() -> createCacheClient(
-        getClientPool(VM.getHostName(), PORT1), regionName,
+        getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()), PORT1), regionName,
         getNonDurableClientDistributedSystemProperties(), true));
 
     durableClientVM.invoke(DurableClientStatsDUnitTest::closeCache);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientStatsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientStatsDUnitTest.java
@@ -32,8 +32,8 @@ import java.util.ArrayList;
 import java.util.Properties;
 import java.util.concurrent.RejectedExecutionException;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import org.apache.geode.cache.Cache;
 import org.apache.geode.cache.CacheException;
@@ -50,7 +50,6 @@ import org.apache.geode.internal.cache.tier.Acceptor;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.Wait;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
-import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
 /**
  * The DUnitTest checks whether the following Three counts are incremented correctly or not: 1)
@@ -62,7 +61,7 @@ import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
  * In the given test DurableClient comes up and goes down discreetly with different
  * DurableClientTimeouts so as to increment the counts
  */
-@Category({ClientSubscriptionTest.class})
+@Tag("ClientSubscriptionTest")
 public class DurableClientStatsDUnitTest extends JUnit4DistributedTestCase {
 
   private VM server1VM;

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableRegistrationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableRegistrationDistributedTest.java
@@ -462,6 +462,12 @@ public class DurableRegistrationDistributedTest extends JUnit4DistributedTestCas
             1),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout)));
 
+    // Step 3: Client registers Interests
+    durableClientVM.invoke(() -> registerKey(K1, Boolean.FALSE));
+    durableClientVM.invoke(() -> registerKey(K2, Boolean.FALSE));
+    durableClientVM.invoke(() -> registerKey(K3, Boolean.TRUE));
+    durableClientVM.invoke(() -> registerKey(K4, Boolean.TRUE));
+
     // Send clientReady message
     durableClientVM.invoke("Send clientReady", new CacheSerializableRunnable() {
       @Override
@@ -469,13 +475,6 @@ public class DurableRegistrationDistributedTest extends JUnit4DistributedTestCas
         getClientCache().readyForEvents();
       }
     });
-
-    // Step 3: Client registers Interests
-    durableClientVM.invoke(() -> registerKey(K1, Boolean.FALSE));
-    durableClientVM.invoke(() -> registerKey(K2, Boolean.FALSE));
-    durableClientVM.invoke(() -> registerKey(K3, Boolean.TRUE));
-    durableClientVM.invoke(() -> registerKey(K4, Boolean.TRUE));
-
     // Close Cache of the DurableClient
     durableClientVM.invoke(this::closeCache);
     GeodeAwaitility.await().until(() -> durableClientVM.invoke(() -> getClientCache().isClosed()));

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQDUnitTest.java
@@ -99,7 +99,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     server1VM.invoke(new CacheSerializableRunnable("Close cq for durable client") {
       @Override
@@ -213,7 +213,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, primaryPort, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // Restart the durable client
     CacheServerTestUtil.createCacheClient(
@@ -285,7 +285,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     closeCQsforDurableClient(durableClientId);
 
@@ -359,7 +359,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     closeCQsforDurableClient(durableClientId);
 
@@ -395,7 +395,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     checkHAQueueSize(server1VM, durableClientId, 0, 1);
 
     // continue to publish and make sure we get the events
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
     checkCqListenerEvents(durableClientVM, "GreaterThan5", 4 /* numEventsExpected */,
         /* numEventsToWaitFor */ 10/* secondsToWait */);
     checkCqListenerEvents(durableClientVM, "LessThan5", 5 /* numEventsExpected */,
@@ -495,7 +495,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     server1VM.invoke(new CacheSerializableRunnable("Close cq for durable client 1") {
       @Override
@@ -611,7 +611,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
       startClient(publisherClientVM, server1Port, regionName);
 
       // Publish some entries
-      publishEntries(regionName, 10);
+      publishEntries(publisherClientVM, regionName, 10);
 
       server1VM.invoke(new CacheSerializableRunnable("Set test hook") {
         @Override
@@ -729,7 +729,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
       startClient(publisherClientVM, server1Port, regionName);
 
       // Publish some entries
-      publishEntries(regionName, 10);
+      publishEntries(publisherClientVM, regionName, 10);
 
       AsyncInvocation async =
           server1VM.invokeAsync(new CacheSerializableRunnable("Close cq for durable client") {
@@ -836,7 +836,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // Attempt to close a cq even though the client is running
     server1VM.invoke(new CacheSerializableRunnable("Close cq for durable client") {
@@ -1001,7 +1001,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
 
       // Publish some entries
       final int numberOfEntries = 10;
-      publishEntries(0, numberOfEntries);
+      publishEntries(publisherClientVM, 0, numberOfEntries);
 
       // Verify the durable client received the updates
       checkCqListenerEvents(durableClientVM, cqName, numberOfEntries,
@@ -1017,7 +1017,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
           server1VM);
 
       // Publish some more entries
-      publishEntries(10, numberOfEntries);
+      publishEntries(publisherClientVM, 10, numberOfEntries);
 
       publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQDUnitTest.java
@@ -33,8 +33,8 @@ import static org.junit.Assert.assertFalse;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.InterestResultPolicy;
@@ -59,10 +59,12 @@ import org.apache.geode.internal.cache.ClientServerObserverAdapter;
 import org.apache.geode.internal.cache.ClientServerObserverHolder;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
+import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
-@Tag("ClientSubscriptionTest")
+@Category({ClientSubscriptionTest.class})
 public class DurableClientCQDUnitTest extends DurableClientTestBase {
 
   /**
@@ -901,7 +903,8 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     // Start a durable client
     durableClientId = getName() + "_client";
     durableClientVM.invoke(() -> {
-      createCacheClient(getClientPool(VM.getHostName(), server1Port, server2Port,
+      createCacheClient(getClientPool(NetworkUtils.getServerHostName(durableClientVM.getHost()),
+          server1Port, server2Port,
           true, 0),
           regionName, getClientDistributedSystemProperties(durableClientId, 60), true);
 
@@ -996,7 +999,8 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
 
       // Start normal publisher client
       publisherClientVM.invoke(() -> createCacheClient(
-          getClientPool(VM.getHostName(), server1Port, false),
+          getClientPool(NetworkUtils.getServerHostName(publisherClientVM.getHost()), server1Port,
+              false),
           regionName));
 
       // Publish some entries

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientCQDUnitTest.java
@@ -25,7 +25,6 @@ import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.g
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.getClientCache;
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.getPool;
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
-import static org.apache.geode.test.dunit.NetworkUtils.getServerHostName;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.Assert.assertEquals;
@@ -34,8 +33,8 @@ import static org.junit.Assert.assertFalse;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.InterestResultPolicy;
@@ -60,12 +59,10 @@ import org.apache.geode.internal.cache.ClientServerObserverAdapter;
 import org.apache.geode.internal.cache.ClientServerObserverHolder;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.IgnoredException;
-import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
-@Category({ClientSubscriptionTest.class})
+@Tag("ClientSubscriptionTest")
 public class DurableClientCQDUnitTest extends DurableClientTestBase {
 
   /**
@@ -181,7 +178,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     // Start a durable client that is kept alive on the server when it stops normally
     durableClientId = getName() + "_client";
     createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(), server1Port, server2Port, true, 0),
+        getClientPool(VM.getHostName(), server1Port, server2Port, true, 0),
         regionName, getClientDistributedSystemProperties(durableClientId), true);
 
     // register non durable cq
@@ -220,7 +217,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
 
     // Restart the durable client
     createCacheClient(
-        getClientPool(NetworkUtils.getServerHostName(), primaryPort, true),
+        getClientPool(VM.getHostName(), primaryPort, true),
         regionName, getClientDistributedSystemProperties(durableClientId), true);
     assertThat(getClientCache()).isNotNull();
 
@@ -904,7 +901,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
     // Start a durable client
     durableClientId = getName() + "_client";
     durableClientVM.invoke(() -> {
-      createCacheClient(getClientPool(getServerHostName(), server1Port, server2Port,
+      createCacheClient(getClientPool(VM.getHostName(), server1Port, server2Port,
           true, 0),
           regionName, getClientDistributedSystemProperties(durableClientId, 60), true);
 
@@ -999,7 +996,7 @@ public class DurableClientCQDUnitTest extends DurableClientTestBase {
 
       // Start normal publisher client
       publisherClientVM.invoke(() -> createCacheClient(
-          getClientPool(getServerHostName(), server1Port, false),
+          getClientPool(VM.getHostName(), server1Port, false),
           regionName));
 
       // Publish some entries

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientHAQueuedDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientHAQueuedDUnitTest.java
@@ -65,7 +65,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // verify cq stats are correct
     checkNumDurableCqs(server1VM, durableClientId, 3);
@@ -148,7 +148,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // verify cq stats are correct
     checkNumDurableCqs(server1VM, durableClientId, 3);
@@ -246,7 +246,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // Restart the durable client
     startDurableClient(durableClientVM, durableClientId, server1Port, server2Port, regionName);
@@ -338,7 +338,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // verify cq stats are correct
     checkNumDurableCqs(server1VM, durableClientId, 3);
@@ -429,7 +429,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // verify cq stats are correct on both servers
     checkNumDurableCqs(server1VM, durableClientId, 3);
@@ -538,7 +538,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // Re-start server2, should get events through gii
     server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
@@ -636,7 +636,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // Restart the durable client
     startDurableClient(durableClientVM, durableClientId, server1Port, server2Port, regionName);
@@ -747,7 +747,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // Re-start server2, should get events through gii
     server2VM.invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE,
@@ -848,7 +848,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     closeCache(server1VM);
 
@@ -933,7 +933,7 @@ public class DurableClientHAQueuedDUnitTest extends DurableClientTestBase {
     startClient(publisherClientVM, server1Port, regionName);
 
     // Publish some entries
-    publishEntries(regionName, 10);
+    publishEntries(publisherClientVM, regionName, 10);
 
     // verify cq stats are correct
     checkNumDurableCqs(server1VM, durableClientId, 3);

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
@@ -19,7 +19,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.geode.cache.InterestResultPolicy.NONE;
 import static org.apache.geode.cache.Region.SEPARATOR;
-import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.TYPE_CREATE;
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.createCacheClient;
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.createCacheClientFromXmlN;
@@ -577,7 +576,6 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
 
   @Test
   public void testReadyForEventsNotCalledImplicitlyForRegisterInterestWithCacheXML() {
-    int[] ports = getRandomAvailableTCPPorts(2);
     regionName = "testReadyForEventsNotCalledImplicitlyWithCacheXML_region";
     // Start a server
     server1Port =

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.internal.cache.tier.sockets;
 
-import static java.lang.Boolean.FALSE;
-import static java.lang.Boolean.TRUE;
 import static java.lang.Thread.sleep;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -32,10 +30,6 @@ import static org.apache.geode.test.dunit.Wait.pause;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -68,14 +62,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testSimpleDurableClientUpdate() {
     // Start a server
     server1Port = server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start a durable client that is not kept alive on the server when it stops
     // normally
     final String durableClientId = getName() + "_client";
     durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
         getClientPool(getServerHostName(), server1Port, true), regionName,
-        getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
+        getClientDistributedSystemProperties(durableClientId), true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -111,7 +105,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testMultipleBridgeClientsInSingleDurableVM() {
     // Start a server
     server1Port = server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start a durable client with 2 regions (and 2 BridgeClients) that is not
     // kept alive on the server when it stops normally
@@ -126,7 +120,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     durableClientVM.invoke(new CacheSerializableRunnable("Send clientReady") {
       @Override
       public void run2() throws CacheException {
-        assertEquals(2, PoolManager.getAll().size());
+        assertThat(2).isEqualTo(PoolManager.getAll().size());
         CacheServerTestUtil.getClientCache().readyForEvents();
       }
     });
@@ -142,16 +136,16 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         checkNumberOfClientProxies(2);
         String firstProxyRegionName = null;
         for (CacheClientProxy proxy : notifier.getClientProxies()) {
-          assertTrue(proxy.isDurable());
-          assertEquals(durableClientId, proxy.getDurableId());
-          assertEquals(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT,
-              proxy.getDurableTimeout());
+          assertThat(proxy.isDurable()).isTrue();
+          assertThat(durableClientId).isEqualTo(proxy.getDurableId());
+          assertThat(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT)
+              .isEqualTo(proxy.getDurableTimeout());
 
           // Verify the two HA region names aren't the same
           if (firstProxyRegionName == null) {
             firstProxyRegionName = proxy.getHARegionName();
           } else {
-            assertTrue(!firstProxyRegionName.equals(proxy.getHARegionName()));
+            assertThat(!firstProxyRegionName.equals(proxy.getHARegionName())).isTrue();
           }
         }
       }
@@ -183,14 +177,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testMultipleVMsWithSameDurableId() {
     // Start a server
     server1Port = server1VM
-        .invoke(() -> createCacheServer(regionName, TRUE));
+        .invoke(() -> createCacheServer(regionName, true));
 
     // Start a durable client that is not kept alive on the server when it
     // stops normally
     final String durableClientId = getName() + "_client";
     durableClientVM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, true), regionName,
-        getClientDistributedSystemProperties(durableClientId), TRUE));
+        getClientDistributedSystemProperties(durableClientId), true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -249,7 +243,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testSimpleTwoDurableClients() {
     // Start a server
     server1Port = server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start a durable client that is not kept alive on the server when it
     // stops normally
@@ -283,18 +277,18 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         checkNumberOfClientProxies(2);
         boolean durableClient1Found = false, durableClient2Found = false;
         for (CacheClientProxy proxy : notifier.getClientProxies()) {
-          assertTrue(proxy.isDurable());
+          assertThat(proxy.isDurable()).isTrue();
           if (proxy.getDurableId().equals(durableClientId)) {
             durableClient1Found = true;
           }
           if (proxy.getDurableId().equals(durableClientId2)) {
             durableClient2Found = true;
           }
-          assertEquals(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT,
-              proxy.getDurableTimeout());
+          assertThat(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT)
+              .isEqualTo(proxy.getDurableTimeout());
         }
-        assertTrue(durableClient1Found);
-        assertTrue(durableClient2Found);
+        assertThat(durableClient1Found).isTrue();
+        assertThat(durableClient2Found).isTrue();
       }
     });
 
@@ -315,11 +309,11 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testDurableClientMultipleServersOneLive() throws InterruptedException {
     // Start server 1
     server1Port = server1VM
-        .invoke(() -> createCacheServer(regionName, TRUE));
+        .invoke(() -> createCacheServer(regionName, true));
 
     // Start server 2
     final int server2Port = server2VM
-        .invoke(() -> createCacheServer(regionName, TRUE));
+        .invoke(() -> createCacheServer(regionName, true));
 
     // Stop server 2
     server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
@@ -332,7 +326,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     durableClientVM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
-        TRUE));
+        true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -355,7 +349,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     sleep(10000);
 
     // Stop the durable client
-    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(TRUE));
+    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(true));
 
     // Verify the durable client still exists on the server
     server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -363,7 +357,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
       public void run2() throws CacheException {
         // Find the proxy
         CacheClientProxy proxy = getClientProxy();
-        assertNotNull(proxy);
+        assertThat(proxy).isNotNull();
       }
     });
 
@@ -373,7 +367,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     // Re-start the durable client
     durableClientVM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, server2Port, true),
-        regionName, getClientDistributedSystemProperties(durableClientId), TRUE));
+        regionName, getClientDistributedSystemProperties(durableClientId), true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -401,7 +395,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testTwoDurableClientsStartStopUpdate() throws InterruptedException {
     // Start a server
     server1Port = server1VM
-        .invoke(() -> createCacheServer(regionName, TRUE));
+        .invoke(() -> createCacheServer(regionName, true));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -411,7 +405,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     durableClientVM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, true), regionName,
         getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
-        TRUE));
+        true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -425,7 +419,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     durableClient2VM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, true), regionName,
         getClientDistributedSystemProperties(durableClientId2, durableClientTimeout),
-        TRUE));
+        true));
 
     // Send clientReady message
     sendClientReady(durableClient2VM);
@@ -454,8 +448,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     sleep(1000);
 
     // Stop the durable clients
-    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(TRUE));
-    durableClient2VM.invoke(() -> CacheServerTestUtil.closeCache(TRUE));
+    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(true));
+    durableClient2VM.invoke(() -> CacheServerTestUtil.closeCache(true));
 
     // Verify the durable clients still exist on the server
     verifyMultupleDurableClients(durableClientId, durableClientTimeout, durableClientId2);
@@ -475,7 +469,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         // Iterate the CacheClientProxies and verify the queue sizes
         checkNumberOfClientProxies(2);
         for (CacheClientProxy proxy : notifier.getClientProxies()) {
-          assertEquals(numberOfEntries, proxy.getQueueSize());
+          assertThat(numberOfEntries).isEqualTo(proxy.getQueueSize());
         }
       }
     });
@@ -483,7 +477,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     // Re-start durable client 1
     durableClientVM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, true), regionName,
-        getClientDistributedSystemProperties(durableClientId), TRUE));
+        getClientDistributedSystemProperties(durableClientId), true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -491,7 +485,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     // Re-start durable client 2
     durableClient2VM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, true), regionName,
-        getClientDistributedSystemProperties(durableClientId2), TRUE));
+        getClientDistributedSystemProperties(durableClientId2), true));
 
     // Send clientReady message
     sendClientReady(durableClient2VM);
@@ -527,17 +521,17 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         checkNumberOfClientProxies(2);
         boolean durableClient1Found = false, durableClient2Found = false;
         for (CacheClientProxy proxy : notifier.getClientProxies()) {
-          assertTrue(proxy.isDurable());
+          assertThat(proxy.isDurable()).isTrue();
           if (proxy.getDurableId().equals(durableClientId)) {
             durableClient1Found = true;
           }
           if (proxy.getDurableId().equals(durableClientId2)) {
             durableClient2Found = true;
           }
-          assertEquals(durableClientTimeout, proxy.getDurableTimeout());
+          assertThat(durableClientTimeout).isEqualTo(proxy.getDurableTimeout());
         }
-        assertTrue(durableClient1Found);
-        assertTrue(durableClient2Found);
+        assertThat(durableClient1Found).isTrue();
+        assertThat(durableClient2Found).isTrue();
       }
     });
   }
@@ -550,15 +544,15 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testDurableClientReconnectTwoServers() throws InterruptedException {
     // Start server 1
     server1Port = server1VM.invoke(
-        () -> createCacheServer(regionName, TRUE));
+        () -> createCacheServer(regionName, true));
 
     // on test flag for periodic ack
     server1VM
-        .invoke(() -> setTestFlagToVerifyActForMarker(TRUE));
+        .invoke(() -> setTestFlagToVerifyActForMarker(true));
 
     // Start server 2 using the same mcast port as server 1
     final int server2Port = server2VM
-        .invoke(() -> createCacheServer(regionName, TRUE));
+        .invoke(() -> createCacheServer(regionName, true));
 
     // Stop server 2
     server2VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
@@ -571,7 +565,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     durableClientVM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
-        TRUE));
+        true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -585,12 +579,12 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         // Find the proxy
         checkNumberOfClientProxies(1);
         CacheClientProxy proxy = getClientProxy();
-        assertNotNull(proxy);
+        assertThat(proxy).isNotNull();
 
         // Verify that it is durable and its properties are correct
-        assertTrue(proxy.isDurable());
-        assertEquals(durableClientId, proxy.getDurableId());
-        assertEquals(durableClientTimeout, proxy.getDurableTimeout());
+        assertThat(proxy.isDurable()).isTrue();
+        assertThat(durableClientId).isEqualTo(proxy.getDurableId());
+        assertThat(durableClientTimeout).isEqualTo(proxy.getDurableTimeout());
         verifyReceivedMarkerAck();
       }
     });
@@ -599,7 +593,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     pause(5000);
 
     // Stop the durable client
-    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(TRUE));
+    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(true));
 
     // Verify durable client on server 1
     server1VM.invoke(new CacheSerializableRunnable("Verify durable client") {
@@ -608,12 +602,12 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         // Find the proxy
         checkNumberOfClientProxies(1);
         CacheClientProxy proxy = getClientProxy();
-        assertNotNull(proxy);
+        assertThat(proxy).isNotNull();
       }
     });
 
     // Re-start server2
-    server2VM.invoke(() -> createCacheServer(regionName, TRUE,
+    server2VM.invoke(() -> createCacheServer(regionName, true,
         server2Port));
 
     // Start normal publisher client
@@ -632,10 +626,10 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
       public void run2() throws CacheException {
         // Find the proxy
         CacheClientProxy proxy = getClientProxy();
-        assertNotNull(proxy);
+        assertThat(proxy).isNotNull();
 
         // Verify the queue size
-        assertEquals(numberOfEntries, proxy.getQueueSize());
+        assertThat(numberOfEntries).isEqualTo(proxy.getQueueSize());
       }
     });
 
@@ -644,7 +638,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     durableClientVM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName, getClientDistributedSystemProperties(durableClientId, durableClientTimeout),
-        TRUE));
+        true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -660,7 +654,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         server1VM.invoke(DurableClientTestBase::getHARegionQueueName);
     String server2HARegionQueueName =
         server2VM.invoke(DurableClientTestBase::getHARegionQueueName);
-    assertEquals(server1HARegionQueueName, server2HARegionQueueName);
+    assertThat(server1HARegionQueueName).isEqualTo(server2HARegionQueueName);
 
     // Verify the durable client received the updates
     checkListenerEvents(numberOfEntries, 1, -1, durableClientVM);
@@ -672,8 +666,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     publisherClientVM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
 
     // off test flag for periodic ack
-    server1VM
-        .invoke(() -> setTestFlagToVerifyActForMarker(FALSE));
+    server1VM.invoke(() -> setTestFlagToVerifyActForMarker(false));
 
     // Stop server 1
     server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
@@ -686,7 +679,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testReadyForEventsNotCalledImplicitly() {
     // Start a server
     server1Port = server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start a durable client that is not kept alive on the server when it
     // stops normally
@@ -701,7 +694,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
       @Override
       public void run2() throws CacheException {
         for (Pool p : PoolManager.getAll().values()) {
-          assertFalse(((PoolImpl) p).getReadyForEventsCalled());
+          assertThat(((PoolImpl) p).getReadyForEventsCalled()).isFalse();
         }
       }
     });
@@ -720,14 +713,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         checkNumberOfClientProxies(1);
         boolean durableClient1Found = false;
         for (CacheClientProxy proxy : notifier.getClientProxies()) {
-          assertTrue(proxy.isDurable());
+          assertThat(proxy.isDurable()).isTrue();
           if (proxy.getDurableId().equals(durableClientId)) {
             durableClient1Found = true;
           }
-          assertEquals(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT,
-              proxy.getDurableTimeout());
+          assertThat(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT)
+              .isEqualTo(proxy.getDurableTimeout());
         }
-        assertTrue(durableClient1Found);
+        assertThat(durableClient1Found).isTrue();
       }
     });
 
@@ -755,14 +748,14 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     // create client cache from xml
     durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClientFromXmlN(
         DurableClientTestBase.class.getResource("durablecq-client-cache.xml"), "client",
-        durableClientId, DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT, Boolean.TRUE));
+        durableClientId, DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT, true));
 
     // verify that readyForEvents has not yet been called on all the client's pools
     durableClientVM.invoke(new CacheSerializableRunnable("check readyForEvents not called") {
       @Override
       public void run2() throws CacheException {
         for (Pool p : PoolManager.getAll().values()) {
-          assertFalse(((PoolImpl) p).getReadyForEventsCalled());
+          assertThat(((PoolImpl) p).getReadyForEventsCalled()).isFalse();
         }
       }
     });
@@ -790,7 +783,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     checkListenerEvents(numberOfEntries, 1, -1, durableClientVM);
 
     // Stop the durable client
-    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
+    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(true));
 
     // Verify the durable client still exists on the server
     verifyDurableClientPresent(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT, durableClientId,
@@ -802,7 +795,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
       public void run2() throws CacheException {
         // Get the region
         Region<String, String> region = CacheServerTestUtil.getCache().getRegion(regionName);
-        assertNotNull(region);
+        assertThat(region).isNotNull();
 
         // Publish some entries
         for (int i = 0; i < numberOfEntries; i++) {
@@ -817,7 +810,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     // Re-start the durable client
     durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClientFromXmlN(
         DurableClientTestBase.class.getResource("durablecq-client-cache.xml"), "client",
-        durableClientId, DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT, Boolean.TRUE));
+        durableClientId, DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT, true));
 
     // Durable client registers durable cq on server'
     registerInterest(durableClientVM, regionName, true, InterestResultPolicy.KEYS_VALUES);
@@ -853,7 +846,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
 
     // Start a server
     server1Port = server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start a durable client that is kept alive on the server when it stops
     // normally
@@ -946,11 +939,11 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testSimpleDurableClientMultipleServers() {
     // Start server 1
     server1Port = server1VM.invoke(
-        () -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        () -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start server 2 using the same mcast port as server 1
     final int server2Port = server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start a durable client connected to both servers that is kept alive when
     // it stops normally
@@ -960,7 +953,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         getClientPool(getServerHostName(), server1Port, server2Port, true),
         regionName,
         getClientDistributedSystemProperties(durableClientId, VERY_LONG_DURABLE_TIMEOUT_SECONDS),
-        Boolean.TRUE));
+        true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -972,7 +965,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     verifyDurableClientPresence(VERY_LONG_DURABLE_TIMEOUT_SECONDS, durableClientId, server2VM, 1);
 
     // Stop the durable client
-    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(Boolean.TRUE));
+    durableClientVM.invoke(() -> CacheServerTestUtil.closeCache(true));
 
     // Verify the durable client is still on server 1
     verifyDurableClientPresence(VERY_LONG_DURABLE_TIMEOUT_SECONDS, durableClientId, server1VM, 1);
@@ -984,7 +977,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     // alive on the servers when it stops normally.
     durableClientVM.invoke(() -> CacheServerTestUtil.createCacheClient(
         getClientPool(getServerHostName(), server1Port, server2Port, true),
-        regionName, getClientDistributedSystemProperties(durableClientId), Boolean.TRUE));
+        regionName, getClientDistributedSystemProperties(durableClientId), true));
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -1017,11 +1010,11 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   public void testDurableClientReceivedClientSessionInitialValue() {
     // Start server 1
     server1Port = server1VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start server 2
     int server2Port = server2VM
-        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, Boolean.TRUE));
+        .invoke(() -> CacheServerTestUtil.createCacheServer(regionName, true));
 
     // Start normal publisher client
     publisherClientVM.invoke(() -> CacheServerTestUtil
@@ -1036,7 +1029,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     durableClientVM.invoke(() -> createCacheClient(
         getClientPool(getServerHostName(), server1Port, server2Port, true), regionName,
         getClientDistributedSystemProperties(durableClientId, VERY_LONG_DURABLE_TIMEOUT_SECONDS),
-        Boolean.TRUE));
+        true));
 
     durableClientVM.invoke(() -> {
       await().atMost(1 * HEAVY_TEST_LOAD_DELAY_SUPPORT_MULTIPLIER, MINUTES)
@@ -1073,7 +1066,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
 
     // restart durable client
     restartDurableClient(VERY_LONG_DURABLE_TIMEOUT_SECONDS,
-        getClientPool(getServerHostName(), server1Port, server2Port, true), Boolean.TRUE);
+        getClientPool(getServerHostName(), server1Port, server2Port, true), true);
 
     // Send clientReady message
     sendClientReady(durableClientVM);
@@ -1119,9 +1112,9 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     HARegionQueueStats haRegionQueueStats = haRegionQueue.getStatistics();
     await()
         .untilAsserted(
-            () -> assertEquals(
+            () -> assertThat(haRegionQueueStats.getEventsRemovedByQrm()).describedAs(
                 "Expected queue removal messages: " + numEvents + " but actual messages: "
-                    + haRegionQueueStats.getEventsRemovedByQrm(),
-                numEvents, haRegionQueueStats.getEventsRemovedByQrm()));
+                    + haRegionQueueStats.getEventsRemovedByQrm())
+                .isEqualTo(numEvents));
   }
 }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
@@ -19,6 +19,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.geode.cache.InterestResultPolicy.NONE;
 import static org.apache.geode.cache.Region.SEPARATOR;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.TYPE_CREATE;
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.createCacheClient;
 import static org.apache.geode.internal.cache.tier.sockets.CacheServerTestUtil.createCacheClientFromXmlN;
@@ -576,6 +577,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
 
   @Test
   public void testReadyForEventsNotCalledImplicitlyForRegisterInterestWithCacheXML() {
+    int[] ports = getRandomAvailableTCPPorts(2);
     regionName = "testReadyForEventsNotCalledImplicitlyWithCacheXML_region";
     // Start a server
     server1Port =

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
@@ -103,8 +103,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
   @Test
   public void testMultipleBridgeClientsInSingleDurableVM() {
     // Start a server
-    server1Port = server1VM
-        .invoke(() -> createCacheServer(regionName, true));
+    server1Port = server1VM.invoke(() -> createCacheServer(regionName, true));
 
     // Start a durable client with 2 regions (and 2 BridgeClients) that is not
     // kept alive on the server when it stops normally
@@ -119,7 +118,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
     durableClientVM.invoke("Send clientReady", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
-        assertThat(2).isEqualTo(PoolManager.getAll().size());
+        assertThat(PoolManager.getAll()).hasSize(2);
         getClientCache().readyForEvents();
       }
     });
@@ -136,15 +135,15 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         String firstProxyRegionName = null;
         for (CacheClientProxy proxy : notifier.getClientProxies()) {
           assertThat(proxy.isDurable()).isTrue();
-          assertThat(durableClientId).isEqualTo(proxy.getDurableId());
-          assertThat(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT)
-              .isEqualTo(proxy.getDurableTimeout());
+          assertThat(proxy.getDurableId()).isEqualTo(durableClientId);
+          assertThat(proxy.getDurableTimeout())
+              .isEqualTo(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT);
 
           // Verify the two HA region names aren't the same
           if (firstProxyRegionName == null) {
             firstProxyRegionName = proxy.getHARegionName();
           } else {
-            assertThat(!firstProxyRegionName.equals(proxy.getHARegionName())).isTrue();
+            assertThat(proxy.getHARegionName()).isNotEqualTo(firstProxyRegionName);
           }
         }
       }
@@ -214,8 +213,8 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
           if (proxy.getDurableId().equals(durableClientId2)) {
             durableClient2Found = true;
           }
-          assertThat(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT)
-              .isEqualTo(proxy.getDurableTimeout());
+          assertThat(proxy.getDurableTimeout())
+              .isEqualTo(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT);
         }
         assertThat(durableClient1Found).isTrue();
         assertThat(durableClient2Found).isTrue();
@@ -311,7 +310,7 @@ public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
         // Iterate the CacheClientProxies and verify the queue sizes
         checkNumberOfClientProxies(2);
         for (CacheClientProxy proxy : notifier.getClientProxies()) {
-          assertThat(numberOfEntries).isEqualTo(proxy.getQueueSize());
+          assertThat(proxy.getQueueSize()).isEqualTo(numberOfEntries);
         }
       }
     });

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientSimpleDUnitTest.java
@@ -33,8 +33,8 @@ import static org.apache.geode.test.dunit.NetworkUtils.getServerHostName;
 import static org.apache.geode.test.dunit.Wait.pause;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.ClientSession;
@@ -49,9 +49,10 @@ import org.apache.geode.internal.cache.ha.HARegionQueue;
 import org.apache.geode.internal.cache.ha.HARegionQueueStats;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 
-@Tag("ClientSubscriptionTest")
-class DurableClientSimpleDUnitTest extends DurableClientTestBase {
+@Category({ClientSubscriptionTest.class})
+public class DurableClientSimpleDUnitTest extends DurableClientTestBase {
 
   /**
    * Test that a durable client correctly receives updates.

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
@@ -486,15 +486,11 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
   }
 
   static void checkNumberOfClientProxies(final int expected) {
-    await()
-        .until(() -> {
-          return expected == getNumberOfClientProxies();
-        });
+    await().atMost(30, SECONDS).until(() -> expected == getNumberOfClientProxies());
   }
 
   static void checkProxyIsAlive(final CacheClientProxy proxy) {
-    await()
-        .until(proxy::isAlive);
+    await().until(proxy::isAlive);
   }
 
   private static int getNumberOfClientProxies() {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
@@ -174,20 +174,19 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
     verifyDurableClientPresence(durableClientTimeout, durableClientId, serverVM, 1);
   }
 
-  void verifyDurableClientNotPresent(int durableClientTimeout, String durableClientId,
+  void verifyDurableClientNotPresent(String durableClientId,
       final VM serverVM) {
-    verifyDurableClientPresence(durableClientTimeout, durableClientId, serverVM, 0);
+    verifyDurableClientPresence(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT, durableClientId,
+        serverVM, 0);
   }
 
-  void waitForDurableClientPresence(String durableClientId, VM serverVM, final int count) {
+  void waitForDurableClientPresence(String durableClientId, VM serverVM) {
     serverVM.invoke(() -> {
-      if (count > 0) {
-        GeodeAwaitility.await().until(() -> {
-          checkNumberOfClientProxies(count);
-          CacheClientProxy proxy = getClientProxy();
-          return proxy != null && durableClientId.equals(proxy.getDurableId());
-        });
-      }
+      GeodeAwaitility.await().until(() -> {
+        checkNumberOfClientProxies(1);
+        CacheClientProxy proxy = getClientProxy();
+        return proxy != null && durableClientId.equals(proxy.getDurableId());
+      });
     });
   }
 
@@ -229,7 +228,6 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
     server1VM.invoke("Logging CCCP and ServerConnection state", new CacheSerializableRunnable() {
       @Override
       public void run2() throws CacheException {
-        // TODO Auto-generated method stub
         getCache().getLogger()
             .info(st + " CCP states: " + getAllClientProxyState());
         getCache().getLogger().info(st + " CHM states: "
@@ -684,7 +682,7 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
     // Get the listener and wait for the appropriate number of events
     ControlCqListener listener =
         (ControlCqListener) cq.getCqAttributes().getCqListener();
-    listener.waitWhileNotEnoughEvents(secondsToWait * 1000L, numEvents);
+    listener.waitWhileNotEnoughEvents(SECONDS.toMillis(secondsToWait), numEvents);
     assertThat(numEvents).isEqualTo(listener.events.size());
   }
 
@@ -698,7 +696,7 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
       // Get the listener and wait for the appropriate number of events
       ControlListener controlListener =
           (ControlListener) region.getAttributes().getCacheListeners()[0];
-      controlListener.waitWhileNotEnoughEvents((long) sleepMinutes * 60 * 1000, numberOfEntries,
+      controlListener.waitWhileNotEnoughEvents(MINUTES.toMillis(sleepMinutes), numberOfEntries,
           controlListener.getEvents(eventType));
     });
   }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
@@ -217,24 +217,9 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
   }
 
   public void disconnectDurableClient(boolean keepAlive) {
-    // printClientProxyState("Before");
     durableClientVM.invoke("close durable client cache",
         () -> CacheServerTestUtil.closeCache(keepAlive));
     await().until(CacheServerTestUtil::getCache, nullValue());
-    // printClientProxyState("after");
-  }
-
-  private void printClientProxyState(String st) {
-    server1VM.invoke("Logging CCCP and ServerConnection state", new CacheSerializableRunnable() {
-      @Override
-      public void run2() throws CacheException {
-        getCache().getLogger()
-            .info(st + " CCP states: " + getAllClientProxyState());
-        getCache().getLogger().info(st + " CHM states: "
-            + printMap(
-                ClientHealthMonitor.getInstance().getConnectedClients(null)));
-      }
-    });
   }
 
   private static String printMap(Map<String, Object[]> m) {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestBase.java
@@ -619,12 +619,8 @@ public class DurableClientTestBase extends JUnit4DistributedTestCase {
             final CacheClientProxy clientProxy = ccnInstance.getClientProxy(durableClientId);
 
             // Wait until we get the expected number of events or until 10 seconds are up
-            await()
-                .until(() -> clientProxy.getQueueSizeStat() == expectedNumber
-                    || clientProxy.getQueueSizeStat() == remaining);
-
-            assertThat(clientProxy.getQueueSizeStat() == expectedNumber
-                || clientProxy.getQueueSizeStat() == remaining).isTrue();
+            await().untilAsserted(
+                () -> assertThat(clientProxy.getQueueSizeStat()).isIn(expectedNumber, remaining));
           }
         });
   }

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
@@ -128,7 +128,7 @@ public class DurableClientTestCase extends DurableClientTestBase {
       disconnectDurableClient(false);
 
       // Verify the durable client is present on the server for closeCache=false case.
-      verifyDurableClientNotPresent(DistributionConfig.DEFAULT_DURABLE_CLIENT_TIMEOUT,
+      verifyDurableClientNotPresent(
           durableClientId, server1VM);
 
       // Stop the server

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
@@ -29,8 +29,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.InterestResultPolicy;
@@ -44,7 +44,6 @@ import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
-import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 
@@ -53,8 +52,8 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *
  * @since GemFire 5.2
  */
-@Category({ClientSubscriptionTest.class})
-public class DurableClientTestCase extends DurableClientTestBase {
+@Tag("ClientSubscriptionTest")
+class DurableClientTestCase extends DurableClientTestBase {
 
 
   /**

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
@@ -77,7 +77,7 @@ public class DurableClientTestCase extends DurableClientTestBase {
    * not
    */
   @Test
-  public void testSpecialDurableProperty() throws InterruptedException {
+  public void testSpecialDurableProperty() {
     final Properties jp = new Properties();
     jp.setProperty(GeodeGlossary.GEMFIRE_PREFIX + "SPECIAL_DURABLE", "true");
 
@@ -96,7 +96,7 @@ public class DurableClientTestCase extends DurableClientTestBase {
           true, jp));
 
       durableClientVM.invoke(() -> {
-        await().atMost(1 * HEAVY_TEST_LOAD_DELAY_SUPPORT_MULTIPLIER, MINUTES)
+        await().atMost(HEAVY_TEST_LOAD_DELAY_SUPPORT_MULTIPLIER, MINUTES)
             .pollInterval(100, MILLISECONDS)
             .until(CacheServerTestUtil::getCache, notNullValue());
       });
@@ -540,15 +540,13 @@ public class DurableClientTestCase extends DurableClientTestBase {
     checkListenerEvents(2, 1, -1, durableClientVM);
 
     // Verify that the 0 entry is not present, but that 2 is.
-    durableClientVM.invoke("Get", () -> {
-      await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
-        Region<Object, Object> region = getCache().getRegion(regionName);
-        assertThat(region).isNotNull();
+    durableClientVM.invoke("Get", () -> await().atMost(10, TimeUnit.SECONDS).untilAsserted(() -> {
+      Region<Object, Object> region = getCache().getRegion(regionName);
+      assertThat(region).isNotNull();
 
-        assertThat(region.getEntry("0")).isNull();
-        assertThat(region.getEntry("2")).isNotNull();
-      });
-    });
+      assertThat(region.getEntry("0")).isNull();
+      assertThat(region.getEntry("2")).isNotNull();
+    }));
 
     // Stop server 1
     server1VM.invoke((SerializableRunnableIF) CacheServerTestUtil::closeCache);
@@ -685,14 +683,12 @@ public class DurableClientTestCase extends DurableClientTestBase {
     }
 
     // Verify that key 0 is not present
-    durableClientVM.invoke("Get", () -> {
-      await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
-        Region<Object, Object> region = getCache().getRegion(regionName);
-        assertThat(region).isNotNull();
+    durableClientVM.invoke("Get", () -> await().atMost(30, TimeUnit.SECONDS).untilAsserted(() -> {
+      Region<Object, Object> region = getCache().getRegion(regionName);
+      assertThat(region).isNotNull();
 
-        assertThat(region.getEntry("0")).isNull();
-      });
-    });
+      assertThat(region.getEntry("0")).isNull();
+    }));
 
     // put key 4
     publishEntries(publisherClientVM, 4, 1);

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/DurableClientTestCase.java
@@ -29,8 +29,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
-import org.junit.jupiter.api.Tag;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import org.apache.geode.cache.CacheException;
 import org.apache.geode.cache.InterestResultPolicy;
@@ -44,6 +44,7 @@ import org.apache.geode.test.dunit.IgnoredException;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.junit.categories.ClientSubscriptionTest;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 
@@ -52,8 +53,8 @@ import org.apache.geode.util.internal.GeodeGlossary;
  *
  * @since GemFire 5.2
  */
-@Tag("ClientSubscriptionTest")
-class DurableClientTestCase extends DurableClientTestBase {
+@Category({ClientSubscriptionTest.class})
+public class DurableClientTestCase extends DurableClientTestBase {
 
 
   /**

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
@@ -140,7 +140,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
     pf.init(poolAttr);
     PoolImpl p = (PoolImpl) pf.create("CacheServerTestUtil");
-    AttributesFactory factory = new AttributesFactory();
+    AttributesFactory factory = new AttributesFactory<>();
     factory.setScope(Scope.LOCAL);
     factory.setPoolName(p.getName());
 
@@ -170,7 +170,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
     pf.init(poolAttr);
     PoolImpl p = (PoolImpl) pf.create("CacheServerTestUtil");
-    AttributesFactory factory = new AttributesFactory();
+    AttributesFactory factory = new AttributesFactory<>();
     factory.setScope(Scope.LOCAL);
     factory.setPoolName(p.getName());
     if (addControlListener) {
@@ -198,7 +198,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
     pf.init(poolAttr);
     PoolImpl p = (PoolImpl) pf.create("CacheServerTestUtil");
-    AttributesFactory factory = new AttributesFactory();
+    AttributesFactory factory = new AttributesFactory<>();
     factory.setScope(Scope.LOCAL);
     factory.setPoolName(p.getName());
     RegionAttributes attrs = factory.create();
@@ -290,14 +290,14 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
     pf.init(poolAttr);
     Pool p = pf.create("CacheServerTestUtil1");
-    AttributesFactory factory1 = new AttributesFactory();
+    AttributesFactory factory1 = new AttributesFactory<>();
     factory1.setScope(Scope.LOCAL);
     factory1.setPoolName(p.getName());
     cache.createRegion(regionName1, factory1.create());
 
     // Initialize region2
     p = pf.create("CacheServerTestUtil2");
-    AttributesFactory factory2 = new AttributesFactory();
+    AttributesFactory factory2 = new AttributesFactory<>();
     factory2.setScope(Scope.LOCAL);
     factory2.setPoolName(p.getName());
     cache.createRegion(regionName2, factory2.create());
@@ -337,7 +337,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOCATORS, "localhost[" + DistributedTestUtils.getDUnitLocatorPort() + "]");
     new CacheServerTestUtil().createCache(props);
-    AttributesFactory factory = new AttributesFactory();
+    AttributesFactory factory = new AttributesFactory<>();
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setEnableBridgeConflation(true);
     factory.setDataPolicy(DataPolicy.REPLICATE);
@@ -352,7 +352,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
   public static Integer createCacheServer(String regionName1, String regionName2,
       Boolean notifyBySubscription) throws Exception {
     new CacheServerTestUtil().createCache(new Properties());
-    AttributesFactory factory = new AttributesFactory();
+    AttributesFactory factory = new AttributesFactory<>();
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setEnableBridgeConflation(true);
     factory.setDataPolicy(DataPolicy.REPLICATE);
@@ -508,6 +508,11 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
       return waitWhileNotEnoughEvents(sleepMs, eventCount, getEvents(eventType));
     }
 
+
+    /**
+     * This method is not implemented to test event count matches the eventsToCheck.size() which is
+     * confusing. It will wait and return if it got something in the eventsToCheck or not.
+     */
     public boolean waitWhileNotEnoughEvents(long sleepMs, int eventCount, List eventsToCheck) {
       long maxMillis = System.currentTimeMillis() + sleepMs;
       synchronized (CONTROL_LOCK) {

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
@@ -583,6 +583,16 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
         CONTROL_LOCK.notifyAll();
       }
     }
+
+    @Override
+    public void close() {
+      synchronized (CONTROL_LOCK) {
+        destroyEvents.clear();
+        createEvents.clear();
+        updateEvents.clear();
+        events.clear();
+      }
+    }
   }
 
   public static class ControlCqListener extends CqListenerAdapter {

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
@@ -21,6 +21,7 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
+import static org.apache.geode.distributed.ConfigurationProperties.TCP_PORT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -244,6 +245,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
       ccf.set(LOCATORS, "localhost[" + DistributedTestUtils.getDUnitLocatorPort() + "]");
       ccf.set(LOG_FILE, "abs_server_system.log");
       ccf.set(LOG_LEVEL, LogWriterUtils.getDUnitLogLevel());
+      ccf.set(TCP_PORT, Integer.toString(getRandomAvailableTCPPort()));
     } catch (URISyntaxException e) {
       throw new ExceptionInInitializerError(e);
     }
@@ -258,6 +260,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
       ccf.set(CACHE_XML_FILE, cacheXmlFile.toURI().getPath());
       ccf.set(MCAST_PORT, "0");
       ccf.set(LOCATORS, "localhost[" + DistributedTestUtils.getDUnitLocatorPort() + "]");
+      ccf.set(TCP_PORT, Integer.toString(getRandomAvailableTCPPort()));
     } catch (URISyntaxException e) {
       throw new ExceptionInInitializerError(e);
     }

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
@@ -22,8 +22,8 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
-import static org.apache.geode.test.dunit.Assert.assertNotNull;
-import static org.apache.geode.test.dunit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.io.File;
 import java.net.InetSocketAddress;
@@ -93,8 +93,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     createClientCache(poolAttr, regionName, getClientProperties());
   }
 
-  public static void createClientCache(Pool poolAttr, String regionName, Properties dsProperties)
-      throws Exception {
+  public static void createClientCache(Pool poolAttr, String regionName, Properties dsProperties) {
     ClientCacheFactory ccf = new ClientCacheFactory(dsProperties);
     if (poolAttr != null) {
       ccf.setPoolFreeConnectionTimeout(poolAttr.getFreeConnectionTimeout())
@@ -130,22 +129,10 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     pool = (PoolImpl) cc.getDefaultPool();
   }
 
-  public static void createPool(PoolAttributes poolAttr) throws Exception {
-    Properties props = new Properties();
-    props.setProperty(MCAST_PORT, "0");
-    props.setProperty(LOCATORS, "");
-
-    DistributedSystem ds = new CacheServerTestUtil().getSystem(props);
-
+  public static void createPool(PoolAttributes poolAttr) {
     PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
     pf.init(poolAttr);
-    PoolImpl p = (PoolImpl) pf.create("CacheServerTestUtil");
-    AttributesFactory factory = new AttributesFactory<>();
-    factory.setScope(Scope.LOCAL);
-    factory.setPoolName(p.getName());
-
-    RegionAttributes attrs = factory.create();
-    pool = p;
+    pool = (PoolImpl) pf.create("CacheServerTestUtil");
   }
 
   public static void createCacheClient(Pool poolAttr, String regionName, Properties dsProperties,
@@ -154,12 +141,12 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
   }
 
   public static void createCacheClient(Pool poolAttr, String regionName, Properties dsProperties,
-      Boolean addControlListener, Properties javaSystemProperties) throws Exception {
+      Boolean addControlListener, Properties javaSystemProperties) {
     new CacheServerTestUtil().createCache(dsProperties);
     IgnoredException.addIgnoredException("java.net.ConnectException||java.net.SocketException");
 
     if (javaSystemProperties != null && javaSystemProperties.size() > 0) {
-      Enumeration e = javaSystemProperties.propertyNames();
+      Enumeration<?> e = javaSystemProperties.propertyNames();
 
       while (e.hasMoreElements()) {
         String key = (String) e.nextElement();
@@ -170,20 +157,20 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
     pf.init(poolAttr);
     PoolImpl p = (PoolImpl) pf.create("CacheServerTestUtil");
-    AttributesFactory factory = new AttributesFactory<>();
+    AttributesFactory<Object, Object> factory = new AttributesFactory<>();
     factory.setScope(Scope.LOCAL);
     factory.setPoolName(p.getName());
     if (addControlListener) {
       factory.addCacheListener(new ControlListener());
     }
-    RegionAttributes attrs = factory.create();
+    RegionAttributes<Object, Object> attrs = factory.create();
     cache.createRegion(regionName, attrs);
     pool = p;
   }
 
   public static void unsetJavaSystemProperties(Properties javaSystemProperties) {
     if (javaSystemProperties != null && javaSystemProperties.size() > 0) {
-      Enumeration e = javaSystemProperties.propertyNames();
+      Enumeration<?> e = javaSystemProperties.propertyNames();
 
       while (e.hasMoreElements()) {
         String key = (String) e.nextElement();
@@ -192,16 +179,15 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     }
   }
 
-  public static void createCacheClient(Pool poolAttr, String regionName1, String regionName2)
-      throws Exception {
+  public static void createCacheClient(Pool poolAttr, String regionName1, String regionName2) {
     new CacheServerTestUtil().createCache(getClientProperties());
     PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
     pf.init(poolAttr);
     PoolImpl p = (PoolImpl) pf.create("CacheServerTestUtil");
-    AttributesFactory factory = new AttributesFactory<>();
+    AttributesFactory<Object, Object> factory = new AttributesFactory<>();
     factory.setScope(Scope.LOCAL);
     factory.setPoolName(p.getName());
-    RegionAttributes attrs = factory.create();
+    RegionAttributes<Object, Object> attrs = factory.create();
     cache.createRegion(regionName1, attrs);
     cache.createRegion(regionName2, attrs);
     pool = p;
@@ -283,21 +269,21 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
    * Create client regions
    */
   public static void createCacheClients(Pool poolAttr, String regionName1, String regionName2,
-      Properties dsProperties) throws Exception {
+      Properties dsProperties) {
     new CacheServerTestUtil().createCache(dsProperties);
 
     // Initialize region1
     PoolFactoryImpl pf = (PoolFactoryImpl) PoolManager.createFactory();
     pf.init(poolAttr);
     Pool p = pf.create("CacheServerTestUtil1");
-    AttributesFactory factory1 = new AttributesFactory<>();
+    AttributesFactory<Object, Object> factory1 = new AttributesFactory<>();
     factory1.setScope(Scope.LOCAL);
     factory1.setPoolName(p.getName());
     cache.createRegion(regionName1, factory1.create());
 
     // Initialize region2
     p = pf.create("CacheServerTestUtil2");
-    AttributesFactory factory2 = new AttributesFactory<>();
+    AttributesFactory<Object, Object> factory2 = new AttributesFactory<>();
     factory2.setScope(Scope.LOCAL);
     factory2.setPoolName(p.getName());
     cache.createRegion(regionName2, factory2.create());
@@ -337,11 +323,11 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     props.setProperty(MCAST_PORT, "0");
     props.setProperty(LOCATORS, "localhost[" + DistributedTestUtils.getDUnitLocatorPort() + "]");
     new CacheServerTestUtil().createCache(props);
-    AttributesFactory factory = new AttributesFactory<>();
+    AttributesFactory<Object, Object> factory = new AttributesFactory<>();
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setEnableBridgeConflation(true);
     factory.setDataPolicy(DataPolicy.REPLICATE);
-    RegionAttributes attrs = factory.create();
+    RegionAttributes<Object, Object> attrs = factory.create();
     cache.createRegion(regionName, attrs);
     CacheServer server = cache.addCacheServer();
     server.setPort(serverPort);
@@ -352,11 +338,11 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
   public static Integer createCacheServer(String regionName1, String regionName2,
       Boolean notifyBySubscription) throws Exception {
     new CacheServerTestUtil().createCache(new Properties());
-    AttributesFactory factory = new AttributesFactory<>();
+    AttributesFactory<Object, Object> factory = new AttributesFactory<>();
     factory.setScope(Scope.DISTRIBUTED_ACK);
     factory.setEnableBridgeConflation(true);
     factory.setDataPolicy(DataPolicy.REPLICATE);
-    RegionAttributes attrs = factory.create();
+    RegionAttributes<Object, Object> attrs = factory.create();
     if (!regionName1.equals("")) {
       cache.createRegion(regionName1, attrs);
     }
@@ -371,23 +357,23 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     return server1.getPort();
   }
 
-  private void createCache(Properties props) throws Exception {
+  private void createCache(Properties props) {
     DistributedSystem ds = getSystem(props);
-    assertNotNull(ds);
+    assertThat(ds).isNotNull();
     ds.disconnect();
     ds = getSystem(props);
     cache = CacheFactory.create(ds);
-    assertNotNull(cache);
+    assertThat(cache).isNotNull();
   }
 
-  private void createClientCache(Properties props, ClientCacheFactory ccf) throws Exception {
+  private void createClientCache(Properties props, ClientCacheFactory ccf) {
     DistributedSystem ds = getSystem(props);
-    assertNotNull(ds);
+    assertThat(ds).isNotNull();
     ds.disconnect();
     ClientCache cc = ccf.create();
     setSystem(props, cc.getDistributedSystem());
     cache = (Cache) cc;
-    assertNotNull(cache);
+    assertThat(cache).isNotNull();
     expected = IgnoredException
         .addIgnoredException("java.net.ConnectionException||java.net.SocketException");
   }
@@ -490,10 +476,10 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
   }
 
   public static class ControlListener extends CacheListenerAdapter implements Declarable {
-    public final LinkedList<EventWrapper> events = new LinkedList();
-    public final LinkedList<EntryEvent> createEvents = new LinkedList();
-    public final LinkedList<EntryEvent> updateEvents = new LinkedList();
-    public final LinkedList<EntryEvent> destroyEvents = new LinkedList();
+    public final LinkedList<EventWrapper> events = new LinkedList<>();
+    public final LinkedList<EntryEvent> createEvents = new LinkedList<>();
+    public final LinkedList<EntryEvent> updateEvents = new LinkedList<>();
+    public final LinkedList<EntryEvent> destroyEvents = new LinkedList<>();
     public final Object CONTROL_LOCK = new Object();
 
     // added to test creation of cache from xml
@@ -532,7 +518,7 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
     }
 
     public List getEvents(int eventType) {
-      List eventsToCheck = null;
+      List eventsToCheck;
       switch (eventType) {
         case TYPE_CREATE:
           eventsToCheck = createEvents;
@@ -581,16 +567,6 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
         events.add(new EventWrapper(e, TYPE_DESTROY));
         destroyEvents.add(e);
         CONTROL_LOCK.notifyAll();
-      }
-    }
-
-    @Override
-    public void close() {
-      synchronized (CONTROL_LOCK) {
-        destroyEvents.clear();
-        createEvents.clear();
-        updateEvents.clear();
-        events.clear();
       }
     }
   }

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil.java
@@ -21,7 +21,6 @@ import static org.apache.geode.distributed.ConfigurationProperties.LOCATORS;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_FILE;
 import static org.apache.geode.distributed.ConfigurationProperties.LOG_LEVEL;
 import static org.apache.geode.distributed.ConfigurationProperties.MCAST_PORT;
-import static org.apache.geode.distributed.ConfigurationProperties.TCP_PORT;
 import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -245,7 +244,6 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
       ccf.set(LOCATORS, "localhost[" + DistributedTestUtils.getDUnitLocatorPort() + "]");
       ccf.set(LOG_FILE, "abs_server_system.log");
       ccf.set(LOG_LEVEL, LogWriterUtils.getDUnitLogLevel());
-      ccf.set(TCP_PORT, Integer.toString(getRandomAvailableTCPPort()));
     } catch (URISyntaxException e) {
       throw new ExceptionInInitializerError(e);
     }
@@ -260,7 +258,6 @@ public class CacheServerTestUtil extends JUnit4DistributedTestCase {
       ccf.set(CACHE_XML_FILE, cacheXmlFile.toURI().getPath());
       ccf.set(MCAST_PORT, "0");
       ccf.set(LOCATORS, "localhost[" + DistributedTestUtils.getDUnitLocatorPort() + "]");
-      ccf.set(TCP_PORT, Integer.toString(getRandomAvailableTCPPort()));
     } catch (URISyntaxException e) {
       throw new ExceptionInInitializerError(e);
     }


### PR DESCRIPTION
There were a couple of basic timing issues with the code.

- Starting the cache server is not a synchronous event.
- We were not waiting for the queues to clear before restarting, this allowed messages to "persist"
across a restart of the durable client.

Basically all of the problems here are timing issues in the tests.

See my PR comments for key changes