### PR TITLE
Short-circuit CI checks for PRs that don't touch buildable files

### DIFF
--- a/ci/scripts/archive_results.sh
+++ b/ci/scripts/archive_results.sh
@@ -31,7 +31,7 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 source ${BASE_DIR}/concourse-metadata-resource/concourse_metadata
 source ${SCRIPTDIR}/shared_utilities.sh
-is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" || exit 0
+is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" "$(get_geode_pr_exclusion_files)" || exit 0
 
 BUILDROOT=$(pwd)
 DEST_DIR=${BUILDROOT}/geode-results

--- a/ci/scripts/create_instance.sh
+++ b/ci/scripts/create_instance.sh
@@ -64,7 +64,7 @@ if [[ -z "${GCP_ZONE}" ]]; then
 fi
 
 . ${SCRIPTDIR}/shared_utilities.sh
-is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" || exit 0
+is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" "$(get_geode_pr_exclusion_files)" || exit 0
 
 if [[ -d geode ]]; then
   pushd geode

--- a/ci/scripts/delete_instance.sh
+++ b/ci/scripts/delete_instance.sh
@@ -30,7 +30,7 @@ done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 . ${SCRIPTDIR}/shared_utilities.sh
-is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" || exit 0
+is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" "$(get_geode_pr_exclusion_files)" || exit 0
 
 INSTANCE_NAME="$(cat instance-data/instance-name)"
 PERMITTED_ZONES=($(gcloud compute zones list --filter="name~'us-central.*'" --format=json | jq -r .[].name))

--- a/ci/scripts/execute_build.sh
+++ b/ci/scripts/execute_build.sh
@@ -30,7 +30,7 @@ done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 source ${SCRIPTDIR}/shared_utilities.sh
 
-is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" || exit 0
+is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" "$(get_geode_pr_exclusion_files)" || exit 0
 
 if [[ -z "${GRADLE_TASK}" ]]; then
   echo "GRADLE_TASK must be set. exiting..."

--- a/ci/scripts/execute_tests.sh
+++ b/ci/scripts/execute_tests.sh
@@ -35,7 +35,7 @@ if [[ -z "${GRADLE_TASK}" ]]; then
 fi
 
 . ${SCRIPTDIR}/shared_utilities.sh
-is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" || exit 0
+is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" "$(get_geode_pr_exclusion_files)" || exit 0
 
 REPODIR=$(cd geode; git rev-parse --show-toplevel)
 

--- a/ci/scripts/repeat-new-tests.sh
+++ b/ci/scripts/repeat-new-tests.sh
@@ -29,7 +29,7 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 . "${SCRIPTDIR}/shared_utilities.sh"
 
-is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" || exit 0
+is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" "$(get_geode_pr_exclusion_files)" || exit 0
 
 function changes_for_path() {
   pushd geode >> /dev/null

--- a/ci/scripts/rsync_code_down.sh
+++ b/ci/scripts/rsync_code_down.sh
@@ -30,7 +30,7 @@ done
 SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 
 . ${SCRIPTDIR}/shared_utilities.sh
-is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" || exit 0
+is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" "$(get_geode_pr_exclusion_files)" || exit 0
 
 SSHKEY_FILE="instance-data/sshkey"
 

--- a/ci/scripts/rsync_code_up.sh
+++ b/ci/scripts/rsync_code_up.sh
@@ -32,7 +32,7 @@ SCRIPTDIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 REPODIR=$(cd geode; git rev-parse --show-toplevel)
 
 . ${SCRIPTDIR}/shared_utilities.sh
-is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" || exit 0
+is_source_from_pr_testable "geode" "$(get_geode_pr_exclusion_dirs)" "$(get_geode_pr_exclusion_files)" || exit 0
 
 SSHKEY_FILE="instance-data/sshkey"
 SSH_OPTIONS="-i ${SSHKEY_FILE} -o ConnectionAttempts=60 -o StrictHostKeyChecking=no"

--- a/ci/scripts/shared_utilities.sh
+++ b/ci/scripts/shared_utilities.sh
@@ -84,12 +84,18 @@ get-full-version() {
 }
 
 get_geode_pr_exclusion_dirs() {
-  local exclude_dirs=".github ci dev-tools etc geode-book geode-docs CODEOWNERS"
+  local exclude_dirs=".github ci dev-tools etc geode-book geode-docs"
   echo "${exclude_dirs}"
 }
 
+get_geode_pr_exclusion_files() {
+  local exclude_files="CODEOWNERS .gitignore .gitattributes .travis.yml CODEWATCHERS COMMITWATCHERS .asf.yaml CODE_OF_CONDUCT.md README.md TESTING.md"
+  echo "${exclude_files}"
+}
+
 is_source_from_pr_testable() {
-  if [[ $# -ne 2 ]]; then
+  set -x
+  if [[ $# -ne 3 ]]; then
     >&2 echo "Invalid args. Try ${0} \"<repo_path>\" \"<list of exclusion dirs>\""
     exit 1
   fi
@@ -98,6 +104,9 @@ is_source_from_pr_testable() {
     # If the repo_dir does not exist, assume call from non-PR
     return 0;
   fi
+
+  local exclude_dirs="${2}"
+  local exclude_files="${3}"
 
   # shellcheck disable=SC2164
   pushd "${repo_dir}" 2>&1 >> /dev/null
@@ -109,11 +118,12 @@ is_source_from_pr_testable() {
     pushd "${base_dir}" 2>&1 >> /dev/null
       local return_code=0
       if [ -d "${github_pr_dir}" ]; then
-        # Modify this path list with directories to exclude
-        local exclude_dirs="${2}"
         local exclude_pathspec=""
         for d in $(echo ${exclude_dirs}); do
           exclude_pathspec="${exclude_pathspec} :(exclude,glob)${d}/**"
+        done
+        for f in $(echo ${exclude_files}); do
+          exclude_pathspec="${exclude_pathspec} :(exclude,glob)${f}"
         done
         # shellcheck disable=SC2164
         pushd "${base_dir}" 2>&1 >> /dev/null

--- a/ci/scripts/shared_utilities.sh
+++ b/ci/scripts/shared_utilities.sh
@@ -94,9 +94,9 @@ get_geode_pr_exclusion_files() {
 }
 
 is_source_from_pr_testable() {
-  set -x
+
   if [[ $# -ne 3 ]]; then
-    >&2 echo "Invalid args. Try ${0} \"<repo_path>\" \"<list of exclusion dirs>\""
+    >&2 echo "Invalid args. Try ${0} \"<repo_path>\" \"<list of exclusion dirs>\" \"<list of exclusion files>\""
     exit 1
   fi
   local repo_dir="${1}"


### PR DESCRIPTION
Examples being CODEOWNERS and .asf.yaml. Saves on CI spend.
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [X] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [X] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [X] Is your initial contribution a single, squashed commit?

- [X] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
