### PR TITLE
GEODE-10294: Compare invalid token during putIfAbsent retry.

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
@@ -409,7 +409,7 @@ public class RegionMapPut extends AbstractRegionMapPut {
             event.isPossibleDuplicate()) {
           Object retainedValue = getRegionEntry().getValueRetain(getOwner());
           try {
-            if (isSomeValueAlreadyInCacheForPutIfAbsent(retainedValue)) {
+            if (isSameValueAlreadyInCacheForPutIfAbsent(retainedValue)) {
               if (logger.isDebugEnabled()) {
                 logger.debug("retried putIfAbsent found same value already in cache "
                     + "- allowing the operation.  entry={}; event={}", getRegionEntry(),
@@ -428,7 +428,7 @@ public class RegionMapPut extends AbstractRegionMapPut {
     return true;
   }
 
-  private boolean isSomeValueAlreadyInCacheForPutIfAbsent(Object retainedValue) {
+  private boolean isSameValueAlreadyInCacheForPutIfAbsent(Object retainedValue) {
     if (Token.isInvalid(retainedValue)) {
       return getEvent().getRawNewValue() == null || Token.isInvalid(getEvent().getRawNewValue());
     }

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
@@ -409,9 +409,7 @@ public class RegionMapPut extends AbstractRegionMapPut {
             event.isPossibleDuplicate()) {
           Object retainedValue = getRegionEntry().getValueRetain(getOwner());
           try {
-            if (ValueComparisonHelper.checkEquals(retainedValue,
-                getEvent().getRawNewValue(),
-                isCompressedOffHeap(event), getOwner().getCache())) {
+            if (isSomeValueAlreadyInCacheForPutIfAbsent(retainedValue)) {
               if (logger.isDebugEnabled()) {
                 logger.debug("retried putIfAbsent found same value already in cache "
                     + "- allowing the operation.  entry={}; event={}", getRegionEntry(),
@@ -428,6 +426,16 @@ public class RegionMapPut extends AbstractRegionMapPut {
       }
     }
     return true;
+  }
+
+  private boolean isSomeValueAlreadyInCacheForPutIfAbsent(Object retainedValue) {
+    if (Token.isInvalid(retainedValue)) {
+      return getEvent().getRawNewValue() == null || Token.isInvalid(getEvent().getRawNewValue());
+    }
+
+    return ValueComparisonHelper.checkEquals(retainedValue,
+        getEvent().getRawNewValue(),
+        isCompressedOffHeap(getEvent()), getOwner().getCache());
   }
 
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapPutTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapPutTest.java
@@ -137,9 +137,20 @@ public class RegionMapPutTest {
   public void doesNotSetEventOldValueIfRetriedPutIfAbsentOperation() {
     final byte[] bytes = new byte[] {1, 2, 3, 4, 5};
     givenExistingRegionEntry();
-    when(existingRegionEntry.getValue()).thenReturn(bytes);
+    when(existingRegionEntry.getValueRetain(internalRegion)).thenReturn(bytes);
     when(internalRegion.getConcurrencyChecksEnabled()).thenReturn(true);
     givenPutIfAbsentOperation(bytes); // duplicate operation
+    doPut();
+    verify(event).setOldValue(null, true);
+    assertThat(instance.isOverwritePutIfAbsent()).isTrue();
+  }
+
+  @Test
+  public void doesNotSetEventOldValueIfRetriedPutIfAbsentOperationOfNull() {
+    givenExistingRegionEntry();
+    when(existingRegionEntry.getValueRetain(internalRegion)).thenReturn(Token.INVALID);
+    when(internalRegion.getConcurrencyChecksEnabled()).thenReturn(true);
+    givenPutIfAbsentOperation(null); // duplicate operation
     doPut();
     verify(event).setOldValue(null, true);
     assertThat(instance.isOverwritePutIfAbsent()).isTrue();
@@ -149,7 +160,7 @@ public class RegionMapPutTest {
   public void overWritePutIfAbsentIsTrueIfRetriedPutIfAbsentOperationHavingValidVersionTag() {
     final byte[] bytes = new byte[] {1, 2, 3, 4, 5};
     givenExistingRegionEntry();
-    when(existingRegionEntry.getValue()).thenReturn(bytes);
+    when(existingRegionEntry.getValueRetain(internalRegion)).thenReturn(bytes);
     when(internalRegion.getConcurrencyChecksEnabled()).thenReturn(true);
     givenPutIfAbsentOperation(bytes); // duplicate operation
     when(event.hasValidVersionTag()).thenReturn(true);
@@ -162,7 +173,7 @@ public class RegionMapPutTest {
 
   private void givenPutIfAbsentOperation(byte[] bytes) {
     when(event.isPossibleDuplicate()).thenReturn(true);
-    when(event.basicGetNewValue()).thenReturn(bytes);
+    when(event.getRawNewValue()).thenReturn(bytes);
     when(event.getOperation()).thenReturn(Operation.PUT_IF_ABSENT);
     when(event.hasValidVersionTag()).thenReturn(false);
     ifNew = true;


### PR DESCRIPTION
 * During putIfAbsent retry, comparing invalid token value when
   putIfAbsent of a null value instead.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
