### PR TITLE
GEODE-10302: Increase call stack timeout for upgrade tests

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -141,7 +141,7 @@ tests:
   RAM: '90'
   name: integration
 - ARTIFACT_SLUG: upgradetestfiles
-  CALL_STACK_TIMEOUT: '8400'
+  CALL_STACK_TIMEOUT: '13500'
   CPUS: '96'
   DISK: '200GB'
   DUNIT_PARALLEL_FORKS: '48'


### PR DESCRIPTION
To be 3h45m, 15 minutes shy of the newly increased task timeout.
