### PR TITLE
GEODE-10254: Use original hostname if host is null.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DistributionLocatorId.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/admin/remote/DistributionLocatorId.java
@@ -248,12 +248,14 @@ public class DistributionLocatorId implements java.io.Serializable {
       sb.append(hostnameForClients);
     } else if (!isEmpty(bindAddress)) {
       sb.append(bindAddress);
-    } else {
+    } else if (null != host) {
       if (isMcastId()) {
         sb.append(host.getHostAddress());
       } else {
         sb.append(SocketCreator.getHostName(host));
       }
+    } else {
+      sb.append(hostname);
     }
 
     sb.append("[").append(port).append("]");

--- a/geode-core/src/test/java/org/apache/geode/internal/admin/remote/DistributionLocatorIdTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/admin/remote/DistributionLocatorIdTest.java
@@ -15,6 +15,7 @@
 
 package org.apache.geode.internal.admin.remote;
 
+import static org.apache.geode.internal.admin.remote.DistributionLocatorId.unmarshal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.Mockito.mock;
@@ -56,7 +57,7 @@ class DistributionLocatorIdTest {
     DistributionLocatorId distributionLocatorId3 =
         new DistributionLocatorId(40404, "127.0.0.1", null, "member3");
     DistributionLocatorId distributionLocatorId4 =
-        DistributionLocatorId.unmarshal(distributionLocatorId3.marshal());
+        unmarshal(distributionLocatorId3.marshal());
 
     assertThat(distributionLocatorId1).isEqualTo(distributionLocatorId2);
     assertThat(distributionLocatorId1).isEqualTo(distributionLocatorId3);
@@ -74,10 +75,17 @@ class DistributionLocatorIdTest {
   }
 
   @Test
-  void marshalForClientsMarshaledAddressWhenConstructedWithMarshaledAddress() {
-    final DistributionLocatorId locatorId = DistributionLocatorId.unmarshal("localhost[1234]");
+  void marshalForClientsReturnsOriginalHostnameWhenUnmarshalledHostnameIsResolvable() {
+    final String marshalled = "localhost[1234]";
+    final DistributionLocatorId locatorId = unmarshal(marshalled);
+    assertThat(locatorId.marshalForClients()).isEqualTo(marshalled);
+  }
 
-    assertThat(locatorId.marshalForClients()).isEqualTo("localhost[1234]");
+  @Test
+  void marshalForClientsReturnsOriginalHostnameWhenUnmarshalledHostnameIsNotResolvable() {
+    final String marshalled = "unknown.invalid[1234]";
+    final DistributionLocatorId locatorId = unmarshal(marshalled);
+    assertThat(locatorId.marshalForClients()).isEqualTo(marshalled);
   }
 
   @Test
@@ -142,9 +150,8 @@ class DistributionLocatorIdTest {
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
-  void hashCodeDoesNotThrowWhenHostIsNull() {
-    final DistributionLocatorId locatorId =
-        DistributionLocatorId.unmarshal("unknown.invalid[1234]");
+  void hashCodeDoesNotThrowWhenHostnameIsNotResolvable() {
+    final DistributionLocatorId locatorId = unmarshal("unknown.invalid[1234]");
     assertThatNoException().isThrownBy(locatorId::hashCode);
   }
 }


### PR DESCRIPTION
If original hostname was not resolvable then host is null. Use hostname
if host is null when marshaling.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
