### PR TITLE
GEODE-6489: fix a flaky test

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/deadlock/GemFireDeadlockDetectorDUnitTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/distributed/internal/deadlock/GemFireDeadlockDetectorDUnitTest.java
@@ -196,10 +196,9 @@ public class GemFireDeadlockDetectorDUnitTest extends JUnit4CacheTestCase {
         .untilAsserted(() -> assertTrue(getBlackboard().isGateSignaled("two")));
 
     GemFireDeadlockDetector detect = new GemFireDeadlockDetector();
+    await().until(() -> (detect.find().findCycle() != null));
+
     LinkedList<Dependency> deadlock = detect.find().findCycle();
-
-    assertTrue(deadlock != null);
-
     System.out.println("Deadlock=" + DeadlockDetector.prettyFormat(deadlock));
 
     assertEquals(4, deadlock.size());


### PR DESCRIPTION
* fix GemFireDeadlockDetectorDUnitTest.testDistributedDeadlockWithDLock

Test Issue. Gate signaled before 2nd lock is acquired and the the assertion comes in before the 2nd lock is locked.