### PR TITLE
GEODE-10352: Update Ruby version in Geode doc preview tool

### DIFF
--- a/dev-tools/docker/docs/Dockerfile
+++ b/dev-tools/docker/docs/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM ruby:2.5
+FROM ruby:2.6.8
 
 LABEL Vendor="Apache Geode"
 LABEL version=unstable
@@ -25,16 +25,16 @@ RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - ; \
     apt-get install -y nodejs
 RUN gem install bundler:1.17.3 \
     rake multi_json:1.13.1 \
-    elasticsearch:2.0.2 \
+    elasticsearch:7.5.0 \
     multipart-post:2.0.0 \
-    faraday:0.15.4 \
+    faraday:0.17.4 \
     libv8:3.16.14.15 \
-    mini_portile2:2.5.0 \
-    racc:1.5.2 \
-    nokogiri:1.11.2 \
-    mimemagic:0.3.9 \
-    puma:4.3.8 \
-    rack:2.1.4 \
+    mini_portile2:2.8.0 \
+    racc:1.6.0 \
+    nokogiri:1.13.3 \
+    mimemagic:0.3.10 \
+    puma:5.6.2 \
+    rack:2.2.3 \
     smtpapi:0.1.0 \
     sendgrid-ruby:1.1.6 \
     therubyracer:0.12.2


### PR DESCRIPTION
The script to preview the documentation of Geode (./preview-user-guide.sh)
is not working anymore.

The following error appears while running it (unless you have a previously downloaded
geodedocs/temp docker image in your local docker repo):

ERROR: Error installing elasticsearch:
The last version of faraday (>= 0) to support your Ruby & RubyGems was 1.10.0. Try installing it with `gem install faraday -v 1.10.0` and then running the current command again
faraday requires Ruby version >= 2.6. The current ruby version is 2.5.9.229.

That error prevents the preview script to work.

It is needed to update the docker image used to preview the documentation to use a Ruby version >= 2.6.
The versions of other gems also need to be updated after the
change of the Ruby version.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
