### PR TITLE
GEODE-10275: Bump spring from 5.3.18 to 5.3.19

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -685,52 +685,52 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aspects</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-oxm</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-webmvc</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -48,7 +48,7 @@ class DependencyConstraints implements Plugin<Project> {
     deps.put("jackson.version", "2.13.2")
     deps.put("jackson.databind.version", "2.13.2.2")
     deps.put("springshell.version", "1.2.0.RELEASE")
-    deps.put("springframework.version", "5.3.18")
+    deps.put("springframework.version", "5.3.19")
 
     // These version numbers are used in testing various versions of tomcat and are consumed explicitly
     // in will be called explicitly in the relevant extensions module, and respective configurations

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1054,12 +1054,12 @@ lib/shiro-event-1.9.0.jar
 lib/shiro-lang-1.9.0.jar
 lib/slf4j-api-1.7.32.jar
 lib/snappy-0.4.jar
-lib/spring-beans-5.3.18.jar
-lib/spring-context-5.3.18.jar
-lib/spring-core-5.3.18.jar
-lib/spring-jcl-5.3.18.jar
+lib/spring-beans-5.3.19.jar
+lib/spring-context-5.3.19.jar
+lib/spring-core-5.3.19.jar
+lib/spring-jcl-5.3.19.jar
 lib/spring-shell-1.2.0.RELEASE.jar
-lib/spring-web-5.3.18.jar
+lib/spring-web-5.3.19.jar
 lib/swagger-annotations-1.6.6.jar
 tools/Extensions/geode-web-0.0.0.war
 tools/Extensions/geode-web-api-0.0.0.war

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -18,7 +18,7 @@ geode-common-0.0.0.jar
 geode-unsafe-0.0.0.jar
 geode-deployment-legacy-0.0.0.jar
 spring-shell-1.2.0.RELEASE.jar
-spring-web-5.3.18.jar
+spring-web-5.3.19.jar
 commons-lang3-3.12.0.jar
 rmiio-2.1.2.jar
 jackson-annotations-2.13.2.jar
@@ -31,8 +31,8 @@ log4j-core-2.17.2.jar
 log4j-jcl-2.17.2.jar
 log4j-jul-2.17.2.jar
 log4j-api-2.17.2.jar
-spring-context-5.3.18.jar
-spring-core-5.3.18.jar
+spring-context-5.3.19.jar
+spring-core-5.3.19.jar
 lucene-analyzers-phonetic-6.6.6.jar
 lucene-analyzers-common-6.6.6.jar
 lucene-queryparser-6.6.6.jar
@@ -74,11 +74,11 @@ shiro-event-1.9.0.jar
 shiro-crypto-core-1.9.0.jar
 shiro-lang-1.9.0.jar
 slf4j-api-1.7.32.jar
-spring-beans-5.3.18.jar
+spring-beans-5.3.19.jar
 javax.activation-api-1.2.0.jar
 jline-2.12.jar
 lucene-queries-6.6.6.jar
-spring-jcl-5.3.18.jar
+spring-jcl-5.3.19.jar
 HdrHistogram-2.1.12.jar
 LatencyUtils-2.0.3.jar
 javax.transaction-api-1.3.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -1,11 +1,11 @@
-spring-web-5.3.18.jar
+spring-web-5.3.19.jar
 shiro-event-1.9.0.jar
 shiro-crypto-hash-1.9.0.jar
 shiro-crypto-cipher-1.9.0.jar
 shiro-config-core-1.9.0.jar
 commons-digester-2.1.jar
 commons-validator-1.7.jar
-spring-jcl-5.3.18.jar
+spring-jcl-5.3.19.jar
 commons-codec-1.15.jar
 classgraph-4.8.145.jar
 jackson-databind-2.13.2.2.jar
@@ -17,7 +17,7 @@ javax.resource-api-1.7.1.jar
 LatencyUtils-2.0.3.jar
 jline-2.12.jar
 jetty-servlet-9.4.46.v20220331.jar
-spring-core-5.3.18.jar
+spring-core-5.3.19.jar
 jetty-util-ajax-9.4.46.v20220331.jar
 geode-cq-0.0.0.jar
 geode-old-client-support-0.0.0.jar
@@ -25,7 +25,7 @@ javax.servlet-api-3.1.0.jar
 jgroups-3.6.14.Final.jar
 shiro-cache-1.9.0.jar
 httpcore-4.4.15.jar
-spring-beans-5.3.18.jar
+spring-beans-5.3.19.jar
 lucene-queries-6.6.6.jar
 shiro-core-1.9.0.jar
 HikariCP-4.0.3.jar
@@ -76,7 +76,7 @@ micrometer-core-1.8.4.jar
 shiro-config-ogdl-1.9.0.jar
 geode-log4j-0.0.0.jar
 lucene-analyzers-phonetic-6.6.6.jar
-spring-context-5.3.18.jar
+spring-context-5.3.19.jar
 jetty-security-9.4.46.v20220331.jar
 geode-logging-0.0.0.jar
 commons-io-2.11.0.jar


### PR DESCRIPTION
Geode endeavors to update to the latest version of 3rd-party
dependencies on develop wherever possible.