### PR TITLE
GEODE-10355: Bump spring-security from 5.2.12 to 5.5.8

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -706,31 +706,31 @@
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-config</artifactId>
-        <version>5.2.12.RELEASE</version>
+        <version>5.5.8</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-core</artifactId>
-        <version>5.2.12.RELEASE</version>
+        <version>5.5.8</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-ldap</artifactId>
-        <version>5.2.12.RELEASE</version>
+        <version>5.5.8</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-test</artifactId>
-        <version>5.2.12.RELEASE</version>
+        <version>5.5.8</version>
         <scope>compile</scope>
       </dependency>
       <dependency>
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-web</artifactId>
-        <version>5.2.12.RELEASE</version>
+        <version>5.5.8</version>
         <scope>compile</scope>
       </dependency>
       <dependency>

--- a/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/buildSrc/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -231,7 +231,7 @@ class DependencyConstraints implements Plugin<Project> {
       entry('selenium-support')
     }
 
-    dependencySet(group: 'org.springframework.security', version: '5.2.12.RELEASE') {
+    dependencySet(group: 'org.springframework.security', version: '5.5.8') {
       entry('spring-security-config')
       entry('spring-security-core')
       entry('spring-security-ldap')

--- a/geode-assembly/src/integrationTest/resources/expected_jars.txt
+++ b/geode-assembly/src/integrationTest/resources/expected_jars.txt
@@ -105,6 +105,7 @@ spring-plugin-core
 spring-plugin-metadata
 spring-security-config
 spring-security-core
+spring-security-crypto
 spring-security-ldap
 spring-security-web
 spring-shell


### PR DESCRIPTION
Geode endeavors to update to the latest version of 3rd-party
dependencies on develop wherever possible.  Doing so increases the
shelf life of releases and increases security and reliability.
Doing so regularly makes the occasional hiccups this can cause easier
to pinpoint and address.

Dependency bumps in this batch:
* Bump spring-security from 5.2.12.RELEASE to 5.5.8
