### PR TITLE
GEODE-10267: fix creating gw sender with non-existent disk store

### DIFF
--- a/geode-wan/src/distributedTest/java/org/apache/geode/cache/CacheXml70GatewayDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/cache/CacheXml70GatewayDUnitTest.java
@@ -125,6 +125,8 @@ public class CacheXml70GatewayDUnitTest extends CacheXmlTestCase {
   public void testParallelGatewaySender() throws Exception {
     getSystem();
     CacheCreation cache = new CacheCreation();
+    DiskStoreFactory dsf = cache.createDiskStoreFactory();
+    dsf.create("LNSender");
 
     GatewaySenderFactory gatewaySenderFactory = cache.createGatewaySenderFactory();
     gatewaySenderFactory.setParallel(true);
@@ -163,6 +165,9 @@ public class CacheXml70GatewayDUnitTest extends CacheXmlTestCase {
   public void testSerialGatewaySender() throws Exception {
     getSystem();
     CacheCreation cache = new CacheCreation();
+    DiskStoreFactory dsf = cache.createDiskStoreFactory();
+    dsf.create("LNSender");
+
     GatewaySenderFactory gatewaySenderFactory = cache.createGatewaySenderFactory();
     gatewaySenderFactory.setParallel(false);
     gatewaySenderFactory.setManualStart(true);

--- a/geode-wan/src/distributedTest/java/org/apache/geode/cache/CacheXml80GatewayDUnitTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/cache/CacheXml80GatewayDUnitTest.java
@@ -105,6 +105,8 @@ public class CacheXml80GatewayDUnitTest extends CacheXmlTestCase {
   public void testGatewaySenderWithSubstitutionFilter() throws Exception {
     getSystem();
     CacheCreation cache = new CacheCreation();
+    DiskStoreFactory dsf = cache.createDiskStoreFactory();
+    dsf.create(DiskStoreFactory.DEFAULT_DISK_STORE_NAME);
 
     // Create a GatewaySender with GatewayEventSubstitutionFilter.
     // Don't start the sender to avoid 'Locators must be configured before starting gateway-sender'
@@ -113,6 +115,7 @@ public class CacheXml80GatewayDUnitTest extends CacheXmlTestCase {
     GatewaySenderFactory factory = cache.createGatewaySenderFactory();
     factory.setManualStart(true);
     factory.setGatewayEventSubstitutionFilter(new MyGatewayEventSubstitutionFilter());
+    factory.setDiskStoreName(DiskStoreFactory.DEFAULT_DISK_STORE_NAME);
     GatewaySender sender = factory.create(id, 2);
 
     // Verify the GatewayEventSubstitutionFilter is set on the GatewaySender.

--- a/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
+++ b/geode-wan/src/integrationTest/java/org/apache/geode/internal/cache/wan/misc/WANConfigurationJUnitTest.java
@@ -223,6 +223,43 @@ public class WANConfigurationJUnitTest {
     }
   }
 
+  @Test
+  public void test_GatewaySender_Serial_NonExistingDiskStore() {
+    cache = new CacheFactory().set(MCAST_PORT, "0").create();
+    GatewaySenderFactory fact = cache.createGatewaySenderFactory();
+    fact.setManualStart(true);
+    fact.setDiskStoreName("FORNY");
+    try {
+      GatewaySender sender1 = fact.create("NYSender", 2);
+      fail("Expected IllegalStateException but not thrown");
+    } catch (Exception e) {
+      if (e instanceof IllegalStateException
+          && e.getMessage().contains("Disk store FORNY not found")) {
+      } else {
+        fail("Expected IllegalStateException but received :" + e);
+      }
+    }
+  }
+
+  @Test
+  public void test_GatewaySender_Parallel_NonExistingDiskStore() {
+    cache = new CacheFactory().set(MCAST_PORT, "0").create();
+    GatewaySenderFactory fact = cache.createGatewaySenderFactory();
+    fact.setManualStart(true);
+    fact.setParallel(true);
+    fact.setDiskStoreName("FORNY");
+    try {
+      GatewaySender sender1 = fact.create("NYSender", 2);
+      fail("Expected IllegalStateException but not thrown");
+    } catch (Exception e) {
+      if (e instanceof IllegalStateException
+          && e.getMessage().contains("Disk store FORNY not found")) {
+      } else {
+        fail("Expected IllegalStateException but received :" + e);
+      }
+    }
+  }
+
   /**
    * Test to validate the gateway receiver attributes are correctly set
    */
@@ -303,7 +340,6 @@ public class WANConfigurationJUnitTest {
     fact.setBatchSize(200);
     fact.setBatchTimeInterval(300);
     fact.setPersistenceEnabled(false);
-    fact.setDiskStoreName("FORNY");
     fact.setMaximumQueueMemory(200);
     fact.setAlertThreshold(1200);
     GatewayEventFilter myEventFilter1 = new MyGatewayEventFilter1();
@@ -327,7 +363,6 @@ public class WANConfigurationJUnitTest {
     assertEquals(sender1.getBatchSize(), gatewaySender.getBatchSize());
     assertEquals(sender1.getBatchTimeInterval(), gatewaySender.getBatchTimeInterval());
     assertEquals(sender1.isPersistenceEnabled(), gatewaySender.isPersistenceEnabled());
-    assertEquals(sender1.getDiskStoreName(), gatewaySender.getDiskStoreName());
     assertEquals(sender1.getMaximumQueueMemory(), gatewaySender.getMaximumQueueMemory());
     assertEquals(sender1.getAlertThreshold(), gatewaySender.getAlertThreshold());
     assertEquals(sender1.getGatewayEventFilters().size(),
@@ -350,7 +385,6 @@ public class WANConfigurationJUnitTest {
     fact.setBatchSize(200);
     fact.setBatchTimeInterval(300);
     fact.setPersistenceEnabled(false);
-    fact.setDiskStoreName("FORNY");
     fact.setMaximumQueueMemory(200);
     fact.setAlertThreshold(1200);
     GatewayEventFilter myEventFilter1 = new MyGatewayEventFilter1();
@@ -374,7 +408,6 @@ public class WANConfigurationJUnitTest {
     assertEquals(sender1.getBatchSize(), gatewaySender.getBatchSize());
     assertEquals(sender1.getBatchTimeInterval(), gatewaySender.getBatchTimeInterval());
     assertEquals(sender1.isPersistenceEnabled(), gatewaySender.isPersistenceEnabled());
-    assertEquals(sender1.getDiskStoreName(), gatewaySender.getDiskStoreName());
     assertEquals(sender1.getMaximumQueueMemory(), gatewaySender.getMaximumQueueMemory());
     assertEquals(sender1.getAlertThreshold(), gatewaySender.getAlertThreshold());
     assertEquals(sender1.getGatewayEventFilters().size(),

--- a/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderFactoryImpl.java
+++ b/geode-wan/src/main/java/org/apache/geode/cache/wan/internal/GatewaySenderFactoryImpl.java
@@ -239,7 +239,6 @@ public class GatewaySenderFactoryImpl implements InternalGatewaySenderFactory {
           String.format("GatewaySender %s can not be created with dispatcher threads less than 1",
               id));
     }
-
     // Verify socket read timeout if a proper logger is available
     if (cache instanceof GemFireCacheImpl) {
       // If socket read timeout is less than the minimum, log a warning.
@@ -252,6 +251,13 @@ public class GatewaySenderFactoryImpl implements InternalGatewaySenderFactory {
             new Object[] {"GatewaySender " + id, attrs.getSocketReadTimeout(),
                 GatewaySender.MINIMUM_SOCKET_READ_TIMEOUT});
         attrs.setSocketReadTimeout(GatewaySender.MINIMUM_SOCKET_READ_TIMEOUT);
+      }
+
+      if (attrs.getDiskStoreName() != null
+          && cache.findDiskStore(attrs.getDiskStoreName()) == null) {
+        throw new IllegalStateException(
+            String.format("Disk store %s not found",
+                attrs.getDiskStoreName()));
       }
 
       // Log a warning if the old system property is set.


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->
Problem:
-**parallel gw sender**:
     When creating a parallel gw sender with a non-existent disk store it will pass as it will not check if disk store exist.
-**serial gw sender**:
     When running the command for creating a serial gw sender with a non-existent disk store it will fail, **but** a serial gw sender will be created. If we then create a disk store and run the same command again it will fail as the gw sender is already created.

Solution:
Check if the disk store parameter is set and check if that disk store exists in the system.

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
