### PR TITLE
GEODE-10351: Wait till the cache is completely closed before re-creating

### DIFF
--- a/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/partitioned/colocation/ModifyColocationIntegrationTest.java
+++ b/geode-core/src/integrationTest/java/org/apache/geode/internal/cache/partitioned/colocation/ModifyColocationIntegrationTest.java
@@ -102,6 +102,9 @@ public class ModifyColocationIntegrationTest {
     // Close everything
     cache.close();
 
+    // await cache close is complete
+    awaitCacheClose();
+
     // Restart uncolocated. We don't allow changing from colocated to uncolocated.
     thrown = catchThrowable(() -> createCacheAndColocatedPRs(null));
 


### PR DESCRIPTION
fix a flaky test