### PR TITLE
GEODE-10275: Bump spring from 5.2.20 to 5.2.21

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -736,61 +736,61 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aspects</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-oxm</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-webmvc</artifactId>
-        <version>5.2.20.RELEASE</version>
+        <version>5.2.21.RELEASE</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -239,7 +239,7 @@ class DependencyConstraints implements Plugin<Project> {
       entry('spring-security-web')
     }
 
-    dependencySet(group: 'org.springframework', version: '5.2.20.RELEASE') {
+    dependencySet(group: 'org.springframework', version: '5.2.21.RELEASE') {
       entry('spring-aspects')
       entry('spring-beans')
       entry('spring-context')

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1060,12 +1060,12 @@ lib/shiro-event-1.8.0.jar
 lib/shiro-lang-1.8.0.jar
 lib/slf4j-api-1.7.28.jar
 lib/snappy-0.4.jar
-lib/spring-beans-5.2.20.RELEASE.jar
-lib/spring-context-5.2.20.RELEASE.jar
-lib/spring-core-5.2.20.RELEASE.jar
-lib/spring-jcl-5.2.20.RELEASE.jar
+lib/spring-beans-5.2.21.RELEASE.jar
+lib/spring-context-5.2.21.RELEASE.jar
+lib/spring-core-5.2.21.RELEASE.jar
+lib/spring-jcl-5.2.21.RELEASE.jar
 lib/spring-shell-1.2.0.RELEASE.jar
-lib/spring-web-5.2.20.RELEASE.jar
+lib/spring-web-5.2.21.RELEASE.jar
 lib/swagger-annotations-1.5.23.jar
 tools/ClientProtocol/geode-protobuf-messages-definitions-0.0.0.zip
 tools/Extensions/geode-web-0.0.0.war

--- a/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/dependency_classpath.txt
@@ -65,13 +65,13 @@ shiro-crypto-core-1.8.0.jar
 shiro-lang-1.8.0.jar
 slf4j-api-1.7.28.jar
 swagger-annotations-1.5.23.jar
-spring-core-5.2.20.RELEASE.jar
+spring-core-5.2.21.RELEASE.jar
 javax.activation-api-1.2.0.jar
 jline-2.12.jar
 HdrHistogram-2.1.12.jar
 LatencyUtils-2.0.3.jar
 javax.transaction-api-1.3.jar
-spring-jcl-5.2.20.RELEASE.jar
+spring-jcl-5.2.21.RELEASE.jar
 commons-codec-1.11.jar
 jetty-xml-9.4.39.v20210325.jar
 jetty-http-9.4.39.v20210325.jar


### PR DESCRIPTION
Geode endeavors to update to the latest version of 3rd-party
dependencies on develop wherever possible.

Latest (5.2.21) is recommended for 5.2-based support branches.