### PR TITLE
GEODE-10209: Use AvailablePortHelper in InternalCacheForClientAccessD…

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/InternalCacheForClientAccessDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/InternalCacheForClientAccessDistributedTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.internal.cache;
 
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPort;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -75,6 +76,7 @@ public class InternalCacheForClientAccessDistributedTest implements java.io.Seri
       cache = serverCache;
 
       CacheServer cacheServer = serverCache.addCacheServer();
+      cacheServer.setPort(getRandomAvailableTCPPort());
       cacheServer.start();
     });
     clientVM.invoke(() -> {


### PR DESCRIPTION
…istributedTest

Prevent BindException by using AvailablePortHelper.
