### PR TITLE
GEODE-10321: Acceptance test for Geode access to JDK internals

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -244,6 +244,7 @@ dependencies {
   // don't have it be the same version as the outer gradle version.
   acceptanceTestImplementation('org.gradle:gradle-tooling-api:' + DependencyConstraints.get('gradle-tooling-api.version'))
 
+  acceptanceTestImplementation('org.junit.jupiter:junit-jupiter-migrationsupport')
   acceptanceTestImplementation('org.testcontainers:testcontainers')
 
   uiTestImplementation(project(':geode-core'))

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/jdk/JdkEncapsulationTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/jdk/JdkEncapsulationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.jdk;
+
+import static java.util.stream.Collectors.joining;
+import static org.apache.geode.internal.AvailablePortHelper.getRandomAvailableTCPPorts;
+import static org.apache.geode.test.util.JarUtils.createJarWithClasses;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.apache.geode.test.junit.rules.FolderRule;
+import org.apache.geode.test.junit.rules.gfsh.GfshExecution;
+import org.apache.geode.test.junit.rules.gfsh.GfshRule;
+import org.apache.geode.test.junit.rules.gfsh.GfshScript;
+import org.apache.geode.test.version.JavaVersions;
+
+/**
+ * Test several ways to make normally inaccessible JDK packages accessible on JDK 17.
+ */
+public class JdkEncapsulationTest {
+  private static final String TRAVERSE_INACCESSIBLE_OBJECT = String.join(" ",
+      "execute", "function", "--id=" + TraverseInaccessibleJdkObject.ID);
+
+  private static final Path LINUX_ARGUMENT_FILE_RELATIVE_PATH =
+      Paths.get(System.getenv("GEODE_HOME"), "config", "open-all-jdk-packages-linux-openjdk-17")
+          .toAbsolutePath().normalize();
+
+  @Rule(order = 0)
+  public final FolderRule folderRule = new FolderRule();
+  @Rule(order = 1)
+  public final GfshRule gfshRule = new GfshRule(folderRule::getFolder);
+
+  private String connectToLocator;
+  private int serverPort;
+  private String locatorString;
+
+  @BeforeClass
+  public static void validOnlyOnJdk17AndLater() {
+    assumeThat(JavaVersions.current().specificationVersion())
+        .isGreaterThanOrEqualTo(17);
+  }
+
+  @Before
+  public void startLocatorWithObjectTraverserFunction() throws IOException {
+    int[] availablePorts = getRandomAvailableTCPPorts(2);
+    int locatorPort = availablePorts[0];
+    serverPort = availablePorts[1];
+    locatorString = "localhost[" + locatorPort + "]";
+    connectToLocator = "connect --locator=" + locatorString;
+
+    String startLocator = String.join(" ",
+        "start",
+        "locator",
+        "--name=locator",
+        "--port=" + locatorPort,
+        "--http-service-port=0");
+
+    Path jarPath = folderRule.getFolder().toPath().resolve("traverse-object.jar");
+    createJarWithClasses(jarPath, TraverseInaccessibleJdkObject.class);
+    String deployObjectTraverserFunction = String.join(" ",
+        "deploy",
+        "--jar=" + jarPath);
+    gfshRule.execute(startLocator, deployObjectTraverserFunction);
+  }
+
+  // If this test fails, it means the object we're trying to traverse has no inaccessible fields,
+  // and so is not useful for the other tests. If it fails, update TraverseInaccessibleJdkObject
+  // to use a type that actually has inaccessible fields.
+  @Test
+  public void cannotMakeInaccessibleFieldsAccessibleByDefault() {
+    gfshRule.execute(startServerWithOptions()); // No options
+
+    GfshExecution execution = GfshScript.of(connectToLocator)
+        .and(TRAVERSE_INACCESSIBLE_OBJECT)
+        .expectExitCode(1) // Because java.math is not opened by default.
+        .execute(gfshRule);
+
+    assertThat(execution.getOutputText())
+        .as("result of traversing %s", TraverseInaccessibleJdkObject.OBJECT.getClass())
+        .contains("Exception: java.lang.reflect.InaccessibleObjectException");
+  }
+
+  @Test
+  public void canMakeFieldsAccessibleOnExplicitlyOpenedPackages() {
+    String opensOptionFormat = "--J=--add-opens=%s/%s=ALL-UNNAMED";
+    String objectPackage = TraverseInaccessibleJdkObject.OBJECT.getClass().getPackage().getName();
+    String objectModule = TraverseInaccessibleJdkObject.MODULE;
+    String opensOption = String.format(opensOptionFormat, objectModule, objectPackage);
+    gfshRule.execute(startServerWithOptions(opensOption));
+
+    GfshScript.of(connectToLocator)
+        .and(TRAVERSE_INACCESSIBLE_OBJECT)
+        .expectExitCode(0) // Because we explicitly opened java.math.
+        .execute(gfshRule);
+  }
+
+  @Test
+  public void canMakeFieldsAccessibleOnPackagesOpenedByArgumentFile() {
+    // A few of the packages opened by this argument file are specific to Linux JDKs. Running this
+    // test on other operating systems might emit some warnings, but they are harmless.
+    gfshRule.execute(startServerWithOptions("--J=@" + LINUX_ARGUMENT_FILE_RELATIVE_PATH));
+
+    GfshScript.of(connectToLocator)
+        .and(TRAVERSE_INACCESSIBLE_OBJECT)
+        .expectExitCode(0) // Because the argument file opens java.math.
+        .execute(gfshRule);
+  }
+
+  private String startServerWithOptions(String... option) {
+    Stream<String> baseCommand = Stream.of(
+        "start",
+        "server",
+        "--name=server",
+        "--server-port=" + serverPort,
+        "--locators=" + locatorString);
+    Stream<String> options = Stream.of(option);
+
+    return Stream.concat(baseCommand, options)
+        .collect(joining(" "));
+  }
+}

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/jdk/TraverseInaccessibleJdkObject.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/jdk/TraverseInaccessibleJdkObject.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.jdk;
+
+import java.math.BigDecimal;
+
+import org.apache.geode.cache.execute.Function;
+import org.apache.geode.cache.execute.FunctionContext;
+import org.apache.geode.internal.size.ObjectTraverser;
+import org.apache.geode.internal.size.ObjectTraverser.Visitor;
+
+public class TraverseInaccessibleJdkObject implements Function<Void> {
+  private static final Visitor TRAVERSE_ENTIRE_OBJECT_GRAPH = (parent, object) -> true;
+  private final ObjectTraverser traverser = new ObjectTraverser();
+
+  // OBJECT must have a JDK type with inaccessible fields, defined in a package that Gfsh does
+  // not open by default.
+  static final BigDecimal OBJECT = BigDecimal.ONE;
+  // MODULE must be the module that defines OBJECT's type.
+  static final String MODULE = "java.base";
+  static final String ID = "traverse-big-decimal";
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public void execute(FunctionContext<Void> context) {
+    try {
+      traverser.breadthFirstSearch(OBJECT, TRAVERSE_ENTIRE_OBJECT_GRAPH, false);
+    } catch (IllegalAccessException e) {
+      context.getResultSender().sendException(e);
+      return;
+    }
+    context.getResultSender().lastResult("OK");
+  }
+}

--- a/geode-junit/src/main/java/org/apache/geode/test/util/JarUtils.java
+++ b/geode-junit/src/main/java/org/apache/geode/test/util/JarUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ */
+
+package org.apache.geode.test.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import org.apache.commons.io.IOUtils;
+
+public class JarUtils {
+  public static Path createJarWithClasses(Path jarPath, Class<?>... classes) throws IOException {
+    Path jarFile = Files.createFile(jarPath);
+    try (OutputStream outputStream = Files.newOutputStream(jarFile);
+        JarOutputStream jarOutputStream = new JarOutputStream(outputStream)) {
+      Arrays.stream(classes)
+          .forEach(clazz -> writeClassTo(clazz, jarOutputStream));
+    }
+    return jarFile;
+  }
+
+  private static void writeClassTo(Class<?> clazz, JarOutputStream jarOutputStream) {
+    String className = clazz.getName();
+    String classAsPath = className.replace('.', '/') + ".class";
+    InputStream classInputStream = clazz.getClassLoader().getResourceAsStream(classAsPath);
+    if (classInputStream == null) {
+      throw new RuntimeException("No such class: " + clazz);
+    }
+    JarEntry classEntry = new JarEntry(classAsPath);
+    classEntry.setTime(System.currentTimeMillis());
+    try {
+      byte[] classBytes = IOUtils.toByteArray(classInputStream);
+      jarOutputStream.putNextEntry(classEntry);
+      jarOutputStream.write(classBytes);
+      jarOutputStream.closeEntry();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}


### PR DESCRIPTION
Add acceptance tests to demonstrate two ways to give Geode access to
encapsulated fields of a JDK 17 class:

- Tell Gfsh to open the class's package when starting a Geode member.
- Tell Gfsh to use `open-all-jdk-packages-linux-openjdk-17` as an
  argument file when starting a Geode member.

Add another test to demonstrate the kind of error that happens when
Geode cannot access an encapsulated field of a JDK 17 class.
