### PR TITLE
GEODE-10309: fixup: Give more memory to windows-core-integration-test

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -200,7 +200,7 @@ tests:
   PARALLEL_DUNIT: 'true'
   PARALLEL_GRADLE: 'true'
   PLATFORM: windows
-  RAM: '24'
+  RAM: '16'
   name: windows-integration
 - ARTIFACT_SLUG: windows-coreintegrationtestfiles
   CPUS: '16'
@@ -212,7 +212,7 @@ tests:
   PARALLEL_DUNIT: 'true'
   PARALLEL_GRADLE: 'true'
   PLATFORM: windows
-  RAM: '16'
+  RAM: '24'
   name: windows-core-integration
 - ARTIFACT_SLUG: windows-unittestfiles
   CPUS: '10'


### PR DESCRIPTION
Fixup of previous commit for this PR. Git Merge added the increased memory to the wrong CI job and we didn't notice.