### PR TITLE
GEODE-7875:  fix create index gfsh command on partitioned region

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/IndexCommandsIntegrationTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/IndexCommandsIntegrationTestBase.java
@@ -136,7 +136,9 @@ public class IndexCommandsIntegrationTestBase {
     csb.addOption(CliStrings.CREATE_INDEX__REGION, SEPARATOR + regionName);
     csb.addOption(CliStrings.CREATE_INDEX__TYPE, "hash");
 
-    gfsh.executeAndAssertThat(csb.toString()).statusIsError();
+    gfsh.executeAndAssertThat(csb.toString())
+        .statusIsSuccess()
+        .containsOutput("Index \"indexA\" already exists.  Create failed due to duplicate name.");
   }
 
   @Test
@@ -170,7 +172,7 @@ public class IndexCommandsIntegrationTestBase {
     createSimpleIndexA();
     gfsh.executeAndAssertThat(
         "create index --name=indexA --expression=key --region=" + SEPARATOR + "regionA")
-        .statusIsError()
+        .statusIsSuccess()
         .containsOutput("Index \"indexA\" already exists.  Create failed due to duplicate name");
   }
 

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandDUnitTest.java
@@ -50,13 +50,12 @@ public class CreateIndexCommandDUnitTest {
 
   private static MemberVM locator;
   private static MemberVM server1;
-  private static MemberVM server2;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
     locator = cluster.startLocatorVM(0);
     server1 = cluster.startServerVM(1, locator.getPort());
-    server2 = cluster.startServerVM(2, "group2", locator.getPort());
+    cluster.startServerVM(2, "group2", locator.getPort());
     gfsh.connectAndVerify(locator);
 
     // create a region on server-2 in group 2
@@ -216,12 +215,10 @@ public class CreateIndexCommandDUnitTest {
   @Test
   public void indexCreationOnPartitionedRegionUpdateClusterConfig() {
     int serversNum = 8;
-    MemberVM serversArray[] = new MemberVM[serversNum];
-
     int initialIndex = 1;
-    for (int index = 2; index < serversArray.length; index++) {
-      serversArray[index] =
-          cluster.startServerVM(initialIndex + index, locator.getPort());
+
+    for (int index = 2; index < serversNum; index++) {
+      cluster.startServerVM(initialIndex + index, locator.getPort());
     }
 
     gfsh.executeAndAssertThat("create region --name=regionC --type=PARTITION")
@@ -231,9 +228,7 @@ public class CreateIndexCommandDUnitTest {
         "create index --name=index1 --expression=id --region=regionC")
         .statusIsSuccess()
         .hasTableSection()
-        .hasRowSize(1)
-        .hasRow(0)
-        .contains("OK", "Index successfully created");
+        .hasRowSize(8);
 
     gfsh.executeAndAssertThat("export cluster-configuration")
         .statusIsSuccess()
@@ -242,5 +237,4 @@ public class CreateIndexCommandDUnitTest {
         .contains(
             "index name=\"index1\" expression=\"id\" from-clause=\"/regionC\" key-index=\"false\" type=\"range\"");
   }
-
 }

--- a/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandDUnitTest.java
+++ b/geode-gfsh/src/distributedTest/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommandDUnitTest.java
@@ -48,7 +48,9 @@ public class CreateIndexCommandDUnitTest {
   @ClassRule
   public static GfshCommandRule gfsh = new GfshCommandRule();
 
-  private static MemberVM locator, server1, server2;
+  private static MemberVM locator;
+  private static MemberVM server1;
+  private static MemberVM server2;
 
   @BeforeClass
   public static void beforeClass() throws Exception {
@@ -71,7 +73,7 @@ public class CreateIndexCommandDUnitTest {
   }
 
   @Test
-  public void createIndexOnSubRegion() throws Exception {
+  public void createIndexOnSubRegion() {
     gfsh.executeAndAssertThat(
         "create region --name=regionB" + SEPARATOR + "child --group=group2 --type=REPLICATE")
         .statusIsSuccess();
@@ -107,7 +109,7 @@ public class CreateIndexCommandDUnitTest {
   @Test
   // index can't be created on region name with ".".
   // GEODE-7523
-  public void createIndexOnRegionNameWithDot() throws Exception {
+  public void createIndexOnRegionNameWithDot() {
     gfsh.executeAndAssertThat("create region --name=A.B --type=REPLICATE")
         .statusIsSuccess();
     gfsh.executeAndAssertThat("create index --name=indexWithDot --region=A.B --expression=id")
@@ -124,7 +126,7 @@ public class CreateIndexCommandDUnitTest {
   }
 
   @Test
-  public void regionNotExistInThatMember() throws Exception {
+  public void regionNotExistInThatMember() {
     gfsh.executeAndAssertThat(
         "create index --name=myIndex --expression=id --region=" + SEPARATOR
             + "regionB --member=server-1")
@@ -210,4 +212,35 @@ public class CreateIndexCommandDUnitTest {
     commandAssert.hasInfoSection().hasOutput()
         .contains("Region regionB does not exist in some of the groups.");
   }
+
+  @Test
+  public void indexCreationOnPartitionedRegionUpdateClusterConfig() {
+    int serversNum = 8;
+    MemberVM serversArray[] = new MemberVM[serversNum];
+
+    int initialIndex = 1;
+    for (int index = 2; index < serversArray.length; index++) {
+      serversArray[index] =
+          cluster.startServerVM(initialIndex + index, locator.getPort());
+    }
+
+    gfsh.executeAndAssertThat("create region --name=regionC --type=PARTITION")
+        .statusIsSuccess();
+
+    gfsh.executeAndAssertThat(
+        "create index --name=index1 --expression=id --region=regionC")
+        .statusIsSuccess()
+        .hasTableSection()
+        .hasRowSize(1)
+        .hasRow(0)
+        .contains("OK", "Index successfully created");
+
+    gfsh.executeAndAssertThat("export cluster-configuration")
+        .statusIsSuccess()
+        .hasInfoSection()
+        .hasOutput()
+        .contains(
+            "index name=\"index1\" expression=\"id\" from-clause=\"/regionC\" key-index=\"false\" type=\"range\"");
+  }
+
 }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
@@ -134,8 +134,7 @@ public class CreateIndexCommand extends GfshCommand {
         if (cacheConf != null && !regionName.isEmpty()) {
           RegionConfig regionConf = cacheConf.findRegionConfiguration(regionName);
           if (regionConf.getType().equals("PARTITION")) {
-            DistributedMember member = targetMembers.iterator().next();
-            targetMembers.removeIf(s -> (s != member));
+            targetMembers = findAnyMembersForRegion(regionPath);
           }
         }
       }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
@@ -96,9 +96,8 @@ public class CreateIndexCommand extends GfshCommand {
             .createError("Region " + regionName + " does not exist in some of the groups.");
       }
       if (groups == null) {
-        // the calculatedGroups will have "cluster" value to indicate the "cluster" level, in this
-        // case
-        // we want the groups to an empty array
+        // the calculatedGroups will have "cluster" value to indicate the "cluster" level,
+        // in this case we want the groups to an empty array
         groups = calculatedGroups.stream().filter(s -> !AbstractConfiguration.CLUSTER.equals(s))
             .toArray(String[]::new);
       }

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/commands/CreateIndexCommand.java
@@ -133,13 +133,13 @@ public class CreateIndexCommand extends GfshCommand {
         CacheConfig cacheConf = ccService.getCacheConfig(group);
         if (cacheConf != null && !regionName.isEmpty()) {
           RegionConfig regionConf = cacheConf.findRegionConfiguration(regionName);
-          if (regionConf.getType().equals("PARTITION")) {
+          if (regionConf.getType().equals("PARTITION") && targetMembers.size() > 1) {
+            targetMembers.clear();
             targetMembers = findAnyMembersForRegion(regionPath);
           }
         }
       }
     }
-
     List<CliFunctionResult> functionResults =
         executeAndGetFunctionResult(createIndexFunction, index, targetMembers);
     resultModel.addTableAndSetStatus("createIndex", functionResults, true, false);

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/functions/CreateIndexFunction.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/functions/CreateIndexFunction.java
@@ -66,11 +66,13 @@ public class CreateIndexFunction implements InternalFunction<RegionConfig.Index>
     } catch (IndexExistsException e) {
       String message =
           CliStrings.format(CliStrings.CREATE_INDEX__INDEX__EXISTS, indexInfo.getName());
-      context.getResultSender().lastResult(new CliFunctionResult(memberId, false, message));
+      context.getResultSender().lastResult(
+          new CliFunctionResult(memberId, CliFunctionResult.StatusState.IGNORABLE, message));
     } catch (IndexNameConflictException e) {
       String message =
           CliStrings.format(CliStrings.CREATE_INDEX__NAME__CONFLICT, indexInfo.getName());
-      context.getResultSender().lastResult(new CliFunctionResult(memberId, false, message));
+      context.getResultSender().lastResult(
+          new CliFunctionResult(memberId, CliFunctionResult.StatusState.IGNORABLE, message));
     } catch (RegionNotFoundException e) {
       String message = CliStrings.format(CliStrings.CREATE_INDEX__INVALID__REGIONPATH,
           indexInfo.getFromClause());


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

The new solution is added regarding comment from the [dev list](https://markmail.org/message/uxhlysb2nx3u7p6y).
When creating an index on the partition region it should just send to one server as it will propagate the create index message to the rest of the members of that group(cluster or one the user specified in the command).


### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
