### PR TITLE
GEODE-10274: Install GCP ops-agent in CI images

### DIFF
--- a/ci/images/google-geode-builder/scripts/setup.sh
+++ b/ci/images/google-geode-builder/scripts/setup.sh
@@ -73,9 +73,9 @@ pushd /tmp
   curl -fO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
   tar xzf google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz -C /
   rm google-cloud-sdk-${CLOUD_SDK_VERSION}-linux-x86_64.tar.gz
-  curl -fsSO https://dl.google.com/cloudagents/install-monitoring-agent.sh
-  bash install-monitoring-agent.sh
-  rm install-monitoring-agent.sh
+  curl -fsSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+  sudo bash  add-google-cloud-ops-agent-repo.sh --also-install
+  rm add-google-cloud-ops-agent-repo.sh
 popd
 export PATH=/google-cloud-sdk/bin:${PATH}
 gcloud config set core/disable_usage_reporting true

--- a/ci/images/google-windows-geode-builder/packer.json
+++ b/ci/images/google-windows-geode-builder/packer.json
@@ -42,6 +42,22 @@
     {
       "type": "powershell",
       "inline": [
+        "(New-Object Net.WebClient).DownloadFile(\"https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.ps1\", \"c:/add-google-cloud-ops-agent-repo.ps1\")",
+        "Invoke-Expression \"c:/add-google-cloud-ops-agent-repo.ps1 -Verbose -AlsoInstall\"",
+        "while ($true) {",
+        "  try {",
+        "    Get-Service -Name google-cloud-ops-agent",
+        "    break",
+        "  } catch {",
+        "    Write-Warning \"Wating on service google-cloud-ops-agent\"",
+        "    Start-Sleep -s 10",
+        "  }",
+        "}"
+      ]
+    },
+    {
+      "type": "powershell",
+      "inline": [
         "$ErrorActionPreference = \"Stop\"",
         "Set-ExecutionPolicy Bypass -Scope Process -Force",
         "Install-WindowsFeature Containers"
@@ -97,24 +113,6 @@
         "winrm set winrm/config/service '@{AllowUnencrypted=\"true\"}'",
         "New-NetFirewallRule -DisplayName sshd -Direction inbound -Action allow -Protocol tcp -LocalPort 22",
         "New-NetFirewallRule -DisplayName \"Docker containers\" -LocalAddress 172.0.0.0/8 -Action allow -Direction inbound"
-      ]
-    },
-    {
-      "type": "powershell",
-      "inline": [
-        "$ErrorActionPreference = \"Stop\"",
-        "Set-ExecutionPolicy Bypass -Scope Process -Force",
-        "(New-Object Net.WebClient).DownloadFile(\"https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.ps1\", \"${env:UserProfile}\\add-google-cloud-ops-agent-repo.ps1\")",
-        "Invoke-Expression \"${env:UserProfile}\\add-google-cloud-ops-agent-repo.ps1 -AlsoInstall\"",
-        "while ($true) {",
-        "  try {",
-        "    Get-Service -Name google-cloud-ops-agent",
-        "    break",
-        "  } catch {",
-        "    Write-Warning \"Wating on service google-cloud-ops-agent\"",
-        "    Start-Sleep -s 10",
-        "  }",
-        "}"
       ]
     },
     {

--- a/ci/images/google-windows-geode-builder/packer.json
+++ b/ci/images/google-windows-geode-builder/packer.json
@@ -104,14 +104,14 @@
       "inline": [
         "$ErrorActionPreference = \"Stop\"",
         "Set-ExecutionPolicy Bypass -Scope Process -Force",
-        "(New-Object Net.WebClient).DownloadFile(\"https://repo.stackdriver.com/windows/StackdriverMonitoring-GCM-46.exe\", \"${env:UserProfile}\\StackdriverMonitoring-GCM-46.exe\")",
-        "Start-Process -FilePath \"${env:UserProfile}\\StackdriverMonitoring-GCM-46.exe\" -ArgumentList \"/S\"",
+        "(New-Object Net.WebClient).DownloadFile(\"https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.ps1\", \"${env:UserProfile}\\add-google-cloud-ops-agent-repo.ps1\")",
+        "Invoke-Expression \"${env:UserProfile}\\add-google-cloud-ops-agent-repo.ps1 -AlsoInstall\"",
         "while ($true) {",
         "  try {",
-        "    Get-Service -Name StackdriverMonitoring",
+        "    Get-Service -Name google-cloud-ops-agent",
         "    break",
         "  } catch {",
-        "    Write-Warning \"Wating on service StackdriverMonitoring\"",
+        "    Write-Warning \"Wating on service google-cloud-ops-agent\"",
         "    Start-Sleep -s 10",
         "  }",
         "}"


### PR DESCRIPTION
Replaces old stackdriver-agent, to enable CI utilization metrics

Authored-by: Robert Houghton <rhoughton@pivotal.io>

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
