### PR TITLE
GEODE-9466: change offheap to not use java.nio.Bits.unaligned

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/OffHeapByteSourceTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/tcp/OffHeapByteSourceTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.tcp;
+
+import static org.apache.geode.internal.tcp.ByteBufferInputStream.OffHeapByteSource.determineUnaligned;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class OffHeapByteSourceTest {
+  @Test
+  public void nullIsNotUnaligned() {
+    assertThat(determineUnaligned(null)).isFalse();
+  }
+
+  @Test
+  public void bogusIsNotUnaligned() {
+    assertThat(determineUnaligned("bogus")).isFalse();
+  }
+
+  @Test
+  public void i386IsUnaligned() {
+    assertThat(determineUnaligned("i386")).isTrue();
+  }
+
+  @Test
+  public void x86IsUnaligned() {
+    assertThat(determineUnaligned("x86")).isTrue();
+  }
+
+  @Test
+  public void amd64IsUnaligned() {
+    assertThat(determineUnaligned("amd64")).isTrue();
+  }
+
+  @Test
+  public void x86_64IsUnaligned() {
+    assertThat(determineUnaligned("x86_64")).isTrue();
+  }
+
+  @Test
+  public void ppc64IsUnaligned() {
+    assertThat(determineUnaligned("ppc64")).isTrue();
+  }
+
+  @Test
+  public void ppc64leIsUnaligned() {
+    assertThat(determineUnaligned("ppc64le")).isTrue();
+  }
+}

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/ByteBufferInputStream.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/ByteBufferInputStream.java
@@ -551,10 +551,9 @@ public class ByteBufferInputStream extends InputStream
     }
 
     /**
-     * Return true if the hardware supported unaligned reads from memory.
+     * Return true if the hardware supports unaligned reads from memory.
      */
-    private static boolean determineUnaligned() {
-      String arch = System.getProperty("os.arch");
+    static boolean determineUnaligned(final String arch) {
       if (arch == null) {
         return false;
       }
@@ -564,7 +563,7 @@ public class ByteBufferInputStream extends InputStream
           || arch.equals("ppc64") || arch.equals("ppc64le");
     }
 
-    private static final boolean unaligned = determineUnaligned();
+    private static final boolean unaligned = determineUnaligned(System.getProperty("os.arch"));
 
     @Override
     public short getShort() {

--- a/geode-core/src/main/java/org/apache/geode/internal/tcp/ByteBufferInputStream.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/tcp/ByteBufferInputStream.java
@@ -21,8 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -556,16 +554,14 @@ public class ByteBufferInputStream extends InputStream
      * Return true if the hardware supported unaligned reads from memory.
      */
     private static boolean determineUnaligned() {
-      try {
-        Class c = Class.forName("java.nio.Bits");
-        Method m = c.getDeclaredMethod("unaligned");
-        m.setAccessible(true);
-        return (boolean) m.invoke(null);
-      } catch (ClassNotFoundException | NoSuchMethodException | SecurityException
-          | IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      String arch = System.getProperty("os.arch");
+      if (arch == null) {
         return false;
-        // throw new IllegalStateException("Could not invoke java.nio.Bits.unaligned()", e);
       }
+      // the following list is what JDK 1.8 uses in java.nio.Bits.unaligned
+      return arch.equals("i386") || arch.equals("x86")
+          || arch.equals("amd64") || arch.equals("x86_64")
+          || arch.equals("ppc64") || arch.equals("ppc64le");
     }
 
     private static final boolean unaligned = determineUnaligned();


### PR DESCRIPTION
Instead of using the jdk internal java.nio.Bits.unaligned, the code
now uses the "os.arch" system property that is part of the public
jdk contract. The list of values came from jdk 1.8.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
