### PR TITLE
GEODE-10295: fix ambiguous overload

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesSet.java
@@ -242,7 +242,7 @@ public class EntriesSet extends AbstractSet implements LogWithToString {
 
   @Override
   public Object[] toArray() {
-    return toArray(null);
+    return toArray((Object[]) null);
   }
 
   @Override


### PR DESCRIPTION
GEODE-6588 mass cleanup removed an explicit cast to remove a warning, however in JDK11, the cast is necessary to disambiguate against a new overloaded added to an interface this class implements, so might be better to keep it
