### PR TITLE
GEODE-10261: VMProvider.invokeAsync uses appropriate parameterization.

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/ConnectionPoolDUnitTest.java
@@ -466,8 +466,8 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
     };
 
     logger.info("before initialize client");
-    AsyncInvocation inv2 = vm2.invokeAsync("Initialize Client", initializeClient);
-    AsyncInvocation inv3 = vm3.invokeAsync("Initialize Client", initializeClient);
+    AsyncInvocation<Void> inv2 = vm2.invokeAsync("Initialize Client", initializeClient);
+    AsyncInvocation<Void> inv3 = vm3.invokeAsync("Initialize Client", initializeClient);
 
     inv2.await();
     inv3.await();
@@ -526,7 +526,7 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
     // Initialize each client with entries (so that afterInvalidate is called)
 
     logger.info("before initialize client");
-    AsyncInvocation inv2 = client.invokeAsync("Initialize Client", () -> {
+    AsyncInvocation<Void> inv2 = client.invokeAsync("Initialize Client", () -> {
       Region<Object, Object> region = getRootRegion().getSubregion(name);
       PoolStats stats = ((PoolImpl) PoolManager.find(poolName)).getStats();
       int oldConnects = stats.getConnects();
@@ -780,8 +780,8 @@ public class ConnectionPoolDUnitTest extends JUnit4CacheTestCase {
       throws CacheException, InterruptedException {
     final String name = getName();
 
-    AsyncInvocation putAI = null;
-    AsyncInvocation putAI2 = null;
+    AsyncInvocation<Void> putAI = null;
+    AsyncInvocation<Void> putAI2 = null;
 
     try {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/CacheServerSSLConnectionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/client/internal/CacheServerSSLConnectionDUnitTest.java
@@ -479,7 +479,8 @@ public class CacheServerSSLConnectionDUnitTest extends JUnit4DistributedTestCase
 
     String hostName = getHostName();
 
-    AsyncInvocation slowAsync = slowClientVM.invokeAsync(() -> connectToServer(hostName, port));
+    AsyncInvocation<Void> slowAsync =
+        slowClientVM.invokeAsync(() -> connectToServer(hostName, port));
     try {
       getBlackboard().waitForGate("serverIsBlocked", 60, TimeUnit.SECONDS);
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsDUnitTest.java
@@ -2016,8 +2016,8 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
     final int fakeHeapMaxSize = 1000;
 
     // Make sure the desired VMs will have a fresh DS.
-    AsyncInvocation d1 = replicate1.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
-    AsyncInvocation d2 = replicate2.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
+    AsyncInvocation<Void> d1 = replicate1.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
+    AsyncInvocation<Void> d2 = replicate2.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
     d1.join();
     assertFalse(d1.exceptionOccurred());
     d2.join();
@@ -2232,8 +2232,8 @@ public class MemoryThresholdsDUnitTest extends ClientServerTestCase {
     final int fakeHeapMaxSize = 1000;
 
     // Make sure the desired VMs will have a fresh DS.
-    AsyncInvocation d0 = accessor.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
-    AsyncInvocation d1 = ds1.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
+    AsyncInvocation<Void> d0 = accessor.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
+    AsyncInvocation<Void> d1 = ds1.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
     d0.join();
     assertFalse(d0.exceptionOccurred());
     d1.join();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsOffHeapDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/management/MemoryThresholdsOffHeapDUnitTest.java
@@ -529,8 +529,8 @@ public class MemoryThresholdsOffHeapDUnitTest extends ClientServerTestCase {
     final String rName = getUniqueName();
 
     // Make sure the desired VMs will have a fresh DS.
-    AsyncInvocation d1 = replicate1.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
-    AsyncInvocation d2 = replicate2.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
+    AsyncInvocation<Void> d1 = replicate1.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
+    AsyncInvocation<Void> d2 = replicate2.invokeAsync(JUnit4DistributedTestCase::disconnectFromDS);
     d1.join();
     assertFalse(d1.exceptionOccurred());
     d2.join();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/partition/PartitionRegionHelperDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/partition/PartitionRegionHelperDUnitTest.java
@@ -98,9 +98,9 @@ public class PartitionRegionHelperDUnitTest extends JUnit4CacheTestCase {
       }
     };
 
-    AsyncInvocation future1 = vm0.invokeAsync(assignBuckets);
-    AsyncInvocation future2 = vm1.invokeAsync(assignBuckets);
-    AsyncInvocation future3 = vm2.invokeAsync(assignBuckets);
+    AsyncInvocation<Void> future1 = vm0.invokeAsync(assignBuckets);
+    AsyncInvocation<Void> future2 = vm1.invokeAsync(assignBuckets);
+    AsyncInvocation<Void> future3 = vm2.invokeAsync(assignBuckets);
     future1.join(60 * 1000);
     future2.join(60 * 1000);
     future3.join(60 * 1000);
@@ -220,9 +220,9 @@ public class PartitionRegionHelperDUnitTest extends JUnit4CacheTestCase {
       }
     };
 
-    AsyncInvocation future1 = vm0.invokeAsync(assignBuckets);
-    AsyncInvocation future2 = vm1.invokeAsync(assignBuckets);
-    AsyncInvocation future3 = vm2.invokeAsync(assignBuckets);
+    AsyncInvocation<Void> future1 = vm0.invokeAsync(assignBuckets);
+    AsyncInvocation<Void> future2 = vm1.invokeAsync(assignBuckets);
+    AsyncInvocation<Void> future3 = vm2.invokeAsync(assignBuckets);
     future1.join();
     future2.join();
     future3.join();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/CompactRangeIndexDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/CompactRangeIndexDUnitTest.java
@@ -149,7 +149,7 @@ public class CompactRangeIndexDUnitTest extends JUnit4DistributedTestCase {
 
   public void doQuery() throws InterruptedException {
     final String[] qarr = {"1", "519", "181"};
-    AsyncInvocation as0 = vm0.invokeAsync(new CacheSerializableRunnable("Executing query") {
+    AsyncInvocation<Void> as0 = vm0.invokeAsync(new CacheSerializableRunnable("Executing query") {
       @Override
       public void run2() throws CacheException {
         for (int i = 0; i < 50; i++) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryVersionedClassDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxLocalQueryVersionedClassDUnitTest.java
@@ -103,7 +103,7 @@ public class PdxLocalQueryVersionedClassDUnitTest extends PDXQueryTestBase {
     // Execute same query remotely from client using 2 threads
     // Since this is a bind query, the query object will be shared
     // between the 2 threads.
-    AsyncInvocation a1 = client.invokeAsync(new SerializableCallable("Query from client") {
+    AsyncInvocation<Void> a1 = client.invokeAsync(new SerializableCallable("Query from client") {
       @Override
       public Object call() throws Exception {
         QueryService qs = null;
@@ -129,7 +129,7 @@ public class PdxLocalQueryVersionedClassDUnitTest extends PDXQueryTestBase {
       }
     });
 
-    AsyncInvocation a2 = client.invokeAsync(new SerializableCallable("Query from client") {
+    AsyncInvocation<Void> a2 = client.invokeAsync(new SerializableCallable("Query from client") {
       @Override
       public Object call() throws Exception {
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxMultiThreadQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/PdxMultiThreadQueryDUnitTest.java
@@ -158,7 +158,7 @@ public class PdxMultiThreadQueryDUnitTest extends PDXQueryTestBase {
         new int[] {port0, port1, port2}, true);
 
     final int size = 100;
-    AsyncInvocation[] asyncInvocationArray = new AsyncInvocation[size];
+    AsyncInvocation<?>[] asyncInvocationArray = new AsyncInvocation[size];
     for (int i = 0; i < size; i++) {
       asyncInvocationArray[i] =
           client.invokeAsync(() -> {

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryDataInconsistencyDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryDataInconsistencyDUnitTest.java
@@ -110,7 +110,7 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
     // Invoke update from client and stop in updateIndex
     // firesultSett before updating the RegionEntry and second after updating
     // the RegionEntry.
-    AsyncInvocation putThread = server.invokeAsync("update a Region Entry", () -> {
+    AsyncInvocation<Void> putThread = server.invokeAsync("update a Region Entry", () -> {
       Region repRegion = cacheRule.getCache().getRegion(repRegionName);
       IndexManager.testHook = new IndexManagerTestHook();
       repRegion.put(new Integer("1"), new Portfolio(cntDest + 1));
@@ -196,7 +196,7 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
     // Invoke update from client and stop in updateIndex
     // firesultSett before updating the RegionEntry and second after updating
     // the RegionEntry.
-    AsyncInvocation putThread = server.invokeAsync("update a Region Entry", () -> {
+    AsyncInvocation<Void> putThread = server.invokeAsync("update a Region Entry", () -> {
       Cache cache = cacheRule.getCache();
       Region repRegion = cache.getRegion(repRegionName);
       IndexManager.testHook = new IndexManagerTestHook();
@@ -281,7 +281,7 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
     // Invoke update from client and stop in updateIndex
     // firesultSett before updating the RegionEntry and second after updating
     // the RegionEntry.
-    AsyncInvocation putThread = server.invokeAsync("update a Region Entry", () -> {
+    AsyncInvocation<Void> putThread = server.invokeAsync("update a Region Entry", () -> {
       Region repRegion = cacheRule.getCache().getRegion(repRegionName);
       IndexManager.testHook = new IndexManagerTestHook();
       // This portfolio with same ID must have different positions.
@@ -361,7 +361,7 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
     // Invoke update from client and stop in updateIndex
     // firesultSett before updating the RegionEntry and second after updating
     // the RegionEntry.
-    AsyncInvocation putThread = server.invokeAsync("update a Region Entry", () -> {
+    AsyncInvocation<Void> putThread = server.invokeAsync("update a Region Entry", () -> {
       Cache cache = cacheRule.getCache();
       Region repRegion = cache.getRegion(repRegionName);
       IndexManager.testHook = new IndexManagerTestHook();
@@ -420,7 +420,7 @@ public class QueryDataInconsistencyDUnitTest implements Serializable {
     await().until(joinThread(putThread));
   }
 
-  private Callable<Boolean> joinThread(AsyncInvocation thread) {
+  private Callable<Boolean> joinThread(AsyncInvocation<Void> thread) {
     return () -> {
       try {
         thread.join(100L);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexDUnitTest.java
@@ -155,8 +155,8 @@ public class QueryIndexDUnitTest extends JUnit4CacheTestCase {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
 
-    AsyncInvocation ai1 = null;
-    AsyncInvocation ai2 = null;
+    AsyncInvocation<Void> ai1 = null;
+    AsyncInvocation<Void> ai2 = null;
 
     vm0.invoke(QueryIndexDUnitTest::createIndex);
     vm0.invoke(QueryIndexDUnitTest::validateIndexUsage);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexUsingXMLDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryIndexUsingXMLDUnitTest.java
@@ -138,8 +138,8 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
 
     getLogWriter().info("Creating index using an xml file name : " + CACHE_XML_FILE_NAME);
 
-    AsyncInvocation async0 = vm0.invokeAsync(createIndexThroughXML(NAME));
-    AsyncInvocation async1 = vm1.invokeAsync(createIndexThroughXML(NAME));
+    AsyncInvocation<Void> async0 = vm0.invokeAsync(createIndexThroughXML(NAME));
+    AsyncInvocation<Void> async1 = vm1.invokeAsync(createIndexThroughXML(NAME));
 
     async1.await();
     async0.await();
@@ -365,7 +365,7 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
 
     getLogWriter().info("Creating index using an xml file name : " + CACHE_XML_FILE_NAME);
 
-    AsyncInvocation async0 = vm0.invokeAsync(createIndexThroughXML(NAME));
+    AsyncInvocation<Void> async0 = vm0.invokeAsync(createIndexThroughXML(NAME));
 
     async0.await();
 
@@ -374,7 +374,7 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
 
     vm1.invoke(setTestHook());
 
-    AsyncInvocation async1 = vm1.invokeAsync(createIndexThroughXML(NAME));
+    AsyncInvocation<Void> async1 = vm1.invokeAsync(createIndexThroughXML(NAME));
 
     vm0.invoke(prIndexCreationCheck(NAME, STATUS_INDEX, 50));
 
@@ -451,7 +451,7 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
 
     getLogWriter().info("Creating index using an xml file name : " + CACHE_XML_FILE_NAME);
 
-    AsyncInvocation async0 = vm0.invokeAsync(createIndexThroughXML(NAME));
+    AsyncInvocation<Void> async0 = vm0.invokeAsync(createIndexThroughXML(NAME));
 
     async0.await();
 
@@ -460,7 +460,7 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
 
     vm1.invoke(setTestHook());
 
-    AsyncInvocation async1 = vm1.invokeAsync(createIndexThroughXML(NAME));
+    AsyncInvocation<Void> async1 = vm1.invokeAsync(createIndexThroughXML(NAME));
 
     async1.await();
     async0.await();
@@ -496,7 +496,7 @@ public class QueryIndexUsingXMLDUnitTest extends JUnit4CacheTestCase {
     vm0.invokeAsync(loadRegion(NAME, 500));
     vm0.invokeAsync(loadRegion(REP_REG_NAME, 500));
 
-    AsyncInvocation async0 = vm0.invokeAsync(loadRegion(PERSISTENT_REG_NAME, 500));
+    AsyncInvocation<Void> async0 = vm0.invokeAsync(loadRegion(PERSISTENT_REG_NAME, 500));
 
     vm0.invokeAsync(loadRegion(NO_INDEX_REP_REG, 500));
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/ResourceManagerWithQueryMonitorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/dunit/ResourceManagerWithQueryMonitorDUnitTest.java
@@ -269,7 +269,7 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
         DefaultQuery.testHook = getPauseHook(true, controller);
       });
       // remove from here to ....
-      AsyncInvocation queryExecution1 = executeQueryOnClient(client);
+      AsyncInvocation<Integer> queryExecution1 = executeQueryOnClient(client);
 
       // Gives async invocation a chance to start
       Thread.sleep(1000);
@@ -291,7 +291,7 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
       });
       // We simulate a low memory/critical heap percentage hit
       setHeapToCriticalAndReleaseLatch(server1);
-      AsyncInvocation queryExecution = executeQueryOnClient(client);
+      AsyncInvocation<Integer> queryExecution = executeQueryOnClient(client);
       await().untilAsserted(() -> assertThat(queryExecution.get()).isEqualTo(0));
 
       verifyDroppedObjectsAndSetHeapToNormal(server1);
@@ -302,7 +302,7 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
     }
   }
 
-  private AsyncInvocation executeQueryOnClient(VM client) {
+  private AsyncInvocation<Integer> executeQueryOnClient(VM client) {
     return client.invokeAsync("execute query from client", () -> {
       try {
         Query query1 =
@@ -659,7 +659,7 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
       throws InterruptedException {
     createLatchTestHook(server, hitCriticalThreshold, VM.getController());
 
-    AsyncInvocation queryExecution = invokeClientQuery(client,
+    AsyncInvocation<Integer> queryExecution = invokeClientQuery(client,
         disabledQueryMonitorForLowMem, queryTimeout, hitCriticalThreshold, VM.getController());
 
     criticalMemoryCountDownLatch.await();
@@ -684,7 +684,7 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
   private void executeQueryWithCriticalHeapCalledAfterTimeout(VM server, VM client)
       throws InterruptedException {
     createLatchTestHook(server, false, VM.getController());
-    AsyncInvocation queryExecution = executeQueryWithTimeout(client);
+    AsyncInvocation<Integer> queryExecution = executeQueryWithTimeout(client);
 
     // Wait till the timeout expires on the query
     Thread.sleep(1 + TEST_QUERY_TIMEOUT);
@@ -702,7 +702,7 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
 
   }
 
-  private AsyncInvocation executeQueryWithTimeout(VM client) {
+  private AsyncInvocation<Integer> executeQueryWithTimeout(VM client) {
     return client.invokeAsync("execute query from client", () -> {
       QueryService qs;
       try {
@@ -738,7 +738,7 @@ public class ResourceManagerWithQueryMonitorDUnitTest extends ClientServerTestCa
 
   }
 
-  private AsyncInvocation invokeClientQuery(VM client,
+  private AsyncInvocation<Integer> invokeClientQuery(VM client,
       final boolean disabledQueryMonitorForLowMem,
       final int queryTimeout,
       final boolean hitCriticalThreshold,

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexInitOnOverflowRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexInitOnOverflowRegionDUnitTest.java
@@ -139,7 +139,7 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
 
     // Start changing the value in Region which should turn into a deadlock if
     // the fix is not there
-    AsyncInvocation asyncInv1 =
+    AsyncInvocation<Void> asyncInv1 =
         vm0.invokeAsync(new CacheSerializableRunnable("Change value in region") {
 
           @Override
@@ -164,7 +164,7 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
           }
         });
 
-    AsyncInvocation asyncInv2 =
+    AsyncInvocation<Void> asyncInv2 =
         vm0.invokeAsync(new CacheSerializableRunnable("Run query on region") {
 
           @Override
@@ -286,7 +286,7 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
       }
     });
 
-    AsyncInvocation asyncInv1 =
+    AsyncInvocation<Void> asyncInv1 =
         vm1.invokeAsync(new CacheSerializableRunnable("Change value in region") {
 
           @Override
@@ -302,7 +302,7 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
           }
         });
 
-    AsyncInvocation asyncInv2 =
+    AsyncInvocation<Void> asyncInv2 =
         vm0.invokeAsync(new CacheSerializableRunnable("Run query on region") {
 
           @Override
@@ -393,7 +393,7 @@ public class ConcurrentIndexInitOnOverflowRegionDUnitTest extends JUnit4CacheTes
     }
 
     // Asynch invocation for continuous index updates
-    AsyncInvocation indexUpdateAsysnch =
+    AsyncInvocation<Void> indexUpdateAsysnch =
         vm0.invokeAsync(new CacheSerializableRunnable("index updates") {
 
           @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexOperationsOnOverflowRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexOperationsOnOverflowRegionDUnitTest.java
@@ -130,7 +130,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
         });
 
     // Start changing the value in Region which should turn into a deadlock if the fix is not there
-    AsyncInvocation asyncInv1 =
+    AsyncInvocation<Void> asyncInv1 =
         vm0.invokeAsync(new CacheSerializableRunnable("Change value in region") {
 
           @Override
@@ -155,7 +155,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
           }
         });
 
-    AsyncInvocation asyncInv2 =
+    AsyncInvocation<Void> asyncInv2 =
         vm0.invokeAsync(new CacheSerializableRunnable("Run query on region") {
 
           @Override
@@ -235,7 +235,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
         });
 
     // Start changing the value in Region which should turn into a deadlock if the fix is not there
-    AsyncInvocation asyncInv1 =
+    AsyncInvocation<Void> asyncInv1 =
         vm0.invokeAsync(new CacheSerializableRunnable("Change value in region") {
 
           @Override
@@ -260,7 +260,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
           }
         });
 
-    AsyncInvocation asyncInv2 =
+    AsyncInvocation<Void> asyncInv2 =
         vm0.invokeAsync(new CacheSerializableRunnable("Run query on region") {
 
           @Override
@@ -341,7 +341,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
 
     // Start changing the value in Region which should turn into a deadlock if
     // the fix is not there
-    AsyncInvocation asyncInv1 =
+    AsyncInvocation<Void> asyncInv1 =
         vm0.invokeAsync(new CacheSerializableRunnable("Change value in region") {
 
           @Override
@@ -364,7 +364,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
           }
         });
 
-    AsyncInvocation asyncInv2 =
+    AsyncInvocation<Void> asyncInv2 =
         vm0.invokeAsync(new CacheSerializableRunnable("Run query on region") {
 
           @Override
@@ -443,7 +443,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
 
     // Start changing the value in Region which should turn into a deadlock if
     // the fix is not there
-    AsyncInvocation asyncInv1 =
+    AsyncInvocation<Void> asyncInv1 =
         vm0.invokeAsync(new CacheSerializableRunnable("Change value in region") {
 
           @Override
@@ -466,7 +466,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
           }
         });
 
-    AsyncInvocation asyncInv2 =
+    AsyncInvocation<Void> asyncInv2 =
         vm0.invokeAsync(new CacheSerializableRunnable("Run query on region") {
 
           @Override
@@ -535,7 +535,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
         });
 
     // Start changing the value in Region which should turn into a deadlock if the fix is not there
-    AsyncInvocation asyncInv1 =
+    AsyncInvocation<Void> asyncInv1 =
         vm0.invokeAsync(new CacheSerializableRunnable("Change value in region") {
 
           @Override
@@ -560,7 +560,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
           }
         });
 
-    AsyncInvocation asyncInv2 =
+    AsyncInvocation<Void> asyncInv2 =
         vm0.invokeAsync(new CacheSerializableRunnable("Run query on region") {
 
           @Override
@@ -631,7 +631,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
         });
 
     // Start changing the value in Region which should turn into a deadlock if the fix is not there
-    AsyncInvocation asyncInv1 =
+    AsyncInvocation<Void> asyncInv1 =
         vm0.invokeAsync(new CacheSerializableRunnable("Change value in region") {
 
           @Override
@@ -654,7 +654,7 @@ public class ConcurrentIndexOperationsOnOverflowRegionDUnitTest extends JUnit4Ca
           }
         });
 
-    AsyncInvocation asyncInv2 =
+    AsyncInvocation<Void> asyncInv2 =
         vm0.invokeAsync(new CacheSerializableRunnable("Run query on region") {
 
           @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest.java
@@ -169,7 +169,7 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
     vm0.invoke(helper.getCacheSerializableRunnableForPRIndexCreate(regionName, indexName,
         indexedExpression, fromClause, alias));
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[2];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[2];
 
     asyncInvs[0] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
@@ -177,11 +177,11 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
     asyncInvs[1] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 30 * 000);
     }
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }
@@ -217,7 +217,7 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
     vm0.invoke(helper.getCacheSerializableRunnableForPRIndexCreate(regionName, rindexName,
         rindexedExpression, rfromClause, ralias));
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[2];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[2];
 
     asyncInvs[0] = vm0.invokeAsync(
         helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, totalDataSize));
@@ -225,10 +225,10 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
     asyncInvs[1] = vm0.invokeAsync(
         helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, totalDataSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 30 * 000);
     }
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }
@@ -263,7 +263,7 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
         indexedExpression, fromClause, alias));
 
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[12];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[12];
 
     asyncInvs[0] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
@@ -301,11 +301,11 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
     asyncInvs[11] = vm3.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName,
         (3 * (stepSize)), totalDataSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 60 * 000);
     }
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }
@@ -344,7 +344,7 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
         rindexedExpression, rfromClause, ralias));
 
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[12];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[12];
 
     asyncInvs[0] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
@@ -382,10 +382,10 @@ public class ConcurrentIndexUpdateWithInplaceObjectModFalseDUnitTest
     asyncInvs[11] = vm3.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName,
         (3 * (stepSize)), totalDataSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 60 * 000);
     }
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexUpdateWithoutWLDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/ConcurrentIndexUpdateWithoutWLDUnitTest.java
@@ -144,7 +144,7 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     vm0.invoke(helper.getCacheSerializableRunnableForPRIndexCreate(regionName, indexName,
         indexedExpression, fromClause, alias));
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[2];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[2];
 
     asyncInvs[0] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
@@ -152,11 +152,11 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     asyncInvs[1] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 30 * 000);
     }
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }
@@ -189,7 +189,7 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     vm0.invoke(
         helper.getCacheSerializableRunnableForDefineIndex(regionName, names, exps, fromClauses));
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[2];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[2];
 
     asyncInvs[0] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
@@ -197,11 +197,11 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     asyncInvs[1] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 30 * 000);
     }
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }
@@ -236,7 +236,7 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     vm0.invoke(helper.getCacheSerializableRunnableForPRIndexCreate(regionName, rindexName,
         rindexedExpression, rfromClause, ralias));
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[2];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[2];
 
     asyncInvs[0] = vm0.invokeAsync(
         helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, totalDataSize));
@@ -244,10 +244,10 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     asyncInvs[1] = vm0.invokeAsync(
         helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, totalDataSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 30 * 000);
     }
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }
@@ -282,7 +282,7 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
         indexedExpression, fromClause, alias));
 
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[12];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[12];
 
     asyncInvs[0] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
@@ -320,11 +320,11 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     asyncInvs[11] = vm3.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName,
         (3 * (stepSize)), totalDataSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 60 * 000);
     }
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }
@@ -362,7 +362,7 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
         rindexedExpression, rfromClause, ralias));
 
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[12];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[12];
 
     asyncInvs[0] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
@@ -400,10 +400,10 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     asyncInvs[11] = vm3.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName,
         (3 * (stepSize)), totalDataSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 60 * 000);
     }
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }
@@ -452,7 +452,7 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     vm0.invoke(
         helper.getCacheSerializableRunnableForDefineIndex(regionName, names, exps, fromClauses));
 
-    AsyncInvocation[] asyncInvs = new AsyncInvocation[12];
+    AsyncInvocation<?>[] asyncInvs = new AsyncInvocation[12];
 
     asyncInvs[0] =
         vm0.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName, 0, stepSize));
@@ -490,11 +490,11 @@ public class ConcurrentIndexUpdateWithoutWLDUnitTest extends JUnit4DistributedTe
     asyncInvs[11] = vm3.invokeAsync(helper.getCacheSerializableRunnableForPRRandomOps(regionName,
         (3 * (stepSize)), totalDataSize));
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       ThreadUtils.join(inv, 60 * 000);
     }
 
-    for (AsyncInvocation inv : asyncInvs) {
+    for (AsyncInvocation<?> inv : asyncInvs) {
       if (inv.exceptionOccurred()) {
         Assert.fail("Random region operation failed on VM_" + inv.getId(), inv.getException());
       }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/IndexTrackingQueryObserverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/IndexTrackingQueryObserverDUnitTest.java
@@ -95,8 +95,8 @@ public class IndexTrackingQueryObserverDUnitTest extends JUnit4CacheTestCase {
     initializeRegion(ds0);
 
     // Check query verbose on both VMs
-    AsyncInvocation async1 = verifyQueryVerboseData(ds0, TOTAL_OBJECTS / 2);
-    AsyncInvocation async2 = verifyQueryVerboseData(ds1, TOTAL_OBJECTS / 2);
+    AsyncInvocation<Void> async1 = verifyQueryVerboseData(ds0, TOTAL_OBJECTS / 2);
+    AsyncInvocation<Void> async2 = verifyQueryVerboseData(ds1, TOTAL_OBJECTS / 2);
 
     // Run query on one vm only.
     runQuery(ds1);
@@ -243,7 +243,7 @@ public class IndexTrackingQueryObserverDUnitTest extends JUnit4CacheTestCase {
     vm.invoke(runQuery);
   }
 
-  private AsyncInvocation verifyQueryVerboseData(VM vm, final int results) {
+  private AsyncInvocation<Void> verifyQueryVerboseData(VM vm, final int results) {
 
     SerializableRunnable testQueryVerbose = new SerializableRunnable("Test Query Verbose Data") {
 
@@ -287,7 +287,7 @@ public class IndexTrackingQueryObserverDUnitTest extends JUnit4CacheTestCase {
         assertEquals(results, totalResults);
       }
     };
-    AsyncInvocation asyncInv = vm.invokeAsync(testQueryVerbose);
+    AsyncInvocation<Void> asyncInv = vm.invokeAsync(testQueryVerbose);
     return asyncInv;
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/InitializeIndexEntryDestroyQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/InitializeIndexEntryDestroyQueryDUnitTest.java
@@ -107,9 +107,9 @@ public class InitializeIndexEntryDestroyQueryDUnitTest extends JUnit4CacheTestCa
       final PortfolioData[] portfolio = createPortfolioData(cnt, cntDest);
       vm0.invoke(
           PRQHelp.getCacheSerializableRunnableForPRPuts(regionName, portfolio, cnt, cntDest));
-      AsyncInvocation asyInvk0 =
+      AsyncInvocation<Void> asyInvk0 =
           vm0.invokeAsync(() -> consecutivelyCreateAndDestroyIndex(regionName));
-      AsyncInvocation asyInvk1 =
+      AsyncInvocation<Void> asyInvk1 =
           vm0.invokeAsync(() -> consecutivelyPutAndDestroyEntries(regionName));
       vm0.invoke(() -> executeAndValidateQueryResults(query));
       waitForAsyncThreadsToComplete(asyInvk0, asyInvk1);
@@ -141,7 +141,8 @@ public class InitializeIndexEntryDestroyQueryDUnitTest extends JUnit4CacheTestCa
 
   }
 
-  private void waitForAsyncThreadsToComplete(AsyncInvocation asyInvk0, AsyncInvocation asyInvk1) {
+  private void waitForAsyncThreadsToComplete(AsyncInvocation<Void> asyInvk0,
+      AsyncInvocation<Void> asyInvk1) {
     ThreadUtils.join(asyInvk0, 1000 * 1000); // TODO: this is way too long: 16.67 minutes!
     if (asyInvk0.exceptionOccurred()) {
       logger.error("Asynchronous thread to create and destroy index failed",

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/MultiIndexCreationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/internal/index/MultiIndexCreationDUnitTest.java
@@ -67,7 +67,7 @@ public class MultiIndexCreationDUnitTest extends JUnit4CacheTestCase {
     final String name = SEPARATOR + regionName;
 
     // Start server1
-    AsyncInvocation a1 = server1.invokeAsync(new SerializableCallable("Create Server1") {
+    AsyncInvocation<Void> a1 = server1.invokeAsync(new SerializableCallable("Create Server1") {
       @Override
       public Object call() throws Exception {
         Region r = getCache().createRegionFactory(RegionShortcut.REPLICATE).create(regionName);
@@ -93,7 +93,7 @@ public class MultiIndexCreationDUnitTest extends JUnit4CacheTestCase {
     final String[] queries = {"select * from " + name + " where status = 'active'",
         "select * from " + name + " where ID > 4"};
 
-    AsyncInvocation a2 = server1.invokeAsync(new SerializableCallable("Create Server1") {
+    AsyncInvocation<Void> a2 = server1.invokeAsync(new SerializableCallable("Create Server1") {
       @Override
       public Object call() throws Exception {
         long giveupTime = System.currentTimeMillis() + 60000;

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicIndexCreationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicIndexCreationDUnitTest.java
@@ -251,9 +251,9 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
     String fileName = "PRIndexCreation.xml";
     setCacheInVMsUsingXML(fileName, vm0, vm1);
 
-    AsyncInvocation async0 = vm0.invokeAsync(
+    AsyncInvocation<Void> async0 = vm0.invokeAsync(
         prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(PARTITIONED_REGION_NAME));
-    AsyncInvocation async1 = vm1.invokeAsync(
+    AsyncInvocation<Void> async1 = vm1.invokeAsync(
         prQueryDUnitHelper.getCacheSerializableRunnableForPRCreate(PARTITIONED_REGION_NAME));
 
     async0.await();
@@ -458,10 +458,10 @@ public class PRBasicIndexCreationDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForCloseCache());
     setCacheInVMs(vm0);
 
-    AsyncInvocation regionCreateFuture =
+    AsyncInvocation<Void> regionCreateFuture =
         vm0.invokeAsync(prQueryDUnitHelper.getCacheSerializableRunnableForPersistentPRCreate(
             PARTITIONED_REGION_NAME, redundancy, PortfolioData.class));
-    AsyncInvocation indexCreateFuture =
+    AsyncInvocation<Void> indexCreateFuture =
         vm1.invokeAsync(prQueryDUnitHelper.getCacheSerializableRunnableForPRIndexCreate(
             PARTITIONED_REGION_NAME, "PrIndexOnId", "p.ID", null, "p"));
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicMultiIndexCreationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicMultiIndexCreationDUnitTest.java
@@ -401,7 +401,7 @@ public class PRBasicMultiIndexCreationDUnitTest extends CacheTestCase {
     vm0.invoke(PRQHelp.getCacheSerializableRunnableForCloseCache());
     setCacheInVMs(vm0);
 
-    AsyncInvocation regionCreateFuture = vm0.invokeAsync(PRQHelp
+    AsyncInvocation<Void> regionCreateFuture = vm0.invokeAsync(PRQHelp
         .getCacheSerializableRunnableForPersistentPRCreate(name, redundancy, PortfolioData.class));
 
     ArrayList<String> names = new ArrayList<>();
@@ -410,7 +410,7 @@ public class PRBasicMultiIndexCreationDUnitTest extends CacheTestCase {
     ArrayList<String> exps = new ArrayList<>();
     exps.add("ID");
 
-    AsyncInvocation indexCreateFuture =
+    AsyncInvocation<Void> indexCreateFuture =
         vm1.invokeAsync(PRQHelp.getCacheSerializableRunnableForDefineIndex(name, names, exps));
 
     regionCreateFuture.await();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicQueryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRBasicQueryDUnitTest.java
@@ -191,10 +191,10 @@ public class PRBasicQueryDUnitTest extends CacheTestCase {
         redundancy, PortfolioData.class, true));
 
     // Now start the child regions asynchronously so queries will happen during persistent recovery
-    AsyncInvocation async0 =
+    AsyncInvocation<Void> async0 =
         vm0.invokeAsync(prQueryDUnitHelper.getCacheSerializableRunnableForColocatedChildCreate(name,
             redundancy, PortfolioData.class, true));
-    AsyncInvocation async1 =
+    AsyncInvocation<Void> async1 =
         vm1.invokeAsync(prQueryDUnitHelper.getCacheSerializableRunnableForColocatedChildCreate(name,
             redundancy, PortfolioData.class, true));
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRQueryRegionCloseDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRQueryRegionCloseDUnitTest.java
@@ -119,7 +119,7 @@ public class PRQueryRegionCloseDUnitTest extends CacheTestCase {
     vm0.invoke(prQueryDUnitHelper.getCacheSerializableRunnableForPRPuts(LOCAL_REGION_NAME,
         portfolio, START_PORTFOLIO_INDEX, END_PORTFOLIO_INDEX));
 
-    AsyncInvocation async0 =
+    AsyncInvocation<Void> async0 =
         vm0.invokeAsync(prQueryDUnitHelper.getCacheSerializableRunnableForPRQueryAndCompareResults(
             PARTITIONED_REGION_NAME, LOCAL_REGION_NAME));
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRQueryRegionDestroyedDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache/query/partitioned/PRQueryRegionDestroyedDUnitTest.java
@@ -120,7 +120,7 @@ public class PRQueryRegionDestroyedDUnitTest extends CacheTestCase {
 
     // Now execute the query. And while query execution in process destroy the region
     // on one of the node.
-    AsyncInvocation async0 =
+    AsyncInvocation<Void> async0 =
         vm0.invokeAsync(prQueryDUnitHelper.getCacheSerializableRunnableForPRQueryAndCompareResults(
             PARTITIONED_REGION_NAME, LOCAL_REGION_NAME));
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/CacheMapTxnDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/CacheMapTxnDUnitTest.java
@@ -150,17 +150,11 @@ public class CacheMapTxnDUnitTest extends JUnit4DistributedTestCase { // TODO: r
     VM vm0 = host.getVM(0);
     VM vm1 = host.getVM(1);
     vm0.invoke(CacheMapTxnDUnitTest::miscMethodsOwner);
-    AsyncInvocation o2 = vm0.invokeAsync(CacheMapTxnDUnitTest::miscMethodsNotOwner);// invoke
-                                                                                    // in
-                                                                                    // same
-                                                                                    // vm but
-                                                                                    // in
-                                                                                    // separate
-                                                                                    // thread
-    AsyncInvocation o3 = vm1.invokeAsync(CacheMapTxnDUnitTest::miscMethodsNotOwner);// invoke
-                                                                                    // in
-                                                                                    // another
-                                                                                    // vm
+    // invoke in same vm but in separate thread
+    AsyncInvocation<Void> o2 = vm0.invokeAsync(CacheMapTxnDUnitTest::miscMethodsNotOwner);
+    // invoke in another vm
+    AsyncInvocation<Void> o3 = vm1.invokeAsync(CacheMapTxnDUnitTest::miscMethodsNotOwner);
+
     ThreadUtils.join(o2, 30 * 1000);
     ThreadUtils.join(o3, 30 * 1000);
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ClearMultiVmDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ClearMultiVmDUnitTest.java
@@ -216,8 +216,8 @@ public class ClearMultiVmDUnitTest extends JUnit4DistributedTestCase { // TODO: 
       vm1.invoke(ClearMultiVmDUnitTest.class, "getMethod", objArr);
     }
 
-    AsyncInvocation as1 = vm0.invokeAsync(ClearMultiVmDUnitTest::firstVM);
-    AsyncInvocation as2 = vm1.invokeAsync(ClearMultiVmDUnitTest::secondVM);
+    AsyncInvocation<Void> as1 = vm0.invokeAsync(ClearMultiVmDUnitTest::firstVM);
+    AsyncInvocation<Void> as2 = vm1.invokeAsync(ClearMultiVmDUnitTest::secondVM);
     ThreadUtils.join(as1, 30 * 1000);
     ThreadUtils.join(as2, 30 * 1000);
 
@@ -324,7 +324,7 @@ public class ClearMultiVmDUnitTest extends JUnit4DistributedTestCase { // TODO: 
       });
 
       // now do the get initial image in vm1
-      AsyncInvocation async1 = vm1.invokeAsync(create);
+      AsyncInvocation<Void> async1 = vm1.invokeAsync(create);
 
       // try to time a distributed clear to happen in the middle of gii
       vm0.invoke(new SerializableRunnable("call clear when gii") {

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ClientServerCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ClientServerCCEDUnitTest.java
@@ -142,7 +142,7 @@ public class ClientServerCCEDUnitTest extends JUnit4CacheTestCase {
 
     final int numIterations = 500;
 
-    AsyncInvocation[] asyncInvocations = new AsyncInvocation[clientVMs.length];
+    AsyncInvocation<?>[] asyncInvocations = new AsyncInvocation[clientVMs.length];
     for (int i = 0; i < clientVMs.length; i++) {
       final String clientGateName = "client" + i + "Ready";
       asyncInvocations[i] = clientVMs[i].invokeAsync("doOps Thread", () -> {
@@ -153,7 +153,7 @@ public class ClientServerCCEDUnitTest extends JUnit4CacheTestCase {
 
     getBlackboard().signalGate("proceed");
 
-    for (final AsyncInvocation asyncInvocation : asyncInvocations) {
+    for (final AsyncInvocation<?> asyncInvocation : asyncInvocations) {
       asyncInvocation.join();
     }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedAckRegionCCEDUnitTest.java
@@ -153,7 +153,7 @@ public class DistributedAckRegionCCEDUnitTest extends DistributedAckRegionDUnitT
       return CCRegion.getDistributionManager().getDistributionManagerId();
     });
 
-    AsyncInvocation partialCreate =
+    AsyncInvocation<Void> partialCreate =
         vm2.invokeAsync("create region with stall", () -> {
 
           final GemFireCacheImpl cache = (GemFireCacheImpl) getCache();

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/DistributedNoAckRegionCCEDUnitTest.java
@@ -113,12 +113,12 @@ public class DistributedNoAckRegionCCEDUnitTest extends DistributedNoAckRegionDU
     vm0.invoke(DistributedNoAckRegionCCEDUnitTest::addBlockingListener);
     vm1.invoke(DistributedNoAckRegionCCEDUnitTest::addBlockingListener);
     vm2.invoke(DistributedNoAckRegionCCEDUnitTest::addBlockingListener);
-    AsyncInvocation vm0Ops = vm0.invokeAsync(DistributedNoAckRegionCCEDUnitTest::doManyOps);
-    AsyncInvocation vm1Ops = vm1.invokeAsync(DistributedNoAckRegionCCEDUnitTest::doManyOps);
-    AsyncInvocation vm2Ops = vm2.invokeAsync(DistributedNoAckRegionCCEDUnitTest::doManyOps);
+    AsyncInvocation<Void> vm0Ops = vm0.invokeAsync(DistributedNoAckRegionCCEDUnitTest::doManyOps);
+    AsyncInvocation<Void> vm1Ops = vm1.invokeAsync(DistributedNoAckRegionCCEDUnitTest::doManyOps);
+    AsyncInvocation<Void> vm2Ops = vm2.invokeAsync(DistributedNoAckRegionCCEDUnitTest::doManyOps);
     // pause to let a bunch of operations build up
     Wait.pause(5000);
-    AsyncInvocation a0 = vm3.invokeAsync(DistributedNoAckRegionCCEDUnitTest::clearRegion);
+    AsyncInvocation<Void> a0 = vm3.invokeAsync(DistributedNoAckRegionCCEDUnitTest::clearRegion);
     vm0.invoke(DistributedNoAckRegionCCEDUnitTest::unblockListener);
     vm1.invoke(DistributedNoAckRegionCCEDUnitTest::unblockListener);
     vm2.invoke(DistributedNoAckRegionCCEDUnitTest::unblockListener);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/GlobalRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/GlobalRegionDUnitTest.java
@@ -176,7 +176,7 @@ public class GlobalRegionDUnitTest extends MultiVMRegionTestCase {
       });
     }
 
-    AsyncInvocation[] invokes = new AsyncInvocation[vmCount];
+    AsyncInvocation<?>[] invokes = new AsyncInvocation[vmCount];
     for (int i = 0; i < vmCount; i++) {
       invokes[i] = VM.getVM(i).invokeAsync("Start Threads and increment", () -> {
         final ThreadGroup group = new ThreadGroup("Incrementors") {

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/PutAllMultiVmDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/PutAllMultiVmDUnitTest.java
@@ -127,13 +127,13 @@ public class PutAllMultiVmDUnitTest extends JUnit4DistributedTestCase { // TODO:
     }
   }// end of closeCache
 
-  private AsyncInvocation invokeClear(VM vm) {
-    AsyncInvocation async = vm.invokeAsync(() -> region.clear());
+  private AsyncInvocation<Void> invokeClear(VM vm) {
+    AsyncInvocation<Void> async = vm.invokeAsync(() -> region.clear());
     return async;
   }
 
-  private AsyncInvocation invokeBulkOp(VM vm) {
-    AsyncInvocation async = vm.invokeAsync(() -> {
+  private AsyncInvocation<Void> invokeBulkOp(VM vm) {
+    AsyncInvocation<Void> async = vm.invokeAsync(() -> {
       Map m = new HashMap();
       for (int i = 0; i < 20; i++) {
         m.put(i, "map" + i);
@@ -159,8 +159,8 @@ public class PutAllMultiVmDUnitTest extends JUnit4DistributedTestCase { // TODO:
     Random rand = new Random();
     for (int k = 0; k < 100; k++) {
       int shuffle = rand.nextInt(2);
-      AsyncInvocation a1 = null;
-      AsyncInvocation a2 = null;
+      AsyncInvocation<Void> a1 = null;
+      AsyncInvocation<Void> a2 = null;
       if (shuffle == 1) {
         a1 = invokeClear(vm1);
         a2 = invokeBulkOp(vm2);

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectDUnitTest.java
@@ -776,13 +776,13 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
         getRoleAPlayerForCacheInitializationRunnable(vm0, locPort, regionName,
             "starting roleAplayer, which will initialize, wait for "
                 + "vm0 to initialize, and then close its cache to cause role loss");
-    AsyncInvocation avkVm1 = vm1.invokeAsync(roleAPlayerForCacheInitialization);
+    AsyncInvocation<Void> avkVm1 = vm1.invokeAsync(roleAPlayerForCacheInitialization);
 
     CacheSerializableRunnable roleLoss =
         getRoleLossRunnable(vm1, locPort, regionName, myKey, myValue,
             "starting role loss vm.  When the role is lost it will start" + " trying to reconnect",
             file.getAbsolutePath());
-    final AsyncInvocation roleLossAsync = vm0.invokeAsync(roleLoss);
+    final AsyncInvocation<Void> roleLossAsync = vm0.invokeAsync(roleLoss);
 
     System.out.println("waiting for role loss vm to start reconnect attempts");
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectWithClusterConfigurationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectWithClusterConfigurationDUnitTest.java
@@ -174,15 +174,15 @@ public class ReconnectWithClusterConfigurationDUnitTest implements Serializable 
         system = cache.getDistributedSystem();
       });
     }
-    AsyncInvocation[] crashers = new AsyncInvocation[NUM_VMS];
+    AsyncInvocation<?>[] crashers = new AsyncInvocation[NUM_VMS];
     for (int i = 0; i < NUM_VMS; i++) {
       crashers[i] = VM.getVM(i).invokeAsync("crash",
           () -> MembershipManagerHelper.crashDistributedSystem(system));
     }
-    for (AsyncInvocation crasher : crashers) {
+    for (AsyncInvocation<?> crasher : crashers) {
       crasher.join();
     }
-    AsyncInvocation[] waiters = new AsyncInvocation[NUM_VMS];
+    AsyncInvocation<?>[] waiters = new AsyncInvocation[NUM_VMS];
     for (int i = NUM_VMS - 1; i >= 0; i--) {
       waiters[i] = VM.getVM(i).invokeAsync("wait for reconnect", () -> {
         system.waitUntilReconnected(GeodeAwaitility.getTimeout().toMillis(),
@@ -194,7 +194,7 @@ public class ReconnectWithClusterConfigurationDUnitTest implements Serializable 
             .isEqualTo(NUM_VMS - 1));
       });
     }
-    for (AsyncInvocation waiter : waiters) {
+    for (AsyncInvocation<?> waiter : waiters) {
       waiter.join();
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/SearchAndLoadDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/SearchAndLoadDUnitTest.java
@@ -220,7 +220,7 @@ public class SearchAndLoadDUnitTest extends JUnit4CacheTestCase {
       }
     });
 
-    AsyncInvocation async1 = null;
+    AsyncInvocation<Void> async1 = null;
     try {
       async1 = vm0.invokeAsync("Concurrently invoke the remote loader on the same key - t1",
           new CacheSerializableRunnable() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/DistributedLockServiceDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/DistributedLockServiceDUnitTest.java
@@ -1386,9 +1386,9 @@ public final class DistributedLockServiceDUnitTest extends JUnit4DistributedTest
     // get a lock
     logger.info("[testSuspendLockingBehaves] line up vms for lock");
     vmOne.invoke(lockKey);
-    AsyncInvocation vmTwoLocking = vmTwo.invokeAsync(lockKey);
+    AsyncInvocation<Void> vmTwoLocking = vmTwo.invokeAsync(lockKey);
     Wait.pause(2000); // make sure vmTwo is first in line
-    AsyncInvocation vmThreeLocking = vmThree.invokeAsync(lockKey);
+    AsyncInvocation<Void> vmThreeLocking = vmThree.invokeAsync(lockKey);
     Wait.pause(2000);
 
     // make sure vmTwo and vmThree are still waiting for lock on key1
@@ -1404,9 +1404,9 @@ public final class DistributedLockServiceDUnitTest extends JUnit4DistributedTest
 
     // start suspending in vmOne and vmTwo
     logger.info("[testSuspendLockingBehaves] start suspending requests");
-    AsyncInvocation vmOneSuspending = vmOne.invokeAsync(suspendLocking);
+    AsyncInvocation<Void> vmOneSuspending = vmOne.invokeAsync(suspendLocking);
     Wait.pause(2000); // make sure vmOne is first in line
-    AsyncInvocation vmTwoSuspending = vmTwo.invokeAsync(suspendLocking);
+    AsyncInvocation<Void> vmTwoSuspending = vmTwo.invokeAsync(suspendLocking);
     Wait.pause(2000);
 
     // let vmThree finish locking key
@@ -1416,7 +1416,7 @@ public final class DistributedLockServiceDUnitTest extends JUnit4DistributedTest
 
     // have vmOne get back in line for locking key
     logger.info("[testSuspendLockingBehaves] start another lock request");
-    AsyncInvocation vmOneLockingAgain = vmOne.invokeAsync(lockKey);
+    AsyncInvocation<Void> vmOneLockingAgain = vmOne.invokeAsync(lockKey);
     Wait.pause(2000);
 
     // let vmOne suspend locking
@@ -1429,7 +1429,7 @@ public final class DistributedLockServiceDUnitTest extends JUnit4DistributedTest
     // start suspending in vmThree
     logger
         .info("[testSuspendLockingBehaves] line up vmThree for suspending");
-    AsyncInvocation vmThreeSuspending = vmThree.invokeAsync(suspendLocking);
+    AsyncInvocation<Void> vmThreeSuspending = vmThree.invokeAsync(suspendLocking);
     Wait.pause(2000);
 
     // let vmTwo suspend locking
@@ -1473,7 +1473,7 @@ public final class DistributedLockServiceDUnitTest extends JUnit4DistributedTest
     // Get lock from other VM. Since same thread needs to lock and unlock,
     // invoke asynchronously, get lock, wait to be notified, then unlock.
     VM vm1 = getVM(1);
-    AsyncInvocation asyncInvocation =
+    AsyncInvocation<Void> asyncInvocation =
         vm1.invokeAsync(new SerializableRunnable("Lock & unlock in vm1") {
           @Override
           public void run() {
@@ -2575,7 +2575,7 @@ public final class DistributedLockServiceDUnitTest extends JUnit4DistributedTest
       }
     });
 
-    AsyncInvocation whileVM1Locks = null;
+    AsyncInvocation<Void> whileVM1Locks = null;
     try {
       // vm1 locks key1
       whileVM1Locks = vm1.invokeAsync(new SerializableRunnable() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/GrantorFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/GrantorFailoverDUnitTest.java
@@ -138,10 +138,10 @@ public class GrantorFailoverDUnitTest {
         .invoke(() -> DistributedLockService.getServiceNamed(SERVICE_NAME).lock(lock2, 2, -1)))
             .isFalse();
 
-    final AsyncInvocation lock1FailsReleaseOnOtherVM =
+    final AsyncInvocation<Void> lock1FailsReleaseOnOtherVM =
         survivor2
             .invokeAsync(() -> DistributedLockService.getServiceNamed(SERVICE_NAME).unlock(lock1));
-    final AsyncInvocation lock2FailsReleaseOnOtherVM =
+    final AsyncInvocation<Void> lock2FailsReleaseOnOtherVM =
         survivor1
             .invokeAsync(() -> DistributedLockService.getServiceNamed(SERVICE_NAME).unlock(lock2));
 
@@ -155,15 +155,15 @@ public class GrantorFailoverDUnitTest {
         .invoke(() -> DistributedLockService.getServiceNamed(SERVICE_NAME).lock(lock3, 20_000, -1)))
             .isTrue();
 
-    final AsyncInvocation lock1SuccessfulRelease =
+    final AsyncInvocation<Void> lock1SuccessfulRelease =
         survivor1
             .invokeAsync(() -> DistributedLockService.getServiceNamed(SERVICE_NAME).unlock(lock1));
 
-    final AsyncInvocation lock3SuccessfulRelease =
+    final AsyncInvocation<Void> lock3SuccessfulRelease =
         survivor1
             .invokeAsync(() -> DistributedLockService.getServiceNamed(SERVICE_NAME).unlock(lock3));
 
-    final AsyncInvocation lock2SuccessfulRelease =
+    final AsyncInvocation<Void> lock2SuccessfulRelease =
         survivor2
             .invokeAsync(() -> DistributedLockService.getServiceNamed(SERVICE_NAME).unlock(lock2));
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/deadlock/GemFireDeadlockDetectorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/deadlock/GemFireDeadlockDetectorDUnitTest.java
@@ -124,10 +124,10 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
     String gateOnMember2 = "gateOnMember2";
 
     // This thread locks the lock member1 first, then member2.
-    AsyncInvocation async1 = lockTheLocks(vm0, member2, gateOnMember1, gateOnMember2);
+    AsyncInvocation<Void> async1 = lockTheLocks(vm0, member2, gateOnMember1, gateOnMember2);
 
     // This thread locks the lock member2 first, then member1.
-    AsyncInvocation async2 = lockTheLocks(vm1, member1, gateOnMember2, gateOnMember1);
+    AsyncInvocation<Void> async2 = lockTheLocks(vm1, member1, gateOnMember2, gateOnMember1);
     try {
       final LinkedList<Dependency>[] deadlockHolder = new LinkedList[1];
       await("waiting for deadlock").until(() -> {
@@ -153,7 +153,7 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
 
 
 
-  private AsyncInvocation lockTheLocks(VM vm0, final InternalDistributedMember member,
+  private AsyncInvocation<Void> lockTheLocks(VM vm0, final InternalDistributedMember member,
       final String gateToSignal, final String gateToWaitOn) {
     return vm0.invokeAsync(new SerializableRunnable() {
 
@@ -186,8 +186,8 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
     TypeRegistry.init();
 
     getSystem();
-    AsyncInvocation async1 = lockTheDLocks(vm0, "one", "two");
-    AsyncInvocation async2 = lockTheDLocks(vm1, "two", "one");
+    AsyncInvocation<Void> async1 = lockTheDLocks(vm0, "one", "two");
+    AsyncInvocation<Void> async2 = lockTheDLocks(vm1, "two", "one");
 
     await("waiting for locks to be acquired")
         .untilAsserted(() -> assertTrue(getBlackboard().isGateSignaled("one")));
@@ -211,7 +211,7 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  private void waitForAsyncInvocation(AsyncInvocation async1, int howLong, TimeUnit units)
+  private void waitForAsyncInvocation(AsyncInvocation<Void> async1, int howLong, TimeUnit units)
       throws java.util.concurrent.ExecutionException, InterruptedException {
     try {
       async1.get(howLong, units);
@@ -220,7 +220,7 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  private AsyncInvocation lockTheDLocks(VM vm, final String first, final String second) {
+  private AsyncInvocation<Void> lockTheDLocks(VM vm, final String first, final String second) {
     return vm.invokeAsync(new SerializableRunnable() {
 
       @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerGetAllDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerGetAllDUnitTest.java
@@ -276,7 +276,7 @@ public class ClientServerGetAllDUnitTest extends ClientServerTestCase {
     // Run getAll
     {
       final int THREAD_COUNT = 4;
-      AsyncInvocation[] ais = new AsyncInvocation[THREAD_COUNT];
+      AsyncInvocation<?>[] ais = new AsyncInvocation[THREAD_COUNT];
       for (int i = 0; i < THREAD_COUNT; i++) {
         ais[i] = client.invokeAsync(clientGetAll);
       }
@@ -414,7 +414,7 @@ public class ClientServerGetAllDUnitTest extends ClientServerTestCase {
     // Run getAll
     {
       final int THREAD_COUNT = 4;
-      AsyncInvocation[] ais = new AsyncInvocation[THREAD_COUNT];
+      AsyncInvocation<?>[] ais = new AsyncInvocation[THREAD_COUNT];
       for (int i = 0; i < THREAD_COUNT; i++) {
         ais[i] = client.invokeAsync(clientGetAll);
       }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClientServerTransactionFailoverDistributedTest.java
@@ -424,7 +424,7 @@ public class ClientServerTransactionFailoverDistributedTest implements Serializa
           });
     });
 
-    AsyncInvocation clientAsync = client.invokeAsync(() -> {
+    AsyncInvocation<Void> clientAsync = client.invokeAsync(() -> {
       {
         CacheTransactionManager transactionManager =
             clientCacheRule.getClientCache().getCacheTransactionManager();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ConcurrentDestroySubRegionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ConcurrentDestroySubRegionDUnitTest.java
@@ -97,7 +97,7 @@ public class ConcurrentDestroySubRegionDUnitTest extends JUnit4CacheTestCase {
         }
       };
 
-      AsyncInvocation future = vm0.invokeAsync(destroyParent);
+      AsyncInvocation<Void> future = vm0.invokeAsync(destroyParent);
       try {
         vm1.invoke(createChild);
       } catch (Exception e) {
@@ -160,7 +160,7 @@ public class ConcurrentDestroySubRegionDUnitTest extends JUnit4CacheTestCase {
         }
       };
 
-      AsyncInvocation future = vm0.invokeAsync(destroyParent);
+      AsyncInvocation<Void> future = vm0.invokeAsync(destroyParent);
       try {
         vm1.invoke(createChild);
       } catch (Exception e) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ConnectDisconnectDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ConnectDisconnectDUnitTest.java
@@ -96,7 +96,7 @@ public class ConnectDisconnectDUnitTest extends JUnit4CacheTestCase {
       vms[i] = Host.getHost(0).getVM(i);
     }
 
-    AsyncInvocation[] asyncs = new AsyncInvocation[numVMs];
+    AsyncInvocation<?>[] asyncs = new AsyncInvocation[numVMs];
     for (int i = 0; i < numVMs; i++) {
       asyncs[i] = vms[i].invokeAsync(new SerializableRunnable("Create a cache") {
         @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DestroyRegionDuringGIIDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/DestroyRegionDuringGIIDistributedTest.java
@@ -239,7 +239,7 @@ public class DestroyRegionDuringGIIDistributedTest implements Serializable {
     });
 
     // start asynchronous process that does updates to the data
-    AsyncInvocation updateDataInVM0 = vm0.invokeAsync(() -> {
+    AsyncInvocation<Void> updateDataInVM0 = vm0.invokeAsync(() -> {
       await().until(() -> getCache().getCachePerfStats().getGetInitialImagesCompleted() < 1);
 
       Region<Object, Object> region = getCache().getRegion(regionName);
@@ -259,7 +259,7 @@ public class DestroyRegionDuringGIIDistributedTest implements Serializable {
     addIgnoredException(RegionDestroyedException.class);
 
     // in the meantime, do the get initial image in vm2
-    AsyncInvocation getInitialImageInVM2 = vm2.invokeAsync(() -> {
+    AsyncInvocation<Void> getInitialImageInVM2 = vm2.invokeAsync(() -> {
       if (!regionDefinition.getScope().isGlobal()) {
         InitialImageOperation.slowImageProcessing = 200;
       }
@@ -341,7 +341,7 @@ public class DestroyRegionDuringGIIDistributedTest implements Serializable {
     });
 
     // start asynchronous process that does updates to the data
-    AsyncInvocation updateDataInVM0 = vm0.invokeAsync("Do Nonblocking Operations", () -> {
+    AsyncInvocation<Void> updateDataInVM0 = vm0.invokeAsync("Do Nonblocking Operations", () -> {
       Region<Object, Object> region = getCache().getRegion(regionName);
 
       // wait for profile of getInitialImage cache to show up
@@ -364,7 +364,7 @@ public class DestroyRegionDuringGIIDistributedTest implements Serializable {
       });
     }
 
-    AsyncInvocation getInitialImageInVM2 = vm2.invokeAsync("Create Mirrored Region", () -> {
+    AsyncInvocation<Void> getInitialImageInVM2 = vm2.invokeAsync("Create Mirrored Region", () -> {
       cacheXmlRule.beginCacheXml();
 
       // root region must be DACK because its used to sync up async subregions

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIDeltaDUnitTest.java
@@ -202,8 +202,8 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
 
     P.invoke(() -> GIIDeltaDUnitTest.slowGII(blocklist));
     R.invoke(() -> GIIDeltaDUnitTest.slowGII(blocklist));
-    AsyncInvocation async1 = doOnePutAsync(P, 2, "key1");
-    AsyncInvocation async2 = doOnePutAsync(R, 3, "key1");
+    AsyncInvocation<Void> async1 = doOnePutAsync(P, 2, "key1");
+    AsyncInvocation<Void> async2 = doOnePutAsync(R, 3, "key1");
 
     // wait for the local puts are done at P & R before distribution
     waitForToVerifyRVV(P, memberP, 2, null, 0); // P's rvv=p2, gc=0
@@ -237,10 +237,10 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
 
     // let r6 to succeed, r4,r5 to be blocked
     R.invoke(() -> GIIDeltaDUnitTest.slowGII(exceptionlist));
-    AsyncInvocation async1 = doOnePutAsync(R, 4, "key4");
+    AsyncInvocation<Void> async1 = doOnePutAsync(R, 4, "key4");
     waitForToVerifyRVV(R, memberR, 4, null, 0); // P's rvv=r4, gc=0
 
-    AsyncInvocation async2 = doOneDestroyAsync(R, 5, "key5");
+    AsyncInvocation<Void> async2 = doOneDestroyAsync(R, 5, "key5");
     waitForToVerifyRVV(R, memberR, 5, null, 0); // P's rvv=r5, gc=0
 
     doOnePut(R, 6, "key1"); // r6 will pass
@@ -480,7 +480,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
 
     // restart and gii
     checkIfFullGII(P, REGION_NAME, R_rvv_bytes, false);
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
 
     // 2
     waitForCallbackStarted(R, GIITestHookType.AfterRequestRVV);
@@ -603,7 +603,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     });
 
     // restart R and gii, it will be blocked at test hook
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
     // 7
     waitForCallbackStarted(P, GIITestHookType.AfterReceivedRequestImage);
 
@@ -779,7 +779,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     final long[] exceptionlist2 = {8};
     // let p9 to succeed, p8 to be blocked
     P.invoke(() -> GIIDeltaDUnitTest.slowGII(exceptionlist2));
-    AsyncInvocation async1 = doOneDestroyAsync(P, 8, "key1");
+    AsyncInvocation<Void> async1 = doOneDestroyAsync(P, 8, "key1");
     waitForToVerifyRVV(P, memberP, 8, null, 0);
     doOnePut(P, 9, "key3");
     waitForToVerifyRVV(P, memberP, 9, null, 0);
@@ -823,10 +823,10 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
 
     final long[] exceptionlist = {4, 5};
     R.invoke(() -> GIIDeltaDUnitTest.slowGII(exceptionlist));
-    AsyncInvocation async1 = doOnePutAsync(R, 4, "key4");
+    AsyncInvocation<Void> async1 = doOnePutAsync(R, 4, "key4");
     waitForToVerifyRVV(R, memberR, 4, null, 0); // P's rvv=r4, gc=0
 
-    AsyncInvocation async2 = doOneDestroyAsync(R, 5, "key5");
+    AsyncInvocation<Void> async2 = doOneDestroyAsync(R, 5, "key5");
     waitForToVerifyRVV(R, memberR, 5, null, 0); // P's rvv=r5, gc=0
 
     // P should have unfinished ops R4,R5, but they did not show up in exception list
@@ -986,7 +986,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
 
     closeCache(R);
     changeForceFullGII(R, true, false);
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
     waitForCallbackStarted(R, GIITestHookType.BeforeSavedReceivedRVV);
 
     doOnePut(P, 4, "key1");
@@ -1055,7 +1055,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     });
 
     closeCache(R);
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
     waitForCallbackStarted(R, GIITestHookType.AfterCalculatedUnfinishedOps);
 
     doOnePut(P, 4, "key1");
@@ -1099,10 +1099,10 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
 
     final long[] exceptionlist = {4, 5};
     R.invoke(() -> GIIDeltaDUnitTest.slowGII(exceptionlist));
-    AsyncInvocation async1 = doOnePutAsync(R, 4, "key4");
+    AsyncInvocation<Void> async1 = doOnePutAsync(R, 4, "key4");
     waitForToVerifyRVV(R, memberR, 4, null, 0); // P's rvv=r4, gc=0
 
-    AsyncInvocation async2 = doOneDestroyAsync(R, 5, "key5");
+    AsyncInvocation<Void> async2 = doOneDestroyAsync(R, 5, "key5");
     waitForToVerifyRVV(R, memberR, 5, null, 0); // P's rvv=r5, gc=0
 
     // P should have unfinished ops R4,R5, but they did not show up in exception list
@@ -1253,7 +1253,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     waitForToVerifyRVV(P, memberR, 3, null, 0); // P's rvv=r3, gc=0
     // now P's rvv=P7,R3, R's RVV=P6,R5
     checkIfFullGII(P, REGION_NAME, R_rvv_bytes, false);
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
 
     // 1
     waitForCallbackStarted(R, GIITestHookType.BeforeRequestRVV);
@@ -1386,9 +1386,9 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     checkIfFullGII(P, REGION_NAME, R_rvv_bytes, false);
 
     // restart R and gii, it will be blocked at test hook
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
     // restart R and gii, it will be blocked at test hook
-    AsyncInvocation async4 = createDistributedRegionAsync(T);
+    AsyncInvocation<Void> async4 = createDistributedRegionAsync(T);
     // 8
     waitForCallbackStarted(P, DuringPackingImage);
     WaitCriterion ev = new WaitCriterion() {
@@ -1530,7 +1530,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     checkIfFullGII(P, REGION_NAME, R_rvv_bytes, false);
 
     // restart R and gii, it will be blocked at test hook
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
     // 8
     waitForCallbackStarted(P, DuringPackingImage);
     WaitCriterion ev = new WaitCriterion() {
@@ -1632,7 +1632,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     checkIfFullGII(P, REGION_NAME, R_rvv_bytes, false);
 
     // restart R and gii, it will be blocked at test hook
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
     // 8
     waitForCallbackStarted(P, GIITestHookType.AfterReceivedRequestImage);
     int count = getDeltaGIICount(P);
@@ -1831,7 +1831,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
 
     // retart R
     checkIfFullGII(P, REGION_NAME, R_rvv_bytes, false);
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
 
     // when chunk arrived, do clear()
     waitForCallbackStarted(R, GIITestHookType.AfterReceivedImageReply);
@@ -1902,7 +1902,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     doOnePut(P, 7, "key1");
 
     // retart R
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
 
     // when chunk arrived, do clear()
     waitForCallbackStarted(R, GIITestHookType.AfterSavedReceivedRVV);
@@ -2055,7 +2055,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     doOnePut(P, 7, "key1");
 
     // retart R
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
 
     // when chunk arrived, do clear()
     waitForCallbackStarted(R, GIITestHookType.AfterSavedReceivedRVV);
@@ -2125,7 +2125,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
 
 
     // retart R
-    AsyncInvocation async3 = createDistributedRegionAsync(R);
+    AsyncInvocation<Void> async3 = createDistributedRegionAsync(R);
 
     // when chunk arrived, do clear()
     waitForCallbackStarted(R, GIITestHookType.BeforeSavedReceivedRVV);
@@ -2214,7 +2214,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
                 && ((TombstoneMessage) message).regionPath.contains(REGION_NAME)) {
               System.err.println("DAN DEBUG  about to send tombstone message, starting up R - "
                   + message.getSender());
-              AsyncInvocation async3 = createDistributedRegionAsync(vmR);
+              AsyncInvocation<Void> async3 = createDistributedRegionAsync(vmR);
 
               // Wait for R to finish requesting the RVV before letting the tombstone GC proceeed.
               waitForCallbackStarted(vmR, GIITestHookType.AfterCalculatedUnfinishedOps);
@@ -2284,7 +2284,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
   }
 
   protected void createDistributedRegion(VM vm) {
-    AsyncInvocation future = createDistributedRegionAsync(vm);
+    AsyncInvocation<Void> future = createDistributedRegionAsync(vm);
     try {
       future.join(MAX_WAIT);
     } catch (InterruptedException e) {
@@ -2298,7 +2298,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  protected AsyncInvocation createDistributedRegionAsync(VM vm) {
+  protected AsyncInvocation<Void> createDistributedRegionAsync(VM vm) {
     SerializableRunnable createRegion = new SerializableRunnable("Create Region") {
       @Override
       public void run() {
@@ -2753,11 +2753,11 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     vm.invoke(putOp);
   }
 
-  private AsyncInvocation doOnePutAsync(final VM vm, final long regionVersionForThisOp,
+  private AsyncInvocation<Void> doOnePutAsync(final VM vm, final long regionVersionForThisOp,
       final String key) {
     SerializableRunnable putOp =
         onePutOp(key, generateValue(vm), regionVersionForThisOp, getMemberID(vm), false);
-    AsyncInvocation async = vm.invokeAsync(putOp);
+    AsyncInvocation<Void> async = vm.invokeAsync(putOp);
     return async;
   }
 
@@ -2787,11 +2787,11 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     vm.invoke(destroyOp);
   }
 
-  private AsyncInvocation doOneDestroyAsync(final VM vm, final long regionVersionForThisOp,
+  private AsyncInvocation<Void> doOneDestroyAsync(final VM vm, final long regionVersionForThisOp,
       final String key) {
     SerializableRunnable destroyOp =
         oneDestroyOp(key, generateValue(vm), regionVersionForThisOp, getMemberID(vm), false);
-    AsyncInvocation async = vm.invokeAsync(destroyOp);
+    AsyncInvocation<Void> async = vm.invokeAsync(destroyOp);
     return async;
   }
 
@@ -2869,7 +2869,7 @@ public class GIIDeltaDUnitTest extends JUnit4CacheTestCase {
     return result;
   }
 
-  private void checkAsyncCall(AsyncInvocation async) {
+  private void checkAsyncCall(AsyncInvocation<Void> async) {
     try {
       async.join(30000);
       if (async.exceptionOccurred()) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIFlowControlDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GIIFlowControlDUnitTest.java
@@ -122,7 +122,7 @@ public class GIIFlowControlDUnitTest extends JUnit4CacheTestCase {
 
     createData(vm0, 0, 50, "1234567890");
 
-    AsyncInvocation async1 = createRegionAsync(vm1);
+    AsyncInvocation<Void> async1 = createRegionAsync(vm1);
 
     async1.join(100);
     assertTrue(async1.isAlive());
@@ -199,7 +199,7 @@ public class GIIFlowControlDUnitTest extends JUnit4CacheTestCase {
 
     createData(vm0, 0, 50, "1234567890");
 
-    AsyncInvocation async1 = createRegionAsync(vm1);
+    AsyncInvocation<Void> async1 = createRegionAsync(vm1);
 
     vm1.invoke(new SerializableRunnable("Wait to flow control messages") {
 
@@ -427,7 +427,7 @@ public class GIIFlowControlDUnitTest extends JUnit4CacheTestCase {
     return createRegion;
   }
 
-  private AsyncInvocation createRegionAsync(VM vm) throws Throwable {
+  private AsyncInvocation<Void> createRegionAsync(VM vm) throws Throwable {
     SerializableRunnable createRegion = getCreateRegionRunnable();
     return vm.invokeAsync(createRegion);
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/InterruptClientServerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/InterruptClientServerDUnitTest.java
@@ -142,7 +142,7 @@ public class InterruptClientServerDUnitTest extends JUnit4CacheTestCase {
       }
     };
 
-    AsyncInvocation async0 = vm2.invokeAsync(doPuts);
+    AsyncInvocation<Void> async0 = vm2.invokeAsync(doPuts);
 
     vm1.invoke(new SerializableCallable() {
       @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/InterruptsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/InterruptsDUnitTest.java
@@ -131,7 +131,7 @@ public class InterruptsDUnitTest extends JUnit4CacheTestCase {
       }
     };
 
-    AsyncInvocation async0 = vm0.invokeAsync(doPuts);
+    AsyncInvocation<Void> async0 = vm0.invokeAsync(doPuts);
 
     vm1.invoke(new SerializableCallable() {
       @Override

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PREntryIdleExpirationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PREntryIdleExpirationDistributedTest.java
@@ -106,7 +106,7 @@ public class PREntryIdleExpirationDistributedTest implements Serializable {
 
   @Test
   public void readsInOtherMemberShouldPreventExpiration() throws Exception {
-    AsyncInvocation<?> memberReading = member3.invokeAsync(() -> {
+    AsyncInvocation<Void> memberReading = member3.invokeAsync(() -> {
       Region<String, String> region = cacheRule.getCache().getRegion(regionName);
       region.put(KEY, VALUE);
       ExpiryTask.permitExpiration();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PREntrySetIteratorRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PREntrySetIteratorRegressionTest.java
@@ -65,14 +65,14 @@ public class PREntrySetIteratorRegressionTest extends CacheTestCase {
 
   @Test
   public void regionEntrySetIteratorNextShouldNeverReturnNull() throws Exception {
-    AsyncInvocation destroySomeEntries = vm1.invokeAsync(() -> {
+    AsyncInvocation<Void> destroySomeEntries = vm1.invokeAsync(() -> {
       Region<Integer, Object> region = getCache().getRegion(uniqueName);
       for (int j = 0; j < ENTRY_COUNT / ENTRY_DESTROY_SEQUENCE; j += ENTRY_DESTROY_SEQUENCE) {
         region.destroy(j);
       }
     });
 
-    AsyncInvocation validateEntrySetIteratorContainsNoNulls = vm2.invokeAsync(() -> {
+    AsyncInvocation<Void> validateEntrySetIteratorContainsNoNulls = vm2.invokeAsync(() -> {
       Region<Integer, Object> region = getCache().getRegion(uniqueName);
       for (Entry<Integer, Object> entry : region.entrySet()) {
         assertThat(entry).isNotNull();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionBucketCreationDistributionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionBucketCreationDistributionDUnitTest.java
@@ -61,7 +61,7 @@ public class PartitionedRegionBucketCreationDistributionDUnitTest extends CacheT
   private VM vm2;
   private VM vm3;
 
-  private transient List<AsyncInvocation> asyncInvocations;
+  private transient List<AsyncInvocation<Void>> asyncInvocations;
 
   @Before
   public void setUp() {
@@ -670,7 +670,7 @@ public class PartitionedRegionBucketCreationDistributionDUnitTest extends CacheT
   }
 
   private void awaitAllAsyncInvocations() throws ExecutionException, InterruptedException {
-    for (AsyncInvocation async : asyncInvocations) {
+    for (AsyncInvocation<Void> async : asyncInvocations) {
       async.await();
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionCreationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionCreationDUnitTest.java
@@ -62,7 +62,7 @@ public class PartitionedRegionCreationDUnitTest extends CacheTestCase {
   private int numberOfRegions;
   private String prNamePrefix;
 
-  private transient List<AsyncInvocation> asyncInvocations;
+  private transient List<AsyncInvocation<Void>> asyncInvocations;
 
   @Rule
   public ExecutorServiceRule executorServiceRule = new ExecutorServiceRule();
@@ -419,7 +419,7 @@ public class PartitionedRegionCreationDUnitTest extends CacheTestCase {
   }
 
   private void awaitAllAsyncInvocations() throws ExecutionException, InterruptedException {
-    for (AsyncInvocation async : asyncInvocations) {
+    for (AsyncInvocation<Void> async : asyncInvocations) {
       async.await();
     }
     asyncInvocations.clear();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionDestroyDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionDestroyDUnitTest.java
@@ -97,7 +97,7 @@ public class PartitionedRegionDestroyDUnitTest extends CacheTestCase {
       }
     });
 
-    AsyncInvocation asyncVM2 = vm2.invokeAsync(() -> {
+    AsyncInvocation<Void> asyncVM2 = vm2.invokeAsync(() -> {
       try (IgnoredException ie = addIgnoredException(RegionDestroyedException.class)) {
         Cache cache = getCache();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionLowBucketRedundancyDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PartitionedRegionLowBucketRedundancyDistributedTest.java
@@ -154,9 +154,9 @@ public class PartitionedRegionLowBucketRedundancyDistributedTest implements Seri
 
     // Asynchronously recreate the regions in servers 1 and 2 (since they are recovering persistent
     // data)
-    AsyncInvocation recreateRegionInServer1 =
+    AsyncInvocation<Void> recreateRegionInServer1 =
         server1.getVM().invokeAsync(() -> createRegion(PARTITION_PERSISTENT, 1));
-    AsyncInvocation recreateRegionInServer2 =
+    AsyncInvocation<Void> recreateRegionInServer2 =
         server2.getVM().invokeAsync(() -> createRegion(PARTITION_PERSISTENT, 1));
     recreateRegionInServer1.await();
     recreateRegionInServer2.await();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PersistentRegionRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/PersistentRegionRecoveryDUnitTest.java
@@ -235,7 +235,7 @@ public class PersistentRegionRecoveryDUnitTest extends JUnit4DistributedTestCase
               getBlackboard()));
     });
 
-    AsyncInvocation asyncVM1 = vm1.invokeAsync(() -> createAsyncDiskRegion());
+    AsyncInvocation<Void> asyncVM1 = vm1.invokeAsync(() -> createAsyncDiskRegion());
 
     logger.info("##### After async create region in vm1");
 
@@ -293,7 +293,7 @@ public class PersistentRegionRecoveryDUnitTest extends JUnit4DistributedTestCase
               getBlackboard()));
     });
 
-    AsyncInvocation asyncVM1 = vm1.invokeAsync(this::createSyncDiskRegion);
+    AsyncInvocation<Void> asyncVM1 = vm1.invokeAsync(this::createSyncDiskRegion);
 
     logger.info("##### After async create region in vm1");
 
@@ -439,7 +439,7 @@ public class PersistentRegionRecoveryDUnitTest extends JUnit4DistributedTestCase
           });
     });
 
-    AsyncInvocation vm0createRegion = vm0.invokeAsync(() -> createAsyncDiskRegion(true));
+    AsyncInvocation<Void> vm0createRegion = vm0.invokeAsync(() -> createAsyncDiskRegion(true));
 
     vm1.invoke(() -> {
       await().until(() -> getBlackboard().isGateSignaled("GotRegionIIRequest"));

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RebalanceWhileCreatingRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RebalanceWhileCreatingRegionDistributedTest.java
@@ -83,7 +83,7 @@ public class RebalanceWhileCreatingRegionDistributedTest implements Serializable
     server2.invoke(() -> createRegion(regionName, RegionShortcut.PARTITION));
 
     // Asynchronously wait to create the proxy region in the accessor
-    AsyncInvocation asyncInvocation =
+    AsyncInvocation<Void> asyncInvocation =
         accessor.invokeAsync(() -> waitToCreateProxyRegion(regionName));
 
     // Connect client1
@@ -180,7 +180,7 @@ public class RebalanceWhileCreatingRegionDistributedTest implements Serializable
     });
 
     // Asynchronously wait to create the proxy region in the accessor
-    AsyncInvocation asyncInvocation = accessor.invokeAsync(() -> {
+    AsyncInvocation<Void> asyncInvocation = accessor.invokeAsync(() -> {
       waitToCreateSingleBucketProxyRegion(regionName);
     });
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoveGlobalDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/RemoveGlobalDUnitTest.java
@@ -120,7 +120,7 @@ public class RemoveGlobalDUnitTest extends JUnit4DistributedTestCase { // TODO: 
     vm0.invoke(createRegionWithWriter);
 
 
-    AsyncInvocation async = vm0.invokeAsync(new CacheSerializableRunnable("put object") {
+    AsyncInvocation<Void> async = vm0.invokeAsync(new CacheSerializableRunnable("put object") {
       @Override
       public void run2() throws CacheException {
         for (int i = 1; i < 5; i++) {
@@ -210,7 +210,7 @@ public class RemoveGlobalDUnitTest extends JUnit4DistributedTestCase { // TODO: 
       }
     });
 
-    AsyncInvocation async = vm0.invokeAsync(new CacheSerializableRunnable("remove object") {
+    AsyncInvocation<Void> async = vm0.invokeAsync(new CacheSerializableRunnable("remove object") {
       @Override
       public void run2() throws CacheException {
         region.remove(2);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ReplicateEntryIdleExpirationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ReplicateEntryIdleExpirationDistributedTest.java
@@ -95,7 +95,7 @@ public class ReplicateEntryIdleExpirationDistributedTest implements Serializable
 
   @Test
   public void readsInOtherMemberShouldPreventExpiration() throws Exception {
-    AsyncInvocation<?> memberReading = member3.invokeAsync(() -> {
+    AsyncInvocation<Void> memberReading = member3.invokeAsync(() -> {
       Region<String, String> region = cacheRule.getCache().getRegion(regionName);
       region.put(KEY, VALUE);
       while (KEEP_READING.get()) {
@@ -140,7 +140,7 @@ public class ReplicateEntryIdleExpirationDistributedTest implements Serializable
       factory.setEntryIdleTimeout(new ExpirationAttributes(1, DESTROY));
       factory.create(regionName);
     });
-    AsyncInvocation<?> memberReading = member4.invokeAsync(() -> {
+    AsyncInvocation<Void> memberReading = member4.invokeAsync(() -> {
       Region<String, String> region = cacheRule.getCache().getRegion(regionName);
       region.put(KEY, VALUE);
       while (KEEP_READING.get()) {
@@ -179,7 +179,7 @@ public class ReplicateEntryIdleExpirationDistributedTest implements Serializable
     member1.invoke(() -> createEvictionRegion(evictionRegionName));
     member2.invoke(() -> createEvictionRegion(evictionRegionName));
     member3.invoke(() -> createEvictionRegion(evictionRegionName));
-    AsyncInvocation<?> memberReading = member3.invokeAsync(() -> {
+    AsyncInvocation<Void> memberReading = member3.invokeAsync(() -> {
       Region<String, String> region = cacheRule.getCache().getRegion(evictionRegionName);
       region.put(KEY, VALUE);
       while (KEEP_READING.get()) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/TransactionsWithGIIDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/TransactionsWithGIIDistributedTest.java
@@ -112,8 +112,8 @@ public class TransactionsWithGIIDistributedTest implements Serializable {
   }
 
   private void doConcurrentOpsAndRebalance(String s, boolean doRebalance) throws Exception {
-    AsyncInvocation async0 = vm0.invokeAsync(this::doConcurrentDestroyInTx);
-    AsyncInvocation async1;
+    AsyncInvocation<Void> async0 = vm0.invokeAsync(this::doConcurrentDestroyInTx);
+    AsyncInvocation<Void> async1;
     if (doRebalance) {
       async1 = vm1.invokeAsync(() -> doConcurrentPutInTx(s));
     } else {
@@ -279,7 +279,7 @@ public class TransactionsWithGIIDistributedTest implements Serializable {
       cacheRule.getOrCreateCache();
     });
 
-    AsyncInvocation async = vm1.invokeAsync(() -> createRegion(regionName));
+    AsyncInvocation<Void> async = vm1.invokeAsync(() -> createRegion(regionName));
     doConcurrentOpsAndRebalance("C", false);
     async.await();
     validateVersionsInVms(false, vm0, vm1);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/backup/BackupDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/backup/BackupDistributedTest.java
@@ -247,7 +247,7 @@ public class BackupDistributedTest extends JUnit4DistributedTestCase implements 
           createTestHookToCreateRegionBeforeSendingPrepareBackupRequest());
     });
 
-    AsyncInvocation asyncVM1CreateRegion = vm1.invokeAsync(() -> {
+    AsyncInvocation<Void> asyncVM1CreateRegion = vm1.invokeAsync(() -> {
       getBlackboard().waitForGate("createRegion", 30, SECONDS);
       createReplicatedRegion(regionName2, diskStoreName, getDiskStoreFor(vm1), false, true);
       getBlackboard().signalGate("createdRegion");
@@ -277,11 +277,11 @@ public class BackupDistributedTest extends JUnit4DistributedTestCase implements 
       getCache().getPartitionedRegionLockService().becomeLockGrantor();
     });
 
-    AsyncInvocation asyncVM1Region1 = vm1.invokeAsync(() -> {
+    AsyncInvocation<Void> asyncVM1Region1 = vm1.invokeAsync(() -> {
       createReplicatedRegion(regionName1, diskStoreName, getDiskStoreFor(vm1), true, true);
     });
 
-    AsyncInvocation asyncVM1Region2 = vm1.invokeAsync(() -> {
+    AsyncInvocation<Void> asyncVM1Region2 = vm1.invokeAsync(() -> {
       createReplicatedRegion(regionName2, diskStoreName, getDiskStoreFor(vm1), false, true);
       getBlackboard().signalGate("createdRegionAfterRecovery");
     });
@@ -554,7 +554,7 @@ public class BackupDistributedTest extends JUnit4DistributedTestCase implements 
     restoreBackup(2);
 
     // in vm0, start doing a bunch of concurrent puts.
-    AsyncInvocation putsInVM0 = vm0.invokeAsync(() -> {
+    AsyncInvocation<Void> putsInVM0 = vm0.invokeAsync(() -> {
       Region region = getCache().getRegion(regionName1);
       try {
         for (int i = 0;; i++) {
@@ -569,8 +569,8 @@ public class BackupDistributedTest extends JUnit4DistributedTestCase implements 
       }
     });
 
-    AsyncInvocation createRegionsInVM1 = vm1.invokeAsync(() -> createColocatedRegions(vm1));
-    AsyncInvocation createRegionsInVM2 = vm2.invokeAsync(() -> createColocatedRegions(vm2));
+    AsyncInvocation<Void> createRegionsInVM1 = vm1.invokeAsync(() -> createColocatedRegions(vm1));
+    AsyncInvocation<Void> createRegionsInVM2 = vm2.invokeAsync(() -> createColocatedRegions(vm2));
 
     createRegionsInVM1.await();
     createRegionsInVM2.await();
@@ -706,11 +706,11 @@ public class BackupDistributedTest extends JUnit4DistributedTestCase implements 
 
   private void createPersistentRegions(final VM... vms)
       throws ExecutionException, InterruptedException {
-    Set<AsyncInvocation> createRegionAsyncs = new HashSet<>();
+    Set<AsyncInvocation<Void>> createRegionAsyncs = new HashSet<>();
     for (VM vm : vms) {
       createRegionAsyncs.add(vm.invokeAsync(() -> createRegions(vm)));
     }
-    for (AsyncInvocation createRegion : createRegionAsyncs) {
+    for (AsyncInvocation<?> createRegion : createRegionAsyncs) {
       createRegion.await();
     }
   }

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/control/RebalanceOperationDistributedTest.java
@@ -1879,10 +1879,10 @@ public class RebalanceOperationDistributedTest extends CacheTestCase {
 
     // We need to restart both VMs at the same time, because
     // they will wait for each other before allowing operations.
-    AsyncInvocation createRegionOnVM0 = vm0.invokeAsync(
+    AsyncInvocation<Void> createRegionOnVM0 = vm0.invokeAsync(
         () -> createPersistentPartitionedRegion("region1", getUniqueName(), getDiskDirs(),
             redundantCopies));
-    AsyncInvocation createRegionOnVM2 = vm2.invokeAsync(
+    AsyncInvocation<Void> createRegionOnVM2 = vm2.invokeAsync(
         () -> createPersistentPartitionedRegion("region1", getUniqueName(), getDiskDirs(),
             redundantCopies));
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/DistributedRegionFunctionExecutionDUnitTest.java
@@ -256,7 +256,7 @@ public class DistributedRegionFunctionExecutionDUnitTest implements Serializable
 
     empty.invoke(() -> populateRegion(200));
 
-    AsyncInvocation executeFunctionInReplicate1 = replicate1.invokeAsync(() -> {
+    AsyncInvocation<Void> executeFunctionInReplicate1 = replicate1.invokeAsync(() -> {
       ResultCollector<String, List<String>> resultCollector = TypedFunctionService
           .<Void, String, List<String>>onRegion(getRegion())
           .withFilter(filter)

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionRetryTestBase.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/FunctionRetryTestBase.java
@@ -141,7 +141,7 @@ public class FunctionRetryTestBase implements Serializable {
 
     IgnoredException.addIgnoredException(FunctionException.class.getName());
 
-    AsyncInvocation clientExecuteAsync = client.invokeAsync(() -> {
+    AsyncInvocation<Void> clientExecuteAsync = client.invokeAsync(() -> {
 
       assertThat(executionTarget).isNotNull();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionDUnitTest.java
@@ -703,23 +703,6 @@ public class PRClientServerRegionFunctionExecutionDUnitTest extends PRClientServ
     }
   }
 
-  static Object executeFunctionHA() {
-    Region region = cache.getRegion(PartitionedRegionName);
-    final HashSet<String> testKeysSet = new HashSet<>();
-    for (int i = (totalNumBuckets * 10); i > 0; i--) {
-      testKeysSet.add("execKey-" + i);
-    }
-    DistributedSystem.setThreadsSocketPolicy(false);
-    Function function = new TestFunction(true, TestFunction.TEST_FUNCTION_HA);
-    FunctionService.registerFunction(function);
-    Execution dataSet = FunctionService.onRegion(region);
-    ResultCollector rc1 =
-        dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
-    List l = ((List) rc1.getResult());
-    logger.info("Result size : " + l.size());
-    return l;
-  }
-
   static void putOperation() {
     Region<String, Integer> region = cache.getRegion(PartitionedRegionName);
     assertNotNull(region);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionFailoverDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionFailoverDUnitTest.java
@@ -101,7 +101,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
    * failover to other available server
    */
   @Test
-  public void testServerFailoverWithTwoServerAliveHA() {
+  public void testServerFailoverWithTwoServerAliveHA() throws InterruptedException {
     IgnoredException.addIgnoredException("FunctionInvocationTargetException");
     ArrayList commonAttributes =
         createCommonServerAttributes("TestPartitionedRegion", null, 1, null);
@@ -111,20 +111,18 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
     server2.invoke(PRClientServerRegionFunctionExecutionDUnitTest::stopServerHA);
     server3.invoke(PRClientServerRegionFunctionExecutionDUnitTest::stopServerHA);
     client.invoke(PRClientServerRegionFunctionExecutionDUnitTest::putOperation);
-    int AsyncInvocationArrSize = 1;
-    AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
-    async[0] = client
+    AsyncInvocation<List<Boolean>> async = client
         .invokeAsync(PRClientServerRegionFunctionExecutionDUnitTest::executeFunctionHA);
     server2.invoke(PRClientServerRegionFunctionExecutionDUnitTest::startServerHA);
     server3.invoke(PRClientServerRegionFunctionExecutionDUnitTest::startServerHA);
     server1.invoke(PRClientServerRegionFunctionExecutionDUnitTest::stopServerHA);
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .verifyDeadAndLiveServers(2));
-    ThreadUtils.join(async[0], 6 * 60 * 1000);
-    if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
+    ThreadUtils.join(async, 6 * 60 * 1000);
+    if (async.getException() != null) {
+      Assert.fail("UnExpected Exception Occurred : ", async.getException());
     }
-    List l = (List) async[0].getReturnValue();
+    List<Boolean> l = async.get();
     assertEquals(2, l.size());
   }
 
@@ -133,7 +131,7 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
    * failover to other available server
    */
   @Test
-  public void testServerCacheClosedFailoverWithTwoServerAliveHA() {
+  public void testServerCacheClosedFailoverWithTwoServerAliveHA() throws InterruptedException {
     IgnoredException.addIgnoredException("FunctionInvocationTargetException");
     ArrayList commonAttributes =
         createCommonServerAttributes("TestPartitionedRegion", null, 1, null);
@@ -143,20 +141,18 @@ public class PRClientServerRegionFunctionExecutionFailoverDUnitTest extends PRCl
     server2.invoke(PRClientServerRegionFunctionExecutionDUnitTest::stopServerHA);
     server3.invoke(PRClientServerRegionFunctionExecutionDUnitTest::stopServerHA);
     client.invoke(PRClientServerRegionFunctionExecutionDUnitTest::putOperation);
-    int AsyncInvocationArrSize = 1;
-    AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
-    async[0] = client
+    AsyncInvocation<List<Boolean>> async = client
         .invokeAsync(PRClientServerRegionFunctionExecutionDUnitTest::executeFunctionHA);
     server2.invoke(PRClientServerRegionFunctionExecutionDUnitTest::startServerHA);
     server3.invoke(PRClientServerRegionFunctionExecutionDUnitTest::startServerHA);
     server1.invoke(PRClientServerRegionFunctionExecutionDUnitTest::closeCacheHA);
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .verifyDeadAndLiveServers(2));
-    ThreadUtils.join(async[0], 5 * 60 * 1000);
-    if (async[0].getException() != null) {
-      Assert.fail("UnExpected Exception Occurred : ", async[0].getException());
+    ThreadUtils.join(async, 5 * 60 * 1000);
+    if (async.getException() != null) {
+      Assert.fail("UnExpected Exception Occurred : ", async.getException());
     }
-    List l = (List) async[0].getReturnValue();
+    List<Boolean> l = async.get();
     assertEquals(2, l.size());
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest.java
@@ -338,9 +338,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest
     server3.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::stopServerHA);
     client.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::putOperation);
 
-    int AsyncInvocationArrSize = 1;
-    AsyncInvocation<?>[] async = new AsyncInvocation<?>[AsyncInvocationArrSize];
-    async[0] = client.invokeAsync(
+    AsyncInvocation<List<Boolean>> async = client.invokeAsync(
         PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::executeFunctionHA);
     server2.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::startServerHA);
     server3.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::startServerHA);
@@ -348,7 +346,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest
     client.invoke(() -> PRClientServerRegionFunctionExecutionDUnitTest
         .verifyDeadAndLiveServers(2));
 
-    List<?> l = (List<?>) async[0].get();
+    List<?> l = async.get();
 
     assertThat(l).hasSize(2);
   }
@@ -368,9 +366,8 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest
     server2.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::stopServerHA);
     server3.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::stopServerHA);
     client.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::putOperation);
-    int AsyncInvocationArrSize = 1;
-    AsyncInvocation<?>[] async = new AsyncInvocation<?>[AsyncInvocationArrSize];
-    async[0] = client.invokeAsync(
+
+    AsyncInvocation<List<Boolean>> async = client.invokeAsync(
         PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::executeFunctionHA);
     server2.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::startServerHA);
     server3.invoke(PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest::startServerHA);
@@ -378,7 +375,7 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest
     client.invoke(() -> PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest
         .verifyDeadAndLiveServers(2));
 
-    List<?> l = (List<?>) async[0].get();
+    List<?> l = async.get();
     assertThat(l).hasSize(2);
   }
 
@@ -550,23 +547,6 @@ public class PRClientServerRegionFunctionExecutionNoSingleHopDistributedTest
       logger.info("Got an exception : " + e.getMessage());
       assertThat(e).isInstanceOf(CacheClosedException.class);
     }
-  }
-
-  private static Object executeFunctionHA() {
-    Region<Object, Object> region = cache.getRegion(PartitionedRegionName);
-    final HashSet<String> testKeysSet = new HashSet<>();
-    for (int i = (totalNumBuckets * 10); i > 0; i--) {
-      testKeysSet.add("execKey-" + i);
-    }
-    DistributedSystem.setThreadsSocketPolicy(false);
-    Function<Object> function = new TestFunction<>(true, TestFunction.TEST_FUNCTION_HA);
-    FunctionService.registerFunction(function);
-    Execution dataSet = FunctionService.onRegion(region);
-    ResultCollector<?, ?> rc1 =
-        dataSet.withFilter(testKeysSet).setArguments(Boolean.TRUE).execute(function.getId());
-    List<?> l = ((List<?>) rc1.getResult());
-    logger.info("Result size : " + l.size());
-    return l;
   }
 
   private static void putOperation() {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRColocationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/execute/PRColocationDUnitTest.java
@@ -1848,9 +1848,9 @@ public class PRColocationDUnitTest extends JUnit4CacheTestCase {
     Object[] attributeObjects2 = new Object[] {regionName, redundancy, localMaxmemory,
         totalNumBuckets, colocatedWith, isPartitionResolver};
 
-    AsyncInvocation async1 =
+    AsyncInvocation<Void> async1 =
         dataStore1.invokeAsync(PRColocationDUnitTest.class, "createPR", attributeObjects2);
-    AsyncInvocation async2 =
+    AsyncInvocation<Void> async2 =
         dataStore2.invokeAsync(PRColocationDUnitTest.class, "createPR", attributeObjects2);
 
     async1.join();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAGIIBugDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ha/HAGIIBugDUnitTest.java
@@ -181,7 +181,7 @@ public class HAGIIBugDUnitTest extends JUnit4DistributedTestCase {
       }
     };
 
-    AsyncInvocation[] async = new AsyncInvocation[4];
+    AsyncInvocation<?>[] async = new AsyncInvocation[4];
     async[0] = vm0.invokeAsync(putFrmVm("vm0_2"));
     t1.start();
     ThreadUtils.join(t1, 30 * 1000);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentColocatedPartitionedRegionDistributedTest.java
@@ -342,7 +342,7 @@ public class PersistentColocatedPartitionedRegionDistributedTest implements Seri
       latch = new CountDownLatch(1);
     });
 
-    AsyncInvocation createPRsInVM0 = vm0.invokeAsync(() -> {
+    AsyncInvocation<Void> createPRsInVM0 = vm0.invokeAsync(() -> {
       createCache();
       createDiskStore(diskStoreName1);
       createPR_withPersistence(regionName, diskStoreName1, DEFAULT_RECOVERY_DELAY,

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionHangsDuringRestartRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionHangsDuringRestartRegressionTest.java
@@ -153,7 +153,8 @@ public class PersistentPartitionHangsDuringRestartRegressionTest implements Seri
 
     try (IgnoredException ie = addIgnoredException(PartitionOfflineException.class)) {
       // This should recover redundancy, which should cause vm0 to bounce/disconnect
-      AsyncInvocation createPRAsync = vm1.invokeAsync(() -> createPartitionedRegion(1, 0, 1, true));
+      AsyncInvocation<Void> createPRAsync =
+          vm1.invokeAsync(() -> createPartitionedRegion(1, 0, 1, true));
 
       beforeBounceLatch.await(TIMEOUT_MILLIS, MILLISECONDS);
       vm0.bounceForcibly();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionTestBase.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionTestBase.java
@@ -200,7 +200,7 @@ public abstract class PersistentPartitionedRegionTestBase extends JUnit4CacheTes
     return attributesFactory.create();
   }
 
-  AsyncInvocation createPRAsync(final VM vm, final int redundancy) {
+  AsyncInvocation<Void> createPRAsync(final VM vm, final int redundancy) {
     return vm.invokeAsync(getCreatePRRunnable(redundancy, -1));
   }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionWithTransactionDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/PersistentPartitionedRegionWithTransactionDUnitTest.java
@@ -94,9 +94,9 @@ public class PersistentPartitionedRegionWithTransactionDUnitTest
     closeCache(vm1);
     closeCache(vm2);
 
-    AsyncInvocation a1 = createPRAsync(vm0, redundancy);
-    AsyncInvocation a2 = createPRAsync(vm1, redundancy);
-    AsyncInvocation a3 = createPRAsync(vm2, redundancy);
+    AsyncInvocation<Void> a1 = createPRAsync(vm0, redundancy);
+    AsyncInvocation<Void> a2 = createPRAsync(vm1, redundancy);
+    AsyncInvocation<Void> a3 = createPRAsync(vm2, redundancy);
 
     a1.getResult(MAX_WAIT);
     a2.getResult(MAX_WAIT);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/ShutdownAllDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/ShutdownAllDUnitTest.java
@@ -114,10 +114,10 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
     assertTrue(InternalDistributedSystem.getExistingSystems().isEmpty());
 
     // restart vm0
-    AsyncInvocation a0 = createRegionAsync(vm0, "region", "disk", true, 1);
+    AsyncInvocation<Void> a0 = createRegionAsync(vm0, "region", "disk", true, 1);
 
     // restart vm1
-    AsyncInvocation a1 = createRegionAsync(vm1, "region", "disk", true, 1);
+    AsyncInvocation<Void> a1 = createRegionAsync(vm1, "region", "disk", true, 1);
 
     a0.getResult(MAX_WAIT);
     a1.getResult(MAX_WAIT);
@@ -215,7 +215,7 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
     closeAllCache();
     // in vm0 create the cache in a way that hangs until
     // it sees that a shutDownAll is in progress
-    AsyncInvocation<?> asyncCreate = vm0.invokeAsync(() -> {
+    AsyncInvocation<Void> asyncCreate = vm0.invokeAsync(() -> {
       cll = new CacheLifecycleListener() {
         @Override
         public void cacheCreated(InternalCache cache) {
@@ -321,11 +321,11 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
     assertTrue(InternalDistributedSystem.getExistingSystems().isEmpty());
 
     // restart vm0, vm1, vm2
-    AsyncInvocation a0 = createRegionAsync(vm0, "region", "disk", true, 1);
+    AsyncInvocation<Void> a0 = createRegionAsync(vm0, "region", "disk", true, 1);
 
-    AsyncInvocation a1 = createRegionAsync(vm1, "region", "disk", true, 1);
+    AsyncInvocation<Void> a1 = createRegionAsync(vm1, "region", "disk", true, 1);
 
-    AsyncInvocation a2 = createRegionAsync(vm2, "region", "disk", true, 1);
+    AsyncInvocation<Void> a2 = createRegionAsync(vm2, "region", "disk", true, 1);
 
     a0.getResult(MAX_WAIT);
     a1.getResult(MAX_WAIT);
@@ -353,13 +353,13 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
 
     shutDownAllMembers(vm2, 2);
 
-    AsyncInvocation a0 = createRegionAsync(vm0, "region", "disk", true, 1);
+    AsyncInvocation<Void> a0 = createRegionAsync(vm0, "region", "disk", true, 1);
     // [dsmith] Make sure that vm0 is waiting for vm1 to recover
     // If VM(0) recovers early, that is a problem, because we
     // are no longer doing a clean recovery.
     Thread.sleep(500);
     assertTrue(a0.isAlive());
-    AsyncInvocation a1 = createRegionAsync(vm1, "region", "disk", true, 1);
+    AsyncInvocation<Void> a1 = createRegionAsync(vm1, "region", "disk", true, 1);
     a0.getResult(MAX_WAIT);
     a1.getResult(MAX_WAIT);
 
@@ -403,13 +403,13 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
 
     shutDownAllMembers(vm2, 2);
 
-    AsyncInvocation a0 = createRegionAsync(vm0, "region", "disk", true, 1);
+    AsyncInvocation<Void> a0 = createRegionAsync(vm0, "region", "disk", true, 1);
     // [dsmith] Make sure that vm0 is waiting for vm1 to recover
     // If VM(0) recovers early, that is a problem, because we
     // are no longer doing a clean recovery.
     Thread.sleep(500);
     assertTrue(a0.isAlive());
-    AsyncInvocation a1 = createRegionAsync(vm1, "region", "disk", true, 1);
+    AsyncInvocation<Void> a1 = createRegionAsync(vm1, "region", "disk", true, 1);
     a0.getResult(MAX_WAIT);
     a1.getResult(MAX_WAIT);
 
@@ -484,7 +484,7 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
 
     // Add a cache listener that will cause the system to hang up.
     // Then do some puts to get us stuck in a put.
-    AsyncInvocation async1 = vm0.invokeAsync(new SerializableRunnable() {
+    AsyncInvocation<Void> async1 = vm0.invokeAsync(new SerializableRunnable() {
       @Override
       public void run() {
         Region<Object, Object> region = getCache().getRegion("region");
@@ -527,10 +527,10 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
     Wait.pause(10000);
 
     // restart vm0
-    AsyncInvocation a0 = createRegionAsync(vm0, "region", "disk", true, 1);
+    AsyncInvocation<Void> a0 = createRegionAsync(vm0, "region", "disk", true, 1);
 
     // restart vm1
-    AsyncInvocation a1 = createRegionAsync(vm1, "region", "disk", true, 1);
+    AsyncInvocation<Void> a1 = createRegionAsync(vm1, "region", "disk", true, 1);
 
     a0.getResult(MAX_WAIT);
     a1.getResult(MAX_WAIT);
@@ -572,7 +572,7 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
 
     // restart one of the members (this will hang, waiting for the other members)
     // restart vm0
-    AsyncInvocation a0 = createRegionAsync(vm0, "region", "disk", true, 1);
+    AsyncInvocation<Void> a0 = createRegionAsync(vm0, "region", "disk", true, 1);
 
     // Wait a bit for the initialization to get stuck
     Wait.pause(20000);
@@ -594,7 +594,7 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
     // now restart both members. This should work, but
     // no guarantee they'll do a clean recovery
     a0 = createRegionAsync(vm0, "region", "disk", true, 1);
-    AsyncInvocation a1 = createRegionAsync(vm1, "region", "disk", true, 1);
+    AsyncInvocation<Void> a1 = createRegionAsync(vm1, "region", "disk", true, 1);
 
     a0.getResult(MAX_WAIT);
     a1.getResult(MAX_WAIT);
@@ -690,7 +690,7 @@ public class ShutdownAllDUnitTest extends JUnit4CacheTestCase {
     }
   }
 
-  protected AsyncInvocation createRegionAsync(VM vm, final String regionName,
+  protected AsyncInvocation<Void> createRegionAsync(VM vm, final String regionName,
       final String diskStoreName, final boolean isPR, final int redundancy) {
     if (isPR) {
       SerializableRunnable createPR = getCreatePRRunnable(regionName, diskStoreName, redundancy);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/partitioned/fixed/FixedPartitioningDUnitTest.java
@@ -500,7 +500,7 @@ public class FixedPartitioningDUnitTest implements Serializable {
     datastore1.invoke(this::setPRObserverBeforeCalculateStartingBucketId);
 
     // Start datastore1 asynchronously. This will get stuck waiting in the PR observer
-    AsyncInvocation createRegionInDatastore1 =
+    AsyncInvocation<Void> createRegionInDatastore1 =
         datastore1.invokeAsync(() -> createRegionWithQuarter(QUARTER_1));
 
     // Make sure datastore 1 gets stuck waiting on the observer
@@ -508,9 +508,9 @@ public class FixedPartitioningDUnitTest implements Serializable {
 
     // Start two more data stores asynchronously. These will get stuck waiting for a dlock behind
     // datastore1
-    AsyncInvocation createRegionInDatastore2 =
+    AsyncInvocation<Void> createRegionInDatastore2 =
         datastore2.invokeAsync(() -> createRegionWithQuarter(QUARTER_2));
-    AsyncInvocation createRegionInDatastore3 =
+    AsyncInvocation<Void> createRegionInDatastore3 =
         datastore3.invokeAsync(() -> createRegionWithQuarter(QUARTER_3));
 
     // Make sure a put to datastore1, which is in the middle of pr initialization, fails correctly

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRVVRecoveryDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRVVRecoveryDUnitTest.java
@@ -427,7 +427,7 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     });
 
     // Do a DESTROY in vm0 when delta GII is in progress in vm1 (Hopefully, Not guaranteed).
-    AsyncInvocation destroyDuringDeltaGiiInVM0 = vm0.invokeAsync(() -> {
+    AsyncInvocation<Void> destroyDuringDeltaGiiInVM0 = vm0.invokeAsync(() -> {
       Region<String, String> region = getCache().getRegion("prRegion");
 
       await().until(() -> region.get("testKey").equals("testValue2"));
@@ -563,14 +563,14 @@ public class PersistentRVVRecoveryDUnitTest extends PersistentReplicatedTestBase
     vm1.invoke(() -> createRegionWithAsyncPersistence(vm1));
 
     // In two different threads, perform updates to the same key on the same region
-    AsyncInvocation doPutsInThread1InVM0 = vm1.invokeAsync(() -> {
+    AsyncInvocation<Void> doPutsInThread1InVM0 = vm1.invokeAsync(() -> {
       Region<String, String> region = getCache().getRegion(regionName);
       for (int i = 0; i < 500; i++) {
         region.put("A", "vm0-" + i);
       }
     });
 
-    AsyncInvocation doPutsInThread2InVM0 = vm1.invokeAsync(() -> {
+    AsyncInvocation<Void> doPutsInThread2InVM0 = vm1.invokeAsync(() -> {
       Region<String, String> region = getCache().getRegion(regionName);
       for (int i = 0; i < 500; i++) {
         region.put("A", "vm1-" + i);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentRecoveryOrderDUnitTest.java
@@ -341,7 +341,7 @@ public class PersistentRecoveryOrderDUnitTest extends CacheTestCase {
       getCache().close();
     });
 
-    AsyncInvocation createRegionInVM0 = vm0.invokeAsync(() -> {
+    AsyncInvocation<Void> createRegionInVM0 = vm0.invokeAsync(() -> {
       createReplicateRegion(regionName, getDiskDirs(getVMId()));
     });
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentReplicatedTestBase.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/persistence/PersistentReplicatedTestBase.java
@@ -105,7 +105,7 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
     vm.invoke(() -> getCache().close());
   }
 
-  AsyncInvocation closeCacheAsync(VM vm) {
+  AsyncInvocation<Void> closeCacheAsync(VM vm) {
     return vm.invokeAsync(() -> getCache().close());
   }
 
@@ -121,7 +121,7 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
     });
   }
 
-  AsyncInvocation createPersistentRegionWithWait(VM vm)
+  AsyncInvocation<Void> createPersistentRegionWithWait(VM vm)
       throws ExecutionException, InterruptedException {
     return createPersistentRegion(vm, true);
   }
@@ -130,9 +130,10 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
     createPersistentRegion(vm, false);
   }
 
-  private AsyncInvocation createPersistentRegion(VM vm, boolean createPersistentRegionWillWait)
+  private AsyncInvocation<Void> createPersistentRegion(VM vm,
+      boolean createPersistentRegionWillWait)
       throws ExecutionException, InterruptedException {
-    AsyncInvocation createPersistentRegionInVM = createPersistentRegionAsync(vm);
+    AsyncInvocation<Void> createPersistentRegionInVM = createPersistentRegionAsync(vm);
 
     if (createPersistentRegionWillWait) {
       createPersistentRegionInVM.join(500);
@@ -144,7 +145,7 @@ public abstract class PersistentReplicatedTestBase extends JUnit4CacheTestCase {
     return createPersistentRegionInVM;
   }
 
-  AsyncInvocation createPersistentRegionAsync(VM vm) {
+  AsyncInvocation<Void> createPersistentRegionAsync(VM vm) {
     return vm.invokeAsync(() -> {
       getCache();
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/SlowDispatcherDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/SlowDispatcherDUnitTest.java
@@ -115,7 +115,7 @@ public class SlowDispatcherDUnitTest {
         c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
             .withPoolSubscription(false)
             .withLocatorConnection(locatorPort));
-    AsyncInvocation putAsync = putClient.invokeAsync(() -> {
+    AsyncInvocation<Void> putAsync = putClient.invokeAsync(() -> {
       UpdatableUserAuthInitialize.setUser("putter");
       Region<Object, Object> proxyRegion =
           ClusterStartupRule.clientCacheRule.createProxyRegion(PARTITION_REGION);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/asyncqueue/AsyncEventQueueStatsDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/asyncqueue/AsyncEventQueueStatsDUnitTest.java
@@ -207,17 +207,18 @@ public class AsyncEventQueueStatsDUnitTest extends AsyncEventQueueTestBase {
     vm4.invoke(() -> AsyncEventQueueTestBase
         .createReplicatedRegionWithAsyncEventQueue(getTestMethodName() + "_RR", "ln", isOffHeap()));
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm2.invokeAsync(() -> AsyncEventQueueTestBase.doPuts(getTestMethodName() + "_RR", 10000));
     Wait.pause(2000);
-    AsyncInvocation inv2 = vm1.invokeAsync(() -> AsyncEventQueueTestBase.killAsyncEventQueue("ln"));
+    AsyncInvocation<Boolean> inv2 =
+        vm1.invokeAsync(() -> AsyncEventQueueTestBase.killAsyncEventQueue("ln"));
     Boolean isKilled = Boolean.FALSE;
     try {
-      isKilled = (Boolean) inv2.getResult();
+      isKilled = inv2.getResult();
     } catch (Throwable e) {
       fail("Unexpected exception while killing a AsyncEventQueue");
     }
-    AsyncInvocation inv3 = null;
+    AsyncInvocation<Boolean> inv3 = null;
     if (!isKilled) {
       inv3 = vm2.invokeAsync(() -> AsyncEventQueueTestBase.killSender("ln"));
       inv3.join();

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/asyncqueue/ParallelSerialAsyncEventListenerStopStartDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/asyncqueue/ParallelSerialAsyncEventListenerStopStartDistributedTest.java
@@ -154,10 +154,10 @@ public class ParallelSerialAsyncEventListenerStopStartDistributedTest implements
     vm3.invoke(this::stopAsyncQueues);
 
     // Start all AEQs
-    AsyncInvocation startAeqsVm0 = vm0.invokeAsync(this::startAsyncQueues);
-    AsyncInvocation startAeqsVm1 = vm1.invokeAsync(this::startAsyncQueues);
-    AsyncInvocation startAeqsVm2 = vm2.invokeAsync(this::startAsyncQueues);
-    AsyncInvocation startAeqsVm3 = vm3.invokeAsync(this::startAsyncQueues);
+    AsyncInvocation<Void> startAeqsVm0 = vm0.invokeAsync(this::startAsyncQueues);
+    AsyncInvocation<Void> startAeqsVm1 = vm1.invokeAsync(this::startAsyncQueues);
+    AsyncInvocation<Void> startAeqsVm2 = vm2.invokeAsync(this::startAsyncQueues);
+    AsyncInvocation<Void> startAeqsVm3 = vm3.invokeAsync(this::startAsyncQueues);
 
     // Wait for async tasks to complete
     ThreadUtils.join(startAeqsVm0, 120 * 1000);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentAsyncEventQueueDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentAsyncEventQueueDUnitTest.java
@@ -163,11 +163,11 @@ public class ConcurrentAsyncEventQueueDUnitTest extends AsyncEventQueueTestBase 
     vm4.invoke(() -> AsyncEventQueueTestBase
         .createReplicatedRegionWithAsyncEventQueue(getTestMethodName() + "_RR", "ln", isOffHeap()));
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm1.invokeAsync(() -> AsyncEventQueueTestBase.doPuts(getTestMethodName() + "_RR", 50));
-    AsyncInvocation inv2 = vm1.invokeAsync(
+    AsyncInvocation<Void> inv2 = vm1.invokeAsync(
         () -> AsyncEventQueueTestBase.doNextPuts(getTestMethodName() + "_RR", 50, 100));
-    AsyncInvocation inv3 = vm1.invokeAsync(
+    AsyncInvocation<Void> inv3 = vm1.invokeAsync(
         () -> AsyncEventQueueTestBase.doNextPuts(getTestMethodName() + "_RR", 100, 150));
 
     try {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/IdleTimeOutDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/IdleTimeOutDUnitTest.java
@@ -257,7 +257,7 @@ public class IdleTimeOutDUnitTest extends JUnit4DistributedTestCase {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
     vm0.invoke(IdleTimeOutDUnitTest::runTest1);
-    AsyncInvocation asyncObj = vm0.invokeAsync(IdleTimeOutDUnitTest::runTest2);
+    AsyncInvocation<Void> asyncObj = vm0.invokeAsync(IdleTimeOutDUnitTest::runTest2);
     ThreadUtils.join(asyncObj, 30 * 1000);
     if (asyncObj.exceptionOccurred()) {
       Assert.fail("asyncObj failed", asyncObj.getException());

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/LoginTimeOutDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/LoginTimeOutDUnitTest.java
@@ -243,8 +243,8 @@ public class LoginTimeOutDUnitTest extends JUnit4DistributedTestCase {
   public void testLoginTimeOut() throws Exception {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
-    AsyncInvocation test1 = vm0.invokeAsync(LoginTimeOutDUnitTest::runTest1);
-    AsyncInvocation test2 = vm0.invokeAsync(LoginTimeOutDUnitTest::runTest2);
+    AsyncInvocation<Void> test1 = vm0.invokeAsync(LoginTimeOutDUnitTest::runTest1);
+    AsyncInvocation<Void> test2 = vm0.invokeAsync(LoginTimeOutDUnitTest::runTest2);
     ThreadUtils.join(test2, 120 * 1000);
     if (test2.exceptionOccurred()) {
       Assert.fail("asyncObj failed", test2.getException());

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/MaxPoolSizeDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/MaxPoolSizeDUnitTest.java
@@ -247,7 +247,7 @@ public class MaxPoolSizeDUnitTest extends JUnit4DistributedTestCase {
   public void testMaxPoolSize() throws Exception {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
-    AsyncInvocation asyncObj = vm0.invokeAsync(MaxPoolSizeDUnitTest::runTest1);
+    AsyncInvocation<Void> asyncObj = vm0.invokeAsync(MaxPoolSizeDUnitTest::runTest1);
     ThreadUtils.join(asyncObj, 30 * 1000);
     if (asyncObj.exceptionOccurred()) {
       Assert.fail("asyncObj failed", asyncObj.getException());

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/TransactionTimeOutDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/TransactionTimeOutDUnitTest.java
@@ -117,8 +117,8 @@ public class TransactionTimeOutDUnitTest extends JUnit4DistributedTestCase {
   public void testTimeOut() {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
-    AsyncInvocation async1 = vm0.invokeAsync(this::userTransactionCanBeTimedOut);
-    AsyncInvocation async2 = vm0.invokeAsync(this::userTransactionCanBeTimedOut);
+    AsyncInvocation<Void> async1 = vm0.invokeAsync(this::userTransactionCanBeTimedOut);
+    AsyncInvocation<Void> async2 = vm0.invokeAsync(this::userTransactionCanBeTimedOut);
 
     ThreadUtils.join(async1, 30 * 1000);
     ThreadUtils.join(async2, 30 * 1000);

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/TxnManagerMultiThreadDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/TxnManagerMultiThreadDUnitTest.java
@@ -386,7 +386,7 @@ public class TxnManagerMultiThreadDUnitTest extends JUnit4DistributedTestCase {
   @Test
   public void test1AllCommit() throws Exception {
     VM vm0 = Host.getHost(0).getVM(0);
-    AsyncInvocation asyncObj1 =
+    AsyncInvocation<Void> asyncObj1 =
         vm0.invokeAsync(TxnManagerMultiThreadDUnitTest::callCommitThreads);
     ThreadUtils.join(asyncObj1, 30 * 1000);
     if (asyncObj1.exceptionOccurred()) {
@@ -419,7 +419,7 @@ public class TxnManagerMultiThreadDUnitTest extends JUnit4DistributedTestCase {
   @Test
   public void test3Commit2Rollback() throws Exception {
     VM vm0 = Host.getHost(0).getVM(0);
-    AsyncInvocation asyncObj1 =
+    AsyncInvocation<Void> asyncObj1 =
         vm0.invokeAsync(TxnManagerMultiThreadDUnitTest::callCommitandRollbackThreads);
     ThreadUtils.join(asyncObj1, 30 * 1000);
     if (asyncObj1.exceptionOccurred()) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/TxnTimeOutDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/jta/dunit/TxnTimeOutDUnitTest.java
@@ -133,23 +133,23 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
 
       Object[] o = new Object[1];
       o[0] = 2;
-      AsyncInvocation asyncObj1 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o);
+      AsyncInvocation<Void> asyncObj1 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o);
 
       Object[] o1 = new Object[1];
       o1[0] = 2;
-      AsyncInvocation asyncObj2 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o1);
+      AsyncInvocation<Void> asyncObj2 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o1);
 
       Object[] o2 = new Object[1];
       o2[0] = 3;
-      AsyncInvocation asyncObj3 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o2);
+      AsyncInvocation<Void> asyncObj3 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o2);
 
       Object[] o3 = new Object[1];
       o3[0] = 3;
-      AsyncInvocation asyncObj4 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o3);
+      AsyncInvocation<Void> asyncObj4 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o3);
 
       Object[] o4 = new Object[1];
       o4[0] = 1;
-      AsyncInvocation asyncObj5 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o4);
+      AsyncInvocation<Void> asyncObj5 = vm0.invokeAsync(TxnTimeOutDUnitTest.class, "runTest3", o4);
 
       ThreadUtils.join(asyncObj1, 5 * 60 * 1000);
       if (asyncObj1.exceptionOccurred()) {
@@ -187,8 +187,8 @@ public class TxnTimeOutDUnitTest extends JUnit4DistributedTestCase {
   public void testLoginTimeOut() throws Throwable {
     Host host = Host.getHost(0);
     VM vm0 = host.getVM(0);
-    AsyncInvocation asyncObj1 = vm0.invokeAsync(TxnTimeOutDUnitTest::runTest2);
-    AsyncInvocation asyncObj2 = vm0.invokeAsync(TxnTimeOutDUnitTest::runTest1);
+    AsyncInvocation<Void> asyncObj1 = vm0.invokeAsync(TxnTimeOutDUnitTest::runTest2);
+    AsyncInvocation<Void> asyncObj2 = vm0.invokeAsync(TxnTimeOutDUnitTest::runTest1);
 
     ThreadUtils.join(asyncObj1, 5 * 60 * 1000);
     if (asyncObj1.exceptionOccurred()) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/statistics/StatisticsDistributedTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/statistics/StatisticsDistributedTest.java
@@ -231,7 +231,7 @@ public class StatisticsDistributedTest extends JUnit4CacheTestCase {
 
     for (int i = 0; i < NUM_PUBS; i++) {
       final int pubVM = i;
-      AsyncInvocation[] publishers = new AsyncInvocation[NUM_PUB_THREADS];
+      AsyncInvocation<?>[] publishers = new AsyncInvocation[NUM_PUB_THREADS];
       for (int j = 0; j < NUM_PUB_THREADS; j++) {
         final int pubThread = j;
         publishers[pubThread] = pubs[pubVM]
@@ -290,7 +290,7 @@ public class StatisticsDistributedTest extends JUnit4CacheTestCase {
             });
       }
 
-      for (final AsyncInvocation publisher : publishers) {
+      for (final AsyncInvocation<?> publisher : publishers) {
         publisher.join();
         assertThat(publisher.exceptionOccurred()).isFalse();
       }

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiClientDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiClientDUnitTest.java
@@ -98,7 +98,7 @@ public class MultiClientDUnitTest {
 
     // client 3 keeps logging in, do some successful put, and log out and keep doing it for multiple
     // times
-    AsyncInvocation vm3Invoke = client3.invokeAsync("run as data", () -> {
+    AsyncInvocation<Void> vm3Invoke = client3.invokeAsync("run as data", () -> {
       ClientCache cache = ClusterStartupRule.getClientCache();
       Region region = cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
       for (int j = 0; j < KEY_COUNT; j++) {
@@ -107,7 +107,7 @@ public class MultiClientDUnitTest {
     });
 
     // client 4 keeps logging in, do an unauthorized put, and log out
-    AsyncInvocation vm4Invoke = client4.invokeAsync("run as stranger", () -> {
+    AsyncInvocation<Void> vm4Invoke = client4.invokeAsync("run as stranger", () -> {
       ClientCache cache = ClusterStartupRule.getClientCache();
       Region region = cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
       for (int j = 0; j < KEY_COUNT; j++) {
@@ -118,7 +118,7 @@ public class MultiClientDUnitTest {
     });
 
     // client 5 keeps logging in, do some successful get, and log out
-    AsyncInvocation vm5Invoke = client5.invokeAsync("run as data", () -> {
+    AsyncInvocation<Void> vm5Invoke = client5.invokeAsync("run as data", () -> {
       ClientCache cache = ClusterStartupRule.getClientCache();
       Region region = cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
       for (int j = 0; j < KEY_COUNT; j++) {
@@ -127,7 +127,7 @@ public class MultiClientDUnitTest {
     });
 
     // // client 6 keeps logging in with incorrect
-    AsyncInvocation vm6Invoke = client6.invokeAsync("run as invalid user", () -> {
+    AsyncInvocation<Void> vm6Invoke = client6.invokeAsync("run as invalid user", () -> {
       ClientCache cache = ClusterStartupRule.getClientCache();
       Region region = cache.createClientRegionFactory(ClientRegionShortcut.PROXY).create("region");
       for (int j = 0; j < 1; j++) {

--- a/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiGfshDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/management/internal/security/MultiGfshDUnitTest.java
@@ -68,7 +68,7 @@ public class MultiGfshDUnitTest {
     VM vm2 = lsRule.getVM(2);
     // set up vm_2 as a gfsh vm, and then connect as "stranger" and try to execute the commands and
     // assert errors comes back are NotAuthorized
-    AsyncInvocation vm2Invoke = vm2.invokeAsync("run as guest", () -> {
+    AsyncInvocation<Void> vm2Invoke = vm2.invokeAsync("run as guest", () -> {
       GfshCommandRule gfsh = new GfshCommandRule();
       gfsh.secureConnectAndVerify(jmxPort, PortType.jmxManager, "guest", "guest");
 
@@ -93,7 +93,7 @@ public class MultiGfshDUnitTest {
     // set up vm_3 as another gfsh vm, and then connect as "super-user" and try to execute the
     // commands and assert we don't get a NotAuthorized Exception
     VM vm3 = lsRule.getVM(3);
-    AsyncInvocation vm3Invoke = vm3.invokeAsync("run as superUser", () -> {
+    AsyncInvocation<Void> vm3Invoke = vm3.invokeAsync("run as superUser", () -> {
       GfshCommandRule gfsh = new GfshCommandRule();
       gfsh.secureConnectAndVerify(jmxPort, PortType.jmxManager, "data,cluster", "data,cluster");
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/pdx/PdxSerializableDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/pdx/PdxSerializableDUnitTest.java
@@ -229,8 +229,8 @@ public class PdxSerializableDUnitTest extends JUnit4CacheTestCase {
 
 
     // Now recreate the region, recoverying from disk
-    AsyncInvocation future1 = vm1.invokeAsync(createRegion);
-    AsyncInvocation future2 = vm2.invokeAsync(createRegion);
+    AsyncInvocation<Void> future1 = vm1.invokeAsync(createRegion);
+    AsyncInvocation<Void> future2 = vm2.invokeAsync(createRegion);
 
     future1.getResult();
     future2.getResult();
@@ -311,7 +311,7 @@ public class PdxSerializableDUnitTest extends JUnit4CacheTestCase {
       });
     });
 
-    AsyncInvocation async0 = vm0.invokeAsync("propagate value with new pdx enum type", () -> {
+    AsyncInvocation<Void> async0 = vm0.invokeAsync("propagate value with new pdx enum type", () -> {
       Cache cache = getCache(properties);
       final Region pdxRegion = cache.getRegion(PeerTypeRegistration.REGION_FULL_PATH);
       final DUnitBlackboard bb = getBlackboard();
@@ -343,7 +343,7 @@ public class PdxSerializableDUnitTest extends JUnit4CacheTestCase {
 
     // vm0 has sent a new TestObject but vm1 does not have the enum type needed to
     // deserialize it.
-    AsyncInvocation async1 = vm1.invokeAsync("try to read object w/o enum type", () -> {
+    AsyncInvocation<Void> async1 = vm1.invokeAsync("try to read object w/o enum type", () -> {
       DUnitBlackboard bb = getBlackboard();
       bb.waitForGate("pdxObjectPut", 10, TimeUnit.SECONDS);
       Region region = getCache(properties).getRegion("testRegion");

--- a/geode-core/src/distributedTest/java/org/apache/geode/pdx/PdxTypeGenerationDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/pdx/PdxTypeGenerationDUnitTest.java
@@ -93,12 +93,12 @@ public class PdxTypeGenerationDUnitTest {
   public void testNoConflictsWhenGeneratingPdxTypesFromJSONOnMultipleServers() {
     int repeats = 10000;
 
-    AsyncInvocation invocation1 = server1.invokeAsync(() -> {
+    AsyncInvocation<Void> invocation1 = server1.invokeAsync(() -> {
       for (int i = 0; i < repeats; ++i) {
         JSONFormatter.fromJSON("{\"counter" + i + "\": " + i + "}");
       }
     });
-    AsyncInvocation invocation2 = server2.invokeAsync(() -> {
+    AsyncInvocation<Void> invocation2 = server2.invokeAsync(() -> {
       for (int i = 0; i < repeats; ++i) {
         JSONFormatter.fromJSON("{\"counter" + i + "\": " + i + "}");
       }

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationMultiServerDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/AuthExpirationMultiServerDUnitTest.java
@@ -339,7 +339,7 @@ public class AuthExpirationMultiServerDUnitTest {
         c -> c.withProperty(SECURITY_CLIENT_AUTH_INIT, UpdatableUserAuthInitialize.class.getName())
             .withPoolSubscription(true)
             .withLocatorConnection(locatorPort));
-    AsyncInvocation invokePut = client.invokeAsync(() -> {
+    AsyncInvocation<Void> invokePut = client.invokeAsync(() -> {
       UpdatableUserAuthInitialize.setUser("user1");
       Region<Object, Object> proxyRegion =
           ClusterStartupRule.getClientCache()

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientContainsKeyAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientContainsKeyAuthDUnitTest.java
@@ -60,7 +60,7 @@ public class ClientContainsKeyAuthDUnitTest extends JUnit4DistributedTestCase {
 
   @Test
   public void testContainsKey() throws Exception {
-    AsyncInvocation ai1 = client1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = client1.invokeAsync(() -> {
       ClientCache cache = createClientCache("key1User", "1234567", server.getPort());
       final Region region = createProxyRegion(cache, REGION_NAME);
       assertTrue(region.containsKeyOnServer("key1"));
@@ -68,7 +68,7 @@ public class ClientContainsKeyAuthDUnitTest extends JUnit4DistributedTestCase {
           "DATA:READ:AuthRegion:key3");
     });
 
-    AsyncInvocation ai2 = client2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = client2.invokeAsync(() -> {
       ClientCache cache = createClientCache("authRegionReader", "1234567", server.getPort());
       final Region region = createProxyRegion(cache, REGION_NAME);
       region.containsKeyOnServer("key3");

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetEntryAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetEntryAuthDUnitTest.java
@@ -63,7 +63,7 @@ public class ClientGetEntryAuthDUnitTest extends JUnit4DistributedTestCase {
   @Test
   public void testGetEntry() throws Exception {
     // client1 connects to server as a user not authorized to do any operations
-    AsyncInvocation ai1 = client1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = client1.invokeAsync(() -> {
       ClientCache cache = createClientCache("stranger", "1234567", server.getPort());
 
       CacheTransactionManager transactionManager = cache.getCacheTransactionManager();
@@ -77,7 +77,7 @@ public class ClientGetEntryAuthDUnitTest extends JUnit4DistributedTestCase {
 
     });
 
-    AsyncInvocation ai2 = client2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = client2.invokeAsync(() -> {
       ClientCache cache = createClientCache("authRegionReader", "1234567", server.getPort());
 
       CacheTransactionManager transactionManager = cache.getCacheTransactionManager();

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetPutAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientGetPutAuthDUnitTest.java
@@ -78,7 +78,7 @@ public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
     keys.add("key2");
 
     // client1 connects to server as a user not authorized to do any operations
-    AsyncInvocation ai1 = client1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = client1.invokeAsync(() -> {
       ClientCache cache = createClientCache("stranger", "1234567", server.getPort());
       Region region = createProxyRegion(cache, REGION_NAME);
 
@@ -97,7 +97,7 @@ public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
 
 
     // client2 connects to user as a user authorized to use AuthRegion region
-    AsyncInvocation ai2 = client2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = client2.invokeAsync(() -> {
       ClientCache cache = createClientCache("authRegionUser", "1234567", server.getPort());
       Region region = createProxyRegion(cache, REGION_NAME);
 
@@ -117,7 +117,7 @@ public class ClientGetPutAuthDUnitTest extends JUnit4DistributedTestCase {
     });
 
     // client3 connects to user as a user authorized to use key1 in AuthRegion region
-    AsyncInvocation ai3 = client3.invokeAsync(() -> {
+    AsyncInvocation<Void> ai3 = client3.invokeAsync(() -> {
       ClientCache cache = createClientCache("key1User", "1234567", server.getPort());
       Region region = createProxyRegion(cache, REGION_NAME);
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRegisterInterestAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRegisterInterestAuthDUnitTest.java
@@ -63,7 +63,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     extraProperties.setProperty(SECURITY_CLIENT_DHALGO, "AES:128");
 
     // client1 connects to server as a user not authorized to do any operations
-    AsyncInvocation ai1 = client1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = client1.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("stranger", "1234567", server.getPort(), extraProperties);
       Region region = createProxyRegion(cache, REGION_NAME);
@@ -71,7 +71,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     });
 
     // client2 connects to user as a user authorized to use AuthRegion region
-    AsyncInvocation ai2 = client2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = client2.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("authRegionUser", "1234567", server.getPort(), extraProperties);
       Region region = createProxyRegion(cache, REGION_NAME);
@@ -79,7 +79,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     });
 
     // client3 connects to user as a user authorized to use key1 in AuthRegion region
-    AsyncInvocation ai3 = client3.invokeAsync(() -> {
+    AsyncInvocation<Void> ai3 = client3.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("key1User", "1234567", server.getPort(), extraProperties);
       Region region = createProxyRegion(cache, REGION_NAME);
@@ -97,7 +97,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     extraProperties.setProperty(SECURITY_CLIENT_DHALGO, "AES:128");
 
     // client1 connects to server as a user not authorized to do any operations
-    AsyncInvocation ai1 = client1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = client1.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("stranger", "1234567", server.getPort(), extraProperties);
 
@@ -107,7 +107,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     });
 
     // client2 connects to user as a user authorized to use AuthRegion region
-    AsyncInvocation ai2 = client2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = client2.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("authRegionUser", "1234567", server.getPort(), extraProperties);
 
@@ -117,7 +117,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     });
 
     // client3 connects to user as a user authorized to use key1 in AuthRegion region
-    AsyncInvocation ai3 = client3.invokeAsync(() -> {
+    AsyncInvocation<Void> ai3 = client3.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("key1User", "1234567", server.getPort(), extraProperties);
 
@@ -142,7 +142,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     keys.add("key2");
 
     // client1 connects to server as a user not authorized to do any operations
-    AsyncInvocation ai1 = client1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = client1.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("stranger", "1234567", server.getPort(), extraProperties);
 
@@ -152,7 +152,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     });
 
     // client2 connects to user as a user authorized to use AuthRegion region
-    AsyncInvocation ai2 = client2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = client2.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("authRegionUser", "1234567", server.getPort(), extraProperties);
 
@@ -162,7 +162,7 @@ public class ClientRegisterInterestAuthDUnitTest extends JUnit4DistributedTestCa
     });
 
     // client3 connects to user as a user authorized to use key1 in AuthRegion region
-    AsyncInvocation ai3 = client3.invokeAsync(() -> {
+    AsyncInvocation<Void> ai3 = client3.invokeAsync(() -> {
       ClientCache cache =
           createClientCache("key1User", "1234567", server.getPort(), extraProperties);
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRemoveAllAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientRemoveAllAuthDUnitTest.java
@@ -55,7 +55,7 @@ public class ClientRemoveAllAuthDUnitTest extends JUnit4DistributedTestCase {
   @Test
   public void testRemoveAll() throws Exception {
 
-    AsyncInvocation ai1 = client1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = client1.invokeAsync(() -> {
       ClientCache cache = createClientCache("authRegionReader", "1234567", server.getPort());
 
       Region region = createProxyRegion(cache, REGION_NAME);
@@ -63,7 +63,7 @@ public class ClientRemoveAllAuthDUnitTest extends JUnit4DistributedTestCase {
           "DATA:WRITE:AuthRegion");
     });
 
-    AsyncInvocation ai2 = client2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = client2.invokeAsync(() -> {
       ClientCache cache = createClientCache("authRegionWriter", "1234567", server.getPort());
 
       Region region = createProxyRegion(cache, REGION_NAME);

--- a/geode-core/src/distributedTest/java/org/apache/geode/security/ClientUnregisterInterestAuthDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/security/ClientUnregisterInterestAuthDUnitTest.java
@@ -51,7 +51,7 @@ public class ClientUnregisterInterestAuthDUnitTest extends JUnit4DistributedTest
   @Test
   public void testUnregisterInterest() throws Exception {
     // client2 connects to user as a user authorized to use AuthRegion region
-    AsyncInvocation ai1 = client2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = client2.invokeAsync(() -> {
       ClientCache cache = createClientCache("authRegionUser", "1234567", server.getPort());
 
       Region region = createProxyRegion(cache, REGION_NAME);

--- a/geode-core/src/upgradeTest/java/org/apache/geode/ClusterCommunicationsDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/ClusterCommunicationsDUnitTest.java
@@ -181,7 +181,7 @@ public class ClusterCommunicationsDUnitTest implements Serializable {
           DistributedLockService.create("testLockService", cache.getDistributedSystem());
       distLockService.lock("myLock", 50000, 50000);
     });
-    AsyncInvocation async = waitForTheLockAsync(dUnitBlackboard, true);
+    AsyncInvocation<Void> async = waitForTheLockAsync(dUnitBlackboard, true);
     for (int i = 0; i < 5; i++) {
       getVM(1).invoke("update cache and release lock in vm1", () -> {
         DistributedLockService distLockService =
@@ -210,10 +210,11 @@ public class ClusterCommunicationsDUnitTest implements Serializable {
   }
 
   @NotNull
-  private AsyncInvocation waitForTheLockAsync(DUnitBlackboard dUnitBlackboard, boolean initialWait)
+  private AsyncInvocation<Void> waitForTheLockAsync(DUnitBlackboard dUnitBlackboard,
+      boolean initialWait)
       throws Exception {
     dUnitBlackboard.clearGate("waitingForLock");
-    AsyncInvocation async = getVM(2).invokeAsync("wait for the lock", () -> {
+    AsyncInvocation<Void> async = getVM(2).invokeAsync("wait for the lock", () -> {
       DistributedLockService distLockService = initialWait
           ? DistributedLockService.create("testLockService", cache.getDistributedSystem())
           : DistributedLockService.getServiceNamed("testLockService");

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeConcurrentPutsReplicated.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeConcurrentPutsReplicated.java
@@ -73,7 +73,7 @@ public class RollingUpgradeConcurrentPutsReplicated extends RollingUpgrade2DUnit
       invokeRunnableInVMs(invokeCreateRegion(regionName, shortcut), server1, server2);
 
       // async puts through server 2
-      AsyncInvocation asyncPutsThroughOld =
+      AsyncInvocation<Void> asyncPutsThroughOld =
           server2.invokeAsync(new CacheSerializableRunnable("async puts") {
             @Override
             public void run2() {
@@ -96,7 +96,7 @@ public class RollingUpgradeConcurrentPutsReplicated extends RollingUpgrade2DUnit
       verifyValues(objectType, regionName, 0, 500, server1);
 
       // aync puts through server 1
-      AsyncInvocation asyncPutsThroughNew =
+      AsyncInvocation<Void> asyncPutsThroughNew =
           server1.invokeAsync(new CacheSerializableRunnable("async puts") {
             @Override
             public void run2() {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataUsingPoolDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataUsingPoolDUnitTest.java
@@ -742,7 +742,7 @@ public class CqDataUsingPoolDUnitTest extends JUnit4CacheTestCase {
     client.invoke(setTestHook());
 
     // Execute CQ while update is in progress.
-    AsyncInvocation executeCq =
+    AsyncInvocation<Void> executeCq =
         client.invokeAsync(new CacheSerializableRunnable("Execute CQ AsyncInvoke") {
           @Override
           public void run2() throws CacheException {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqStateDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqStateDUnitTest.java
@@ -76,7 +76,7 @@ public class CqStateDUnitTest extends HelperTestCase {
     createReplicatedRegion(serverB, regionName, null);
     startCacheServers(serverB);
 
-    AsyncInvocation async = executeCQ(client, cqName);
+    AsyncInvocation<Void> async = executeCQ(client, cqName);
     ThreadUtils.join(async, 10000);
 
     client.invoke(() -> {

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionTxDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionTxDUnitTest.java
@@ -98,7 +98,7 @@ public class PartitionedRegionTxDUnitTest implements Serializable {
     client = clusterStartupRule.startClientVM(3,
         cacheRule -> cacheRule.withServerConnection(server2.getPort()).withPoolSubscription(true));
 
-    AsyncInvocation<?> serverAsync = server1.invokeAsync(() -> {
+    AsyncInvocation<Void> serverAsync = server1.invokeAsync(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
       TXManagerImpl txManager = (TXManagerImpl) cache.getCacheTransactionManager();
       txManager.begin();
@@ -192,7 +192,7 @@ public class PartitionedRegionTxDUnitTest implements Serializable {
     client = clusterStartupRule.startClientVM(3,
         cacheRule -> cacheRule.withServerConnection(server2.getPort()).withPoolSubscription(true));
 
-    AsyncInvocation serverAsync = server1.invokeAsync(() -> {
+    AsyncInvocation<Void> serverAsync = server1.invokeAsync(() -> {
       InternalCache cache = ClusterStartupRule.getCache();
       TXManagerImpl txManager = (TXManagerImpl) cache.getCacheTransactionManager();
       txManager.begin();

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryMonitorDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/dunit/QueryMonitorDUnitTest.java
@@ -325,20 +325,20 @@ public class QueryMonitorDUnitTest {
       populateRegion(100, 1000);
     });
 
-    AsyncInvocation ai1 = server1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = server1.invokeAsync(() -> {
       for (int j = 0; j < 5; j++) {
         populateRegion(0, 2000);
       }
     });
 
-    AsyncInvocation ai2 = server2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = server2.invokeAsync(() -> {
       for (int j = 0; j < 5; j++) {
         populateRegion(1000, 3000);
       }
     });
 
     // server3 performs a region put after a query is canceled.
-    AsyncInvocation ai3 = server3.invokeAsync(() -> {
+    AsyncInvocation<Void> ai3 = server3.invokeAsync(() -> {
       Region exampleRegion = ClusterStartupRule.getCache().getRegion("exampleRegion");
       QueryService queryService = GemFireCacheImpl.getInstance().getQueryService();
       String qStr =

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/examples/AsyncInvokeRunnableExampleTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/examples/AsyncInvokeRunnableExampleTest.java
@@ -40,13 +40,13 @@ public class AsyncInvokeRunnableExampleTest {
 
   @Test
   public void invokeAsyncHelloWorldInEachVMWithAwait() throws Exception {
-    List<AsyncInvocation> invocations = new ArrayList<>();
+    List<AsyncInvocation<Void>> invocations = new ArrayList<>();
     for (VM vm : getAllVMs()) {
-      AsyncInvocation invocation =
+      AsyncInvocation<Void> invocation =
           vm.invokeAsync(() -> System.out.println(vm + " says Hello World!"));
       invocations.add(invocation);
     }
-    for (AsyncInvocation invocation : invocations) {
+    for (AsyncInvocation<Void> invocation : invocations) {
       invocation.await();
     }
   }

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/BasicDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/BasicDistributedTest.java
@@ -81,15 +81,17 @@ public class BasicDistributedTest extends DistributedTestCase {
 
   @Test
   public void testInvokeAsyncOnClassTargetWithEmptyArgs() throws Exception {
-    AsyncInvocation<?> async =
-        vm0.invokeAsync(BasicDistributedTest.class, "booleanValue", new Object[] {}).join();
+    AsyncInvocation<Boolean> async =
+        vm0.<Boolean>invokeAsync(BasicDistributedTest.class, "booleanValue", new Object[] {})
+            .await();
     assertThat(async.getResult(), is(true));
   }
 
   @Test
   public void testInvokeAsyncOnObjectTargetWithEmptyArgs() throws Exception {
-    AsyncInvocation<?> async =
-        vm0.invokeAsync(new BasicDistributedTest(), "booleanValue", new Object[] {}).join();
+    AsyncInvocation<Boolean> async =
+        vm0.<Boolean>invokeAsync(new BasicDistributedTest(), "booleanValue", new Object[] {})
+            .await();
     assertThat(async.getResult(), is(true));
   }
 
@@ -105,15 +107,15 @@ public class BasicDistributedTest extends DistributedTestCase {
 
   @Test
   public void testInvokeAsyncOnClassTargetWithNullArgs() throws Exception {
-    AsyncInvocation<?> async =
-        vm0.invokeAsync(BasicDistributedTest.class, "booleanValue", null).join();
+    AsyncInvocation<Boolean> async =
+        vm0.<Boolean>invokeAsync(BasicDistributedTest.class, "booleanValue", null).await();
     assertThat(async.getResult(), is(true));
   }
 
   @Test
   public void testInvokeAsyncOnObjectTargetWithNullArgs() throws Exception {
-    AsyncInvocation<?> async =
-        vm0.invokeAsync(new BasicDistributedTest(), "booleanValue", null).join();
+    AsyncInvocation<Boolean> async =
+        vm0.<Boolean>invokeAsync(new BasicDistributedTest(), "booleanValue", null).await();
     assertThat(async.getResult(), is(true));
   }
 
@@ -154,21 +156,23 @@ public class BasicDistributedTest extends DistributedTestCase {
     String name = getUniqueName();
     String value = "Hello";
 
-    AsyncInvocation async1 = vm0.invokeAsync(() -> remoteBind(name, value)).join().checkException();
-    AsyncInvocation async2 =
-        vm0.invokeAsync(() -> remoteValidateBind(name, value)).join().checkException();
-    async1.join();
-    async2.join();
+    AsyncInvocation<Void> async1 =
+        vm0.<Void>invokeAsync(() -> remoteBind(name, value)).await();
+    AsyncInvocation<Void> async2 =
+        vm0.<Void>invokeAsync(() -> remoteValidateBind(name, value)).await();
+    async1.await();
+    async2.await();
   }
 
   @Test
   public void testRemoteInvokeAsyncWithException() throws Exception {
-    AsyncInvocation<?> async = vm0.invokeAsync(BasicDistributedTest::remoteThrowException).join();
+    AsyncInvocation<Void> async =
+        vm0.<Void>invokeAsync(BasicDistributedTest::remoteThrowException).join();
 
     assertThat(async.exceptionOccurred(), is(true));
     assertThat(async.getException(), instanceOf(BasicTestException.class));
 
-    Throwable thrown = catchThrowable(async::checkException);
+    Throwable thrown = catchThrowable(async::await);
 
     assertThat(thrown, instanceOf(AssertionError.class));
     assertThat(thrown.getCause(), notNullValue());
@@ -180,8 +184,7 @@ public class BasicDistributedTest extends DistributedTestCase {
   public void testInvokeNamedRunnableLambdaAsync() throws Exception {
     Throwable thrown =
         catchThrowable(
-            () -> vm0.invokeAsync("throwSomething", BasicDistributedTest::throwException).join()
-                .checkException());
+            () -> vm0.invokeAsync("throwSomething", BasicDistributedTest::throwException).await());
 
     assertThat(thrown, notNullValue());
     assertThat(thrown.getCause(), notNullValue());

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/VMDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/VMDistributedTest.java
@@ -89,13 +89,13 @@ public class VMDistributedTest extends DistributedTestCase {
     final Host host = Host.getHost(0);
     final VM vm = host.getVM(0);
     // Assert class static invocation works
-    AsyncInvocation a1 = vm.invokeAsync(VMDistributedTest::getAndIncStaticCount);
+    AsyncInvocation<Integer> a1 = vm.invokeAsync(VMDistributedTest::getAndIncStaticCount);
     a1.join();
-    assertEquals(0, a1.getReturnValue());
+    assertEquals(0, (long) a1.getReturnValue());
     // Assert class static invocation with args works
     a1 = vm.invokeAsync(() -> incrementStaticCount(2));
     a1.join();
-    assertEquals(3, a1.getReturnValue());
+    assertEquals(3, (long) a1.getReturnValue());
     // Assert that previous values are not returned when invoking method w/ no return val
     a1 = vm.invokeAsync(VMDistributedTest::incStaticCount);
     a1.join();
@@ -103,13 +103,13 @@ public class VMDistributedTest extends DistributedTestCase {
     // Assert that previous null returns are over-written
     a1 = vm.invokeAsync(VMDistributedTest::getAndIncStaticCount);
     a1.join();
-    assertEquals(4, a1.getReturnValue());
+    assertEquals(4, (long) a1.getReturnValue());
 
     // Assert object method invocation works with zero arg method
     final VMTestObject o = new VMTestObject(0);
     a1 = vm.invokeAsync(o, "incrementAndGet", new Object[] {});
     a1.join();
-    assertEquals(1, a1.getReturnValue());
+    assertEquals(1, (long) a1.getReturnValue());
     // Assert object method invocation works with no return
     a1 = vm.invokeAsync(o, "set", new Object[] {3});
     a1.join();

--- a/geode-dunit/src/main/java/org/apache/geode/cache/query/dunit/HelperTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache/query/dunit/HelperTestCase.java
@@ -189,7 +189,7 @@ public abstract class HelperTestCase extends JUnit4CacheTestCase {
     return cqa;
   }
 
-  protected AsyncInvocation executeCQ(VM vm, final String cqName) {
+  protected AsyncInvocation<Void> executeCQ(VM vm, final String cqName) {
     return vm.invokeAsync(new SerializableCallable() {
       @Override
       public Object call() throws CqException, RegionNotFoundException {

--- a/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/cache30/MultiVMRegionTestCase.java
@@ -457,7 +457,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       flushIfNecessary(region);
     });
 
-    AsyncInvocation verify = vm1.invokeAsync("Verify", () -> {
+    AsyncInvocation<Void> verify = vm1.invokeAsync("Verify", () -> {
       Region<String, Integer> region = getRootRegion().getSubregion(regionName);
       @SuppressWarnings("unchecked")
       BlockingQueue<Integer> queue = (BlockingQueue<Integer>) region.getUserAttribute();
@@ -471,7 +471,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       }
     });
 
-    AsyncInvocation populate = vm0.invokeAsync("Populate", () -> {
+    AsyncInvocation<Void> populate = vm0.invokeAsync("Populate", () -> {
       Region<String, Integer> region = getRootRegion().getSubregion(regionName);
       for (int i = 0; i <= lastValue; i++) {
         region.put(key, i);
@@ -3240,7 +3240,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
     });
 
     // start asynchronous process that does updates to the data
-    AsyncInvocation async =
+    AsyncInvocation<Void> async =
         vm0.invokeAsync("Do Nonblocking Operations", () -> {
           Region<Object, Object> region = getRootRegion().getSubregion(name);
 
@@ -3356,7 +3356,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       }
     };
 
-    AsyncInvocation asyncGII = vm2.invokeAsync("Create Mirrored Region", create);
+    AsyncInvocation<Void> asyncGII = vm2.invokeAsync("Create Mirrored Region", create);
 
     if (!getRegionAttributes().getScope().isGlobal()) {
       // wait for nonblocking operations to complete
@@ -3495,7 +3495,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
     });
 
     // start asynchronous process that does updates to the data
-    AsyncInvocation async =
+    AsyncInvocation<Void> async =
         vm0.invokeAsync("Do Nonblocking Operations", new CacheSerializableRunnable() {
           @Override
           public void run2() throws CacheException {
@@ -3589,7 +3589,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       });
     }
 
-    AsyncInvocation asyncGII = vm2.invokeAsync(create);
+    AsyncInvocation<Void> asyncGII = vm2.invokeAsync(create);
 
     if (!getRegionAttributes().getScope().isGlobal()) {
       // wait for nonblocking operations to complete
@@ -5870,8 +5870,8 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       }
     };
 
-    AsyncInvocation a0 = vm0.invokeAsync("perform concurrent ops", performOps);
-    AsyncInvocation a1 = vm1.invokeAsync("perform concurrent ops", performOps);
+    AsyncInvocation<Void> a0 = vm0.invokeAsync("perform concurrent ops", performOps);
+    AsyncInvocation<Void> a1 = vm1.invokeAsync("perform concurrent ops", performOps);
 
     vm2.invoke(createRegion);
 
@@ -5975,7 +5975,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
     return DataSerializer.readObject(dis);
   }
 
-  private AsyncInvocation performOps4ClearWithConcurrentEvents(VM vm) {
+  private AsyncInvocation<Void> performOps4ClearWithConcurrentEvents(VM vm) {
     return vm.invokeAsync("perform concurrent ops", () -> {
       try {
         doOpsLoop(true);
@@ -6010,8 +6010,8 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
     createRegionWithAttribute(vm0, name, syncDiskWrite);
     createRegionWithAttribute(vm1, name, syncDiskWrite);
 
-    AsyncInvocation a0 = performOps4ClearWithConcurrentEvents(vm0);
-    AsyncInvocation a1 = performOps4ClearWithConcurrentEvents(vm1);
+    AsyncInvocation<Void> a0 = performOps4ClearWithConcurrentEvents(vm0);
+    AsyncInvocation<Void> a1 = performOps4ClearWithConcurrentEvents(vm1);
 
     try {
       Thread.sleep(500);
@@ -6062,14 +6062,14 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
     });
 
 
-    AsyncInvocation a0 = vm0.invokeAsync("perform concurrent ops", () -> {
+    AsyncInvocation<Void> a0 = vm0.invokeAsync("perform concurrent ops", () -> {
       doOpsLoop(true);
       if (CCRegion.getScope().isDistributedNoAck()) {
         sendSerialMessageToAll(); // flush the ops
       }
     });
 
-    AsyncInvocation a1 = vm1.invokeAsync("perform concurrent ops", () -> {
+    AsyncInvocation<Void> a1 = vm1.invokeAsync("perform concurrent ops", () -> {
 
       doOpsLoop(true);
       if (CCRegion.getScope().isDistributedNoAck()) {
@@ -6411,8 +6411,8 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
       }
     };
 
-    AsyncInvocation a0 = vm0.invokeAsync("perform concurrent ops", performOps);
-    AsyncInvocation a1 = vm1.invokeAsync("perform concurrent ops", performOps);
+    AsyncInvocation<Void> a0 = vm0.invokeAsync("perform concurrent ops", performOps);
+    AsyncInvocation<Void> a1 = vm1.invokeAsync("perform concurrent ops", performOps);
 
     // try {
     // Thread.sleep(500);
@@ -6677,7 +6677,7 @@ public abstract class MultiVMRegionTestCase extends RegionTestCase {
     });
   }
 
-  boolean waitForAsyncProcessing(AsyncInvocation async, String expectedError) {
+  boolean waitForAsyncProcessing(AsyncInvocation<Void> async, String expectedError) {
     try {
       async.await();
     } catch (Throwable e) {

--- a/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/junit/rules/VMProvider.java
@@ -112,21 +112,19 @@ public abstract class VMProvider {
     return getVM().invokeAsync(callable);
   }
 
-
   public <T> AsyncInvocation<T> invokeAsync(String name, final SerializableCallableIF<T> callable) {
     return getVM().invokeAsync(name, callable);
   }
 
-  public AsyncInvocation invokeAsync(final SerializableRunnableIF runnable) {
+  public AsyncInvocation<Void> invokeAsync(final SerializableRunnableIF runnable) {
     return getVM().invokeAsync(runnable);
   }
 
-  public AsyncInvocation invokeAsync(String name, final SerializableRunnableIF runnable) {
+  public AsyncInvocation<Void> invokeAsync(String name, final SerializableRunnableIF runnable) {
     return getVM().invokeAsync(name, runnable);
   }
 
   public File getWorkingDir() {
     return getVM().getWorkingDirectory();
   }
-
 }

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexCreationDUnitTest.java
@@ -319,11 +319,11 @@ public class LuceneIndexCreationDUnitTest extends LuceneDUnitTest {
       regionType.createDataStore(getCache(), REGION_NAME);
     });
 
-    AsyncInvocation createIndex1 = dataStore1.invokeAsync(() -> {
+    AsyncInvocation<Void> createIndex1 = dataStore1.invokeAsync(() -> {
       createIndexAfterRegion("field1");
     });
 
-    AsyncInvocation createIndex2 = dataStore2.invokeAsync(() -> {
+    AsyncInvocation<Void> createIndex2 = dataStore2.invokeAsync(() -> {
       createIndexAfterRegion("field1");
     });
 

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneIndexDestroyDUnitTest.java
@@ -195,7 +195,7 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
     dataStore2.invoke(this::verifyIndexCreated);
 
     // Start puts
-    AsyncInvocation putter = dataStore1.invokeAsync(this::doPutsUntilStopped);
+    AsyncInvocation<Void> putter = dataStore1.invokeAsync(this::doPutsUntilStopped);
 
     // Wait until puts have started
     dataStore1.invoke(this::waitUntilPutsHaveStarted);
@@ -236,7 +236,7 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
     dataStore2.invoke(this::verifyIndexesCreated);
 
     // Start puts
-    AsyncInvocation putter = dataStore1.invokeAsync(this::doPutsUntilStopped);
+    AsyncInvocation<Void> putter = dataStore1.invokeAsync(this::doPutsUntilStopped);
 
     // Wait until puts have started
     dataStore1.invoke(this::waitUntilPutsHaveStarted);
@@ -284,7 +284,7 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
     accessor.invoke(() -> waitUntilFlushed(INDEX_NAME));
 
     // Start queries
-    AsyncInvocation querier = accessor
+    AsyncInvocation<Void> querier = accessor
         .invokeAsync(() -> doQueriesUntilException(INDEX_NAME, "field1Value", "field1", numPuts));
 
     // Wait until queries have started
@@ -329,7 +329,7 @@ public class LuceneIndexDestroyDUnitTest extends LuceneDUnitTest {
     accessor.invoke(() -> waitUntilFlushed(INDEX2_NAME));
 
     // Start queries
-    AsyncInvocation querier = accessor
+    AsyncInvocation<Void> querier = accessor
         .invokeAsync(() -> doQueriesUntilException(INDEX1_NAME, "field1Value", "field1", numPuts));
 
     // Wait until queries have started

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesReindexDUnitTest.java
@@ -80,11 +80,11 @@ public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
     dataStore1.invoke(this::destroyIndex);
 
     // re-index stored data
-    AsyncInvocation ai1 = dataStore1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = dataStore1.invokeAsync(() -> {
       createIndex("text");
     });
 
-    AsyncInvocation ai2 = dataStore2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = dataStore2.invokeAsync(() -> {
       createIndex("text");
     });
 
@@ -115,15 +115,15 @@ public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
     putDataInRegion(accessor);
 
     // re-index stored data
-    AsyncInvocation ai1 = dataStore1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = dataStore1.invokeAsync(() -> {
       createIndex("text");
     });
 
-    AsyncInvocation ai2 = dataStore2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = dataStore2.invokeAsync(() -> {
       createIndex("text");
     });
 
-    AsyncInvocation ai3 = accessor.invokeAsync(() -> {
+    AsyncInvocation<Void> ai3 = accessor.invokeAsync(() -> {
       if (regionTestType != PARTITION_WITH_CLIENT) {
         createIndex("text");
       }
@@ -208,29 +208,29 @@ public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
     putDataInRegion(accessor);
 
     // re-index stored data
-    AsyncInvocation ai1 = dataStore1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = dataStore1.invokeAsync(() -> {
       createIndex("text");
     });
 
-    AsyncInvocation ai2 = dataStore2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = dataStore2.invokeAsync(() -> {
       createIndex(INDEX_NAME + "2", "text2");
     });
 
-    AsyncInvocation ai3 = dataStore1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai3 = dataStore1.invokeAsync(() -> {
       createIndex(INDEX_NAME + "2", "text2");
     });
 
-    AsyncInvocation ai4 = dataStore2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai4 = dataStore2.invokeAsync(() -> {
       createIndex("text");
     });
 
-    AsyncInvocation ai5 = accessor.invokeAsync(() -> {
+    AsyncInvocation<Void> ai5 = accessor.invokeAsync(() -> {
       if (getCache().getRegion(REGION_NAME) instanceof PartitionedRegion) {
         createIndex(INDEX_NAME + "1", "text");
       }
     });
 
-    AsyncInvocation ai6 = accessor.invokeAsync(() -> {
+    AsyncInvocation<Void> ai6 = accessor.invokeAsync(() -> {
       if (getCache().getRegion(REGION_NAME) instanceof PartitionedRegion) {
         createIndex(INDEX_NAME + "2", "text2");
       }
@@ -255,11 +255,11 @@ public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
   }
 
   private void verifyCreateIndexWithDifferentFieldShouldFail() throws Exception {
-    AsyncInvocation ai1 = dataStore1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = dataStore1.invokeAsync(() -> {
       createIndex("text");
     });
 
-    AsyncInvocation ai2 = dataStore2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = dataStore2.invokeAsync(() -> {
       createIndex("text2");
     });
 
@@ -309,12 +309,12 @@ public class LuceneQueriesReindexDUnitTest extends LuceneQueriesAccessorBase {
     putDataInRegion(accessor);
 
     // re-index stored data
-    AsyncInvocation ai1 = dataStore1.invokeAsync(() -> {
+    AsyncInvocation<Void> ai1 = dataStore1.invokeAsync(() -> {
       createIndex("text");
     });
 
     // re-index stored data
-    AsyncInvocation ai2 = dataStore2.invokeAsync(() -> {
+    AsyncInvocation<Void> ai2 = dataStore2.invokeAsync(() -> {
       createIndex("text");
     });
 

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithRegionCreatedBeforeReindexClientDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithRegionCreatedBeforeReindexClientDUnitTest.java
@@ -52,10 +52,10 @@ public class LuceneQueriesWithRegionCreatedBeforeReindexClientDUnitTest
     accessor.invoke(() -> initAccessor(regionTestType));
 
     // re-index stored data
-    AsyncInvocation ai1 = dataStore1.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai1 = dataStore1.invokeAsync(createIndex);
 
     // re-index stored data
-    AsyncInvocation ai2 = dataStore2.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai2 = dataStore2.invokeAsync(createIndex);
 
     ai1.join();
     ai2.join();

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithRegionCreatedBeforeReindexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/LuceneQueriesWithRegionCreatedBeforeReindexDUnitTest.java
@@ -60,9 +60,9 @@ public class LuceneQueriesWithRegionCreatedBeforeReindexDUnitTest extends Lucene
     accessor.invoke(() -> initAccessor(regionTestType));
 
     // re-index stored data
-    AsyncInvocation ai1 = dataStore1.invokeAsync(createIndex);
-    AsyncInvocation ai2 = dataStore2.invokeAsync(createIndex);
-    AsyncInvocation ai3 = accessor.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai1 = dataStore1.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai2 = dataStore2.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai3 = accessor.invokeAsync(createIndex);
 
     ai1.join();
     ai2.join();

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/RebalanceWithRedundancyWithRegionCreatedBeforeReindexDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/RebalanceWithRedundancyWithRegionCreatedBeforeReindexDUnitTest.java
@@ -134,19 +134,19 @@ public class RebalanceWithRedundancyWithRegionCreatedBeforeReindexDUnitTest
     // dataStore4.invoke(() -> (createIndex));
     dataStore4.invoke(() -> initDataStore(regionTestType));
 
-    AsyncInvocation aiRebalancer = dataStore1.invokeAsync(rebalance);
+    AsyncInvocation<Void> aiRebalancer = dataStore1.invokeAsync(rebalance);
 
     if (doOps) {
-      AsyncInvocation aiConcOps = dataStore1.invokeAsync(doConcOps);
+      AsyncInvocation<Void> aiConcOps = dataStore1.invokeAsync(doConcOps);
       aiConcOps.join();
       aiConcOps.checkException();
     }
 
     // re-index stored data
-    AsyncInvocation ai1 = dataStore1.invokeAsync(createIndex);
-    AsyncInvocation ai2 = dataStore2.invokeAsync(createIndex);
-    AsyncInvocation ai3 = dataStore3.invokeAsync(createIndex);
-    AsyncInvocation ai4 = dataStore4.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai1 = dataStore1.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai2 = dataStore2.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai3 = dataStore3.invokeAsync(createIndex);
+    AsyncInvocation<Void> ai4 = dataStore4.invokeAsync(createIndex);
 
     aiRebalancer.join();
     aiRebalancer.checkException();

--- a/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/internal/cli/DestroyLuceneIndexCommandsDUnitTest.java
+++ b/geode-lucene/src/distributedTest/java/org/apache/geode/cache/lucene/internal/cli/DestroyLuceneIndexCommandsDUnitTest.java
@@ -158,8 +158,8 @@ public class DestroyLuceneIndexCommandsDUnitTest implements Serializable {
     // to be invoked which will wait for the index to be destroyed before invoking the real
     // afterDataRegionCreated method and completing region creation. The registerIndex method will
     // realize the defined index has been destroyed and destroy the real one.
-    AsyncInvocation server1RegionCreationInvocation = server1.invokeAsync(this::createRegion);
-    AsyncInvocation server2RegionCreationInvocation = server2.invokeAsync(this::createRegion);
+    AsyncInvocation<Void> server1RegionCreationInvocation = server1.invokeAsync(this::createRegion);
+    AsyncInvocation<Void> server2RegionCreationInvocation = server2.invokeAsync(this::createRegion);
 
     // Wait for index creation to be in progress
     server1.invoke(this::waitForIndexCreationInProgress);
@@ -315,8 +315,8 @@ public class DestroyLuceneIndexCommandsDUnitTest implements Serializable {
     // to be invoked which will wait for the indexes to be destroyed before invoking the real
     // afterDataRegionCreated method and completing region creation. The registerIndex method will
     // realize the defined index has been destroyed and destroy the real one.
-    AsyncInvocation server1RegionCreationInvocation = server1.invokeAsync(this::createRegion);
-    AsyncInvocation server2RegionCreationInvocation = server2.invokeAsync(this::createRegion);
+    AsyncInvocation<Void> server1RegionCreationInvocation = server1.invokeAsync(this::createRegion);
+    AsyncInvocation<Void> server2RegionCreationInvocation = server2.invokeAsync(this::createRegion);
 
     // Wait for index creation to be in progress
     server1.invoke(this::waitForIndexCreationInProgress);

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion.java
@@ -96,10 +96,10 @@ public class RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentV
           regionName, new int[] {locatorPort});
 
 
-      AsyncInvocation ai1 = server1
+      AsyncInvocation<Void> ai1 = server1
           .invokeAsync(() -> createLuceneIndexOnExistingRegion(cache, regionName, INDEX_NAME));
 
-      AsyncInvocation ai2 = server2
+      AsyncInvocation<Void> ai2 = server2
           .invokeAsync(() -> createLuceneIndexOnExistingRegion(cache, regionName, INDEX_NAME));
 
       ai1.join();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/WANTestBase.java
@@ -1061,11 +1061,11 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void startSenderInVMsAsync(String senderId, VM... vms) {
-    List<AsyncInvocation<?>> tasks = new LinkedList<>();
+    List<AsyncInvocation<Void>> tasks = new LinkedList<>();
     for (VM vm : vms) {
       tasks.add(vm.invokeAsync(() -> startSender(senderId)));
     }
-    for (AsyncInvocation<?> invocation : tasks) {
+    for (AsyncInvocation<Void> invocation : tasks) {
       try {
         invocation.await();
       } catch (InterruptedException e) {
@@ -1076,11 +1076,11 @@ public class WANTestBase extends DistributedTestCase {
 
 
   public static void startSenderwithCleanQueuesInVMsAsync(String senderId, VM... vms) {
-    List<AsyncInvocation<?>> tasks = new LinkedList<>();
+    List<AsyncInvocation<Void>> tasks = new LinkedList<>();
     for (VM vm : vms) {
       tasks.add(vm.invokeAsync(() -> startSenderwithCleanQueues(senderId)));
     }
-    for (AsyncInvocation<?> invocation : tasks) {
+    for (AsyncInvocation<Void> invocation : tasks) {
       try {
         invocation.await();
       } catch (InterruptedException e) {
@@ -1640,11 +1640,11 @@ public class WANTestBase extends DistributedTestCase {
   }
 
   public static void stopSenderInVMsAsync(String senderId, VM... vms) {
-    List<AsyncInvocation<?>> tasks = new LinkedList<>();
+    List<AsyncInvocation<Void>> tasks = new LinkedList<>();
     for (VM vm : vms) {
       tasks.add(vm.invokeAsync(() -> stopSender(senderId)));
     }
-    for (AsyncInvocation<?> invocation : tasks) {
+    for (AsyncInvocation<Void> invocation : tasks) {
       try {
         invocation.await();
       } catch (InterruptedException e) {
@@ -3873,12 +3873,12 @@ public class WANTestBase extends DistributedTestCase {
   @Override
   public final void preTearDown() throws Exception {
     cleanupVM();
-    List<AsyncInvocation<?>> invocations = new ArrayList<>();
+    List<AsyncInvocation<Void>> invocations = new ArrayList<>();
     final Host host = getHost(0);
     for (int i = 0; i < host.getVMCount(); i++) {
       invocations.add(host.getVM(i).invokeAsync(WANTestBase::cleanupVM));
     }
-    for (AsyncInvocation<?> invocation : invocations) {
+    for (AsyncInvocation<Void> invocation : invocations) {
       invocation.await();
     }
   }

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderDistributedTest.java
@@ -620,7 +620,7 @@ public class ConcurrentParallelGatewaySenderDistributedTest extends WANTestBase 
 
     startSenderInVMs("ln", vm4, vm5, vm6, vm7);
 
-    AsyncInvocation putsToVM7 =
+    AsyncInvocation<Void> putsToVM7 =
         vm7.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 5000));
 
     vm2.invoke(() -> await()
@@ -628,18 +628,18 @@ public class ConcurrentParallelGatewaySenderDistributedTest extends WANTestBase 
             "Failure in waiting for at least 10 events to be received by the receiver", true,
             (getRegionSize(getTestMethodName() + "_PR") > 10))));
 
-    AsyncInvocation killsSenderFromVM4 = vm4.invokeAsync(() -> WANTestBase.killSender());
+    AsyncInvocation<Void> killsSenderFromVM4 = vm4.invokeAsync(() -> WANTestBase.killSender());
 
     int prevRegionSize = vm2.invoke(() -> WANTestBase.getRegionSize(getTestMethodName() + "_PR"));
 
-    AsyncInvocation putsToVM6 =
+    AsyncInvocation<Void> putsToVM6 =
         vm6.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 10000));
 
     vm2.invoke(() -> await().untilAsserted(() -> assertEquals(
         "Failure in waiting for additional 20 events to be received by the receiver ", true,
         getRegionSize(getTestMethodName() + "_PR") > 20 + prevRegionSize)));
 
-    AsyncInvocation killsSenderFromVM5 = vm5.invokeAsync(() -> WANTestBase.killSender());
+    AsyncInvocation<Void> killsSenderFromVM5 = vm5.invokeAsync(() -> WANTestBase.killSender());
 
     putsToVM7.get();
     killsSenderFromVM4.get();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderOperation_1_DUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentParallelGatewaySenderOperation_1_DUnitTest.java
@@ -461,10 +461,10 @@ public class ConcurrentParallelGatewaySenderOperation_1_DUnitTest extends WANTes
     vm2.invoke(() -> WANTestBase.validateRegionSizeRemainsSame(getTestMethodName() + "_PR", 200));
 
     // start the senders again
-    AsyncInvocation vm4start = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
-    AsyncInvocation vm5start = vm5.invokeAsync(() -> WANTestBase.startSender("ln"));
-    AsyncInvocation vm6start = vm6.invokeAsync(() -> WANTestBase.startSender("ln"));
-    AsyncInvocation vm7start = vm7.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> vm4start = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> vm5start = vm5.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> vm6start = vm6.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> vm7start = vm7.invokeAsync(() -> WANTestBase.startSender("ln"));
     int START_TIMEOUT = 30000;
     vm4start.getResult(START_TIMEOUT);
     vm5start.getResult(START_TIMEOUT);
@@ -482,7 +482,7 @@ public class ConcurrentParallelGatewaySenderOperation_1_DUnitTest extends WANTes
     vm2.invoke(() -> WANTestBase.validateRegionSizeRemainsSame(getTestMethodName() + "_PR", 200));
 
     // SECOND RUN: do some more puts
-    AsyncInvocation async =
+    AsyncInvocation<Void> async =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
     async.join();
 
@@ -573,7 +573,7 @@ public class ConcurrentParallelGatewaySenderOperation_1_DUnitTest extends WANTes
     vm2.invoke(() -> WANTestBase.validateRegionSizeRemainsSame(getTestMethodName() + "_PR", 200));
 
     // SECOND RUN: start async puts on region
-    AsyncInvocation async =
+    AsyncInvocation<Void> async =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 5000));
     LogWriterUtils.getLogWriter().info("Started high number of puts by async thread");
 
@@ -662,10 +662,10 @@ public class ConcurrentParallelGatewaySenderOperation_1_DUnitTest extends WANTes
     vm2.invoke(() -> WANTestBase.validateRegionSizeRemainsSame(getTestMethodName() + "_PR", 200));
 
     // start the senders again
-    AsyncInvocation vm4start = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
-    AsyncInvocation vm5start = vm5.invokeAsync(() -> WANTestBase.startSender("ln"));
-    AsyncInvocation vm6start = vm6.invokeAsync(() -> WANTestBase.startSender("ln"));
-    AsyncInvocation vm7start = vm7.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> vm4start = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> vm5start = vm5.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> vm6start = vm6.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> vm7start = vm7.invokeAsync(() -> WANTestBase.startSender("ln"));
     vm4start.join();
     vm5start.join();
     vm6start.join();
@@ -682,7 +682,7 @@ public class ConcurrentParallelGatewaySenderOperation_1_DUnitTest extends WANTes
     vm2.invoke(() -> WANTestBase.validateRegionSizeRemainsSame(getTestMethodName() + "_PR", 200));
 
     // SECOND RUN: do some more puts
-    AsyncInvocation async =
+    AsyncInvocation<Void> async =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
     async.join();
 
@@ -770,7 +770,7 @@ public class ConcurrentParallelGatewaySenderOperation_1_DUnitTest extends WANTes
     vm6.invoke(() -> WANTestBase.verifySenderPausedState("ln"));
     vm7.invoke(() -> WANTestBase.verifySenderPausedState("ln"));
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
     LogWriterUtils.getLogWriter().info("Started 1000 async puts on local site");
 

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentWANPropagation_1_DUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentWANPropagation_1_DUnitTest.java
@@ -270,7 +270,7 @@ public class ConcurrentWANPropagation_1_DUnitTest extends WANTestBase {
         () -> WANTestBase.createReplicatedRegion(getUniqueName() + "_RR_2", "ln", isOffHeap()));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 1000));
     // do puts in RR_2 in main thread
     vm4.invoke(() -> WANTestBase.doPuts(getUniqueName() + "_RR_2", 500));
@@ -340,7 +340,7 @@ public class ConcurrentWANPropagation_1_DUnitTest extends WANTestBase {
     IgnoredException.addIgnoredException(ServerOperationException.class.getName());
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 100));
     // destroy RR_1 in remote site
     vm2.invoke(() -> WANTestBase.destroyRegion(getUniqueName() + "_RR_1"));
@@ -429,7 +429,7 @@ public class ConcurrentWANPropagation_1_DUnitTest extends WANTestBase {
     vm4.invoke(() -> WANTestBase.doPuts(getUniqueName() + "_RR_2", 1000));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 1000));
 
     try {
@@ -502,10 +502,10 @@ public class ConcurrentWANPropagation_1_DUnitTest extends WANTestBase {
     IgnoredException.addIgnoredException(ServerOperationException.class.getName());
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 1000));
     // start puts in RR_2 in another thread
-    AsyncInvocation inv2 =
+    AsyncInvocation<Void> inv2 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_2", 1000));
     // destroy RR_2 on remote site in the middle
     vm2.invoke(() -> WANTestBase.destroyRegion(getUniqueName() + "_RR_2"));

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentWANPropagation_2_DUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/concurrent/ConcurrentWANPropagation_2_DUnitTest.java
@@ -202,10 +202,10 @@ public class ConcurrentWANPropagation_2_DUnitTest extends WANTestBase {
     vm7.invoke(
         () -> WANTestBase.createReplicatedRegion(getUniqueName() + "_RR", "ln", isOffHeap()));
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm5.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR", 10000));
     Wait.pause(2000);
-    AsyncInvocation inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
+    AsyncInvocation<Void> inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
 
     inv1.join();
     inv2.join();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/CommonParallelGatewaySenderDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/CommonParallelGatewaySenderDUnitTest.java
@@ -340,13 +340,13 @@ public class CommonParallelGatewaySenderDUnitTest extends WANTestBase {
 
     LogWriterUtils.getLogWriter().info("Created the senders back from the disk store.");
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase
         .createPartitionedRegion(getTestMethodName() + "PR1", "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv2 = vm5.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(() -> WANTestBase
         .createPartitionedRegion(getTestMethodName() + "PR1", "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(() -> WANTestBase
         .createPartitionedRegion(getTestMethodName() + "PR1", "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv4 = vm7.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(() -> WANTestBase
         .createPartitionedRegion(getTestMethodName() + "PR1", "ln", 1, 100, isOffHeap()));
 
     try {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/NewWANConcurrencyCheckForDestroyDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/NewWANConcurrencyCheckForDestroyDUnitTest.java
@@ -179,7 +179,7 @@ public class NewWANConcurrencyCheckForDestroyDUnitTest extends WANTestBase {
     Wait.pause(2000);
 
     // Perform a put in vm1
-    AsyncInvocation asynch1 =
+    AsyncInvocation<Void> asynch1 =
         vm1.invokeAsync(new CacheSerializableRunnable("Putting an entry in ds1") {
 
           @Override
@@ -202,7 +202,7 @@ public class NewWANConcurrencyCheckForDestroyDUnitTest extends WANTestBase {
     // wait for vm1 to propagate put to vm3
     Wait.pause(1000);
 
-    AsyncInvocation asynch2 =
+    AsyncInvocation<Void> asynch2 =
         vm1.invokeAsync(new CacheSerializableRunnable("Putting an entry in ds1") {
 
           @Override
@@ -289,7 +289,7 @@ public class NewWANConcurrencyCheckForDestroyDUnitTest extends WANTestBase {
     Wait.pause(2000);
 
     // Perform a put in vm1
-    AsyncInvocation asynch1 =
+    AsyncInvocation<Void> asynch1 =
         vm1.invokeAsync(new CacheSerializableRunnable("Putting an entry in ds1") {
 
           @Override
@@ -312,7 +312,7 @@ public class NewWANConcurrencyCheckForDestroyDUnitTest extends WANTestBase {
     // wait for vm1 to propagate put to vm3
     Wait.pause(1000);
 
-    AsyncInvocation asynch2 =
+    AsyncInvocation<Void> asynch2 =
         vm1.invokeAsync(new CacheSerializableRunnable("Putting an entry in ds1") {
 
           @Override
@@ -420,7 +420,7 @@ public class NewWANConcurrencyCheckForDestroyDUnitTest extends WANTestBase {
     // wait for vm4 to have later timestamp before sending operation to vm1
     Wait.pause(300);
 
-    AsyncInvocation asynch =
+    AsyncInvocation<Void> asynch =
         vm4.invokeAsync(new CacheSerializableRunnable("Putting an entry in ds2 in vm4") {
 
           @Override

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/PDXNewWanDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/PDXNewWanDUnitTest.java
@@ -527,7 +527,7 @@ public class PDXNewWanDUnitTest extends WANTestBase {
     vm3.invoke(() -> WANTestBase.createPartitionedRegion(getTestMethodName() + "_PR", null, 0, 4,
         isOffHeap()));
 
-    AsyncInvocation deserializationFuture;
+    AsyncInvocation<Void> deserializationFuture;
     try {
       // Delay processing of sending type registry update from vm2
       vm2.invoke(() -> {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/ReplicatedRegion_ParallelWANPersistenceDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/ReplicatedRegion_ParallelWANPersistenceDUnitTest.java
@@ -139,13 +139,13 @@ public class ReplicatedRegion_ParallelWANPersistenceDUnitTest extends WANTestBas
     LogWriterUtils.getLogWriter().info("Created the senders back from the disk store.");
 
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(
         () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
-    AsyncInvocation inv2 = vm5.invokeAsync(
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(
         () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(
         () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
-    AsyncInvocation inv4 = vm7.invokeAsync(
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(
         () -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
     try {
       inv1.join();
@@ -282,16 +282,16 @@ public class ReplicatedRegion_ParallelWANPersistenceDUnitTest extends WANTestBas
     LogWriterUtils.getLogWriter().info("Created the senders back from the disk store.");
 
     // create PR on local site
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
-    AsyncInvocation inv2 =
+    AsyncInvocation<Void> inv2 =
         vm5.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
-    AsyncInvocation inv3 =
+    AsyncInvocation<Void> inv3 =
         vm6.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
-    AsyncInvocation inv4 =
+    AsyncInvocation<Void> inv4 =
         vm7.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
 
@@ -459,16 +459,16 @@ public class ReplicatedRegion_ParallelWANPersistenceDUnitTest extends WANTestBas
     LogWriterUtils.getLogWriter().info("Created the senders back from the disk store.");
 
     // create PR on local site
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
-    AsyncInvocation inv2 =
+    AsyncInvocation<Void> inv2 =
         vm5.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
-    AsyncInvocation inv3 =
+    AsyncInvocation<Void> inv3 =
         vm6.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
-    AsyncInvocation inv4 =
+    AsyncInvocation<Void> inv4 =
         vm7.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
 
@@ -605,15 +605,17 @@ public class ReplicatedRegion_ParallelWANPersistenceDUnitTest extends WANTestBas
 
     Thread.sleep(60000);
     {
-      AsyncInvocation inv1 = vm7.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
-          .doPuts0(getTestMethodName() + "_RR", 10000));
+      AsyncInvocation<Void> inv1 =
+          vm7.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
+              .doPuts0(getTestMethodName() + "_RR", 10000));
       Thread.sleep(1000);
-      AsyncInvocation inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
+      AsyncInvocation<Void> inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
       Thread.sleep(2000);
-      AsyncInvocation inv3 = vm6.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
-          .doPuts1(getTestMethodName() + "_RR", 10000));
+      AsyncInvocation<Void> inv3 =
+          vm6.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
+              .doPuts1(getTestMethodName() + "_RR", 10000));
       Thread.sleep(1500);
-      AsyncInvocation inv4 = vm5.invokeAsync(() -> WANTestBase.killSender());
+      AsyncInvocation<Void> inv4 = vm5.invokeAsync(() -> WANTestBase.killSender());
       try {
         inv1.join();
         inv2.join();
@@ -637,14 +639,15 @@ public class ReplicatedRegion_ParallelWANPersistenceDUnitTest extends WANTestBas
 
     LogWriterUtils.getLogWriter().info("Created the senders back from the disk store.");
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
-    AsyncInvocation inv2 =
+    AsyncInvocation<Void> inv2 =
         vm5.invokeAsync(() -> WANTestBase.createReplicatedRegion(getTestMethodName() + "_RR", "ln",
             Scope.DISTRIBUTED_ACK, DataPolicy.PERSISTENT_REPLICATE, isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
-        .doPuts2(getTestMethodName() + "_RR", 15000));
+    AsyncInvocation<Void> inv3 =
+        vm6.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
+            .doPuts2(getTestMethodName() + "_RR", 15000));
     try {
       inv1.join();
       inv2.join();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/ReplicatedRegion_ParallelWANPropagationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/ReplicatedRegion_ParallelWANPropagationDUnitTest.java
@@ -769,10 +769,11 @@ public class ReplicatedRegion_ParallelWANPropagationDUnitTest extends WANTestBas
     /*
      * ExpectedException exp1 = addExpectedException(CacheClosedException.class .getName()); try {
      */
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
-        .doPuts0(getTestMethodName() + "_RR", 1000));
+    AsyncInvocation<Void> inv1 =
+        vm4.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
+            .doPuts0(getTestMethodName() + "_RR", 1000));
     Wait.pause(1000);
-    AsyncInvocation inv2 = vm5.invokeAsync(() -> WANTestBase.killSender());
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(() -> WANTestBase.killSender());
     try {
       inv1.join();
       inv2.join();
@@ -845,15 +846,17 @@ public class ReplicatedRegion_ParallelWANPropagationDUnitTest extends WANTestBas
     /*
      * ExpectedException exp1 = addExpectedException(CacheClosedException.class .getName()); try
      */ {
-      AsyncInvocation inv1 = vm7.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
-          .doPuts0(getTestMethodName() + "_RR", 10000));
+      AsyncInvocation<Void> inv1 =
+          vm7.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
+              .doPuts0(getTestMethodName() + "_RR", 10000));
       Thread.sleep(1000);
-      AsyncInvocation inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
+      AsyncInvocation<Void> inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
       Thread.sleep(2000);
-      AsyncInvocation inv3 = vm6.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
-          .doPuts1(getTestMethodName() + "_RR", 10000));
+      AsyncInvocation<Void> inv3 =
+          vm6.invokeAsync(() -> ReplicatedRegion_ParallelWANPropagationDUnitTest
+              .doPuts1(getTestMethodName() + "_RR", 10000));
       Thread.sleep(1500);
-      AsyncInvocation inv4 = vm5.invokeAsync(() -> WANTestBase.killSender());
+      AsyncInvocation<Void> inv4 = vm5.invokeAsync(() -> WANTestBase.killSender());
       try {
         inv1.join();
         inv2.join();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WanAutoDiscoveryDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/misc/WanAutoDiscoveryDUnitTest.java
@@ -235,7 +235,7 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
 
   @Category({WanTest.class})
   @Test
-  public void test_NY_Recognises_TK_AND_HK_Simultaneously() {
+  public void test_NY_Recognises_TK_AND_HK_Simultaneously() throws InterruptedException {
     Map<Integer, Set<InetSocketAddress>> dsVsPort = new HashMap<>();
 
     Set<InetSocketAddress> locatorPortsln = new HashSet<>();
@@ -249,8 +249,8 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
         vm1.invoke(() -> WANTestBase.createFirstRemoteLocator(2, lnLocPort1));
     locatorPortsny.add(new InetSocketAddress("localhost", nyLocPort1));
 
-    int AsyncInvocationArrSize = 4;
-    AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
+    int asyncInvocationArrSize = 4;
+    AsyncInvocation<Integer>[] async = new AsyncInvocation[asyncInvocationArrSize];
 
     Set<InetSocketAddress> locatorPortstk = new HashSet<>();
     dsVsPort.put(3, locatorPortstk);
@@ -277,10 +277,10 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
       fail();
     }
 
-    locatorPortstk.add(new InetSocketAddress("localhost", (Integer) async[0].getReturnValue()));
-    locatorPortshk.add(new InetSocketAddress("localhost", (Integer) async[1].getReturnValue()));
-    locatorPortsln.add(new InetSocketAddress("localhost", (Integer) async[2].getReturnValue()));
-    locatorPortsny.add(new InetSocketAddress("localhost", (Integer) async[3].getReturnValue()));
+    locatorPortstk.add(new InetSocketAddress("localhost", async[0].get()));
+    locatorPortshk.add(new InetSocketAddress("localhost", async[1].get()));
+    locatorPortsln.add(new InetSocketAddress("localhost", async[2].get()));
+    locatorPortsny.add(new InetSocketAddress("localhost", async[3].get()));
 
     final int siteSizeToCheck = dsVsPort.size();
     vm0.invoke(() -> WANTestBase.checkAllSiteMetaData(dsVsPort, siteSizeToCheck));
@@ -377,8 +377,8 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
     dsVsPort.put(3, site33LocatorsPort);
     dsVsPort.put(4, site44LocatorsPort);
 
-    int AsyncInvocationArrSize = 9;
-    AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
+    int asyncInvocationArrSize = 9;
+    AsyncInvocation<?>[] async = new AsyncInvocation[asyncInvocationArrSize];
 
     async[0] = vm0.invokeAsync(
         () -> WANTestBase.createLocator(1, ports[0], site1LocatorsPort, site2LocatorsPort));
@@ -441,8 +441,8 @@ public class WanAutoDiscoveryDUnitTest extends WANTestBase {
     dsVsPort.put(2, site2LocatorsPort);
     dsVsPort.put(3, site3LocatorsPort);
 
-    int AsyncInvocationArrSize = 9;
-    AsyncInvocation[] async = new AsyncInvocation[AsyncInvocationArrSize];
+    int asyncInvocationArrSize = 9;
+    AsyncInvocation<?>[] async = new AsyncInvocation[asyncInvocationArrSize];
 
     async[0] = vm0.invokeAsync(
         () -> WANTestBase.createLocator(1, site1Port1, site1LocatorsPort, site2LocatorsPort));

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPersistenceEnabledGatewaySenderDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPersistenceEnabledGatewaySenderDUnitTest.java
@@ -277,10 +277,10 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
 
     logger.info("Created the senders back from the disk store.");
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(createPartitionedRegionRunnable());
-    AsyncInvocation inv2 = vm5.invokeAsync(createPartitionedRegionRunnable());
-    AsyncInvocation inv3 = vm6.invokeAsync(createPartitionedRegionRunnable());
-    AsyncInvocation inv4 = vm7.invokeAsync(createPartitionedRegionRunnable());
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(createPartitionedRegionRunnable());
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(createPartitionedRegionRunnable());
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(createPartitionedRegionRunnable());
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(createPartitionedRegionRunnable());
 
     try {
       inv1.join();
@@ -433,13 +433,13 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
 
     logger.info("Created the senders back from the disk store.");
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv2 = vm5.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv4 = vm7.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
 
     try {
@@ -559,13 +559,13 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
     logger.info("Created the senders back from the disk store.");
 
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv2 = vm5.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv4 = vm7.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
 
     try {
@@ -719,13 +719,13 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
     logger.info("Created the senders back from the disk store.");
 
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv2 = vm5.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv4 = vm7.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
 
     try {
@@ -756,7 +756,8 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
     // ----------------------------------------------------------------------------------------------------
 
     // Dispatcher should be dispatching now. Do some more puts through async thread
-    AsyncInvocation async1 = vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName(), 1000));
+    AsyncInvocation<Void> async1 =
+        vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName(), 1000));
     try {
       async1.join();
     } catch (InterruptedException e) {
@@ -862,13 +863,13 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
     logger.info("Created the senders back from the disk store.");
 
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv2 = vm5.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv4 = vm7.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
 
     try {
@@ -1087,13 +1088,13 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
     // new Object[] { testName, "ln", 1, 100, isOffHeap() });
 
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv2 = vm5.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv4 = vm7.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
 
     try {
@@ -1452,13 +1453,13 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
     logger.info("All the senders are now running...");
 
     // create PR on local site
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv2 = vm5.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv2 = vm5.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv3 = vm6.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv3 = vm6.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
-    AsyncInvocation inv4 = vm7.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv4 = vm7.invokeAsync(() -> WANTestBase
         .createPersistentPartitionedRegion(getTestMethodName(), "ln", 1, 100, isOffHeap()));
 
     try {
@@ -1593,13 +1594,13 @@ public class ParallelWANPersistenceEnabledGatewaySenderDUnitTest extends WANTest
 
       createCacheInVMs(lnPort, vm4, vm5, vm6, vm7);
 
-      AsyncInvocation async4 = vm4.invokeAsync(() -> WANTestBase
+      AsyncInvocation<Void> async4 = vm4.invokeAsync(() -> WANTestBase
           .createPersistentPartitionedRegion(getTestMethodName(), null, 1, 100, isOffHeap()));
-      AsyncInvocation async5 = vm5.invokeAsync(() -> WANTestBase
+      AsyncInvocation<Void> async5 = vm5.invokeAsync(() -> WANTestBase
           .createPersistentPartitionedRegion(getTestMethodName(), null, 1, 100, isOffHeap()));
-      AsyncInvocation async6 = vm6.invokeAsync(() -> WANTestBase
+      AsyncInvocation<Void> async6 = vm6.invokeAsync(() -> WANTestBase
           .createPersistentPartitionedRegion(getTestMethodName(), null, 1, 100, isOffHeap()));
-      AsyncInvocation async7 = vm7.invokeAsync(() -> WANTestBase
+      AsyncInvocation<Void> async7 = vm7.invokeAsync(() -> WANTestBase
           .createPersistentPartitionedRegion(getTestMethodName(), null, 1, 100, isOffHeap()));
 
       async7.getResult(30 * 1000);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationConcurrentOpsDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANPropagationConcurrentOpsDistributedTest.java
@@ -75,13 +75,13 @@ public class ParallelWANPropagationConcurrentOpsDistributedTest extends WANTestB
     vm4.invoke(() -> WANTestBase.pauseSender("ln"));
     vm5.invoke(() -> WANTestBase.pauseSender("ln"));
 
-    AsyncInvocation<?> async1 =
+    AsyncInvocation<Void> async1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 700));
-    AsyncInvocation<?> async2 =
+    AsyncInvocation<Void> async2 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
-    AsyncInvocation<?> async3 =
+    AsyncInvocation<Void> async3 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 800));
-    AsyncInvocation<?> async4 =
+    AsyncInvocation<Void> async4 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
 
     async1.join();
@@ -134,13 +134,13 @@ public class ParallelWANPropagationConcurrentOpsDistributedTest extends WANTestB
     vm4.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
     vm5.invoke(() -> WANTestBase.waitForSenderRunningState("ln"));
 
-    AsyncInvocation<?> async1 =
+    AsyncInvocation<Void> async1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 700));
-    AsyncInvocation<?> async2 =
+    AsyncInvocation<Void> async2 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
-    AsyncInvocation<?> async3 =
+    AsyncInvocation<Void> async3 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 800));
-    AsyncInvocation<?> async4 =
+    AsyncInvocation<Void> async4 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getTestMethodName() + "_PR", 1000));
 
     async1.join();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANStatsDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANStatsDistributedTest.java
@@ -451,12 +451,12 @@ public class ParallelWANStatsDistributedTest extends WANTestBase {
       }
     }
 
-    List<AsyncInvocation<?>> asyncInvocations = new ArrayList<>(clients);
+    List<AsyncInvocation<Void>> asyncInvocations = new ArrayList<>(clients);
 
     int eventsPerTransaction = shipmentsPerTransaction + 1;
     for (int i = 0; i < clients; i++) {
       final int intCustId = i;
-      AsyncInvocation<?> asyncInvocation =
+      AsyncInvocation<Void> asyncInvocation =
           vm4.invokeAsync(() -> WANTestBase.doOrderAndShipmentPutsInsideTransactions(
               customerData.get(intCustId),
               eventsPerTransaction));
@@ -464,7 +464,7 @@ public class ParallelWANStatsDistributedTest extends WANTestBase {
     }
 
     try {
-      for (AsyncInvocation<?> asyncInvocation : asyncInvocations) {
+      for (AsyncInvocation<Void> asyncInvocation : asyncInvocations) {
         asyncInvocation.await();
       }
     } catch (InterruptedException e) {

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderAlterOperationsDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderAlterOperationsDUnitTest.java
@@ -233,7 +233,7 @@ public class SerialGatewaySenderAlterOperationsDUnitTest extends CacheTestCase {
     }
 
     // Do some puts from both vm4 and vm5 while restarting a sender
-    AsyncInvocation doPutsInVm4 =
+    AsyncInvocation<Void> doPutsInVm4 =
         vm4.invokeAsync(() -> doPuts(className + "_RR", 1000));
 
     updateBatchSize(50);
@@ -288,7 +288,7 @@ public class SerialGatewaySenderAlterOperationsDUnitTest extends CacheTestCase {
     }
 
     // Do some puts from both vm4 and vm5 while restarting a sender
-    AsyncInvocation doPutsInVm4 =
+    AsyncInvocation<Void> doPutsInVm4 =
         vm4.invokeAsync(() -> doPuts(className + "_RR", 5000));
 
     updateBatchSize(40);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderDistributedDeadlockDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderDistributedDeadlockDUnitTest.java
@@ -69,13 +69,13 @@ public class SerialGatewaySenderDistributedDeadlockDUnitTest extends WANTestBase
 
     // exercise region and gateway operations with different messaging
     exerciseWANOperations();
-    AsyncInvocation invVM4transaction =
+    AsyncInvocation<Void> invVM4transaction =
         vm4.invokeAsync("doTxPutsAsync", () -> WANTestBase.doTxPuts(getTestMethodName() + "_RR"));
-    AsyncInvocation invVM5transaction =
+    AsyncInvocation<Void> invVM5transaction =
         vm5.invokeAsync("doTxPutsAsync", () -> WANTestBase.doTxPuts(getTestMethodName() + "_RR"));
-    AsyncInvocation invVM4 =
+    AsyncInvocation<Void> invVM4 =
         vm4.invokeAsync("doPutsAsync", () -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
-    AsyncInvocation invVM5 =
+    AsyncInvocation<Void> invVM5 =
         vm5.invokeAsync("doPutsAsync", () -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
 
     exerciseFunctions();
@@ -110,16 +110,16 @@ public class SerialGatewaySenderDistributedDeadlockDUnitTest extends WANTestBase
     startSerialSenders();
 
     exerciseWANOperations();
-    AsyncInvocation invVM4transaction =
+    AsyncInvocation<Void> invVM4transaction =
         vm4.invokeAsync("doTxPutsPRAsync", () -> SerialGatewaySenderDistributedDeadlockDUnitTest
             .doTxPutsPR(getTestMethodName() + "_RR", 100, 1000));
-    AsyncInvocation invVM5transaction =
+    AsyncInvocation<Void> invVM5transaction =
         vm5.invokeAsync("doTxPutsPRAsync", () -> SerialGatewaySenderDistributedDeadlockDUnitTest
             .doTxPutsPR(getTestMethodName() + "_RR", 100, 1000));
 
-    AsyncInvocation invVM4 =
+    AsyncInvocation<Void> invVM4 =
         vm4.invokeAsync("doPutsAsync", () -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
-    AsyncInvocation invVM5 =
+    AsyncInvocation<Void> invVM5 =
         vm5.invokeAsync("doPutsAsync", () -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
 
     exerciseFunctions();
@@ -152,14 +152,14 @@ public class SerialGatewaySenderDistributedDeadlockDUnitTest extends WANTestBase
 
     // exercise region and gateway operations with messaging
     exerciseWANOperations();
-    AsyncInvocation invVM4transaction =
+    AsyncInvocation<Void> invVM4transaction =
         vm4.invokeAsync("doTxPutsAsync", () -> WANTestBase.doTxPuts(getTestMethodName() + "_RR"));
-    AsyncInvocation invVM5transaction =
+    AsyncInvocation<Void> invVM5transaction =
         vm5.invokeAsync("doTxPutsAsync", () -> WANTestBase.doTxPuts(getTestMethodName() + "_RR"));
 
-    AsyncInvocation invVM4 =
+    AsyncInvocation<Void> invVM4 =
         vm4.invokeAsync("doPutsAsync", () -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
-    AsyncInvocation invVM5 =
+    AsyncInvocation<Void> invVM5 =
         vm5.invokeAsync("doPutsAsync", () -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
 
     exerciseFunctions();
@@ -189,16 +189,16 @@ public class SerialGatewaySenderDistributedDeadlockDUnitTest extends WANTestBase
     startSerialSenders();
 
     exerciseWANOperations();
-    AsyncInvocation invVM4transaction =
+    AsyncInvocation<Void> invVM4transaction =
         vm4.invokeAsync("doTxPutsPRAsync", () -> SerialGatewaySenderDistributedDeadlockDUnitTest
             .doTxPutsPR(getTestMethodName() + "_RR", 100, 1000));
-    AsyncInvocation invVM5transaction =
+    AsyncInvocation<Void> invVM5transaction =
         vm5.invokeAsync("doTxPutsPRAsync", () -> SerialGatewaySenderDistributedDeadlockDUnitTest
             .doTxPutsPR(getTestMethodName() + "_RR", 100, 1000));
 
-    AsyncInvocation invVM4 =
+    AsyncInvocation<Void> invVM4 =
         vm4.invokeAsync("doPutsAsync", () -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
-    AsyncInvocation invVM5 =
+    AsyncInvocation<Void> invVM5 =
         vm5.invokeAsync("doPutsAsync", () -> WANTestBase.doPuts(getTestMethodName() + "_RR", 1000));
 
     exerciseFunctions();

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderOperationsDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialGatewaySenderOperationsDistributedTest.java
@@ -233,7 +233,7 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
     vm4.invoke(() -> validateSenderPausedState("ln"));
     vm5.invoke(() -> validateSenderPausedState("ln"));
 
-    AsyncInvocation doPutsInVm4 =
+    AsyncInvocation<Void> doPutsInVm4 =
         vm4.invokeAsync(() -> doPuts(className + "_RR", 10));
 
     vm4.invoke(() -> resumeSender("ln"));
@@ -315,8 +315,8 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
     vm4.invoke(() -> validateSenderStoppedState("ln"));
     vm5.invoke(() -> validateSenderStoppedState("ln"));
 
-    AsyncInvocation startSenderInVm4 = vm4.invokeAsync(() -> startSender("ln"));
-    AsyncInvocation startSenderInVm5 = vm5.invokeAsync(() -> startSender("ln"));
+    AsyncInvocation<Void> startSenderInVm4 = vm4.invokeAsync(() -> startSender("ln"));
+    AsyncInvocation<Void> startSenderInVm5 = vm5.invokeAsync(() -> startSender("ln"));
 
     startSenderInVm4.await();
     startSenderInVm5.await();
@@ -392,10 +392,10 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
 
 
     // do a lot of puts while senders are restarting
-    AsyncInvocation doPutsInVm7 = vm7.invokeAsync(() -> doPuts(className + "_RR", 5000));
+    AsyncInvocation<Void> doPutsInVm7 = vm7.invokeAsync(() -> doPuts(className + "_RR", 5000));
 
-    AsyncInvocation startSenderInVm4 = vm4.invokeAsync(() -> startSender("ln"));
-    AsyncInvocation startSenderInVm5 = vm5.invokeAsync(() -> startSender("ln"));
+    AsyncInvocation<Void> startSenderInVm4 = vm4.invokeAsync(() -> startSender("ln"));
+    AsyncInvocation<Void> startSenderInVm5 = vm5.invokeAsync(() -> startSender("ln"));
 
     startSenderInVm4.await();
     startSenderInVm5.await();
@@ -455,8 +455,8 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
             .sum(),
             greaterThan(0));
 
-    AsyncInvocation resumeSenderInVm4 = vm4.invokeAsync(() -> resumeSender("ln"));
-    AsyncInvocation resumeSenderInVm5 = vm5.invokeAsync(() -> resumeSender("ln"));
+    AsyncInvocation<Void> resumeSenderInVm4 = vm4.invokeAsync(() -> resumeSender("ln"));
+    AsyncInvocation<Void> resumeSenderInVm5 = vm5.invokeAsync(() -> resumeSender("ln"));
 
     resumeSenderInVm4.await();
     resumeSenderInVm5.await();
@@ -511,7 +511,7 @@ public class SerialGatewaySenderOperationsDistributedTest extends CacheTestCase 
     vm3.invoke(() -> validateRegionSize(className + "_RR", 200));
 
     // Do some puts from both vm4 and vm5 while restarting a sender
-    AsyncInvocation doPutsInVm4 =
+    AsyncInvocation<Void> doPutsInVm4 =
         vm4.invokeAsync(() -> doPuts(className + "_RR", 300));
 
     Thread.sleep(10);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPersistenceEnabledGatewaySenderDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPersistenceEnabledGatewaySenderDUnitTest.java
@@ -230,7 +230,7 @@ public class SerialWANPersistenceEnabledGatewaySenderDUnitTest extends WANTestBa
     vm5.invoke(() -> WANTestBase.createSenderWithDiskStore("ln", 2, false, 100, 10, false, true,
         null, secondDStore, true));
     logger.info("Created the sender.... in vm5 ");
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
     logger.info("Started the sender in vm 4");
 
     vm5.invoke(() -> WANTestBase.startSender("ln"));
@@ -314,7 +314,7 @@ public class SerialWANPersistenceEnabledGatewaySenderDUnitTest extends WANTestBa
     vm5.invoke(() -> WANTestBase.createPersistentReplicatedRegion(getTestMethodName() + "_RR", "ln",
         isOffHeap()));
 
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
     logger.info("Started the sender in vm 4");
 
     vm5.invoke(() -> WANTestBase.startSender("ln"));
@@ -390,7 +390,7 @@ public class SerialWANPersistenceEnabledGatewaySenderDUnitTest extends WANTestBa
     vm5.invoke(() -> WANTestBase.startSender("ln"));
     logger.info("Started the sender in vm 5");
 
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase
         .createPersistentReplicatedRegion(getTestMethodName() + "_RR", "ln", isOffHeap()));
     vm5.invoke(() -> WANTestBase.createPersistentReplicatedRegion(getTestMethodName() + "_RR", "ln",
         isOffHeap()));
@@ -477,7 +477,7 @@ public class SerialWANPersistenceEnabledGatewaySenderDUnitTest extends WANTestBa
     vm5.invoke(() -> WANTestBase.createPersistentReplicatedRegion(getTestMethodName() + "_RR", "ln",
         isOffHeap()));
 
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
     logger.info("Started the sender in vm 4");
 
     vm5.invoke(() -> WANTestBase.startSender("ln"));
@@ -544,7 +544,7 @@ public class SerialWANPersistenceEnabledGatewaySenderDUnitTest extends WANTestBa
 
     logger.info("Stopped all the senders. ");
 
-    AsyncInvocation inv1 = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync(() -> WANTestBase.startSender("ln"));
     logger.info("Started the sender in vm 4");
 
     vm5.invoke(() -> WANTestBase.startSender("ln"));
@@ -610,7 +610,7 @@ public class SerialWANPersistenceEnabledGatewaySenderDUnitTest extends WANTestBa
 
     createReceiverInVMs(vm2, vm3);
 
-    AsyncInvocation<?> inv1 = vm4.invokeAsync("Starting sender with clean queues",
+    AsyncInvocation<Void> inv1 = vm4.invokeAsync("Starting sender with clean queues",
         () -> WANTestBase.startSenderwithCleanQueues("ln"));
     vm5.invoke("Starting sender with clean queues",
         () -> WANTestBase.startSenderwithCleanQueues("ln"));

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagationDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANPropagationDUnitTest.java
@@ -336,7 +336,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
         () -> WANTestBase.createReplicatedRegion(getUniqueName() + "_RR_2", "ln", isOffHeap()));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 1000));
     // do puts in RR_2 in main thread
     vm4.invoke(() -> WANTestBase.doPuts(getUniqueName() + "_RR_2", 500));
@@ -398,7 +398,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
     IgnoredException.addIgnoredException(ServerOperationException.class.getName());
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 1000));
     // destroy RR_1 in remote site
     vm2.invoke(() -> WANTestBase.destroyRegion(getUniqueName() + "_RR_1"));
@@ -480,7 +480,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
     vm4.invoke(() -> WANTestBase.doPuts(getUniqueName() + "_RR_2", 1000));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 1000));
 
     inv1.join();
@@ -545,10 +545,10 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
     IgnoredException.addIgnoredException(ServerOperationException.class.getName());
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 1000));
     // start puts in RR_2 in another thread
-    AsyncInvocation inv2 =
+    AsyncInvocation<Void> inv2 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_2", 1000));
     // destroy RR_2 on remote site in the middle
     vm2.invoke(() -> WANTestBase.destroyRegion(getUniqueName() + "_RR_2"));
@@ -629,7 +629,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
         () -> WANTestBase.createReplicatedRegion(getUniqueName() + "_RR_1", "ln", isOffHeap()));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 500));
     // close cache in remote site. This will automatically kill the remote receivers.
     vm2.invoke(WANTestBase::closeCache);
@@ -671,7 +671,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
 
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 8000));
     // close cache in remote site. This will automatically kill the remote
     // receivers.
@@ -727,7 +727,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
         () -> WANTestBase.createReplicatedRegion(getUniqueName() + "_RR_1", "ln", isOffHeap()));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 8000));
     // close cache in remote site. This will automatically kill the remote
     // receivers.
@@ -782,7 +782,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
         () -> WANTestBase.createReplicatedRegion(getUniqueName() + "_RR_1", "ln", isOffHeap()));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 8000));
     // close cache in remote site. This will automatically kill the remote
     // receivers.
@@ -848,7 +848,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
         () -> WANTestBase.createReplicatedRegion(getUniqueName() + "_RR_1", "ln", isOffHeap()));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 8000));
     // close cache in remote site. This will automatically kill the remote
     // receivers.
@@ -909,7 +909,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
     vm4.invoke(() -> WANTestBase.startSender("ln"));
 
     // start puts in RR_1 in another thread
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR_1", 8000));
     // close cache in remote site. This will automatically kill the remote
     // receivers.
@@ -1005,10 +1005,10 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
     vm6.invoke(createReplicatedRegionRunnable());
     vm7.invoke(createReplicatedRegionRunnable());
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm5.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR", 10000));
     Wait.pause(2000);
-    AsyncInvocation inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
+    AsyncInvocation<Void> inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
 
     inv1.join();
     inv2.join();
@@ -1060,7 +1060,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
     vm4.invoke(createReplicatedRegionRunnable());
     vm5.invoke(createReplicatedRegionRunnable());
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm5.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR", 10000));
     LogWriterUtils.getLogWriter().info("Started async puts on local site");
     Wait.pause(1000);
@@ -1072,7 +1072,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
     int oldServerPort = (Integer) oldConnectionInfo.get("serverPort");
     LogWriterUtils.getLogWriter().info("Got sender to receiver connection information");
 
-    AsyncInvocation inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
+    AsyncInvocation<Void> inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
     inv2.join();
     LogWriterUtils.getLogWriter().info("Killed primary sender on local site");
     Wait.pause(5000);// give some time for vm5 to take primary charge
@@ -1137,7 +1137,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
     vm4.invoke(createReplicatedRegionRunnable());
     vm5.invoke(createReplicatedRegionRunnable());
 
-    AsyncInvocation inv1 =
+    AsyncInvocation<Void> inv1 =
         vm5.invokeAsync(() -> WANTestBase.doPuts(getUniqueName() + "_RR", 10000));
     LogWriterUtils.getLogWriter().info("Started async puts on local site");
     Wait.pause(1000);
@@ -1151,7 +1151,7 @@ public class SerialWANPropagationDUnitTest extends WANTestBase {
 
     // ---------------------------- KILL vm4
     // --------------------------------------
-    AsyncInvocation inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
+    AsyncInvocation<Void> inv2 = vm4.invokeAsync(() -> WANTestBase.killSender());
     inv2.join();
     LogWriterUtils.getLogWriter().info("Killed vm4 (primary sender) on local site");
     // -----------------------------------------------------------------------------

--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANStatsDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/serial/SerialWANStatsDistributedTest.java
@@ -280,17 +280,17 @@ public class SerialWANStatsDistributedTest extends WANTestBase {
 
     int entries = entriesPerInvocation * clients;
 
-    List<AsyncInvocation<?>> invocations = new ArrayList<>(clients);
+    List<AsyncInvocation<Void>> invocations = new ArrayList<>(clients);
     for (int i = 0; i < clients; i++) {
       final int index = i;
-      AsyncInvocation<?> asyncInvocation =
+      AsyncInvocation<Void> asyncInvocation =
           vm4.invokeAsync(() -> WANTestBase.doPutsInsideTransactions(regionName, data.get(index),
               eventsPerTransaction));
       invocations.add(asyncInvocation);
     }
 
     try {
-      for (AsyncInvocation<?> invocation : invocations) {
+      for (AsyncInvocation<Void> invocation : invocations) {
         invocation.await();
       }
     } catch (InterruptedException e) {
@@ -568,7 +568,7 @@ public class SerialWANStatsDistributedTest extends WANTestBase {
     vm6.invoke(() -> WANTestBase.createReplicatedRegion(testName + "_RR", "ln", isOffHeap()));
     vm7.invoke(() -> WANTestBase.createReplicatedRegion(testName + "_RR", "ln", isOffHeap()));
 
-    AsyncInvocation<?> inv1 = vm5.invokeAsync(() -> WANTestBase.doPuts(testName + "_RR", 10000));
+    AsyncInvocation<Void> inv1 = vm5.invokeAsync(() -> WANTestBase.doPuts(testName + "_RR", 10000));
     pause(2000);
     AsyncInvocation<Boolean> inv2 = vm4.invokeAsync(() -> WANTestBase.killSender("ln"));
     Boolean isKilled = Boolean.FALSE;
@@ -578,7 +578,7 @@ public class SerialWANStatsDistributedTest extends WANTestBase {
       fail("Unexpected exception while killing a sender");
     }
     if (!isKilled) {
-      AsyncInvocation<?> inv3 = vm5.invokeAsync(() -> WANTestBase.killSender("ln"));
+      AsyncInvocation<Boolean> inv3 = vm5.invokeAsync(() -> WANTestBase.killSender("ln"));
       inv3.join();
     }
     inv1.join();
@@ -629,9 +629,9 @@ public class SerialWANStatsDistributedTest extends WANTestBase {
     vm6.invoke(() -> WANTestBase.createReplicatedRegion(testName + "_RR", "ln", isOffHeap()));
     vm7.invoke(() -> WANTestBase.createReplicatedRegion(testName + "_RR", "ln", isOffHeap()));
 
-    AsyncInvocation<?> inv1 =
+    AsyncInvocation<Void> inv1 =
         vm6.invokeAsync(() -> WANTestBase.doTxPutsWithRetryIfError(testName + "_RR", 2, 5000, 0));
-    AsyncInvocation<?> inv2 =
+    AsyncInvocation<Void> inv2 =
         vm7.invokeAsync(() -> WANTestBase.doTxPutsWithRetryIfError(testName + "_RR", 2, 5000, 1));
 
     vm2.invoke(() -> await()
@@ -646,7 +646,7 @@ public class SerialWANStatsDistributedTest extends WANTestBase {
       fail("Unexpected exception while killing a sender");
     }
     if (!isKilled) {
-      AsyncInvocation<?> inv4 = vm5.invokeAsync(() -> WANTestBase.killSender("ln"));
+      AsyncInvocation<Boolean> inv4 = vm5.invokeAsync(() -> WANTestBase.killSender("ln"));
       inv4.join();
     }
     inv1.join();
@@ -783,7 +783,7 @@ public class SerialWANStatsDistributedTest extends WANTestBase {
     startSenderInVMs("ln", vm4, vm5);
 
     // start puts in RR_1 in another thread
-    AsyncInvocation<?> inv1 =
+    AsyncInvocation<Void> inv1 =
         vm4.invokeAsync(() -> WANTestBase.doPuts(testName + "_RR_1", numEntries));
     // destroy RR_1 in remote site
     vm2.invoke(() -> WANTestBase.destroyRegion(testName + "_RR_1", 5));


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
