### PR TITLE
GEODE-10089: update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -280,8 +280,6 @@ Apache Geode bundles the following files under the MIT License:
     Kelvin Luck
   - MooTools (http://mootools.net), Copyright (c) 2006-2015 Valerio
     Proietti, <http://mad4milk.net/>
-  - OrderStatisticTree (https://github.com/coderodde/OrderStatisticTree),
-    Copyright (c) 2021 Rodion Efremov
   - Sizzle.js (http://sizzlejs.com/), Copyright (c) 2011, The Dojo Foundation
   - Split.js (https://github.com/nathancahill/Split.js), Copyright (c)
     2015 Nathan Cahill

--- a/dev-tools/release/license_review.sh
+++ b/dev-tools/release/license_review.sh
@@ -222,6 +222,7 @@ jsr305
 jetty-
 jgroups
 jna-
+joda-time
 lang-tag
 listenablefuture
 log4j-
@@ -233,11 +234,14 @@ nimbus-jose-jwt
 oauth2-oidc-sdk
 rmiio
 shiro-
+snakeyaml
 snappy
 spring-
 springdoc-
 swagger-annotations
-swagger-models"
+swagger-core
+swagger-models
+swagger-ui"
   echo "$1" | egrep -q "(mx4j-remote|jaxb-api|$(echo -n "$apache" | tr '\n' '|'))"
 }
 function shortenDep() {
@@ -246,7 +250,7 @@ function shortenDep() {
     -e 's/-impl//' \
     -e 's/-java//' \
     -e 's/shiro-.*/shiro-*/' \
-    -e 's/jackson-.*/shiro-*/' \
+    -e 's/jackson-.*/jackson-*/' \
     -e 's/jetty-.*/jetty-*/' \
     -e 's/jna-.*/jna-*/' \
     -e 's/lucene-.*/lucene-*/' \
@@ -266,7 +270,7 @@ for REPORT in report1 report2 ; do
   banner "Comparing $topic dep versions in ${NEW_DIR##*/} to $LICENSE"
   rm -f missing-$REPORT apache-$REPORT
   touch missing-$REPORT apache-$REPORT
-  tail -n +2 $NEW_DIR/$REPORT | sed -e 's#.*/##' -e 's/.jar//' | sed 's/-\([0-9]\)/ \1/' | sort -u | grep -v '^ra$' | while read dep ver; do
+  tail -n +2 $NEW_DIR/$REPORT | sed -e 's#.*/##' -e 's/\.jar//' | sed 's/-\([0-9]\)/ \1/' | sort -u | grep -v '^ra$' | while read dep ver; do
     if isApache2 $dep ; then
       echo $dep $ver >> apache-$REPORT
     else
@@ -363,4 +367,11 @@ if [ "${licFromWs}" = "true" ] ; then
   fi
 fi
 
-exit $result
+if [ "$result" == 1 ] ; then
+    banner "ERRORS WERE FOUND"
+    echo "review each section above for details"
+    exit 1
+else
+    banner "SUMMARY"
+    echo 'ALL GOOD!'
+fi

--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -1023,6 +1023,9 @@ The EDL 1.0 License (http://www.eclipse.org/org/documents/edl-v10.php)
 Apache Geode bundles the following file under the EDL 1.0 License:
 
   - istack-commons-runtime v4.0.1
+  - jakarta.activation v1.2.1
+  - jakarta.validation v2.0.2
+  - jakarta.xml.bind v2.3.2
 
 Eclipse Distribution License - v 1.0
 
@@ -1062,8 +1065,6 @@ The MIT License (http://opensource.org/licenses/mit-license.html)
 
 Apache Geode bundles the following files under the MIT License:
 
-  - Checker Qual v3.12.0 (https://checkerframework.org), Copyright (c)
-    2004-present by the Checker Framework developers
   - ClassGraph v4.8.146 (https://github.com/classgraph/classgraph), Copyright
     (c) 2019 Luke Hutchison
   - HTML5 Shiv vpre3.5 (https://github.com/aFarkas/html5shiv), Copyright
@@ -1095,8 +1096,6 @@ Apache Geode bundles the following files under the MIT License:
     Proietti, <http://mad4milk.net/>
   - Normalize.css v2.1.0 (https://necolas.github.io/normalize.css/),
     Copyright (c) Nicolas Gallagher and Jonathan Neal
-  - OrderStatisticTree (https://github.com/coderodde/OrderStatisticTree),
-    Copyright (c) 2021 Rodion Efremov
   - Sizzle.js (http://sizzlejs.com/), Copyright (c) 2011, The Dojo Foundation
   - SLF4J API v1.7.32 (http://www.slf4j.org), Copyright (c) 2004-2017 QOS.ch
   - Split.js (https://github.com/nathancahill/Split.js), Copyright (c)
@@ -1106,6 +1105,7 @@ Apache Geode bundles the following files under the MIT License:
     contributors
   - Timeago v1.3.0 (http://timeago.yarp.com), Copyright (c) 2008-2015 Ryan
     McGeary
+  - webjars-locator-core (https://webjars.org), Copyright (c) 2013 James Ward
   - zTree v3.5.02 (http://zTree.me/), Copyright (c) 2010 Hunter.z
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
we have some dependency changes due to recent redis removal, change to springdoc and inclusion of joda-time