### PR TITLE
GEODE-10242: Do not release primary lock prematurely

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
@@ -888,9 +888,9 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
           ((BucketRegion) br).beforeReleasingPrimaryLockDuringDemotion();
         }
 
+        releasePrimaryLock();
         // this was a deposePrimary call so we need to depose children as well
         deposePrimaryForColocatedChildren();
-        releasePrimaryLock();
 
         if (pRegion.isFixedPartitionedRegion()) {
           deposeOtherPrimaryBucketForFixedPartition();

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/BucketAdvisor.java
@@ -301,7 +301,7 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    * Caller must synchronize on this BucketAdvisor.
    *
    */
-  void deposePrimaryForColocatedChildren() {
+  private void deposePrimaryForColocatedChildren() {
     boolean deposedChildPrimaries = true;
     List<PartitionedRegion> colocatedChildPRs = ColocationHelper.getColocatedChildRegions(pRegion);
     if (colocatedChildPRs != null) {
@@ -837,7 +837,7 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    *
    * @param member the member who is not primary
    */
-  void removePrimary(InternalDistributedMember member) {
+  private void removePrimary(InternalDistributedMember member) {
     boolean needToVolunteerForPrimary = false;
     if (!isClosed()) { // hole: requestPrimaryState not hosting
       initializationGate();
@@ -1663,7 +1663,7 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
    *
    * @param id the member to use as primary for this bucket
    */
-  synchronized void setPrimaryMember(InternalDistributedMember id) {
+  private void setPrimaryMember(InternalDistributedMember id) {
     if (!getDistributionManager().getId().equals(id)) {
       // volunteerForPrimary handles primary state change if its our id
       if (isHosting()) {
@@ -1802,7 +1802,7 @@ public class BucketAdvisor extends CacheDistributionAdvisor {
   /**
    * Releases the primary lock for this bucket.
    */
-  void releasePrimaryLock() {
+  private void releasePrimaryLock() {
     // We don't have a lock if we have a parent advisor
     if (parentAdvisor != null) {
       return;

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketAdvisorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketAdvisorTest.java
@@ -33,13 +33,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
-import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
 
 import org.apache.geode.cache.PartitionAttributes;
 import org.apache.geode.cache.server.CacheServer;
@@ -49,14 +45,6 @@ import org.apache.geode.internal.cache.partitioned.Bucket;
 import org.apache.geode.internal.cache.partitioned.RegionAdvisor;
 
 class BucketAdvisorTest {
-  @Mock
-  private PartitionedRegion partitionedRegion;
-  @Mock
-  private Bucket bucket;
-  @Mock
-  private RegionAdvisor regionAdvisor;
-
-  private AutoCloseable closeable;
 
   @Test
   void shouldBeMockable() throws Exception {
@@ -334,6 +322,9 @@ class BucketAdvisorTest {
 
   @Test
   void removePrimaryDeposePrimaryForColocatedChildrenBeforeReleasePrimaryLock() {
+    PartitionedRegion partitionedRegion = mock(PartitionedRegion.class);
+    Bucket bucket = mock(Bucket.class);
+    RegionAdvisor regionAdvisor = mock(RegionAdvisor.class);
     when(regionAdvisor.getPartitionedRegion()).thenReturn(partitionedRegion);
     when(regionAdvisor.getBucket(any(Integer.class))).thenReturn(bucket);
     when(partitionedRegion.getPartitionAttributes()).thenReturn(new PartitionAttributesImpl());
@@ -344,7 +335,7 @@ class BucketAdvisorTest {
     doReturn(true).when(bucketAdvisor).isPrimary();
     doReturn(manager).when(bucketAdvisor).getDistributionManager();
     when(manager.getId()).thenReturn(member);
-    bucketAdvisor.setPrimaryMemberForTest(member);
+    bucketAdvisor.setPrimaryMember(member);
     bucketAdvisor.setInitialized();
     doNothing().when(bucketAdvisor).deposePrimaryForColocatedChildren();
 
@@ -354,15 +345,5 @@ class BucketAdvisorTest {
     order.verify(bucketAdvisor).deposePrimaryForColocatedChildren();
     order.verify(bucketAdvisor).releasePrimaryLock();
     assertThat(bucketAdvisor.basicGetPrimaryMember()).isNull();
-  }
-
-  @BeforeEach
-  void init() {
-    closeable = MockitoAnnotations.openMocks(this);
-  }
-
-  @AfterEach
-  void close() throws Exception {
-    closeable.close();
   }
 }

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/BucketAdvisorTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/BucketAdvisorTest.java
@@ -23,7 +23,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -34,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
 import org.mockito.Mockito;
 
 import org.apache.geode.cache.PartitionAttributes;
@@ -318,32 +316,5 @@ class BucketAdvisorTest {
     assertThat(bucketAdvisor.putProfile(bp2, true)).isTrue();
 
     assertThat(bucketAdvisor.adviseInitialized().size()).isEqualTo(1);
-  }
-
-  @Test
-  void removePrimaryDeposePrimaryForColocatedChildrenBeforeReleasePrimaryLock() {
-    PartitionedRegion partitionedRegion = mock(PartitionedRegion.class);
-    Bucket bucket = mock(Bucket.class);
-    RegionAdvisor regionAdvisor = mock(RegionAdvisor.class);
-    when(regionAdvisor.getPartitionedRegion()).thenReturn(partitionedRegion);
-    when(regionAdvisor.getBucket(any(Integer.class))).thenReturn(bucket);
-    when(partitionedRegion.getPartitionAttributes()).thenReturn(new PartitionAttributesImpl());
-    when(bucket.getDistributionManager()).thenReturn(mock(DistributionManager.class));
-    BucketAdvisor bucketAdvisor = spy(BucketAdvisor.createBucketAdvisor(bucket, regionAdvisor));
-    InternalDistributedMember member = mock(InternalDistributedMember.class);
-    DistributionManager manager = mock(DistributionManager.class);
-    doReturn(true).when(bucketAdvisor).isPrimary();
-    doReturn(manager).when(bucketAdvisor).getDistributionManager();
-    when(manager.getId()).thenReturn(member);
-    bucketAdvisor.setPrimaryMember(member);
-    bucketAdvisor.setInitialized();
-    doNothing().when(bucketAdvisor).deposePrimaryForColocatedChildren();
-
-    InOrder order = inOrder(bucketAdvisor);
-    bucketAdvisor.removePrimary(member);
-
-    order.verify(bucketAdvisor).deposePrimaryForColocatedChildren();
-    order.verify(bucketAdvisor).releasePrimaryLock();
-    assertThat(bucketAdvisor.basicGetPrimaryMember()).isNull();
   }
 }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -770,10 +770,17 @@ public class WANTestBase extends DistributedTestCase {
 
   public static void createCustomerOrderShipmentPartitionedRegion(String senderIds,
       Integer redundantCopies, Integer totalNumBuckets, Boolean offHeap) {
+    createCustomerOrderShipmentPartitionedRegion(senderIds, redundantCopies, totalNumBuckets,
+        offHeap, RegionShortcut.PARTITION);
+  }
+
+  public static void createCustomerOrderShipmentPartitionedRegion(String senderIds,
+      Integer redundantCopies, Integer totalNumBuckets, Boolean offHeap,
+      RegionShortcut regionShortcut) {
     IgnoredException exp =
         addIgnoredException(ForceReattemptException.class.getName());
     try {
-      RegionFactory<?, ?> fact = cache.createRegionFactory(RegionShortcut.PARTITION);
+      RegionFactory<?, ?> fact = cache.createRegionFactory(regionShortcut);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -795,7 +802,7 @@ public class WANTestBase extends DistributedTestCase {
       paf.setRedundantCopies(redundantCopies).setTotalNumBuckets(totalNumBuckets)
           .setColocatedWith(customerRegionName)
           .setPartitionResolver(new CustomerIDPartitionResolver("CustomerIDPartitionResolver"));
-      fact = cache.createRegionFactory(RegionShortcut.PARTITION);
+      fact = cache.createRegionFactory(regionShortcut);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -813,7 +820,7 @@ public class WANTestBase extends DistributedTestCase {
       paf.setRedundantCopies(redundantCopies).setTotalNumBuckets(totalNumBuckets)
           .setColocatedWith(orderRegionName)
           .setPartitionResolver(new CustomerIDPartitionResolver("CustomerIDPartitionResolver"));
-      fact = cache.createRegionFactory(RegionShortcut.PARTITION);
+      fact = cache.createRegionFactory(regionShortcut);
       if (senderIds != null) {
         StringTokenizer tokenizer = new StringTokenizer(senderIds, ",");
         while (tokenizer.hasMoreTokens()) {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANConflationDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANConflationDistributedTest.java
@@ -21,7 +21,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.Logger;
@@ -499,12 +498,9 @@ public class ParallelWANConflationDistributedTest extends WANTestBase {
     int sid = oid + 1;
     ShipmentId shipmentId = new ShipmentId(sid, orderId);
 
-    await().atMost(15, TimeUnit.SECONDS)
-        .untilAsserted(() -> assertThat(orderRegion.get(orderId)).isNotNull());
-    await().atMost(15, TimeUnit.SECONDS)
-        .untilAsserted(() -> assertThat(shipmentRegion.get(shipmentId)).isNotNull());
-    await().atMost(15, TimeUnit.SECONDS)
-        .untilAsserted(() -> assertThat(customerRegion.get(custid)).isNotNull());
+    await().untilAsserted(() -> assertThat(orderRegion.get(orderId)).isNotNull());
+    await().untilAsserted(() -> assertThat(shipmentRegion.get(shipmentId)).isNotNull());
+    await().untilAsserted(() -> assertThat(customerRegion.get(custid)).isNotNull());
   }
 
   protected void validateColocatedRegionContents(Map<?, ?> custKeyValues, Map<?, ?> orderKeyValues,


### PR DESCRIPTION
 * When depose primary during rebalance, do not release the primary lock
   before all colocated child buckets has deposed primary. This is to
   ensure that the node becomes new primary can only acquire the primary
   lock afterwards.
 * All colocated buckets now share the same primaryMoveReadWriteLock.
   When parent bucket is being moved, no operations will be executed on
   child buckets as well. So moving primary for all colocated buckets
   shold be faster, and there is no need to hold parent locks anymore.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
