### PR TITLE
GEODE-10046: fix classgraph version in LICENSE

### DIFF
--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -1064,7 +1064,7 @@ Apache Geode bundles the following files under the MIT License:
 
   - Checker Qual v3.12.0 (https://checkerframework.org), Copyright (c)
     2004-present by the Checker Framework developers
-  - ClassGraph v4.8.143 (https://github.com/classgraph/classgraph), Copyright
+  - ClassGraph v4.8.146 (https://github.com/classgraph/classgraph), Copyright
     (c) 2019 Luke Hutchison
   - HTML5 Shiv vpre3.5 (https://github.com/aFarkas/html5shiv), Copyright
     (c) 2014 Alexander Farkas (aFarkas)


### PR DESCRIPTION
this was overlooked in #7605 and again in #7650, oops