### PR TITLE
GEODE-10046: Bump 3rd-party dependency versions

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -685,52 +685,52 @@
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-aspects</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-beans</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-core</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-expression</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-oxm</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-test</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-tx</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-web</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-webmvc</artifactId>
-        <version>5.3.18</version>
+        <version>5.3.19</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -735,22 +735,22 @@
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter</artifactId>
-        <version>2.6.6</version>
+        <version>2.6.7</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-jetty</artifactId>
-        <version>2.6.6</version>
+        <version>2.6.7</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-web</artifactId>
-        <version>2.6.6</version>
+        <version>2.6.7</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-data-redis</artifactId>
-        <version>2.6.6</version>
+        <version>2.6.7</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.session</groupId>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -615,12 +615,12 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-codec-redis</artifactId>
-        <version>4.1.75.Final</version>
+        <version>4.1.76.Final</version>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-handler</artifactId>
-        <version>4.1.75.Final</version>
+        <version>4.1.76.Final</version>
       </dependency>
       <dependency>
         <groupId>org.seleniumhq.selenium</groupId>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -645,42 +645,42 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-config</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-ldap</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-test</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-web</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-oauth2-core</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-oauth2-client</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-oauth2-jose</artifactId>
-        <version>5.6.2</version>
+        <version>5.6.3</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -195,7 +195,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-core</artifactId>
-        <version>1.8.4</version>
+        <version>1.8.5</version>
       </dependency>
       <dependency>
         <groupId>io.swagger</groupId>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -180,7 +180,7 @@
       <dependency>
         <groupId>io.github.classgraph</groupId>
         <artifactId>classgraph</artifactId>
-        <version>4.8.145</version>
+        <version>4.8.146</version>
       </dependency>
       <dependency>
         <groupId>io.github.resilience4j</groupId>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -425,7 +425,7 @@
       <dependency>
         <groupId>org.springframework.ldap</groupId>
         <artifactId>spring-ldap-core</artifactId>
-        <version>2.3.6.RELEASE</version>
+        <version>2.3.7.RELEASE</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.shell</groupId>

--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -420,7 +420,7 @@
       <dependency>
         <groupId>org.springframework.hateoas</groupId>
         <artifactId>spring-hateoas</artifactId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.ldap</groupId>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -48,7 +48,7 @@ class DependencyConstraints implements Plugin<Project> {
     deps.put("jackson.version", "2.13.2")
     deps.put("jackson.databind.version", "2.13.2.2")
     deps.put("springshell.version", "1.2.0.RELEASE")
-    deps.put("springframework.version", "5.3.18")
+    deps.put("springframework.version", "5.3.19")
 
     // These version numbers are used in testing various versions of tomcat and are consumed explicitly
     // in will be called explicitly in the relevant extensions module, and respective configurations

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -258,7 +258,7 @@ class DependencyConstraints implements Plugin<Project> {
       entry('selenium-support')
     }
 
-    dependencySet(group: 'org.springframework.security', version: '5.6.2') {
+    dependencySet(group: 'org.springframework.security', version: '5.6.3') {
       entry('spring-security-config')
       entry('spring-security-core')
       entry('spring-security-ldap')

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -246,7 +246,7 @@ class DependencyConstraints implements Plugin<Project> {
       entry('junit-vintage-engine')
     }
 
-    dependencySet(group: 'io.netty', version: '4.1.75.Final') {
+    dependencySet(group: 'io.netty', version: '4.1.76.Final') {
       entry('netty-codec-redis')
       entry('netty-handler')
     }

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -41,7 +41,7 @@ class DependencyConstraints implements Plugin<Project> {
     deps.put("javax.transaction-api.version", "1.3")
     deps.put("jgroups.version", "3.6.14.Final")
     deps.put("log4j.version", "2.17.2")
-    deps.put("micrometer.version", "1.8.4")
+    deps.put("micrometer.version", "1.8.5")
     deps.put("shiro.version", "1.9.0")
     deps.put("slf4j-api.version", "1.7.32")
     deps.put("jboss-modules.version", "1.11.0.Final")

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -166,7 +166,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0')
         api(group: 'org.slf4j', name: 'slf4j-api', version: get('slf4j-api.version'))
         api(group: 'org.springframework.hateoas', name: 'spring-hateoas', version: '1.4.2')
-        api(group: 'org.springframework.ldap', name: 'spring-ldap-core', version: '2.3.6.RELEASE')
+        api(group: 'org.springframework.ldap', name: 'spring-ldap-core', version: '2.3.7.RELEASE')
         api(group: 'org.springframework.shell', name: 'spring-shell', version: get('springshell.version'))
         api(group: 'org.testcontainers', name: 'testcontainers', version: '1.15.3')
         api(group: 'pl.pragmatists', name: 'JUnitParams', version: '1.1.0')

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -117,7 +117,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'commons-modeler', name: 'commons-modeler', version: '2.0.1')
         api(group: 'commons-validator', name: 'commons-validator', version: get('commons-validator.version'))
         // Careful when upgrading this dependency: see GEODE-7370 and GEODE-8150.
-        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.145')
+        api(group: 'io.github.classgraph', name: 'classgraph', version: '4.8.146')
         api(group: 'io.github.resilience4j', name: 'resilience4j-retry', version: '1.7.1')
         api(group: 'io.lettuce', name: 'lettuce-core', version: '6.1.8.RELEASE')
         api(group: 'io.micrometer', name: 'micrometer-core', version: get('micrometer.version'))

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -282,7 +282,7 @@ class DependencyConstraints implements Plugin<Project> {
       entry('spring-webmvc')
     }
 
-    dependencySet(group: 'org.springframework.boot', version: '2.6.6') {
+    dependencySet(group: 'org.springframework.boot', version: '2.6.7') {
       entry('spring-boot-starter')
       entry('spring-boot-starter-jetty')
       entry('spring-boot-starter-web')

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -165,7 +165,7 @@ class DependencyConstraints implements Plugin<Project> {
         api(group: 'org.postgresql', name: 'postgresql', version: '42.2.8')
         api(group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0')
         api(group: 'org.slf4j', name: 'slf4j-api', version: get('slf4j-api.version'))
-        api(group: 'org.springframework.hateoas', name: 'spring-hateoas', version: '1.4.1')
+        api(group: 'org.springframework.hateoas', name: 'spring-hateoas', version: '1.4.2')
         api(group: 'org.springframework.ldap', name: 'spring-ldap-core', version: '2.3.6.RELEASE')
         api(group: 'org.springframework.shell', name: 'spring-shell', version: get('springshell.version'))
         api(group: 'org.testcontainers', name: 'testcontainers', version: '1.15.3')

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -966,7 +966,7 @@ lib/HdrHistogram-2.1.12.jar
 lib/HikariCP-4.0.3.jar
 lib/LatencyUtils-2.0.3.jar
 lib/antlr-2.7.7.jar
-lib/classgraph-4.8.145.jar
+lib/classgraph-4.8.146.jar
 lib/commons-beanutils-1.9.4.jar
 lib/commons-codec-1.15.jar
 lib/commons-collections-3.2.2.jar

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1054,12 +1054,12 @@ lib/shiro-event-1.9.0.jar
 lib/shiro-lang-1.9.0.jar
 lib/slf4j-api-1.7.32.jar
 lib/snappy-0.4.jar
-lib/spring-beans-5.3.18.jar
-lib/spring-context-5.3.18.jar
-lib/spring-core-5.3.18.jar
-lib/spring-jcl-5.3.18.jar
+lib/spring-beans-5.3.19.jar
+lib/spring-context-5.3.19.jar
+lib/spring-core-5.3.19.jar
+lib/spring-jcl-5.3.19.jar
 lib/spring-shell-1.2.0.RELEASE.jar
-lib/spring-web-5.3.18.jar
+lib/spring-web-5.3.19.jar
 lib/swagger-annotations-1.6.6.jar
 tools/Extensions/geode-web-0.0.0.war
 tools/Extensions/geode-web-api-0.0.0.war

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1037,7 +1037,7 @@ lib/lucene-analyzers-phonetic-6.6.6.jar
 lib/lucene-core-6.6.6.jar
 lib/lucene-queries-6.6.6.jar
 lib/lucene-queryparser-6.6.6.jar
-lib/micrometer-core-1.8.4.jar
+lib/micrometer-core-1.8.5.jar
 lib/mx4j-3.0.2.jar
 lib/mx4j-remote-3.0.2.jar
 lib/mx4j-tools-3.0.1.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -18,7 +18,7 @@ geode-common-0.0.0.jar
 geode-unsafe-0.0.0.jar
 geode-deployment-legacy-0.0.0.jar
 spring-shell-1.2.0.RELEASE.jar
-spring-web-5.3.18.jar
+spring-web-5.3.19.jar
 commons-lang3-3.12.0.jar
 rmiio-2.1.2.jar
 jackson-annotations-2.13.2.jar
@@ -31,8 +31,8 @@ log4j-core-2.17.2.jar
 log4j-jcl-2.17.2.jar
 log4j-jul-2.17.2.jar
 log4j-api-2.17.2.jar
-spring-context-5.3.18.jar
-spring-core-5.3.18.jar
+spring-context-5.3.19.jar
+spring-core-5.3.19.jar
 lucene-analyzers-phonetic-6.6.6.jar
 lucene-analyzers-common-6.6.6.jar
 lucene-queryparser-6.6.6.jar
@@ -74,11 +74,11 @@ shiro-event-1.9.0.jar
 shiro-crypto-core-1.9.0.jar
 shiro-lang-1.9.0.jar
 slf4j-api-1.7.32.jar
-spring-beans-5.3.18.jar
+spring-beans-5.3.19.jar
 javax.activation-api-1.2.0.jar
 jline-2.12.jar
 lucene-queries-6.6.6.jar
-spring-jcl-5.3.18.jar
+spring-jcl-5.3.19.jar
 HdrHistogram-2.1.12.jar
 LatencyUtils-2.0.3.jar
 javax.transaction-api-1.3.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -53,7 +53,7 @@ commons-collections-3.2.2.jar
 commons-digester-2.1.jar
 commons-io-2.11.0.jar
 commons-logging-1.2.jar
-classgraph-4.8.145.jar
+classgraph-4.8.146.jar
 micrometer-core-1.8.4.jar
 fastutil-8.5.8.jar
 javax.resource-api-1.7.1.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -54,7 +54,7 @@ commons-digester-2.1.jar
 commons-io-2.11.0.jar
 commons-logging-1.2.jar
 classgraph-4.8.146.jar
-micrometer-core-1.8.4.jar
+micrometer-core-1.8.5.jar
 fastutil-8.5.8.jar
 javax.resource-api-1.7.1.jar
 jetty-webapp-9.4.46.v20220331.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -1,11 +1,11 @@
-spring-web-5.3.18.jar
+spring-web-5.3.19.jar
 shiro-event-1.9.0.jar
 shiro-crypto-hash-1.9.0.jar
 shiro-crypto-cipher-1.9.0.jar
 shiro-config-core-1.9.0.jar
 commons-digester-2.1.jar
 commons-validator-1.7.jar
-spring-jcl-5.3.18.jar
+spring-jcl-5.3.19.jar
 commons-codec-1.15.jar
 classgraph-4.8.145.jar
 jackson-databind-2.13.2.2.jar
@@ -17,7 +17,7 @@ javax.resource-api-1.7.1.jar
 LatencyUtils-2.0.3.jar
 jline-2.12.jar
 jetty-servlet-9.4.46.v20220331.jar
-spring-core-5.3.18.jar
+spring-core-5.3.19.jar
 jetty-util-ajax-9.4.46.v20220331.jar
 geode-cq-0.0.0.jar
 geode-old-client-support-0.0.0.jar
@@ -25,7 +25,7 @@ javax.servlet-api-3.1.0.jar
 jgroups-3.6.14.Final.jar
 shiro-cache-1.9.0.jar
 httpcore-4.4.15.jar
-spring-beans-5.3.18.jar
+spring-beans-5.3.19.jar
 lucene-queries-6.6.6.jar
 shiro-core-1.9.0.jar
 HikariCP-4.0.3.jar
@@ -76,7 +76,7 @@ micrometer-core-1.8.4.jar
 shiro-config-ogdl-1.9.0.jar
 geode-log4j-0.0.0.jar
 lucene-analyzers-phonetic-6.6.6.jar
-spring-context-5.3.18.jar
+spring-context-5.3.19.jar
 jetty-security-9.4.46.v20220331.jar
 geode-logging-0.0.0.jar
 commons-io-2.11.0.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -7,7 +7,7 @@ commons-digester-2.1.jar
 commons-validator-1.7.jar
 spring-jcl-5.3.19.jar
 commons-codec-1.15.jar
-classgraph-4.8.145.jar
+classgraph-4.8.146.jar
 jackson-databind-2.13.2.2.jar
 commons-logging-1.2.jar
 geode-management-0.0.0.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -72,7 +72,7 @@ jna-platform-5.11.0.jar
 log4j-jul-2.17.2.jar
 HdrHistogram-2.1.12.jar
 jackson-annotations-2.13.2.jar
-micrometer-core-1.8.4.jar
+micrometer-core-1.8.5.jar
 shiro-config-ogdl-1.9.0.jar
 geode-log4j-0.0.0.jar
 lucene-analyzers-phonetic-6.6.6.jar


### PR DESCRIPTION
Geode endeavors to update to the latest version of 3rd-party
dependencies on develop wherever possible.  Doing so increases the
shelf life of releases and increases security and reliability.
Doing so regularly makes the occasional hiccups this can cause easier
to pinpoint and address.

Dependency bumps in this batch:
classgraph 4.8.145 -> 4.8.146
micrometer 1.8.4 -> 1.8.5
netty-handler 4.1.75 -> 4.1.76
spring-boot-starter-web 2.6.6 -> 2.6.7
spring-hateoas 1.4.1 -> 1.4.2
spring-ldap-core 2.3.6 -> 2.3.7
spring-security 5.6.2 -> 5.6.3