### PR TITLE
GEODE-10294: Compare invalid token during putIfAbsent retry.

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/RetryPutIfAbsentIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/RetryPutIfAbsentIntegrationTest.java
@@ -47,7 +47,6 @@ class RetryPutIfAbsentIntegrationTest {
 
     clientEvent.setRegion(myRegion);
     byte[] valueBytes = new VMCachedDeserializable("myValue", 7).getSerializedValue();
-    System.out.println("first putIfAbsent");
     Object oldValue =
         myRegion.basicBridgePutIfAbsent(key, valueBytes, true, null, id, true, clientEvent);
     assertThat(oldValue).isNull();
@@ -59,7 +58,6 @@ class RetryPutIfAbsentIntegrationTest {
     clientEvent.setOperation(Operation.PUT_IF_ABSENT);
     assertThat(myRegion.getEventTracker().hasSeenEvent(clientEvent)).isFalse();
 
-    System.out.println("second putIfAbsent");
     oldValue = myRegion.basicBridgePutIfAbsent(key, valueBytes, true, null, id, true, clientEvent);
     assertThat(oldValue).isNull();
   }
@@ -76,7 +74,6 @@ class RetryPutIfAbsentIntegrationTest {
         }).create("myRegion");
 
     clientEvent.setRegion(myRegion);
-    System.out.println("first putIfAbsent of null value");
     Object oldValue =
         myRegion.basicBridgePutIfAbsent(key, null, true, null, id, true, clientEvent);
     assertThat(oldValue).isNull();
@@ -88,7 +85,6 @@ class RetryPutIfAbsentIntegrationTest {
     clientEvent.setOperation(Operation.PUT_IF_ABSENT);
     assertThat(myRegion.getEventTracker().hasSeenEvent(clientEvent)).isFalse();
 
-    System.out.println("second putIfAbsent of null value");
     oldValue = myRegion.basicBridgePutIfAbsent(key, null, true, null, id, true, clientEvent);
     assertThat(oldValue).isNull();
     assertThat(updateCount).isEqualTo(0);

--- a/geode-core/src/integrationTest/java/org/apache/geode/cache/RetryPutIfAbsentIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/cache/RetryPutIfAbsentIntegrationTest.java
@@ -14,17 +14,14 @@
  */
 package org.apache.geode.cache;
 
-import static org.apache.geode.internal.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import org.apache.geode.cache.query.CacheUtils;
+import org.apache.geode.cache.util.CacheListenerAdapter;
 import org.apache.geode.distributed.internal.membership.InternalDistributedMember;
 import org.apache.geode.internal.cache.EventID;
 import org.apache.geode.internal.cache.EventIDHolder;
@@ -32,55 +29,79 @@ import org.apache.geode.internal.cache.LocalRegion;
 import org.apache.geode.internal.cache.VMCachedDeserializable;
 import org.apache.geode.internal.cache.tier.sockets.ClientProxyMembershipID;
 
-public class RetryPutIfAbsentIntegrationTest {
+class RetryPutIfAbsentIntegrationTest {
 
-  Cache cache;
-
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
+  private Cache cache;
+  private LocalRegion myRegion;
+  private final ClientProxyMembershipID id =
+      new ClientProxyMembershipID(new InternalDistributedMember("localhost", 1));
+  private final EventIDHolder clientEvent =
+      new EventIDHolder(new EventID(new byte[] {1, 2, 3, 4, 5}, 1, 1));
+  private final String key = "key";
+  private int updateCount;
 
   @Test
-  public void duplicatePutIfAbsentIsAccepted() {
-    final String key = "mykey";
-    final String value = "myvalue";
+  void duplicatePutIfAbsentIsAccepted() {
+    myRegion = (LocalRegion) cache.createRegionFactory(RegionShortcut.REPLICATE)
+        .setConcurrencyChecksEnabled(true).create("myRegion");
 
-    LocalRegion myregion =
-        (LocalRegion) CacheUtils.getCache().createRegionFactory(RegionShortcut.REPLICATE)
-            .setConcurrencyChecksEnabled(true).create("myregion");
-
-    ClientProxyMembershipID id =
-        new ClientProxyMembershipID(new InternalDistributedMember("localhost", 1));
-    EventIDHolder clientEvent = new EventIDHolder(new EventID(new byte[] {1, 2, 3, 4, 5}, 1, 1));
-    clientEvent.setRegion(myregion);
-    byte[] valueBytes = new VMCachedDeserializable("myvalue", 7).getSerializedValue();
+    clientEvent.setRegion(myRegion);
+    byte[] valueBytes = new VMCachedDeserializable("myValue", 7).getSerializedValue();
     System.out.println("first putIfAbsent");
     Object oldValue =
-        myregion.basicBridgePutIfAbsent("mykey", valueBytes, true, null, id, true, clientEvent);
-    assertEquals(null, oldValue);
-    assertTrue(myregion.containsKey(key));
+        myRegion.basicBridgePutIfAbsent(key, valueBytes, true, null, id, true, clientEvent);
+    assertThat(oldValue).isNull();
+    assertThat(myRegion.containsKey(key)).isTrue();
 
-    myregion.getEventTracker().clear();
+    myRegion.getEventTracker().clear();
 
-    clientEvent = new EventIDHolder(new EventID(new byte[] {1, 2, 3, 4, 5}, 1, 1));
-    clientEvent.setRegion(myregion);
     clientEvent.setPossibleDuplicate(true);
     clientEvent.setOperation(Operation.PUT_IF_ABSENT);
-    assertFalse(myregion.getEventTracker().hasSeenEvent(clientEvent));
+    assertThat(myRegion.getEventTracker().hasSeenEvent(clientEvent)).isFalse();
 
     System.out.println("second putIfAbsent");
-    oldValue =
-        myregion.basicBridgePutIfAbsent("mykey", valueBytes, true, null, id, true, clientEvent);
-    assertEquals(null, oldValue);
+    oldValue = myRegion.basicBridgePutIfAbsent(key, valueBytes, true, null, id, true, clientEvent);
+    assertThat(oldValue).isNull();
   }
 
-  @Before
-  public void setUp() throws Exception {
+  @Test
+  void duplicatePutIfAbsentOfNullValueDoesNotInvokeAfterUpdateListener() {
+    myRegion = (LocalRegion) cache.createRegionFactory(RegionShortcut.REPLICATE)
+        .setConcurrencyChecksEnabled(true)
+        .addCacheListener(new CacheListenerAdapter<Object, Object>() {
+          @Override
+          public void afterUpdate(EntryEvent<Object, Object> event) {
+            ++updateCount;
+          }
+        }).create("myRegion");
+
+    clientEvent.setRegion(myRegion);
+    System.out.println("first putIfAbsent of null value");
+    Object oldValue =
+        myRegion.basicBridgePutIfAbsent(key, null, true, null, id, true, clientEvent);
+    assertThat(oldValue).isNull();
+    assertThat(myRegion.containsKey(key)).isTrue();
+
+    myRegion.getEventTracker().clear();
+
+    clientEvent.setPossibleDuplicate(true);
+    clientEvent.setOperation(Operation.PUT_IF_ABSENT);
+    assertThat(myRegion.getEventTracker().hasSeenEvent(clientEvent)).isFalse();
+
+    System.out.println("second putIfAbsent of null value");
+    oldValue = myRegion.basicBridgePutIfAbsent(key, null, true, null, id, true, clientEvent);
+    assertThat(oldValue).isNull();
+    assertThat(updateCount).isEqualTo(0);
+  }
+
+  @BeforeEach
+  void setUp() {
     CacheUtils.startCache();
     cache = CacheUtils.getCache();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterEach
+  void tearDown() {
     CacheUtils.closeCache();
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
@@ -433,12 +433,12 @@ public class RegionMapPut extends AbstractRegionMapPut {
   }
 
   private boolean isSameValueAlreadyInCacheForPutIfAbsent(Object retainedValue) {
+    Object rawNewValue = getEvent().getRawNewValue();
     if (Token.isInvalid(retainedValue)) {
-      return getEvent().getRawNewValue() == null || Token.isInvalid(getEvent().getRawNewValue());
+      return rawNewValue == null || Token.isInvalid(rawNewValue);
     }
 
-    return ValueComparisonHelper.checkEquals(retainedValue,
-        getEvent().getRawNewValue(),
+    return ValueComparisonHelper.checkEquals(retainedValue, rawNewValue,
         isCompressedOffHeap(getEvent()), getOwner().getCache());
   }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/map/RegionMapPut.java
@@ -235,7 +235,8 @@ public class RegionMapPut extends AbstractRegionMapPut {
     final EntryEventImpl event = getEvent();
     if (getOwner().isInitialized() && isCacheWrite()) {
       if (!isReplaceOnClient()) {
-        if (getRegionEntry().isDestroyedOrRemoved()) {
+        if (getRegionEntry().isDestroyedOrRemoved()
+            || (getRegionEntry().isInvalid() && event.getOperation() == Operation.PUT_IF_ABSENT)) {
           event.makeCreate();
         } else {
           event.makeUpdate();
@@ -343,6 +344,9 @@ public class RegionMapPut extends AbstractRegionMapPut {
     if (isReplaceOnClient()) {
       return true;
     }
+    if (getRegionEntry().isInvalid() && getEvent().getOperation() == Operation.PUT_IF_ABSENT) {
+      return false;
+    }
     return !getRegionEntry().isRemoved();
   }
 
@@ -409,9 +413,7 @@ public class RegionMapPut extends AbstractRegionMapPut {
             event.isPossibleDuplicate()) {
           Object retainedValue = getRegionEntry().getValueRetain(getOwner());
           try {
-            if (ValueComparisonHelper.checkEquals(retainedValue,
-                getEvent().getRawNewValue(),
-                isCompressedOffHeap(event), getOwner().getCache())) {
+            if (isSameValueAlreadyInCacheForPutIfAbsent(retainedValue)) {
               if (logger.isDebugEnabled()) {
                 logger.debug("retried putIfAbsent found same value already in cache "
                     + "- allowing the operation.  entry={}; event={}", getRegionEntry(),
@@ -428,6 +430,16 @@ public class RegionMapPut extends AbstractRegionMapPut {
       }
     }
     return true;
+  }
+
+  private boolean isSameValueAlreadyInCacheForPutIfAbsent(Object retainedValue) {
+    if (Token.isInvalid(retainedValue)) {
+      return getEvent().getRawNewValue() == null || Token.isInvalid(getEvent().getRawNewValue());
+    }
+
+    return ValueComparisonHelper.checkEquals(retainedValue,
+        getEvent().getRawNewValue(),
+        isCompressedOffHeap(getEvent()), getOwner().getCache());
   }
 
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapPutTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/map/RegionMapPutTest.java
@@ -137,9 +137,20 @@ public class RegionMapPutTest {
   public void doesNotSetEventOldValueIfRetriedPutIfAbsentOperation() {
     final byte[] bytes = new byte[] {1, 2, 3, 4, 5};
     givenExistingRegionEntry();
-    when(existingRegionEntry.getValue()).thenReturn(bytes);
+    when(existingRegionEntry.getValueRetain(internalRegion)).thenReturn(bytes);
     when(internalRegion.getConcurrencyChecksEnabled()).thenReturn(true);
     givenPutIfAbsentOperation(bytes); // duplicate operation
+    doPut();
+    verify(event).setOldValue(null, true);
+    assertThat(instance.isOverwritePutIfAbsent()).isTrue();
+  }
+
+  @Test
+  public void doesNotSetEventOldValueIfRetriedPutIfAbsentOperationOfNull() {
+    givenExistingRegionEntry();
+    when(existingRegionEntry.getValueRetain(internalRegion)).thenReturn(Token.INVALID);
+    when(internalRegion.getConcurrencyChecksEnabled()).thenReturn(true);
+    givenPutIfAbsentOperation(null); // duplicate operation
     doPut();
     verify(event).setOldValue(null, true);
     assertThat(instance.isOverwritePutIfAbsent()).isTrue();
@@ -149,7 +160,7 @@ public class RegionMapPutTest {
   public void overWritePutIfAbsentIsTrueIfRetriedPutIfAbsentOperationHavingValidVersionTag() {
     final byte[] bytes = new byte[] {1, 2, 3, 4, 5};
     givenExistingRegionEntry();
-    when(existingRegionEntry.getValue()).thenReturn(bytes);
+    when(existingRegionEntry.getValueRetain(internalRegion)).thenReturn(bytes);
     when(internalRegion.getConcurrencyChecksEnabled()).thenReturn(true);
     givenPutIfAbsentOperation(bytes); // duplicate operation
     when(event.hasValidVersionTag()).thenReturn(true);
@@ -162,7 +173,7 @@ public class RegionMapPutTest {
 
   private void givenPutIfAbsentOperation(byte[] bytes) {
     when(event.isPossibleDuplicate()).thenReturn(true);
-    when(event.basicGetNewValue()).thenReturn(bytes);
+    when(event.getRawNewValue()).thenReturn(bytes);
     when(event.getOperation()).thenReturn(Operation.PUT_IF_ABSENT);
     when(event.hasValidVersionTag()).thenReturn(false);
     ifNew = true;


### PR DESCRIPTION
 * During putIfAbsent retry, comparing invalid token value when
   putIfAbsent of a null value instead.
 * Do not make putIfAbsent event to update event if current
   entry value is null or invalidate.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
