### PR TITLE
GEODE-10301: support LocalDate and JodaTime (#7737)

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -245,7 +245,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.10.9</version>
+        <version>2.10.14</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>

--- a/build-tools/geode-dependency-management/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/build-tools/geode-dependency-management/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -128,7 +128,7 @@ class DependencyConstraints {
         api(group: 'javax.resource', name: 'javax.resource-api', version: '1.7.1')
         api(group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0')
         api(group: 'javax.xml.bind', name: 'jaxb-api', version: '2.3.1')
-        api(group: 'joda-time', name: 'joda-time', version: '2.10.9')
+        api(group: 'joda-time', name: 'joda-time', version: '2.10.14')
         api(group: 'junit', name: 'junit', version: get('junit.version'))
         api(group: 'mx4j', name: 'mx4j-tools', version: '3.0.1')
         api(group: 'mysql', name: 'mysql-connector-java', version: '5.1.46')

--- a/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/rest/StandaloneClientManagementAPIAcceptanceTest.java
+++ b/geode-assembly/src/acceptanceTest/java/org/apache/geode/management/internal/rest/StandaloneClientManagementAPIAcceptanceTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
@@ -123,18 +124,18 @@ public class StandaloneClientManagementAPIAcceptanceTest {
         .withName("startCluster")
         .execute(gfshRule);
 
+    int expectedReturnCode = 0;
     assertThat(startCluster.getProcess().exitValue())
-        .as("Cluster did not start correctly")
-        .isEqualTo(0);
+        .as("Cluster did not start correctly").isEqualTo(expectedReturnCode);
 
     Process process = launchClientProcess(outputJar, httpPort);
 
-    boolean exited = process.waitFor(getTimeout().toMillis(), MILLISECONDS);
-    assertThat(exited)
-        .as("Process did not exit within 10 seconds")
+    long processTimeout = getTimeout().getSeconds();
+    boolean exited = process.waitFor(processTimeout, TimeUnit.SECONDS);
+    assertThat(exited).as(String.format("Process did not exit within %d seconds", processTimeout))
         .isTrue();
     assertThat(process.exitValue())
-        .as("Process did not exit with 0 return code")
+        .as(String.format("Process did not exit with %d return code", expectedReturnCode))
         .isEqualTo(0);
 
     GfshExecution listRegionsResult = GfshScript
@@ -162,6 +163,9 @@ public class StandaloneClientManagementAPIAcceptanceTest {
         "jackson-annotations",
         "jackson-core",
         "jackson-databind",
+        "jackson-datatype-jsr310",
+        "jackson-datatype-joda",
+        "joda-time",
         "httpclient",
         "httpcore",
         "spring-beans",

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1070,3 +1070,6 @@ tools/Modules/Apache_Geode_Modules-0.0.0-Tomcat.zip
 tools/Modules/Apache_Geode_Modules-0.0.0-tcServer.zip
 tools/Modules/Apache_Geode_Modules-0.0.0-tcServer30.zip
 tools/Pulse/geode-pulse-0.0.0.war
+lib/jackson-datatype-joda-2.13.2.jar
+lib/jackson-datatype-jsr310-2.13.2.jar
+lib/joda-time-2.10.14.jar

--- a/geode-assembly/src/integrationTest/resources/expected_jars.txt
+++ b/geode-assembly/src/integrationTest/resources/expected_jars.txt
@@ -26,6 +26,7 @@ jackson-annotations
 jackson-core
 jackson-databind
 jackson-dataformat-yaml
+jackson-datatype-joda
 jackson-datatype-jsr
 jakarta.activation-api
 jakarta.validation-api
@@ -51,6 +52,7 @@ jgroups
 jline
 jna
 jna-platform
+joda-time
 jopt-simple
 json-path
 json-smart

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -87,3 +87,6 @@ jetty-http-9.4.46.v20220331.jar
 jetty-io-9.4.46.v20220331.jar
 jetty-util-ajax-9.4.46.v20220331.jar
 jetty-util-9.4.46.v20220331.jar
+jackson-datatype-joda-2.13.2.jar
+jackson-datatype-jsr310-2.13.2.jar
+joda-time-2.10.14.jar

--- a/geode-common/build.gradle
+++ b/geode-common/build.gradle
@@ -32,6 +32,8 @@ dependencies {
 
 
   implementation('com.fasterxml.jackson.core:jackson-databind')
+  implementation('com.fasterxml.jackson.datatype:jackson-datatype-jsr310')
+  implementation('com.fasterxml.jackson.datatype:jackson-datatype-joda')
 
   // test
   testImplementation('com.github.stefanbirkner:system-rules') {

--- a/geode-common/src/main/java/org/apache/geode/util/internal/GeodeJsonMapper.java
+++ b/geode-common/src/main/java/org/apache/geode/util/internal/GeodeJsonMapper.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 /**
  * helper class for creating various json mappers used by Geode Project
@@ -34,10 +36,18 @@ public class GeodeJsonMapper {
    */
   public static ObjectMapper getMapper() {
     ObjectMapper mapper = JsonMapper.builder()
+        .addModule(new JavaTimeModule())
+        .addModule(new JodaModule())
         .enable(JsonParser.Feature.ALLOW_SINGLE_QUOTES)
         .enable(MapperFeature.USE_BASE_TYPE_AS_DEFAULT_IMPL)
         .build();
     mapper.setSerializationInclusion(JsonInclude.Include.NON_EMPTY);
+    return mapper;
+  }
+
+  public static ObjectMapper getMapperWithAlwaysInclusion() {
+    ObjectMapper mapper = getMapper();
+    mapper.setSerializationInclusion(JsonInclude.Include.ALWAYS);
     return mapper;
   }
 

--- a/geode-common/src/test/resources/expected-pom.xml
+++ b/geode-common/src/test/resources/expected-pom.xml
@@ -51,5 +51,15 @@
       <artifactId>jackson-databind</artifactId>
       <scope>runtime</scope>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-joda</artifactId>
+      <scope>runtime</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/geode-core/src/test/java/org/apache/geode/management/internal/json/QueryResultFormatterTest.java
+++ b/geode-core/src/test/java/org/apache/geode/management/internal/json/QueryResultFormatterTest.java
@@ -15,7 +15,6 @@
 package org.apache.geode.management.internal.json;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -31,7 +30,8 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.joda.time.DateTime;
+import org.junit.jupiter.api.Test;
 
 import org.apache.geode.cache.query.data.CollectionHolder;
 import org.apache.geode.internal.logging.DateFormatter;
@@ -138,6 +138,12 @@ public class QueryResultFormatterTest {
         new QueryResultFormatter(100).add(RESULT, sqlDate);
     checkResult(sqlDateResult,
         "{\"result\":[[\"java.sql.Date\",\"" + expectedString + "\"]]}");
+
+    DateTime jodaTime = new DateTime(time);
+    QueryResultFormatter jodaTimeResult =
+        new QueryResultFormatter(100).add(RESULT, jodaTime);
+    String jsonString = jodaTimeResult.toString();
+    assertThat(jsonString).contains("{\"result\":[[\"org.joda.time.DateTime\",\"");
   }
 
   @Test

--- a/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase.java
+++ b/geode-dunit/src/main/java/org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import com.google.common.io.Files;
 import org.apache.commons.io.FileUtils;
+import org.joda.time.DateTime;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -200,7 +201,8 @@ public class QueryCommandIntegrationTestBase {
   @Test
   public void outputDisplaysResultsFromComplexRegion() throws Exception {
     String result = gfsh
-        .execute("query --query='select c.name, c.address from " + SEPARATOR + "complexRegion c'");
+        .execute("query --query='select c.name, c.address, c.birthday from " + SEPARATOR
+            + "complexRegion c'");
 
     String[] resultLines = splitOnLineBreaks(result);
 
@@ -209,7 +211,7 @@ public class QueryCommandIntegrationTestBase {
     assertThat(resultLines[2]).containsPattern("Rows\\s+:\\s+100");
     assertThat(resultLines[3]).containsPattern("name\\s+\\|\\s+address");
     Arrays.asList(resultLines).subList(5, resultLines.length)
-        .forEach(line -> assertThat(line).matches("name\\d+.*\"city\":\"Hometown\".*"));
+        .forEach(line -> assertThat(line).matches("name\\d+.*\"city\":\"Hometown\".*\\d*"));
   }
 
   @Test
@@ -275,14 +277,17 @@ public class QueryCommandIntegrationTestBase {
   public static class Customer implements Serializable {
     public String name;
     public Address address;
+    public DateTime birthday;
+
 
     public Customer(String name, String street, String city) {
       this.name = name;
-      address = new Address(street, city);
+      this.address = new Address(street, city);
+      this.birthday = new DateTime();
     }
 
     public String toString() {
-      return name + address;
+      return name + address + birthday;
     }
   }
 

--- a/geode-dunit/src/main/resources/org/apache/geode/test/dunit/internal/sanctioned-geode-dunit-serializables.txt
+++ b/geode-dunit/src/main/resources/org/apache/geode/test/dunit/internal/sanctioned-geode-dunit-serializables.txt
@@ -113,7 +113,7 @@ org/apache/geode/management/ManagementTestBase$3,false,this$0:org/apache/geode/m
 org/apache/geode/management/internal/cli/commands/ExportLogsDistributedTestBase$LogLine,false,level:java/lang/String,message:java/lang/String,shouldBeIgnoredDueToTimestamp:boolean
 org/apache/geode/management/internal/cli/commands/Product,false,contractSize:java/lang/String,productCodes:java/util/TreeMap,productID:java/lang/Long,status:java/lang/String
 org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase$Address,false,city:java/lang/String,street:java/lang/String
-org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase$Customer,false,address:org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase$Address,name:java/lang/String
+org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase$Customer,false,address:org/apache/geode/management/internal/cli/commands/QueryCommandIntegrationTestBase$Address,birthday:org/joda/time/DateTime,name:java/lang/String
 org/apache/geode/management/internal/cli/commands/ShowDeadlockDistributedTestBase$LockFunction,false
 org/apache/geode/management/internal/cli/commands/ShowLogCommandDistributedTestBase,false
 org/apache/geode/management/internal/configuration/ClusterConfig,false,groups:java/util/List

--- a/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/GetCommandIntegrationTest.java
+++ b/geode-gfsh/src/integrationTest/java/org/apache/geode/management/internal/cli/commands/GetCommandIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.Formatter;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.joda.time.DateTime;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -100,7 +101,11 @@ public class GetCommandIntegrationTest {
 
   @Test
   public void get() throws Exception {
-    gfsh.executeAndAssertThat("get --region=Users --key=jonbloom").statusIsSuccess();
+    gfsh.executeAndAssertThat("get --region=Users --key=jonbloom")
+        .statusIsSuccess()
+        .hasDataSection(DataCommandResult.DATA_INFO_SECTION)
+        .hasContent()
+        .hasEntrySatisfying("Value", v -> v.contains("\"startTime\":1653595626520"));
   }
 
   @Test
@@ -205,14 +210,26 @@ public class GetCommandIntegrationTest {
 
   private static class User implements Serializable {
     private final String username;
+    private final DateTime startTime;
 
     public User(final String username) {
       assert username != null : "The username cannot be null!";
       this.username = username;
+      this.startTime = new DateTime();
+    }
+
+    public User(final String username, DateTime startTime) {
+      assert username != null : "The username cannot be null!";
+      this.username = username;
+      this.startTime = startTime;
     }
 
     public String getUsername() {
       return username;
+    }
+
+    public DateTime getStartTime() {
+      return startTime;
     }
 
     public String getHashcode() {

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/domain/DataCommandResult.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/domain/DataCommandResult.java
@@ -39,6 +39,7 @@ import org.apache.geode.management.internal.cli.result.model.TabularResultModel;
 import org.apache.geode.management.internal.i18n.CliStrings;
 import org.apache.geode.pdx.JSONFormatter;
 import org.apache.geode.pdx.PdxInstance;
+import org.apache.geode.util.internal.GeodeJsonMapper;
 
 
 /**
@@ -691,7 +692,7 @@ public class DataCommandResult implements Serializable {
       } else if (value instanceof UUID) {
         columnData.put("Result", valueToJson(value));
       } else {
-        ObjectMapper mapper = new ObjectMapper();
+        ObjectMapper mapper = GeodeJsonMapper.getMapperWithAlwaysInclusion();
         JsonNode node = mapper.valueToTree(value);
 
         node.fieldNames().forEachRemaining(field -> {
@@ -729,7 +730,7 @@ public class DataCommandResult implements Serializable {
         return JSONFormatter.toJSON((PdxInstance) value);
       }
 
-      ObjectMapper mapper = new ObjectMapper();
+      ObjectMapper mapper = GeodeJsonMapper.getMapperWithAlwaysInclusion();
       try {
         return mapper.writeValueAsString(value);
       } catch (JsonProcessingException jex) {

--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/functions/DataCommandFunction.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/cli/functions/DataCommandFunction.java
@@ -600,7 +600,6 @@ public class DataCommandFunction implements InternalFunction<DataCommandRequest>
 
   private Object[] getClassAndJson(Object obj) {
     Object[] array = new Object[2];
-
     if (obj == null) {
       array[0] = null;
       array[1] = null;
@@ -614,7 +613,7 @@ public class DataCommandFunction implements InternalFunction<DataCommandRequest>
       return array;
     }
 
-    ObjectMapper mapper = new ObjectMapper();
+    ObjectMapper mapper = GeodeJsonMapper.getMapperWithAlwaysInclusion();
     try {
       array[1] = mapper.writeValueAsString(obj);
     } catch (JsonProcessingException e) {

--- a/geode-junit/build.gradle
+++ b/geode-junit/build.gradle
@@ -47,6 +47,7 @@ dependencies {
   api('io.github.classgraph:classgraph')
   api('com.fasterxml.jackson.core:jackson-annotations')
   api('com.fasterxml.jackson.core:jackson-databind')
+  api('joda-time:joda-time')
   api('com.github.stefanbirkner:system-rules') {
     exclude module: 'junit-dep'
   }

--- a/geode-junit/src/main/java/org/apache/geode/management/model/Employee.java
+++ b/geode-junit/src/main/java/org/apache/geode/management/model/Employee.java
@@ -20,6 +20,7 @@ import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
 
 /**
  * a domain object that has various date objects and json annotations.
@@ -33,6 +34,7 @@ public class Employee {
   private Date startDate;
   private java.sql.Date endDate;
   private LocalDate birthday;
+  private DateTime anniversary;
 
   @JsonIgnore
   public int getId() {
@@ -90,5 +92,13 @@ public class Employee {
 
   public void setBirthday(LocalDate birthday) {
     this.birthday = birthday;
+  }
+
+  public DateTime getAnniversary() {
+    return anniversary;
+  }
+
+  public void setAnniversary(DateTime anniversary) {
+    this.anniversary = anniversary;
   }
 }

--- a/geode-junit/src/test/resources/expected-pom.xml
+++ b/geode-junit/src/test/resources/expected-pom.xml
@@ -93,6 +93,11 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>joda-time</groupId>
+      <artifactId>joda-time</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.stefanbirkner</groupId>
       <artifactId>system-rules</artifactId>
       <scope>compile</scope>

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -87,3 +87,6 @@ antlr-2.7.7.jar
 jetty-xml-9.4.46.v20220331.jar
 geode-rebalancer-0.0.0.jar
 jetty-server-9.4.46.v20220331.jar
+jackson-datatype-jsr310-2.13.2.jar
+jackson-datatype-joda-2.13.2.jar
+joda-time-2.10.14.jar


### PR DESCRIPTION
* GEODE-10301: support LocalDate and JodaTime

Co-authored-by: Jinmei Liao <jliao@pivotal.io>

- include libraries so that end-users won't have to add them to the java
  path
- ensure proper serialization in gfsh and pulse
