### PR TITLE
GEODE-10272: Handle RejectedExecutionException during shutdown.

### DIFF
--- a/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANConflationDistributedTest.java
+++ b/geode-wan/src/distributedTest/java/org/apache/geode/internal/cache/wan/parallel/ParallelWANConflationDistributedTest.java
@@ -631,8 +631,7 @@ public class ParallelWANConflationDistributedTest extends WANTestBase {
     public void beforeProcessMessage(ClusterDistributionManager dm, DistributionMessage message) {
       if (message instanceof DeposePrimaryBucketMessage) {
         logger.info(
-            "TestDistributionMessageObserver.beforeProcessMessage about to signal received_deposePrimaryMessage gate",
-            new Exception());
+            "TestDistributionMessageObserver.beforeProcessMessage about to signal received_deposePrimaryMessage gate");
         blackboard.signalGate(DEPOSE_PRIMARY_MESSAGE_RECEIVED);
         logger.info(
             "TestDistributionMessageObserver.beforeProcessMessage done signal received_deposePrimaryMessage gate");


### PR DESCRIPTION
 * Do not throw RejectedExecutionException if it is caused by cache
   closing.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
