### PR TITLE
GEODE-10196: handle 'Connection reset" for jdk17

### DIFF
--- a/geode-dunit/src/main/java/org/apache/geode/test/greplogs/ExpectedStrings.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/greplogs/ExpectedStrings.java
@@ -59,6 +59,7 @@ public class ExpectedStrings {
     expected.add(Pattern.compile("Found expected warning"));
     expected.add(Pattern.compile("CacheClosedException: The cache is closed."));
     expected.add(Pattern.compile("Invoked MembershipNotifierHook"));
+    expected.add(Pattern.compile("java.io.IOException: Connection reset"));
     expected.add(Pattern.compile("java.io.IOException: Connection reset by peer"));
     expected.add(Pattern.compile("client connections exceeds the licensed limit"));
     // Exclude this since the only tests with security enabled, expect to see

--- a/geode-dunit/src/main/java/org/apache/geode/test/greplogs/ExpectedStrings.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/greplogs/ExpectedStrings.java
@@ -59,8 +59,7 @@ public class ExpectedStrings {
     expected.add(Pattern.compile("Found expected warning"));
     expected.add(Pattern.compile("CacheClosedException: The cache is closed."));
     expected.add(Pattern.compile("Invoked MembershipNotifierHook"));
-    expected.add(Pattern.compile("java.io.IOException: Connection reset"));
-    expected.add(Pattern.compile("java.io.IOException: Connection reset by peer"));
+    expected.add(Pattern.compile("Exception: Connection reset"));
     expected.add(Pattern.compile("client connections exceeds the licensed limit"));
     // Exclude this since the only tests with security enabled, expect to see
     // these and if they don't then the test fails

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyInboundHandler.java
@@ -178,7 +178,7 @@ public class RedisProxyInboundHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-    if (!cause.getMessage().contains("Connection reset by peer")) {
+    if (!cause.getMessage().contains("Connection reset")) {
       logger.info(cause);
     }
     closeOnFlush(ctx.channel());

--- a/geode-for-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyOutboundHandler.java
+++ b/geode-for-redis/src/commonTest/java/org/apache/geode/redis/internal/proxy/RedisProxyOutboundHandler.java
@@ -66,7 +66,7 @@ public class RedisProxyOutboundHandler extends ChannelInboundHandlerAdapter {
 
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
-    if (!cause.getMessage().contains("Connection reset by peer")) {
+    if (!cause.getMessage().contains("Connection reset")) {
       logger.info(cause);
     }
     RedisProxyInboundHandler.closeOnFlush(ctx.channel());

--- a/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HdelDUnitTest.java
+++ b/geode-for-redis/src/distributedTest/java/org/apache/geode/redis/internal/commands/executor/hash/HdelDUnitTest.java
@@ -146,7 +146,7 @@ public class HdelDUnitTest {
         command.run();
         return;
       } catch (RedisException rex) {
-        if (!rex.getMessage().contains("Connection reset by peer")) {
+        if (!rex.getMessage().contains("Connection reset")) {
           throw rex;
         }
       }


### PR DESCRIPTION
more handling of "Connection reset" instead of "Connection reset by peer" for jdk17

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
