### PR TITLE
GEODE-10270: Add OpenAllJdkPackages utility

### DIFF
--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1070,3 +1070,4 @@ tools/Modules/Apache_Geode_Modules-0.0.0-tcServer.zip
 tools/Modules/Apache_Geode_Modules-0.0.0-tcServer30.zip
 tools/Modules/geode-for-redis-0.0.0.zip
 tools/Pulse/geode-pulse-0.0.0.war
+tools/Utilities/OpenAllJdkPackages.java

--- a/geode-assembly/src/main/dist/tools/Utilities/OpenAllJdkPackages.java
+++ b/geode-assembly/src/main/dist/tools/Utilities/OpenAllJdkPackages.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+import static java.lang.String.format;
+
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleFinder;
+import java.lang.module.ModuleReference;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+
+public class OpenAllJdkPackages {
+  public static void main(String[] ignored) {
+    ModuleFinder.ofSystem()
+        .findAll().stream()
+        .map(ModuleReference::descriptor)
+        .flatMap(toAddOpensOptions())
+        .sorted()
+        .forEach(System.out::println);
+  }
+
+  private static Function<ModuleDescriptor, Stream<String>> toAddOpensOptions() {
+    return descriptor -> {
+      String moduleName = descriptor.name();
+      return descriptor.packages().stream()
+          .map(packageName -> format("--add-opens=%s/%s=ALL-UNNAMED", moduleName, packageName));
+    };
+  }
+}


### PR DESCRIPTION
This single-source Java program inspects its JVM and emits an argument
file that opens every JVM package to all unnamed modules.

Starting a Java 17 JVM with the resulting argument file essentially
mimics Java 11's `--illegal-access=permit` option.

Run this tool with the JDK you will use to launch Geode:
```
/my/java/17/home/bin/java OpenAllJdkPackages.java
```
