### PR TITLE
GEODE-10304: locator thread should not exit after reconnecting

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/cache30/ReconnectDUnitTest.java
@@ -528,10 +528,9 @@ public class ReconnectDUnitTest extends JUnit4CacheTestCase {
       startWaitOnLocatorToStopThread(vm0);
       forceDisconnect(vm0);
       newdm = waitForReconnect(vm0);
-      // wait for some time before checking to make sure the thread won't exit.
-      Thread.sleep(1000);
       vm0.invoke("assert the locator thread is still waiting", () -> {
-        assertThat(waitOnLocatorToStopThread.isAlive()).isTrue();
+        await().during(1, SECONDS)
+            .untilAsserted(() -> assertThat(waitOnLocatorToStopThread.isAlive()).isTrue());
       });
 
       assertTrue("Expected the restarted member to be hosting a running locator",

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1077,16 +1077,12 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
       restarted = false;
       membershipLocator.waitToShutdown();
       if (stoppedForReconnect) {
-        logger.info("waiting for distributed system to disconnect...");
-        while (system.isConnected()) {
-          Thread.sleep(5000);
-        }
         // there would be a gap between stoppedForReconnect being to true and isReconnecting()
         // being true, if system.waitUntilReconnected happened in between, this method would return
         // false immediately. We should also to wait till system is reconnecting here
         // in this call to prevent that.
-        logger.info("waiting for distributed system to reconnect...");
-        while (!system.isReconnecting()) {
+        logger.info("waiting for distributed system to disconnect and reconnect...");
+        while (system.isConnected() || !system.isReconnecting()) {
           Thread.sleep(1000);
         }
 

--- a/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
+++ b/geode-core/src/main/java/org/apache/geode/distributed/internal/InternalLocator.java
@@ -1081,9 +1081,10 @@ public class InternalLocator extends Locator implements ConnectListener, LogConf
         while (system.isConnected()) {
           Thread.sleep(5000);
         }
-        // there would be a gap between stoppedForReconnect being to true and attemptingToReconnect
+        // there would be a gap between stoppedForReconnect being to true and isReconnecting()
         // being true, if system.waitUntilReconnected happened in between, this method would return
-        // with "restarted" being false, so we need also to wait till system is reconnecting
+        // false immediately. We should also to wait till system is reconnecting here
+        // in this call to prevent that.
         logger.info("waiting for distributed system to reconnect...");
         while (!system.isReconnecting()) {
           Thread.sleep(1000);


### PR DESCRIPTION
* Also refactor ReconnectDUnitTest to use lamdas instead of `Callable` and `Runnable` interfaces.

This flakiness shows up in a test. In a production environment, the call to `locator.waitToStop()` happened immediately after the locator is launched, not as the test, it happened just before we force to stop the locator, so a rare race condition in the call would make the thread to exit.