### PR TITLE
GEODE-10309: Enable parallel tests for windows-gfsh-distributed-test

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -177,17 +177,17 @@ tests:
   RAM: '8'
   name: windows-acceptance
 - ARTIFACT_SLUG: windows-gfshdistributedtest
-  CPUS: '6'
+  CPUS: '16'
   DISK: '200GB'
-  DUNIT_PARALLEL_FORKS: '0'
+  DUNIT_PARALLEL_FORKS: '8'
   EXECUTE_TEST_TIMEOUT: 6h
   GRADLE_TASK: distributedTest
   GRADLE_TASK_OPTIONS: -PtestCategory=org.apache.geode.test.junit.categories.GfshTest
   MAX_IN_FLIGHT: 3
-  PARALLEL_DUNIT: 'false'
-  PARALLEL_GRADLE: 'false'
+  PARALLEL_DUNIT: 'true'
+  PARALLEL_GRADLE: 'true'
   PLATFORM: windows
-  RAM: '12'
+  RAM: '32'
   name: windows-gfsh-distributed
 - ARTIFACT_SLUG: windows-integrationtestfiles
   CPUS: '6'


### PR DESCRIPTION
Using the test-isolation plugin for parallelism, instead of Docker,
enables parallel testing on Windows for some jobs.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
