### PR TITLE
GEODE-10320: Bump micrometer from 1.8.5 to 1.9.0

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -195,7 +195,7 @@
       <dependency>
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-core</artifactId>
-        <version>1.8.5</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <groupId>io.swagger.core.v3</groupId>

--- a/build-tools/geode-dependency-management/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/build-tools/geode-dependency-management/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -40,7 +40,7 @@ class DependencyConstraints {
     deps.put("javax.transaction-api.version", "1.3")
     deps.put("jgroups.version", "3.6.14.Final")
     deps.put("log4j.version", "2.17.2")
-    deps.put("micrometer.version", "1.8.5")
+    deps.put("micrometer.version", "1.9.0")
     deps.put("shiro.version", "1.9.0")
     deps.put("slf4j-api.version", "1.7.32")
     deps.put("jboss-modules.version", "1.11.0.Final")

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1038,7 +1038,7 @@ lib/lucene-analyzers-phonetic-6.6.6.jar
 lib/lucene-core-6.6.6.jar
 lib/lucene-queries-6.6.6.jar
 lib/lucene-queryparser-6.6.6.jar
-lib/micrometer-core-1.8.5.jar
+lib/micrometer-core-1.9.0.jar
 lib/mx4j-3.0.2.jar
 lib/mx4j-remote-3.0.2.jar
 lib/mx4j-tools-3.0.1.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -54,7 +54,7 @@ commons-digester-2.1.jar
 commons-io-2.11.0.jar
 commons-logging-1.2.jar
 classgraph-4.8.146.jar
-micrometer-core-1.8.5.jar
+micrometer-core-1.9.0.jar
 fastutil-8.5.8.jar
 javax.resource-api-1.7.1.jar
 jetty-webapp-9.4.46.v20220331.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -72,7 +72,7 @@ jna-platform-5.11.0.jar
 log4j-jul-2.17.2.jar
 HdrHistogram-2.1.12.jar
 jackson-annotations-2.13.2.jar
-micrometer-core-1.8.5.jar
+micrometer-core-1.9.0.jar
 shiro-config-ogdl-1.9.0.jar
 geode-log4j-0.0.0.jar
 lucene-analyzers-phonetic-6.6.6.jar


### PR DESCRIPTION
Geode endeavors to update to the latest version of 3rd-party
dependencies on develop wherever possible.  Doing so increases the
shelf life of releases and increases security and reliability.
Doing so regularly makes the occasional hiccups this can cause easier
to pinpoint and address.

This will also help out Spring.

Dependency bumps in this batch:
* Bump micrometer from 1.8.5 to 1.9.0
