### PR TITLE
spike/upgrade jdk

### DIFF
--- a/build-tools/scripts/src/main/groovy/multi-process-test.gradle
+++ b/build-tools/scripts/src/main/groovy/multi-process-test.gradle
@@ -45,6 +45,18 @@ def multiProcessTestTasks = [acceptanceTest, repeatAcceptanceTest,
                              upgradeTest, repeatUpgradeTest,
                              uiTest, repeatUnitTest]
 
+for (task in multiProcessTestTasks) {
+  if(project.hasProperty('testJava8Home')) {
+    task.environment "TEST_JAVA_8_HOME", "${project.testJava8Home}"
+  }
+  if(project.hasProperty('testJava11Home')) {
+    task.environment "TEST_JAVA_11_HOME", "${project.testJava11Home}"
+  }
+  if(project.hasProperty('testJava17Home')) {
+    task.environment "TEST_JAVA_17_HOME", "${project.testJava17Home}"
+  }
+}
+
 if (project.hasProperty('testJVM') && !testJVM.trim().isEmpty()) {
   for (task in multiProcessTestTasks) {
     task.environment "JAVA_HOME", "${project.testJVM}"

--- a/geode-assembly/src/upgradeTest/java/org/apache/geode/management/OperationManagementUpgradeTest.java
+++ b/geode-assembly/src/upgradeTest/java/org/apache/geode/management/OperationManagementUpgradeTest.java
@@ -15,7 +15,6 @@
 
 package org.apache.geode.management;
 
-import static org.apache.geode.test.dunit.Host.getHost;
 import static org.apache.geode.test.junit.rules.gfsh.GfshRule.startLocatorCommand;
 import static org.apache.geode.test.junit.rules.gfsh.GfshRule.startServerCommand;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,7 +64,7 @@ public class OperationManagementUpgradeTest {
     oldGfsh = new GfshRule(oldVersion);
     DUnitLauncher.launchIfNeeded(false);
     // get the vm with the same version of the oldGfsh
-    vm = getHost(0).getVM(oldVersion, 0);
+    vm = VM.getVM(oldVersion, 0);
   }
 
   @Rule

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeClients.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeClients.java
@@ -33,10 +33,10 @@ public class RollingUpgradeClients extends RollingUpgrade2DUnitTestBase {
   @Test
   public void testClients() throws Exception {
     final Host host = Host.getHost(0);
-    VM locator = host.getVM(oldVersion, 0);
-    VM server2 = host.getVM(oldVersion, 1);
-    VM server3 = host.getVM(oldVersion, 2);
-    VM client = host.getVM(oldVersion, 3);
+    VM locator = host.getVM(sourceConfiguration, 0);
+    VM server2 = host.getVM(sourceConfiguration, 1);
+    VM server3 = host.getVM(sourceConfiguration, 2);
+    VM client = host.getVM(sourceConfiguration, 3);
 
     final String objectType = "strings";
     final String regionName = "aRegion";

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeConcurrentPutsReplicated.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeConcurrentPutsReplicated.java
@@ -26,7 +26,6 @@ import org.apache.geode.distributed.internal.InternalLocator;
 import org.apache.geode.internal.AvailablePortHelper;
 import org.apache.geode.test.dunit.AsyncInvocation;
 import org.apache.geode.test.dunit.DistributedTestUtils;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.Invoke;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.ThreadUtils;
@@ -41,10 +40,9 @@ public class RollingUpgradeConcurrentPutsReplicated extends RollingUpgrade2DUnit
    */
   @Test
   public void testConcurrentPutsReplicated() {
-    Host host = Host.getHost(0);
-    VM locator = host.getVM(oldVersion, 1);
-    VM server1 = host.getVM(oldVersion, 2);
-    VM server2 = host.getVM(oldVersion, 3);
+    VM locator = VM.getVM(sourceConfiguration, 1);
+    VM server1 = VM.getVM(sourceConfiguration, 2);
+    VM server2 = VM.getVM(sourceConfiguration, 3);
 
     final String objectType = "strings";
     final String regionName = "aRegion";

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeCreateIndexesMixedServersOnPartitionedRegions.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeCreateIndexesMixedServersOnPartitionedRegions.java
@@ -22,7 +22,7 @@ public class RollingUpgradeCreateIndexesMixedServersOnPartitionedRegions
 
   @Test
   public void testCreateIndexesMixedServersOnPartitionedRegions() throws Exception {
-    doTestCreateIndexes(false, true, oldVersion);
+    doTestCreateIndexes(false, true, sourceConfiguration);
   }
 
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeCreateMultiIndexesMixedServersOnPartitionedRegions.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeCreateMultiIndexesMixedServersOnPartitionedRegions.java
@@ -24,7 +24,7 @@ public class RollingUpgradeCreateMultiIndexesMixedServersOnPartitionedRegions
   @Ignore("GEODE_2356: test fails when index creation succeeds")
   @Test
   public void testCreateMultiIndexesMixedServersOnPartitionedRegions() throws Exception {
-    doTestCreateIndexes(true, true, oldVersion);
+    doTestCreateIndexes(true, true, sourceConfiguration);
   }
 
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeHARegionNameOnDifferentServerVersions.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeHARegionNameOnDifferentServerVersions.java
@@ -34,10 +34,10 @@ public class RollingUpgradeHARegionNameOnDifferentServerVersions
   @Test
   public void testHARegionNameOnDifferentServerVersions() {
     final Host host = Host.getHost(0);
-    VM locator = host.getVM(oldVersion, 0);
-    VM server1 = host.getVM(oldVersion, 1);
+    VM locator = host.getVM(sourceConfiguration, 0);
+    VM server1 = host.getVM(sourceConfiguration, 1);
     VM server2 = host.getVM(VersionManager.CURRENT_VERSION, 2);
-    VM client = host.getVM(oldVersion, 3);
+    VM client = host.getVM(sourceConfiguration, 3);
 
     int[] ports = AvailablePortHelper.getRandomAvailableTCPPorts(3);
     int[] locatorPorts = new int[] {ports[0]};

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeNonHAFunction.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeNonHAFunction.java
@@ -49,9 +49,9 @@ public class RollingUpgradeNonHAFunction extends RollingUpgrade2DUnitTestBase {
       throws Exception {
     final Host host = Host.getHost(0);
     VM currentServer1 = host.getVM(VersionManager.CURRENT_VERSION, 0);
-    VM oldServer = host.getVM(oldVersion, 1);
+    VM oldServer = host.getVM(sourceConfiguration, 1);
     VM currentServer2 = host.getVM(VersionManager.CURRENT_VERSION, 2);
-    VM oldServerAndLocator = host.getVM(oldVersion, 3);
+    VM oldServerAndLocator = host.getVM(sourceConfiguration, 3);
 
     String regionName = "cqs";
 

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeOldMemberCantJoinRolledLocators.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeOldMemberCantJoinRolledLocators.java
@@ -31,7 +31,7 @@ public class RollingUpgradeOldMemberCantJoinRolledLocators extends RollingUpgrad
    */
   @Test
   public void testOldMemberCantJoinRolledLocators() {
-    VM oldServer = Host.getHost(0).getVM(oldVersion, 1);
+    VM oldServer = Host.getHost(0).getVM(sourceConfiguration, 1);
     Properties props = getSystemProperties(); // uses the DUnit locator
     try {
       oldServer.invoke(invokeCreateCache(props));

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeOplogMagicSeqBackwardCompactibility.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeOplogMagicSeqBackwardCompactibility.java
@@ -40,10 +40,10 @@ public class RollingUpgradeOplogMagicSeqBackwardCompactibility
 
 
     final Host host = Host.getHost(0);
-    VM server1 = host.getVM(oldVersion, 0);
-    VM server2 = host.getVM(oldVersion, 1);
-    VM server3 = host.getVM(oldVersion, 2);
-    VM locator = host.getVM(oldVersion, 3);
+    VM server1 = host.getVM(sourceConfiguration, 0);
+    VM server2 = host.getVM(sourceConfiguration, 1);
+    VM server3 = host.getVM(sourceConfiguration, 2);
+    VM locator = host.getVM(sourceConfiguration, 3);
 
     String regionName = "aRegion";
     RegionShortcut shortcut = RegionShortcut.REPLICATE_PERSISTENT;

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradePutAndGetMixedServerPartitionedRegion.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradePutAndGetMixedServerPartitionedRegion.java
@@ -22,7 +22,7 @@ public class RollingUpgradePutAndGetMixedServerPartitionedRegion
 
   @Test
   public void testPutAndGetMixedServerPartitionedRegion() throws Exception {
-    doTestPutAndGetMixedServers("dataserializable", true, oldVersion);
+    doTestPutAndGetMixedServers("dataserializable", true, sourceConfiguration);
   }
 
 

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradePutAndGetMixedServersReplicateRegion.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradePutAndGetMixedServersReplicateRegion.java
@@ -22,7 +22,7 @@ public class RollingUpgradePutAndGetMixedServersReplicateRegion
 
   @Test
   public void testPutAndGetMixedServersReplicateRegion() throws Exception {
-    doTestPutAndGetMixedServers("dataserializable", false, oldVersion);
+    doTestPutAndGetMixedServers("dataserializable", false, sourceConfiguration);
   }
 
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeQueryMixedServersOnPartitionedRegions.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeQueryMixedServersOnPartitionedRegions.java
@@ -22,7 +22,7 @@ public class RollingUpgradeQueryMixedServersOnPartitionedRegions
 
   @Test
   public void testQueryMixedServersOnPartitionedRegions() throws Exception {
-    doTestQueryMixedServers(true, oldVersion);
+    doTestQueryMixedServers(true, sourceConfiguration);
   }
 
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeQueryMixedServersOnReplicatedRegions.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeQueryMixedServersOnReplicatedRegions.java
@@ -21,7 +21,7 @@ public class RollingUpgradeQueryMixedServersOnReplicatedRegions
 
   @Test
   public void testQueryMixedServersOnReplicatedRegions() throws Exception {
-    doTestQueryMixedServers(false, oldVersion);
+    doTestQueryMixedServers(false, sourceConfiguration);
   }
 
 }

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollLocatorWithTwoServers.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollLocatorWithTwoServers.java
@@ -36,9 +36,9 @@ public class RollingUpgradeRollLocatorWithTwoServers extends RollingUpgrade2DUni
   @Test
   public void testRollLocatorWithTwoServers() throws Exception {
     final Host host = Host.getHost(0);
-    VM locator1 = host.getVM(oldVersion, 0);
-    VM server3 = host.getVM(oldVersion, 2);
-    VM server4 = host.getVM(oldVersion, 3);
+    VM locator1 = host.getVM(sourceConfiguration, 0);
+    VM server3 = host.getVM(sourceConfiguration, 2);
+    VM server4 = host.getVM(sourceConfiguration, 3);
 
     final String objectType = "strings";
     final String regionName = "aRegion";

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollLocatorsWithOldServer.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollLocatorsWithOldServer.java
@@ -35,9 +35,9 @@ public class RollingUpgradeRollLocatorsWithOldServer extends RollingUpgrade2DUni
   @Test
   public void testRollLocatorsWithOldServer() {
     final Host host = Host.getHost(0);
-    VM locator1 = host.getVM(oldVersion, 0);
-    VM locator2 = host.getVM(oldVersion, 1);
-    VM server4 = host.getVM(oldVersion, 3);
+    VM locator1 = host.getVM(sourceConfiguration, 0);
+    VM locator2 = host.getVM(sourceConfiguration, 1);
+    VM server4 = host.getVM(sourceConfiguration, 3);
 
     int[] locatorPorts = AvailablePortHelper.getRandomAvailableTCPPorts(3);
     locator1.invoke(() -> DistributedTestUtils.deleteLocatorStateFile(locatorPorts));

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollSingleLocatorWithMultipleServersReplicatedRegion.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeRollSingleLocatorWithMultipleServersReplicatedRegion.java
@@ -33,9 +33,9 @@ public class RollingUpgradeRollSingleLocatorWithMultipleServersReplicatedRegion
   @Test
   public void testRollSingleLocatorWithMultipleServersReplicatedRegion() throws Exception {
     final Host host = Host.getHost(0);
-    VM locator = host.getVM(oldVersion, 0);
-    VM server2 = host.getVM(oldVersion, 1);
-    VM server3 = host.getVM(oldVersion, 2);
+    VM locator = host.getVM(sourceConfiguration, 0);
+    VM server2 = host.getVM(sourceConfiguration, 1);
+    VM server3 = host.getVM(sourceConfiguration, 2);
 
     final String objectType = "strings";
     final String regionName = "aRegion";

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeTracePRQuery.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeTracePRQuery.java
@@ -37,9 +37,9 @@ public class RollingUpgradeTracePRQuery extends RollingUpgrade2DUnitTestBase {
   public void testTracePRQuery() throws Exception {
     final Host host = Host.getHost(0);
     VM currentServer1 = host.getVM(VersionManager.CURRENT_VERSION, 0);
-    VM oldServer = host.getVM(oldVersion, 1);
+    VM oldServer = host.getVM(sourceConfiguration, 1);
     VM currentServer2 = host.getVM(VersionManager.CURRENT_VERSION, 2);
-    VM oldServerAndLocator = host.getVM(oldVersion, 3);
+    VM oldServerAndLocator = host.getVM(sourceConfiguration, 3);
 
     String regionName = "cqs";
 

--- a/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeVerifyXmlEntity.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/internal/cache/rollingupgrade/RollingUpgradeVerifyXmlEntity.java
@@ -36,8 +36,8 @@ public class RollingUpgradeVerifyXmlEntity extends RollingUpgrade2DUnitTestBase 
   // previous versions and vice versa.
   public void testVerifyXmlEntity() {
     final Host host = Host.getHost(0);
-    VM oldLocator = host.getVM(oldVersion, 0);
-    VM oldServer = host.getVM(oldVersion, 1);
+    VM oldLocator = host.getVM(sourceConfiguration, 0);
+    VM oldServer = host.getVM(sourceConfiguration, 1);
     VM currentServer1 = host.getVM(VersionManager.CURRENT_VERSION, 2);
     VM currentServer2 = host.getVM(VersionManager.CURRENT_VERSION, 3);
 

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationDUnitTest.java
@@ -14,6 +14,9 @@
  */
 package org.apache.geode.security;
 
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.util.Collection;
 import java.util.List;
 
@@ -27,7 +30,8 @@ import org.junit.runners.Parameterized.UseParametersRunnerFactory;
 
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
-import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.test.version.VmConfiguration;
+import org.apache.geode.test.version.VmConfigurations;
 
 /**
  * Test for authentication from client to server. This tests for both valid and invalid
@@ -41,18 +45,18 @@ import org.apache.geode.test.version.VersionManager;
 @UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class ClientAuthenticationDUnitTest extends ClientAuthenticationTestCase {
 
-  @Parameters(name = "{0}")
-  public static Collection<String> data() {
-    List<String> result = VersionManager.getInstance().getVersions();
-    if (result.size() < 1) {
-      throw new RuntimeException("No older versions of Geode were found to test against");
-    }
-    System.out.println("running against these versions: " + result);
-    return result;
+  @Parameters(name = "Client {0}")
+  public static Collection<VmConfiguration> data() {
+    List<VmConfiguration> vmConfigurations = VmConfigurations.all();
+    assertThat(vmConfigurations)
+        .as("client configurations")
+        .isNotEmpty();
+    System.out.println("using client configurations: " + vmConfigurations);
+    return vmConfigurations;
   }
 
-  public ClientAuthenticationDUnitTest(String version) {
-    clientVersion = version;
+  public ClientAuthenticationDUnitTest(VmConfiguration clientVmConfiguration) {
+    super(clientVmConfiguration);
   }
 
   @Test

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationPart2DUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationPart2DUnitTest.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.security;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -27,13 +28,15 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 import org.apache.geode.internal.cache.tier.MessageType;
 import org.apache.geode.internal.cache.tier.sockets.Message;
 import org.apache.geode.internal.cache.tier.sockets.ServerConnection;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
-import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.test.version.VmConfiguration;
+import org.apache.geode.test.version.VmConfigurations;
 
 /**
  * this class contains test methods that used to be in its superclass but that test started taking
@@ -43,20 +46,18 @@ import org.apache.geode.test.version.VersionManager;
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class ClientAuthenticationPart2DUnitTest extends ClientAuthenticationTestCase {
-  @Parameterized.Parameters
-  public static Collection<String> data() {
-    List<String> result = VersionManager.getInstance().getVersions();
-    if (result.size() < 1) {
-      throw new RuntimeException("No older versions of Geode were found to test against");
-    } else {
-      System.out.println("running against these versions: " + result);
-    }
-    return result;
+  @Parameters(name = "Client {0}")
+  public static Collection<VmConfiguration> data() {
+    List<VmConfiguration> vmConfigurations = VmConfigurations.all();
+    assertThat(vmConfigurations)
+        .as("client configurations")
+        .isNotEmpty();
+    System.out.println("using client configurations: " + vmConfigurations);
+    return vmConfigurations;
   }
 
-  public ClientAuthenticationPart2DUnitTest(String version) {
-    super();
-    clientVersion = version;
+  public ClientAuthenticationPart2DUnitTest(VmConfiguration clientVmConfiguration) {
+    super(clientVmConfiguration);
   }
 
   @Test

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationTestCase.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthenticationTestCase.java
@@ -67,6 +67,7 @@ import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.test.version.VmConfiguration;
 
 public abstract class ClientAuthenticationTestCase extends JUnit4DistributedTestCase {
 
@@ -84,6 +85,10 @@ public abstract class ClientAuthenticationTestCase extends JUnit4DistributedTest
   private static final String[] clientIgnoredExceptions =
       {AuthenticationRequiredException.class.getName(),
           AuthenticationFailedException.class.getName(), SSLHandshakeException.class.getName()};
+
+  public ClientAuthenticationTestCase(VmConfiguration clientVmConfiguration) {
+    this.clientVmConfiguration = clientVmConfiguration;
+  }
 
 
   public enum Color {
@@ -115,7 +120,8 @@ public abstract class ClientAuthenticationTestCase extends JUnit4DistributedTest
     }
   }
 
-  public String clientVersion = VersionManager.CURRENT_VERSION;
+  protected final VmConfiguration clientVmConfiguration;
+
 
   @Override
   public final void postSetUp() throws Exception {
@@ -124,13 +130,8 @@ public abstract class ClientAuthenticationTestCase extends JUnit4DistributedTest
     server2 = host.getVM(VersionManager.CURRENT_VERSION, 1);
     server1.invoke(() -> ServerConnection.allowInternalMessagesWithoutCredentials = false);
     server2.invoke(() -> ServerConnection.allowInternalMessagesWithoutCredentials = false);
-    if (VersionManager.isCurrentVersion(clientVersion)) {
-      client1 = host.getVM(VersionManager.CURRENT_VERSION, 2);
-      client2 = host.getVM(VersionManager.CURRENT_VERSION, 3);
-    } else {
-      client1 = host.getVM(clientVersion, 2);
-      client2 = host.getVM(clientVersion, 3);
-    }
+    client1 = host.getVM(clientVmConfiguration, 2);
+    client2 = host.getVM(clientVmConfiguration, 3);
 
     addIgnoredException("Connection refused: connect");
 

--- a/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthorizationLegacyConfigurationDUnitTest.java
+++ b/geode-core/src/upgradeTest/java/org/apache/geode/security/ClientAuthorizationLegacyConfigurationDUnitTest.java
@@ -44,7 +44,8 @@ import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.MemberVM;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
-import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.test.version.VmConfiguration;
+import org.apache.geode.test.version.VmConfigurations;
 
 @Category({SecurityTest.class})
 @RunWith(Parameterized.class)
@@ -75,11 +76,11 @@ public class ClientAuthorizationLegacyConfigurationDUnitTest {
 
   // Using a client of every version...
   @Parameterized.Parameter
-  public String clientVersion;
+  public VmConfiguration clientVmConfiguration;
 
-  @Parameterized.Parameters(name = "clientVersion={0}")
-  public static Collection<String> data() {
-    return VersionManager.getInstance().getVersions();
+  @Parameterized.Parameters(name = "Client {0}")
+  public static Collection<VmConfiguration> data() {
+    return VmConfigurations.all();
   }
 
   @Test
@@ -96,8 +97,8 @@ public class ClientAuthorizationLegacyConfigurationDUnitTest {
 
     int locatorPort = locator.getPort();
 
-    ClientVM client = csRule.startClientVM(2, clientVersion, c -> c.withCredential("data", "data")
-        .withLocatorConnection(locatorPort));
+    ClientVM client = csRule.startClientVM(2, clientVmConfiguration,
+        c -> c.withCredential("data", "data").withLocatorConnection(locatorPort));
 
     client.invoke(() -> {
       ClientCache cache = ClusterStartupRule.getClientCache();
@@ -139,7 +140,7 @@ public class ClientAuthorizationLegacyConfigurationDUnitTest {
 
     int locatorPort = locator.getPort();
 
-    ClientVM client = csRule.startClientVM(2, clientVersion,
+    ClientVM client = csRule.startClientVM(2, clientVmConfiguration,
         c -> c.withCredential("data", "data").withLocatorConnection(locatorPort));
     client.invoke(() -> {
       ClientCache cache = ClusterStartupRule.getClientCache();

--- a/geode-cq/src/upgradeTest/java/org/apache/geode/security/ClientAuthorizationCQDUnitTest.java
+++ b/geode-cq/src/upgradeTest/java/org/apache/geode/security/ClientAuthorizationCQDUnitTest.java
@@ -16,6 +16,7 @@ package org.apache.geode.security;
 
 import static org.apache.geode.security.SecurityTestUtils.closeCache;
 import static org.apache.geode.test.dunit.IgnoredException.addIgnoredException;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.List;
@@ -28,7 +29,8 @@ import org.junit.runners.Parameterized;
 import org.apache.geode.cache.operations.OperationContext.OperationCode;
 import org.apache.geode.test.junit.categories.SecurityTest;
 import org.apache.geode.test.junit.runners.CategoryWithParameterizedRunnerFactory;
-import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.test.version.VmConfiguration;
+import org.apache.geode.test.version.VmConfigurations;
 
 /**
  * Tests for authorization from client to server. This tests for authorization of all operations
@@ -44,20 +46,18 @@ import org.apache.geode.test.version.VersionManager;
 @RunWith(Parameterized.class)
 @Parameterized.UseParametersRunnerFactory(CategoryWithParameterizedRunnerFactory.class)
 public class ClientAuthorizationCQDUnitTest extends ClientAuthorizationTestCase {
-  @Parameterized.Parameters(name = "from_v{0}")
-  public static Collection<String> data() {
-    List<String> result = VersionManager.getInstance().getVersions();
-    if (result.size() < 1) {
-      throw new RuntimeException("No older versions of Geode were found to test against");
-    } else {
-      System.out.println("running against these versions: " + result);
-    }
-    return result;
+  @Parameterized.Parameters(name = "From {0}")
+  public static Collection<VmConfiguration> data() {
+    List<VmConfiguration> configurations = VmConfigurations.upgrades();
+    assertThat(configurations)
+        .as("configurations to upgrade from")
+        .isNotEmpty();
+    System.out.println("upgrading from configurations: " + configurations);
+    return configurations;
   }
 
-  public ClientAuthorizationCQDUnitTest(String version) {
-    super();
-    clientVersion = version;
+  public ClientAuthorizationCQDUnitTest(VmConfiguration clientVmConfiguration) {
+    super(clientVmConfiguration);
   }
 
   @Override

--- a/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/GetDefaultDiskStoreNameDistributedTest.java
+++ b/geode-dunit/src/distributedTest/java/org/apache/geode/test/dunit/tests/GetDefaultDiskStoreNameDistributedTest.java
@@ -56,8 +56,7 @@ public class GetDefaultDiskStoreNameDistributedTest extends DistributedTestCase 
 
   private String createDefaultDiskStoreName(final int hostIndex, final int vmIndex,
       final String methodName) {
-    return "DiskStore-" + hostIndex + "-" + vmIndex + "-" + getClass().getCanonicalName() + "."
-        + methodName;
+    return "DiskStore-" + hostIndex + '-' + vmIndex + '-' + methodName;
   }
 
   private String getDefaultDiskStoreName() {

--- a/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase.java
@@ -92,6 +92,7 @@ import org.apache.geode.test.dunit.cache.internal.JUnit4CacheTestCase;
 import org.apache.geode.test.dunit.internal.DUnitLauncher;
 import org.apache.geode.test.junit.categories.ClientServerTest;
 import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.test.version.VmConfiguration;
 import org.apache.geode.util.internal.GeodeGlossary;
 
 /**
@@ -138,11 +139,15 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
   private final int putRange_2End = 10;
 
 
-  String testVersion; // version for client caches for backward-compatibility
-                      // testing
+  // configuration for client caches for backward-compatibility testing
+  final VmConfiguration clientVmConfiguration;
 
   public ClientServerMiscDUnitTestBase() {
-    testVersion = VersionManager.CURRENT_VERSION;
+    this(VmConfiguration.current());
+  }
+
+  public ClientServerMiscDUnitTestBase(VmConfiguration clientVmConfiguration) {
+    this.clientVmConfiguration = clientVmConfiguration;
   }
 
   @Override
@@ -178,15 +183,15 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
     int port1 = initServerCache(true); // vm0
     int port2 = initServerCache2(); // vm1
     String serverName = NetworkUtils.getServerHostName();
-    host.getVM(testVersion, 0).invoke(() -> createClientCacheV(serverName, port1));
-    host.getVM(testVersion, 1).invoke(() -> createClientCacheV(serverName, port2));
+    host.getVM(clientVmConfiguration, 0).invoke(() -> createClientCacheV(serverName, port1));
+    host.getVM(clientVmConfiguration, 1).invoke(() -> createClientCacheV(serverName, port2));
     LogService.getLogger()
         .info("Testing concurrent map operations from a client with a distributed region");
-    concurrentMapTest(host.getVM(testVersion, 0), SEPARATOR + REGION_NAME1);
+    concurrentMapTest(host.getVM(clientVmConfiguration, 0), SEPARATOR + REGION_NAME1);
     // TODO add verification in vm1
     LogService.getLogger()
         .info("Testing concurrent map operations from a client with a partitioned region");
-    concurrentMapTest(host.getVM(testVersion, 0), SEPARATOR + PR_REGION_NAME);
+    concurrentMapTest(host.getVM(clientVmConfiguration, 0), SEPARATOR + PR_REGION_NAME);
     // TODO add verification in vm1
   }
 
@@ -197,7 +202,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
    */
   @Test
   public void testClientReceivesPingIntervalSetting() {
-    VM clientVM = Host.getHost(0).getVM(testVersion, 0);
+    VM clientVM = Host.getHost(0).getVM(clientVmConfiguration, 0);
 
     final int port = initServerCache(true);
     final String host = NetworkUtils.getServerHostName();
@@ -242,15 +247,15 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
     int port1 = initServerCache(true); // vm0
     int port2 = initServerCache2(); // vm1
     String serverName = NetworkUtils.getServerHostName();
-    host.getVM(testVersion, 0).invoke(() -> createEmptyClientCache(serverName, port1));
-    host.getVM(testVersion, 1).invoke(() -> createClientCacheV(serverName, port2));
+    host.getVM(clientVmConfiguration, 0).invoke(() -> createEmptyClientCache(serverName, port1));
+    host.getVM(clientVmConfiguration, 1).invoke(() -> createClientCacheV(serverName, port2));
     LogService.getLogger()
         .info("Testing concurrent map operations from a client with a distributed region");
-    concurrentMapTest(host.getVM(testVersion, 0), SEPARATOR + REGION_NAME1);
+    concurrentMapTest(host.getVM(clientVmConfiguration, 0), SEPARATOR + REGION_NAME1);
     // TODO add verification in vm1
     LogService.getLogger()
         .info("Testing concurrent map operations from a client with a partitioned region");
-    concurrentMapTest(host.getVM(testVersion, 0), SEPARATOR + PR_REGION_NAME);
+    concurrentMapTest(host.getVM(clientVmConfiguration, 0), SEPARATOR + PR_REGION_NAME);
     // TODO add verification in vm1
   }
 
@@ -462,7 +467,7 @@ public class ClientServerMiscDUnitTestBase extends JUnit4CacheTestCase {
     // start server first
     PORT1 = initServerCache(true);
     int serverPort = PORT1;
-    VM client1 = Host.getHost(0).getVM(testVersion, 1);
+    VM client1 = Host.getHost(0).getVM(clientVmConfiguration, 1);
     String hostname = NetworkUtils.getServerHostName();
     client1.invoke("create client1 cache", () -> {
       createClientCache(hostname, serverPort);

--- a/geode-dunit/src/main/java/org/apache/geode/security/ClientAuthorizationTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/security/ClientAuthorizationTestCase.java
@@ -90,6 +90,7 @@ import org.apache.geode.test.dunit.internal.JUnit4DistributedTestCase;
 import org.apache.geode.test.dunit.rules.ClusterStartupRule;
 import org.apache.geode.test.dunit.rules.DistributedRule;
 import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.test.version.VmConfiguration;
 
 /**
  * Base class for tests for authorization from client to server. It contains utility functions for
@@ -110,7 +111,7 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
   protected static VM client1 = null;
   protected static VM client2 = null;
 
-  public String clientVersion = VersionManager.CURRENT_VERSION;
+  public final VmConfiguration clientVmConfiguration;
 
   protected static final String regionName = REGION_NAME; // TODO: remove
   protected static final String SUBREGION_NAME = "AuthSubregion";
@@ -124,6 +125,14 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
   private static final String[] clientIgnoredExceptions =
       {AuthenticationFailedException.class.getName(), NotAuthorizedException.class.getName(),
           RegionDestroyedException.class.getName()};
+
+  public ClientAuthorizationTestCase() {
+    this(VmConfiguration.current());
+  }
+
+  protected ClientAuthorizationTestCase(VmConfiguration clientVmConfiguration) {
+    this.clientVmConfiguration = clientVmConfiguration;
+  }
 
   @Override
   public final void preSetUp() throws Exception {}
@@ -141,13 +150,8 @@ public abstract class ClientAuthorizationTestCase extends JUnit4DistributedTestC
     server2 = host.getVM(VersionManager.CURRENT_VERSION, 1);
     server1.invoke(() -> ServerConnection.allowInternalMessagesWithoutCredentials = false);
     server2.invoke(() -> ServerConnection.allowInternalMessagesWithoutCredentials = false);
-    if (VersionManager.isCurrentVersion(clientVersion)) {
-      client1 = host.getVM(VersionManager.CURRENT_VERSION, 2);
-      client2 = host.getVM(VersionManager.CURRENT_VERSION, 3);
-    } else {
-      client1 = host.getVM(clientVersion, 2);
-      client2 = host.getVM(clientVersion, 3);
-    }
+    client1 = host.getVM(clientVmConfiguration, 2);
+    client2 = host.getVM(clientVmConfiguration, 3);
     setUpIgnoredExceptions();
   }
 

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/Host.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/Host.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.test.dunit;
 
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +23,7 @@ import org.apache.geode.test.dunit.internal.ChildVMLauncher;
 import org.apache.geode.test.dunit.internal.ProcessHolder;
 import org.apache.geode.test.dunit.internal.RemoteDUnitVMIF;
 import org.apache.geode.test.dunit.internal.VMEventNotifier;
-import org.apache.geode.test.version.VersionManager;
+import org.apache.geode.test.version.VmConfiguration;
 
 /**
  * This class represents a host on which a remote method may be invoked. It provides access to the
@@ -35,16 +36,21 @@ import org.apache.geode.test.version.VersionManager;
  */
 @SuppressWarnings("serial")
 public abstract class Host implements Serializable {
-
-  /** The available hosts */
+  /**
+   * The available hosts
+   */
   private static final List<Host> hosts = new ArrayList<>();
 
   private static VM locator;
 
-  /** The name of this host machine */
+  /**
+   * The name of this host machine
+   */
   private final String hostName;
 
-  /** The VMs that run on this host */
+  /**
+   * The VMs that run on this host
+   */
   private final List<VM> vms;
 
   private final transient VMEventNotifier vmEventNotifier;
@@ -68,7 +74,6 @@ public abstract class Host implements Serializable {
    *
    * @param whichHost A zero-based identifier of the host
    * @return the Host
-   *
    * @throws IllegalArgumentException {@code n} is more than the number of hosts
    */
   public static Host getHost(int whichHost) {
@@ -93,7 +98,7 @@ public abstract class Host implements Serializable {
       int numVMs = host.getVMCount();
       for (int i = 0; i < numVMs; i++) {
         try {
-          host.getVM(VersionManager.CURRENT_VERSION, i);
+          host.getVM(VmConfiguration.current(), i);
         } catch (UnsupportedOperationException e) {
           // not all implementations support versioning
         }
@@ -132,12 +137,18 @@ public abstract class Host implements Serializable {
     return vms.size();
   }
 
+  /*
+   * return a collection of all VMs
+   */
+  public List<VM> getAllVMs() {
+    return new ArrayList<>(vms);
+  }
+
   /**
    * Returns a VM that runs on this host
    *
    * @param n A zero-based identifier of the VM
    * @return a VM that runs on this host
-   *
    * @throws IllegalArgumentException {@code n} is more than the number of VMs
    * @deprecated use the static methods in VM instead
    */
@@ -155,28 +166,41 @@ public abstract class Host implements Serializable {
     }
   }
 
-  /*
-   * return a collection of all VMs
+  /**
+   * Returns the nth VM, ensuring that it is configured with the given geode version. Optional
+   * operation currently supported only in distributedTests.
+   *
+   * @param geodeVersion the desired geode version for the VM
+   * @param n the index the VM
+   * @return the specified VM, configured with the specified Geode version
+   * @deprecated use {@link VM#getVM(String, int)}
    */
-  public List<VM> getAllVMs() {
-    return new ArrayList<>(vms);
+  @Deprecated
+  public VM getVM(String geodeVersion, int n) {
+    throw new UnsupportedOperationException("Not supported in this implementation of Host");
   }
 
-  /*
-   * Returns the nth VM of the given version. Optional operation currently supported only in
-   * distributedTests.
+  /**
+   * Returns the nth VM, ensuring that it is configured with the given VM configuration. Optional
+   * operation currently supported only in distributedTests.
+   *
+   * @param configuration the desired configuration for the VM
+   * @param whichVM the index the VM
+   * @return the specified VM, configured with the specified configuration
+   * @deprecated use {@link VM#getVM(VmConfiguration, int)}
    */
-  public VM getVM(String version, int n) {
+  @Deprecated
+  public VM getVM(VmConfiguration configuration, int whichVM) {
     throw new UnsupportedOperationException("Not supported in this implementation of Host");
   }
 
   /*
    * Adds a VM to this Host with the given process id and client record.
    */
-  protected void addVM(int vmid, final String version, RemoteDUnitVMIF client,
+  protected void addVM(int vmid, VmConfiguration configuration, RemoteDUnitVMIF client,
       ProcessHolder processHolder,
       ChildVMLauncher childVMLauncher) {
-    VM vm = new VM(this, version, vmid, client, processHolder,
+    VM vm = new VM(this, configuration, vmid, client, processHolder,
         childVMLauncher);
     vms.add(vm);
     vmEventNotifier.notifyAfterCreateVM(vm);
@@ -192,8 +216,8 @@ public abstract class Host implements Serializable {
 
   protected void addLocator(int vmid, RemoteDUnitVMIF client, ProcessHolder processHolder,
       ChildVMLauncher childVMLauncher) {
-    setLocator(new VM(this, VersionManager.CURRENT_VERSION, vmid, client, processHolder,
-        childVMLauncher));
+    setLocator(
+        new VM(this, VmConfiguration.current(), vmid, client, processHolder, childVMLauncher));
   }
 
   @Override

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ChildVMLauncher.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/ChildVMLauncher.java
@@ -18,10 +18,12 @@ import java.io.IOException;
 import java.rmi.NotBoundException;
 import java.rmi.RemoteException;
 
+import org.apache.geode.test.version.VmConfiguration;
+
 public interface ChildVMLauncher {
 
-  ProcessHolder launchVM(String version, int vmNum, boolean bouncedVM, int remoteStubPort)
-      throws IOException;
+  ProcessHolder launchVM(VmConfiguration configuration, int vmNum, boolean bouncedVM,
+      int remoteStubPort) throws IOException;
 
   RemoteDUnitVMIF getStub(int i) throws RemoteException, NotBoundException, InterruptedException;
 }

--- a/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/test/dunit/internal/JUnit4DistributedTestCase.java
@@ -376,18 +376,17 @@ public abstract class JUnit4DistributedTestCase implements DistributedTestFixtur
    * Do not override this method.
    */
   private void doSetUpDistributedTestCase() {
-    final String className = getTestClass().getCanonicalName();
     final String methodName = getName();
 
     TestHistoryLogger.logTestHistory(getTestClass().getSimpleName(), methodName);
 
-    setUpVM(methodName, getDefaultDiskStoreName(0, -1, className, methodName));
+    setUpVM(methodName, getDefaultDiskStoreName(0, -1, methodName));
 
     for (int hostIndex = 0; hostIndex < Host.getHostCount(); hostIndex++) {
       Host host = Host.getHost(hostIndex);
       for (int vmIndex = 0; vmIndex < host.getVMCount(); vmIndex++) {
         final String vmDefaultDiskStoreName =
-            getDefaultDiskStoreName(hostIndex, vmIndex, className, methodName);
+            getDefaultDiskStoreName(hostIndex, vmIndex, methodName);
         host.getVM(vmIndex).invoke("setupVM", () -> setUpVM(methodName, vmDefaultDiskStoreName));
       }
     }
@@ -422,9 +421,8 @@ public abstract class JUnit4DistributedTestCase implements DistributedTestFixtur
   }
 
   private static String getDefaultDiskStoreName(final int hostIndex, final int vmIndex,
-      final String className, final String methodName) {
-    return "DiskStore-" + hostIndex + "-" + vmIndex + "-"
-        + className + "." + methodName; // used to be getDeclaringClass()
+      final String methodName) {
+    return "DiskStore-" + hostIndex + "-" + vmIndex + "-" + methodName;
   }
 
   private static void setUpVM(final String methodName, final String defaultDiskStoreName) {

--- a/geode-dunit/src/main/resources/org/apache/geode/test/dunit/internal/sanctioned-geode-dunit-serializables.txt
+++ b/geode-dunit/src/main/resources/org/apache/geode/test/dunit/internal/sanctioned-geode-dunit-serializables.txt
@@ -105,7 +105,7 @@ org/apache/geode/cache30/RegionTestCase$7,false,this$0:org/apache/geode/cache30/
 org/apache/geode/cache30/RegionTestCase$8,false,this$0:org/apache/geode/cache30/RegionTestCase,val$name:java/lang/String
 org/apache/geode/cache30/RegionTestCase$9,false,this$0:org/apache/geode/cache30/RegionTestCase,val$name:java/lang/String
 org/apache/geode/internal/cache/tier/sockets/CacheServerTestUtil,false
-org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase,false,props:java/util/Properties,putRange_1End:int,putRange_1Start:int,putRange_2End:int,putRange_2Start:int,testVersion:java/lang/String
+org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase,false,clientVmConfiguration:org/apache/geode/test/version/VmConfiguration,props:java/util/Properties,putRange_1End:int,putRange_1Start:int,putRange_2End:int,putRange_2Start:int
 org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase$1,false,this$0:org/apache/geode/internal/cache/tier/sockets/ClientServerMiscDUnitTestBase,val$rName:java/lang/String
 org/apache/geode/internal/cache/wan/AsyncEventQueueTestBase,false
 org/apache/geode/management/ManagementTestBase,false,restoreSystemProperties:org/apache/geode/test/dunit/rules/DistributedRestoreSystemProperties
@@ -117,7 +117,7 @@ org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBas
 org/apache/geode/management/internal/cli/commands/ShowDeadlockDistributedTestBase$LockFunction,false
 org/apache/geode/management/internal/cli/commands/ShowLogCommandDistributedTestBase,false
 org/apache/geode/management/internal/configuration/ClusterConfig,false,groups:java/util/List
-org/apache/geode/security/ClientAuthorizationTestCase,false,clientVersion:java/lang/String
+org/apache/geode/security/ClientAuthorizationTestCase,false,clientVmConfiguration:org/apache/geode/test/version/VmConfiguration
 org/apache/geode/security/SecurityTestUtils$1,false,this$0:org/apache/geode/security/SecurityTestUtils
 org/apache/geode/security/query/AbstractQuerySecurityDistributedTest,false,cluster:org/apache/geode/test/dunit/rules/ClusterStartupRule,keys:java/lang/Object[],regionName:java/lang/String,server:org/apache/geode/test/dunit/rules/MemberVM,specificUserClient:org/apache/geode/test/dunit/rules/ClientVM,superUserClient:org/apache/geode/test/dunit/rules/ClientVM,values:java/lang/Object[]
 org/apache/geode/security/templates/PKCSPrincipal,false,alias:java/lang/String
@@ -130,7 +130,7 @@ org/apache/geode/test/dunit/RMIException,false,cause:java/lang/Throwable,classNa
 org/apache/geode/test/dunit/RMIException$HokeyException,false,stackTrace:java/lang/String,toString:java/lang/String
 org/apache/geode/test/dunit/SerializableCallable,false,id:long,name:java/lang/String
 org/apache/geode/test/dunit/SerializableRunnable,false,id:long,name:java/lang/String
-org/apache/geode/test/dunit/VM,false,available:boolean,client:org/apache/geode/test/dunit/internal/RemoteDUnitVMIF,host:org/apache/geode/test/dunit/Host,id:int,version:java/lang/String
+org/apache/geode/test/dunit/VM,false,available:boolean,client:org/apache/geode/test/dunit/internal/RemoteDUnitVMIF,configuration:org/apache/geode/test/version/VmConfiguration,host:org/apache/geode/test/dunit/Host,id:int
 org/apache/geode/test/dunit/cache/CacheTestCase,false
 org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase,false,RootRegionName:java/lang/String,cacheTestFixture:org/apache/geode/test/dunit/cache/internal/CacheTestFixture
 org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase$1,false,this$0:org/apache/geode/test/dunit/cache/internal/JUnit4CacheTestCase,val$exceptionStringToIgnore:java/lang/String

--- a/geode-junit/src/main/java/org/apache/geode/test/version/JavaVersion.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/JavaVersion.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.test.version;
+
+import java.io.Serializable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Objects;
+
+/**
+ * Represents an installed version of Java.
+ */
+public class JavaVersion implements Comparable<JavaVersion>, Serializable {
+  public final int specificationVersion;
+  public final String home;
+
+  public JavaVersion(int specificationVersion, Path home) {
+    this.specificationVersion = specificationVersion;
+    this.home = home.toAbsolutePath().normalize().toString();
+  }
+
+  /**
+   * @return the absolute, normalized path to this version's home
+   */
+  public Path home() {
+    return Paths.get(home);
+  }
+
+  /**
+   * @return this Java version's specification version
+   */
+  public int specificationVersion() {
+    return specificationVersion;
+  }
+
+  @Override
+  public String toString() {
+    return "" + specificationVersion;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return specificationVersion == ((JavaVersion) o).specificationVersion;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(specificationVersion);
+  }
+
+  @Override
+  public int compareTo(JavaVersion other) {
+    return Integer.compare(specificationVersion, other.specificationVersion);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/version/JavaVersions.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/JavaVersions.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.test.version;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.logging.log4j.util.Strings.isBlank;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+
+/**
+ * Discovers Java versions for use in {@link VmConfiguration}s. The known versions include:
+ * <ul>
+ * <li>The version of the current JVM.
+ * <li>Each of the following if its specification version is lower than current JVM's and if the
+ * corresponding environment variable identifies a directory:
+ * <ul>
+ * <li>Java 8: {@code TEST_JAVA_8_HOME}.</li>
+ * <li>Java 11: {@code TEST_JAVA_11_HOME}.</li>
+ * <li>Java 17: {@code TEST_JAVA_17_HOME}.</li>
+ * </ul>
+ * </li>
+ * </ul>
+ */
+public class JavaVersions {
+  private static final JavaVersion CURRENT_VERSION =
+      new JavaVersion(currentJavaSpecificationVersion(), currentJavaHome());
+
+  private static final Set<JavaVersion> KNOWN_VERSIONS = new HashSet<>();
+
+  static {
+    discover(8);
+    discover(11);
+    discover(17);
+    add(CURRENT_VERSION, "java.home");
+  }
+
+  /**
+   * @return a list of known Java versions
+   */
+  public static List<JavaVersion> all() {
+    return KNOWN_VERSIONS.stream()
+        .sorted()
+        .collect(toList());
+  }
+
+  /**
+   * @return the Java version of this JVM
+   */
+  public static JavaVersion current() {
+    return CURRENT_VERSION;
+  }
+
+  /**
+   * Returns a predicate that tests if its argument is less than {@code bound}.
+   *
+   * @param bound the upper bound
+   * @return a predicate that tests if its argument is less than @{code bound}
+   */
+  public static Predicate<JavaVersion> lessThan(JavaVersion bound) {
+    return v -> v.compareTo(bound) < 0;
+  }
+
+  /**
+   * Returns a predicate that tests if its argument is at most {@code bound}.
+   *
+   * @param bound the upper bound
+   * @return a predicate that tests if its argument is at most {@code bound}
+   */
+  public static Predicate<JavaVersion> atMost(JavaVersion bound) {
+    return v -> v.compareTo(bound) <= 0;
+  }
+
+  /**
+   * Returns a predicate that tests if its argument is at least {@code bound}.
+   *
+   * @param bound the lower bound
+   * @return a predicate that tests if its argument is at least {@code bound}
+   */
+  public static Predicate<JavaVersion> atLeast(JavaVersion bound) {
+    return v -> v.compareTo(bound) >= 0;
+  }
+
+  /**
+   * Returns a predicate that tests if its argument is greater than {@code bound}.
+   *
+   * @param bound the lower bound
+   * @return a predicate that tests if its argument is greater than {@code bound}
+   */
+  public static Predicate<JavaVersion> greaterThan(JavaVersion bound) {
+    return v -> v.compareTo(bound) > 0;
+  }
+
+  private static void discover(int specificationVersion) {
+    // Add the Java version only if its specification version is lower than the current JVM's.
+    if (specificationVersion >= CURRENT_VERSION.specificationVersion()) {
+      return;
+    }
+    String homeVariable = "TEST_JAVA_" + specificationVersion + "_HOME";
+    String home = System.getenv(homeVariable);
+    if (isBlank(home)) {
+      return;
+    }
+    add(new JavaVersion(specificationVersion, Paths.get(home)), homeVariable);
+  }
+
+  private static void add(JavaVersion javaVersion, String source) {
+    assertThat(javaVersion.home())
+        .as("Java %d home from %s", javaVersion, source)
+        .isDirectory();
+    KNOWN_VERSIONS.add(javaVersion);
+  }
+
+  private static int currentJavaSpecificationVersion() {
+    String specificationVersion = System.getProperty("java.specification.version");
+    if (specificationVersion.contains(".")) {
+      return Integer.parseInt(specificationVersion.split("\\.")[1]);
+    }
+    return Integer.parseInt(specificationVersion);
+  }
+
+  private static Path currentJavaHome() {
+    return Paths.get(System.getProperty("java.home"));
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/version/TestVersion.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/TestVersion.java
@@ -41,6 +41,10 @@ public class TestVersion implements Comparable<TestVersion>, Serializable {
     release = Integer.parseInt(split[2]);
   }
 
+  public String majorMinor() {
+    return "" + major + '.' + minor;
+  }
+
   /*
    * Perform a comparison of the major, minor and patch versions of the two version strings.
    * The version strings should be in dot notation.
@@ -53,7 +57,6 @@ public class TestVersion implements Comparable<TestVersion>, Serializable {
   public String toString() {
     return "" + major + "." + minor + "." + release;
   }
-
 
   @Override
   public boolean equals(Object o) {

--- a/geode-junit/src/main/java/org/apache/geode/test/version/TestVersions.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/TestVersions.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.test.version;
+
+import java.util.function.Predicate;
+
+/**
+ * Factory methods for predicates to evaluate {@link TestVersion}s.
+ */
+public class TestVersions {
+  /**
+   * Returns a predicate that tests if its argument is less than {@code bound}.
+   *
+   * @param bound the upper bound
+   * @return a predicate that tests if its argument is less than @{code bound}
+   */
+  public static Predicate<TestVersion> lessThan(TestVersion bound) {
+    return v -> v.lessThan(bound);
+  }
+
+  /**
+   * Returns a predicate that tests if its argument is at most {@code bound}.
+   *
+   * @param bound the upper bound
+   * @return a predicate that tests if its argument is at most @{code bound}
+   */
+  public static Predicate<TestVersion> atMost(TestVersion bound) {
+    return v -> v.lessThanOrEqualTo(bound);
+  }
+
+  /**
+   * Returns a predicate that tests if its argument at least {@code bound}.
+   *
+   * @param bound the lower bound
+   * @return a predicate that tests if its argument is at least @{code bound}
+   */
+  public static Predicate<TestVersion> atLeast(TestVersion bound) {
+    return v -> v.greaterThanOrEqualTo(bound);
+  }
+
+  /**
+   * Returns a predicate that tests if its argument is greater than {@code bound}.
+   *
+   * @param bound the lower bound
+   * @return a predicate that tests if its argument is greater than @{code bound}
+   */
+  public static Predicate<TestVersion> greaterThan(TestVersion bound) {
+    return v -> v.greaterThanOrEqualTo(bound);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VmConfiguration.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VmConfiguration.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.test.version;
+
+import static java.lang.String.format;
+import static org.apache.geode.test.version.TestVersion.CURRENT_VERSION;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * A configuration for a JVM used in a Geode test, defined by the version of Geode and the
+ * version of Java.
+ */
+public class VmConfiguration implements Serializable {
+  private final TestVersion geodeVersion;
+  private final JavaVersion javaVersion;
+
+  private VmConfiguration(JavaVersion javaVersion, TestVersion geodeVersion) {
+    this.javaVersion = javaVersion;
+    this.geodeVersion = geodeVersion;
+  }
+
+  /**
+   * Returns a configuration for {@code geodeVersion} and the current JVM's version of Java.
+   *
+   * @param geodeVersion the Geode version for the configuration
+   * @return the configuration
+   */
+  public static VmConfiguration forGeodeVersion(TestVersion geodeVersion) {
+    return new VmConfiguration(JavaVersions.current(), geodeVersion);
+  }
+
+  /**
+   * Returns a configuration for {@code geodeVersion} and the current JVM's version of Java.
+   *
+   * @param geodeVersion the Geode version for the configuration
+   * @return the configuration
+   */
+  public static VmConfiguration forGeodeVersion(String geodeVersion) {
+    return forGeodeVersion(TestVersion.valueOf(geodeVersion));
+  }
+
+  /**
+   * Returns a configuration for {@code javaVersion} and the current JVM's version of Geode.
+   *
+   * @param javaVersion the Java version for the configuration
+   * @return the configuration
+   */
+  public static VmConfiguration forJavaVersion(JavaVersion javaVersion) {
+    return new VmConfiguration(javaVersion, CURRENT_VERSION);
+  }
+
+  /**
+   * @return the configuration of the current JVM
+   */
+  public static VmConfiguration current() {
+    return new VmConfiguration(JavaVersions.current(), CURRENT_VERSION);
+  }
+
+  /**
+   * @return this configuration's Geode version
+   */
+  public TestVersion geodeVersion() {
+    return geodeVersion;
+  }
+
+  /**
+   * @return this configuration's Java version
+   */
+  public JavaVersion javaVersion() {
+    return javaVersion;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    VmConfiguration that = (VmConfiguration) o;
+    return geodeVersion.equals(that.geodeVersion) && javaVersion == that.javaVersion;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(geodeVersion, javaVersion);
+  }
+
+  @Override
+  public String toString() {
+    return format("%s{java=%s, geode=%s}", getClass().getSimpleName(), javaVersion, geodeVersion);
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/version/VmConfigurations.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/version/VmConfigurations.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.test.version;
+
+import static java.util.stream.Collectors.toList;
+import static org.apache.geode.test.version.TestVersion.CURRENT_VERSION;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Methods to enumerate and evaluate VM configurations available for use in Geode tests.
+ */
+public class VmConfigurations {
+  private static final List<VmConfiguration> ALL_CONFIGURATIONS = Stream.concat(
+      currentGeodeWithEachJava(), currentJavaWithEachCompatibleOldGeode())
+      .collect(toList());
+
+  /**
+   * Returns the list of available VM configurations. This includes:
+   * <ul>
+   * <li>Configurations for the current version of Java with each compatible version of Geode.</li>
+   * <li>Configurations for the current version of Geode with each compatible version of Java.</li>
+   * </ul>
+   *
+   * @return the list of available VM configurations
+   */
+  public static List<VmConfiguration> all() {
+    return new ArrayList<>(ALL_CONFIGURATIONS);
+  }
+
+  /**
+   * Returns the list of VM configurations suitable for use as starting configurations in upgrade
+   * tests. Each upgrade configuration has either an old version of Geode or an old version of
+   * Java, but not both.
+   *
+   * @return the list of VM configurations suitable for upgrade tests
+   */
+  public static List<VmConfiguration> upgrades() {
+    return ALL_CONFIGURATIONS.stream()
+        .filter(isUpgrade())
+        .collect(toList());
+  }
+
+  /**
+   * Returns a predicate that applies {@code predicate} to a configuration's Geode version.
+   *
+   * @param predicate a Geode version predicate
+   * @return a predicate that applies {@code predicate} to a configuration's Geode version
+   */
+  public static Predicate<VmConfiguration> hasGeodeVersion(Predicate<TestVersion> predicate) {
+    return config -> predicate.test(config.geodeVersion());
+  }
+
+  /**
+   * Returns a predicate that applies {@code predicate} to a configuration's Java version.
+   *
+   * @param predicate a Java version predicate
+   * @return a predicate that applies {@code predicate} to a configuration's Java version
+   */
+  public static Predicate<VmConfiguration> hasJavaVersion(Predicate<JavaVersion> predicate) {
+    return config -> predicate.test(config.javaVersion());
+  }
+
+  private static Stream<VmConfiguration> currentGeodeWithEachJava() {
+    return JavaVersions.all().stream()
+        .map(VmConfiguration::forJavaVersion);
+  }
+
+  private static Stream<VmConfiguration> currentJavaWithEachCompatibleOldGeode() {
+    return VersionManager.getInstance().getVersionsWithoutCurrent().stream()
+        .map(TestVersion::valueOf)
+        .filter(isCompatibleWithCurrentJava())
+        .map(VmConfiguration::forGeodeVersion);
+  }
+
+  private static Predicate<VmConfiguration> isUpgrade() {
+    return hasGeodeVersion(TestVersions.lessThan(CURRENT_VERSION)).or(
+        hasJavaVersion(JavaVersions.lessThan(JavaVersions.current())));
+  }
+
+  private static Predicate<TestVersion> isCompatibleWithCurrentJava() {
+    return geodeVersion
+    // Every version of Geode is compatible with Java 11 and below
+    -> JavaVersions.current().specificationVersion() <= 11
+        // Geode 1.15 and above are compatible with every Java version through Java 17
+        || geodeVersion.greaterThanOrEqualTo(TestVersion.valueOf("1.15.0"));
+  }
+}

--- a/geode-junit/src/main/resources/org/apache/geode/test/junit/internal/sanctioned-geode-junit-serializables.txt
+++ b/geode-junit/src/main/resources/org/apache/geode/test/junit/internal/sanctioned-geode-junit-serializables.txt
@@ -108,7 +108,9 @@ org/apache/geode/test/junit/rules/serializable/SerializableTestWatcher,false
 org/apache/geode/test/junit/rules/serializable/SerializableTimeout,false
 org/apache/geode/test/junit/rules/serializable/SerializableTimeout$SerializationProxy,false,lookForStuckThread:boolean,timeUnit:java/util/concurrent/TimeUnit,timeout:long
 org/apache/geode/test/junit/support/IgnoreConditionEvaluationException,false
+org/apache/geode/test/version/JavaVersion,false,home:java/lang/String,specificationVersion:int
 org/apache/geode/test/version/TestVersion,false,major:int,minor:int,release:int
+org/apache/geode/test/version/VmConfiguration,false,geodeVersion:org/apache/geode/test/version/TestVersion,javaVersion:org/apache/geode/test/version/JavaVersion
 parReg/query/unittest/NewPortfolio,false,MAX_NUM_OF_POSITIONS:int,MAX_PRICE:int,MAX_QTY:int,NUM_OF_SECURITIES:int,NUM_OF_TYPES:int,id:int,myVersion:java/lang/String,name:java/lang/String,positions:java/util/Map,status:java/lang/String,type:java/lang/String,undefinedTestField:java/lang/String
 parReg/query/unittest/Position,false,MAX_PRICE:int,NUM_OF_SECURITIES:int,mktValue:double,qty:double,secId:java/lang/String
 util/TestException,false

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServersAreRolled.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServersAreRolled.java
@@ -35,10 +35,10 @@ public class RollingUpgradeQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServe
   public void luceneQueryReturnsCorrectResultAfterTwoLocatorsWithTwoServersAreRolled()
       throws Exception {
     final Host host = Host.getHost(0);
-    VM locator1 = host.getVM(oldVersion, 0);
-    VM locator2 = host.getVM(oldVersion, 1);
-    VM server1 = host.getVM(oldVersion, 2);
-    VM server2 = host.getVM(oldVersion, 3);
+    VM locator1 = host.getVM(sourceConfiguration, 0);
+    VM locator2 = host.getVM(sourceConfiguration, 1);
+    VM server1 = host.getVM(sourceConfiguration, 2);
+    VM server2 = host.getVM(sourceConfiguration, 3);
 
     final String regionName = "aRegion";
     RegionShortcut shortcut = RegionShortcut.PARTITION_REDUNDANT;

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOver.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOver.java
@@ -35,10 +35,10 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRol
   public void luceneQueryReturnsCorrectResultsAfterClientAndServersAreRolledOver()
       throws Exception {
     final Host host = Host.getHost(0);
-    VM locator = host.getVM(oldVersion, 0);
-    VM server2 = host.getVM(oldVersion, 1);
-    VM server3 = host.getVM(oldVersion, 2);
-    VM client = host.getVM(oldVersion, 3);
+    VM locator = host.getVM(sourceConfiguration, 0);
+    VM server2 = host.getVM(sourceConfiguration, 1);
+    VM server3 = host.getVM(sourceConfiguration, 2);
+    VM client = host.getVM(sourceConfiguration, 3);
 
     final String regionName = "aRegion";
     String regionType = "partitionedRedundant";

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOverAllBucketsCreated.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRolledOverAllBucketsCreated.java
@@ -47,10 +47,10 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterClientAndServersAreRol
     // buckets
     // - do a query which causes the IndexFormatTooNewException to be thrown
     final Host host = Host.getHost(0);
-    VM locator = host.getVM(oldVersion, 0);
-    VM server1 = host.getVM(oldVersion, 1);
-    VM server2 = host.getVM(oldVersion, 2);
-    VM client = host.getVM(oldVersion, 3);
+    VM locator = host.getVM(sourceConfiguration, 0);
+    VM server1 = host.getVM(sourceConfiguration, 1);
+    VM server2 = host.getVM(sourceConfiguration, 2);
+    VM client = host.getVM(sourceConfiguration, 3);
 
     final String regionName = "aRegion";
     String regionType = "partitionedRedundant";

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterServersRollOverOnPartitionRegion.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterServersRollOverOnPartitionRegion.java
@@ -21,7 +21,7 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterServersRollOverOnParti
   @Test
   public void luceneQueryReturnsCorrectResultsAfterServersRollOverOnPartitionRegion()
       throws Exception {
-    executeLuceneQueryWithServerRollOvers("partitionedRedundant", oldVersion);
+    executeLuceneQueryWithServerRollOvers("partitionedRedundant", sourceConfiguration);
   }
 
 }

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterServersRollOverOnPersistentPartitionRegion.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeQueryReturnsCorrectResultsAfterServersRollOverOnPersistentPartitionRegion.java
@@ -22,7 +22,7 @@ public class RollingUpgradeQueryReturnsCorrectResultsAfterServersRollOverOnPersi
   @Test
   public void luceneQueryReturnsCorrectResultsAfterServersRollOverOnPersistentPartitionRegion()
       throws Exception {
-    executeLuceneQueryWithServerRollOvers("persistentPartitioned", oldVersion);
+    executeLuceneQueryWithServerRollOvers("persistentPartitioned", sourceConfiguration);
   }
 
 }

--- a/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion.java
+++ b/geode-lucene/src/upgradeTest/java/org/apache/geode/cache/lucene/RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion.java
@@ -15,11 +15,11 @@
 package org.apache.geode.cache.lucene;
 
 import static org.apache.geode.test.awaitility.GeodeAwaitility.await;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.assertj.core.api.Assertions;
-import org.junit.Assume;
 import org.junit.Test;
 
 import org.apache.geode.cache.RegionShortcut;
@@ -31,19 +31,22 @@ import org.apache.geode.test.dunit.DistributedTestUtils;
 import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.NetworkUtils;
 import org.apache.geode.test.dunit.VM;
+import org.apache.geode.test.version.TestVersion;
 
 public class RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion
     extends LuceneSearchWithRollingUpgradeDUnit {
 
   @Test
   public void luceneReindexShouldBeSuccessfulWhenAllServersRollToCurrentVersion() throws Exception {
-    Assume.assumeFalse("minor versions should be different",
-        majorMinor(oldVersion).equals(majorMinor(KnownVersion.CURRENT.getName())));
+    assumeThat(sourceConfiguration.geodeVersion().majorMinor())
+        .as("source configuration Geode version major minor")
+        .isNotEqualTo(TestVersion.CURRENT_VERSION.majorMinor())
+        .isNotEqualTo(majorMinor(KnownVersion.CURRENT.getName()));
 
     final Host host = Host.getHost(0);
-    VM locator1 = host.getVM(oldVersion, 0);
-    VM server1 = host.getVM(oldVersion, 1);
-    VM server2 = host.getVM(oldVersion, 2);
+    VM locator1 = host.getVM(sourceConfiguration, 0);
+    VM server1 = host.getVM(sourceConfiguration, 1);
+    VM server2 = host.getVM(sourceConfiguration, 2);
 
     final String regionName = "aRegion";
     RegionShortcut shortcut = RegionShortcut.PARTITION_REDUNDANT;
@@ -120,8 +123,7 @@ public class RollingUpgradeReindexShouldBeSuccessfulWhenAllServersRollToCurrentV
    */
   private static String majorMinor(String version) {
     String[] parts = version.split("\\.");
-    Assertions.assertThat(parts.length).isGreaterThanOrEqualTo(2);
+    assertThat(parts.length).isGreaterThanOrEqualTo(2);
     return parts[0] + "." + parts[1];
   }
-
 }

--- a/geode-tcp-server/src/upgradeTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionUpgradeTest.java
+++ b/geode-tcp-server/src/upgradeTest/java/org/apache/geode/distributed/internal/tcpserver/TcpServerProductVersionUpgradeTest.java
@@ -52,7 +52,6 @@ import org.apache.geode.internal.net.SocketCreatorFactory;
 import org.apache.geode.internal.security.SecurableCommunicationChannel;
 import org.apache.geode.test.awaitility.GeodeAwaitility;
 import org.apache.geode.test.dunit.DistributedTestUtils;
-import org.apache.geode.test.dunit.Host;
 import org.apache.geode.test.dunit.SerializableRunnableIF;
 import org.apache.geode.test.dunit.VM;
 import org.apache.geode.test.dunit.internal.DUnitLauncher;
@@ -156,9 +155,8 @@ public class TcpServerProductVersionUpgradeTest implements Serializable {
     int locatorVMNumber =
         versions.locatorProductVersion.equals(TestVersion.CURRENT_VERSION)
             ? DUnitLauncher.DEBUGGING_VM_NUM : 0;
-    VM clientVM = Host.getHost(0).getVM(versions.clientProductVersion.toString(), clientVMNumber);
-    VM locatorVM =
-        Host.getHost(0).getVM(versions.locatorProductVersion.toString(), locatorVMNumber);
+    VM clientVM = VM.getVM(versions.clientProductVersion.toString(), clientVMNumber);
+    VM locatorVM = VM.getVM(versions.locatorProductVersion.toString(), locatorVMNumber);
     int locatorPort = createLocator(locatorVM);
 
     clientVM.invoke("issue version request",

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo.java
@@ -36,10 +36,10 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo
     final Host host = Host.getHost(0);
 
     // Get mixed site members
-    VM site1Locator = host.getVM(oldVersion, 0);
-    VM site1Server1 = host.getVM(oldVersion, 1);
-    VM site1Server2 = host.getVM(oldVersion, 2);
-    VM site1Client = host.getVM(oldVersion, 3);
+    VM site1Locator = host.getVM(sourceVmConfiguration, 0);
+    VM site1Server1 = host.getVM(sourceVmConfiguration, 1);
+    VM site1Server2 = host.getVM(sourceVmConfiguration, 2);
+    VM site1Client = host.getVM(sourceVmConfiguration, 3);
 
     // Get current site members
     VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
@@ -81,8 +81,9 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo
     });
 
     // Start and configure mixed site servers
-    String regionName = getName() + "_region";
-    String site1SenderId = getName() + "_gatewaysender_" + site2DistributedSystemId;
+    String sanitizedTestName = getSanitizedTestName();
+    String regionName = sanitizedTestName + "_region";
+    String site1SenderId = sanitizedTestName + "_gatewaysender_" + site2DistributedSystemId;
     startAndConfigureServers(site1Server1, site1Server2, site1Locators, site2DistributedSystemId,
         regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 
@@ -95,7 +96,7 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneCurrentSiteTwo
         regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 
     // Start and configure old current servers
-    String site2SenderId = getName() + "_gatewaysender_" + site1DistributedSystemId;
+    String site2SenderId = sanitizedTestName + "_gatewaysender_" + site1DistributedSystemId;
     startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
         regionName, site2SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingMixedSiteOneOldSiteTwo.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingMixedSiteOneOldSiteTwo.java
@@ -35,15 +35,15 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneOldSiteTwo
     final Host host = Host.getHost(0);
 
     // Get mixed site members
-    VM site1Locator = host.getVM(oldVersion, 0);
-    VM site1Server1 = host.getVM(oldVersion, 1);
-    VM site1Server2 = host.getVM(oldVersion, 2);
-    VM site1Client = host.getVM(oldVersion, 3);
+    VM site1Locator = host.getVM(sourceVmConfiguration, 0);
+    VM site1Server1 = host.getVM(sourceVmConfiguration, 1);
+    VM site1Server2 = host.getVM(sourceVmConfiguration, 2);
+    VM site1Client = host.getVM(sourceVmConfiguration, 3);
 
     // Get old site members
-    VM site2Locator = host.getVM(oldVersion, 4);
-    VM site2Server1 = host.getVM(oldVersion, 5);
-    VM site2Server2 = host.getVM(oldVersion, 6);
+    VM site2Locator = host.getVM(sourceVmConfiguration, 4);
+    VM site2Server1 = host.getVM(sourceVmConfiguration, 5);
+    VM site2Server2 = host.getVM(sourceVmConfiguration, 6);
 
     // Get mixed site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
@@ -81,8 +81,9 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneOldSiteTwo
                     || InternalLocator.getLocator().isSharedConfigurationRunning())));
 
     // Start and configure mixed site servers
-    String regionName = getName() + "_region";
-    String site1SenderId = getName() + "_gatewaysender_" + site2DistributedSystemId;
+    String sanitizedTestName = getSanitizedTestName();
+    String regionName = sanitizedTestName + "_region";
+    String site1SenderId = sanitizedTestName + "_gatewaysender_" + site2DistributedSystemId;
     startAndConfigureServers(site1Server1, site1Server2, site1Locators, site2DistributedSystemId,
         regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 
@@ -95,7 +96,7 @@ public class WANRollingUpgradeEventProcessingMixedSiteOneOldSiteTwo
         regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 
     // Start and configure old site servers
-    String site2SenderId = getName() + "_gatewaysender_" + site1DistributedSystemId;
+    String site2SenderId = sanitizedTestName + "_gatewaysender_" + site1DistributedSystemId;
     startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
         regionName, site2SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingOldSiteOneCurrentSiteTwo.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeEventProcessingOldSiteOneCurrentSiteTwo.java
@@ -37,10 +37,10 @@ public class WANRollingUpgradeEventProcessingOldSiteOneCurrentSiteTwo
     final Host host = Host.getHost(0);
 
     // Get old site members
-    VM site1Locator = host.getVM(oldVersion, 0);
-    VM site1Server1 = host.getVM(oldVersion, 1);
-    VM site1Server2 = host.getVM(oldVersion, 2);
-    VM site1Client = host.getVM(oldVersion, 3);
+    VM site1Locator = host.getVM(sourceVmConfiguration, 0);
+    VM site1Server1 = host.getVM(sourceVmConfiguration, 1);
+    VM site1Server2 = host.getVM(sourceVmConfiguration, 2);
+    VM site1Client = host.getVM(sourceVmConfiguration, 3);
 
     // Get current site members
     VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
@@ -80,13 +80,14 @@ public class WANRollingUpgradeEventProcessingOldSiteOneCurrentSiteTwo
         site2Locators, site1Locators));
 
     // Start and configure old site servers
-    String regionName = getName() + "_region";
-    String site1SenderId = getName() + "_gatewaysender_" + site2DistributedSystemId;
+    String sanitizedTestName = getSanitizedTestName();
+    String regionName = sanitizedTestName + "_region";
+    String site1SenderId = sanitizedTestName + "_gatewaysender_" + site2DistributedSystemId;
     startAndConfigureServers(site1Server1, site1Server2, site1Locators, site2DistributedSystemId,
         regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 
     // Start and configure current site servers
-    String site2SenderId = getName() + "_gatewaysender_" + site1DistributedSystemId;
+    String site2SenderId = sanitizedTestName + "_gatewaysender_" + site1DistributedSystemId;
     startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
         regionName, site2SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeNewSenderProcessOldEvent.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeNewSenderProcessOldEvent.java
@@ -60,15 +60,15 @@ public class WANRollingUpgradeNewSenderProcessOldEvent
   @Before
   public void prepare() {
     // Get mixed site members
-    site1Locator = host.getVM(oldVersion, 0);
-    site1Server1 = host.getVM(oldVersion, 1);
-    site1Server2 = host.getVM(oldVersion, 2);
-    site1Client = host.getVM(oldVersion, 3);
+    site1Locator = host.getVM(sourceVmConfiguration, 0);
+    site1Server1 = host.getVM(sourceVmConfiguration, 1);
+    site1Server2 = host.getVM(sourceVmConfiguration, 2);
+    site1Client = host.getVM(sourceVmConfiguration, 3);
 
     // Get old site members
-    site2Locator = host.getVM(oldVersion, 4);
-    site2Server1 = host.getVM(oldVersion, 5);
-    site2Server2 = host.getVM(oldVersion, 6);
+    site2Locator = host.getVM(sourceVmConfiguration, 4);
+    site2Server1 = host.getVM(sourceVmConfiguration, 5);
+    site2Server2 = host.getVM(sourceVmConfiguration, 6);
 
     // Get mixed site locator properties
     String hostName = NetworkUtils.getServerHostName(host);
@@ -104,12 +104,13 @@ public class WANRollingUpgradeNewSenderProcessOldEvent
                     || InternalLocator.getLocator().isSharedConfigurationRunning())));
 
     // Start and configure mixed site servers
-    regionName = getName() + "_region";
-    site1SenderId = getName() + "_gatewaysender_" + site2DistributedSystemId;
+    String sanitizedTestName = getSanitizedTestName();
+    regionName = sanitizedTestName + "_region";
+    site1SenderId = sanitizedTestName + "_gatewaysender_" + site2DistributedSystemId;
     startAndConfigureServers(site1Server1, site1Server2, site1Locators, site2DistributedSystemId,
         regionName, site1SenderId, ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL);
 
-    site2SenderId = getName() + "_gatewaysender_" + site1DistributedSystemId;
+    site2SenderId = sanitizedTestName + "_gatewaysender_" + site1DistributedSystemId;
 
     // pause the senders at mixed site
     site1Server1.invoke(() -> pauseSender(site1SenderId));

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailover.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailover.java
@@ -34,9 +34,9 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMembe
     final Host host = Host.getHost(0);
 
     // Get old site members
-    VM site1Locator = host.getVM(oldVersion, 0);
-    VM site1Server1 = host.getVM(oldVersion, 1);
-    VM site1Server2 = host.getVM(oldVersion, 2);
+    VM site1Locator = host.getVM(sourceVmConfiguration, 0);
+    VM site1Server1 = host.getVM(sourceVmConfiguration, 1);
+    VM site1Server2 = host.getVM(sourceVmConfiguration, 2);
 
     // Get current site members
     VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
@@ -77,13 +77,14 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMembe
 
     try {
       // Start and configure old site servers with secondary removals prevented
-      String regionName = getName() + "_region";
-      String site1SenderId = getName() + "_gatewaysender_" + site2DistributedSystemId;
+      String sanitizedTestName = getSanitizedTestName();
+      String regionName = sanitizedTestName + "_region";
+      String site1SenderId = sanitizedTestName + "_gatewaysender_" + site2DistributedSystemId;
       startAndConfigureServers(site1Server1, site1Server2, site1Locators, site2DistributedSystemId,
           regionName, site1SenderId, Integer.MAX_VALUE);
 
       // Start and configure current site servers with secondary removals prevented
-      String site2SenderId = getName() + "_gatewaysender_" + site1DistributedSystemId;
+      String site2SenderId = sanitizedTestName + "_gatewaysender_" + site1DistributedSystemId;
       startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
           regionName, site2SenderId, Integer.MAX_VALUE);
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailoverWithOldClient.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMemberFailoverWithOldClient.java
@@ -35,10 +35,10 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMembe
     final Host host = Host.getHost(0);
 
     // Get old site members
-    VM site1Locator = host.getVM(oldVersion, 0);
-    VM site1Server1 = host.getVM(oldVersion, 1);
-    VM site1Server2 = host.getVM(oldVersion, 2);
-    VM site1Client = host.getVM(oldVersion, 3);
+    VM site1Locator = host.getVM(sourceVmConfiguration, 0);
+    VM site1Server1 = host.getVM(sourceVmConfiguration, 1);
+    VM site1Server2 = host.getVM(sourceVmConfiguration, 2);
+    VM site1Client = host.getVM(sourceVmConfiguration, 3);
 
     // Get current site members
     VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
@@ -78,13 +78,14 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterCurrentSiteMembe
 
     try {
       // Start and configure old site servers with secondary removals prevented
-      String regionName = getName() + "_region";
-      String site1SenderId = getName() + "_gatewaysender_" + site2DistributedSystemId;
+      String sanitizedTestName = getSanitizedTestName();
+      String regionName = sanitizedTestName + "_region";
+      String site1SenderId = sanitizedTestName + "_gatewaysender_" + site2DistributedSystemId;
       startAndConfigureServers(site1Server1, site1Server2, site1Locators, site2DistributedSystemId,
           regionName, site1SenderId, Integer.MAX_VALUE);
 
       // Start and configure current site servers with secondary removals prevented
-      String site2SenderId = getName() + "_gatewaysender_" + site1DistributedSystemId;
+      String site2SenderId = sanitizedTestName + "_gatewaysender_" + site1DistributedSystemId;
       startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
           regionName, site2SenderId, Integer.MAX_VALUE);
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterOldSiteMemberFailover.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeSecondaryEventsNotReprocessedAfterOldSiteMemberFailover.java
@@ -34,10 +34,10 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterOldSiteMemberFai
     final Host host = Host.getHost(0);
 
     // Get old site members
-    VM site1Locator = host.getVM(oldVersion, 0);
-    VM site1Server1 = host.getVM(oldVersion, 1);
-    VM site1Server2 = host.getVM(oldVersion, 2);
-    VM site1Client = host.getVM(oldVersion, 3);
+    VM site1Locator = host.getVM(sourceVmConfiguration, 0);
+    VM site1Server1 = host.getVM(sourceVmConfiguration, 1);
+    VM site1Server2 = host.getVM(sourceVmConfiguration, 2);
+    VM site1Client = host.getVM(sourceVmConfiguration, 3);
 
     // Get current site members
     VM site2Locator = host.getVM(VersionManager.CURRENT_VERSION, 4);
@@ -77,13 +77,14 @@ public class WANRollingUpgradeSecondaryEventsNotReprocessedAfterOldSiteMemberFai
 
     try {
       // Start and configure old site servers with secondary removals prevented
-      String regionName = getName() + "_region";
-      String site1SenderId = getName() + "_gatewaysender_" + site2DistributedSystemId;
+      String sanitizedTestName = getSanitizedTestName();
+      String regionName = sanitizedTestName + "_region";
+      String site1SenderId = sanitizedTestName + "_gatewaysender_" + site2DistributedSystemId;
       startAndConfigureServers(site1Server1, site1Server2, site1Locators, site2DistributedSystemId,
           regionName, site1SenderId, Integer.MAX_VALUE);
 
       // Start and configure current site servers with secondary removals prevented
-      String site2SenderId = getName() + "_gatewaysender_" + site1DistributedSystemId;
+      String site2SenderId = sanitizedTestName + "_gatewaysender_" + site1DistributedSystemId;
       startAndConfigureServers(site2Server1, site2Server2, site2Locators, site1DistributedSystemId,
           regionName, site2SenderId, Integer.MAX_VALUE);
 

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeVerifyGatewayReceiverDoesNotSendRemoveCacheServerProfileToMembersOlderThan1dot5.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeVerifyGatewayReceiverDoesNotSendRemoveCacheServerProfileToMembersOlderThan1dot5.java
@@ -34,8 +34,8 @@ public class WANRollingUpgradeVerifyGatewayReceiverDoesNotSendRemoveCacheServerP
   @Test
   public void VerifyGatewayReceiverDoesNotSendRemoveCacheServerProfileToMembersOlderThan1dot5() {
     final Host host = Host.getHost(0);
-    VM oldLocator = host.getVM(oldVersion, 0);
-    VM oldServer = host.getVM(oldVersion, 1);
+    VM oldLocator = host.getVM(sourceVmConfiguration, 0);
+    VM oldServer = host.getVM(sourceVmConfiguration, 1);
     VM currentServer = host.getVM(VersionManager.CURRENT_VERSION, 2);
 
     // Start locator

--- a/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeVerifyGatewaySenderProfile.java
+++ b/geode-wan/src/upgradeTest/java/org/apache/geode/cache/wan/WANRollingUpgradeVerifyGatewaySenderProfile.java
@@ -34,8 +34,8 @@ public class WANRollingUpgradeVerifyGatewaySenderProfile extends WANRollingUpgra
   // This test verifies that a GatewaySenderProfile serializes properly between versions new to old.
   public void testVerifyGatewaySenderProfile() {
     final Host host = Host.getHost(0);
-    VM oldLocator = host.getVM(oldVersion, 0);
-    VM oldServer = host.getVM(oldVersion, 1);
+    VM oldLocator = host.getVM(sourceVmConfiguration, 0);
+    VM oldServer = host.getVM(sourceVmConfiguration, 1);
     VM currentServer = host.getVM(VersionManager.CURRENT_VERSION, 2);
 
     // Start locator
@@ -59,7 +59,7 @@ public class WANRollingUpgradeVerifyGatewaySenderProfile extends WANRollingUpgra
                       || InternalLocator.getLocator().isSharedConfigurationRunning())));
 
       // Create GatewaySender in old server
-      String senderId = getName() + "_gatewaysender";
+      String senderId = getSanitizedTestName() + "_gatewaysender";
       oldServer.invoke(() -> createGatewaySender(senderId, 10,
           ParallelGatewaySenderQueue.DEFAULT_MESSAGE_SYNC_INTERVAL));
 
@@ -78,8 +78,8 @@ public class WANRollingUpgradeVerifyGatewaySenderProfile extends WANRollingUpgra
   // This test verifies that a GatewaySenderProfile serializes properly between versions old to new.
   public void testOldServerCanUnderstandNewGatewaySenderProfile() {
 
-    VM oldLocator = VM.getVM(oldVersion, 0);
-    VM oldServer = VM.getVM(oldVersion, 1);
+    VM oldLocator = VM.getVM(sourceVmConfiguration, 0);
+    VM oldServer = VM.getVM(sourceVmConfiguration, 1);
     VM currentServer = VM.getVM(VersionManager.CURRENT_VERSION, 2);
 
     // Start locator
@@ -91,7 +91,7 @@ public class WANRollingUpgradeVerifyGatewaySenderProfile extends WANRollingUpgra
     IgnoredException ie =
         IgnoredException.addIgnoredException("could not get remote locator information");
     try {
-      String senderId = getName() + "_gatewaysender";
+      String senderId = getSanitizedTestName() + "_gatewaysender";
 
       // Start current server
       currentServer.invoke(() -> createCache(locators));


### PR DESCRIPTION
- WIP: Add UpgradeSource
- Make DUnit framework launch with specified Java home
- Extract TestJavaVersions
- Fix more things
- Cluster config test can upgrade JDK
- UpgradeSource -> TestVmDescriptor
- Names
- Pass VmConfig down
- ClusterCommunicationsDUnitTest
- Lucene rolling upgrade tests
- WAN rolling upgrade tests
- Security upgrade tests
