### PR TITLE
(no JIRA ticket) user guide Security section: Typo & format fixes

### DIFF
--- a/geode-docs/managing/security/implementing_authentication_expiry.html.md.erb
+++ b/geode-docs/managing/security/implementing_authentication_expiry.html.md.erb
@@ -48,7 +48,7 @@ is one of the following types where the exception will always be propagated up t
 * multi-user client mode
 * event-dispatching (CQ and registered interest)
 
-## <id="authentication_expiry_considerations"></a>Authentication Expiry Considerations
+## <a id="authentication_expiry_considerations"></a>Authentication Expiry Considerations
 
 The common cycle for authentication and authorization is the following:
 

--- a/geode-docs/managing/security/implementing_ssl.html.md.erb
+++ b/geode-docs/managing/security/implementing_ssl.html.md.erb
@@ -32,32 +32,32 @@ You can specify that SSL be used system-wide, or you can independently configure
 system components.  The following list shows the system components that can be separately configured
 to communicate using SSL, and the kind of communications to which each component name refers:
 
-<dt>**cluster**</dt>
-<dd>Peer-to-peer communications among members of a cluster</dd>
+**cluster**
+:    Peer-to-peer communications among members of a cluster
 
-<dt>**gateway**</dt>
-<dd>Communication across WAN gateways from one site to another</dd>
+**gateway**
+:    Communication across WAN gateways from one site to another
 
-<dt>**web**</dt>
-<dd>All web-based services hosted on the configured server, which can include the Developer REST API
+**web**
+:    All web-based services hosted on the configured server, which can include the Developer REST API
 service, the Management REST API service (used for remote cluster management) and the Pulse
-monitoring tool's web-based user interface.</dd>
+monitoring tool's web-based user interface.
 
-<dt>**jmx**</dt>
-<dd>Java management extension communications, including communications with the `gfsh` utility. 
+**jmx**
+:    Java management extension communications, including communications with the `gfsh` utility. 
 The Pulse monitoring tool uses JMX for server-side communication with a locator, but SSL
 applies to this connection only if Pulse is located on an app server separate from the
 locator. When Pulse and the locator are colocated, JMX communication between the two does not
-involve a TCP connection, so SSL does not apply.</dd>
+involve a TCP connection, so SSL does not apply.
 
-<dt>**locator**</dt>
-<dd>Communication with and between locators</dd>
+**locator**
+:    Communication with and between locators
 
-<dt>**server**</dt>
-<dd>Communication between clients and servers</dd>
+**server**
+:    Communication between clients and servers
 
-<dt>**all**</dt>
-<dd>All of the above (use SSL system-wide)</dd>
+**all**
+:    All of the above (use SSL system-wide)
 
 Specifying that a component is enabled for SSL applies to the component's server-socket side and its
 client-socket side.  For example, if you enable SSL for locators, then any process that communicates
@@ -68,55 +68,55 @@ with a locator must also have SSL enabled.  If you provide "" as the value, SSL 
 You can use <%=vars.product_name%> configuration properties to enable or disable SSL, to identify SSL ciphers and
 protocols, and to provide the location and credentials for key and trust stores.
 
-<dt>**ssl-enabled-components**</dt>
-<dd>List of components for which to enable SSL. Component list can be "" (disable SSL), "all", or a comma-separated list of components.</dd>
+**ssl-enabled-components**
+:    List of components for which to enable SSL. Component list can be "" (disable SSL), "all", or a comma-separated list of components.
 
-<dt>**ssl-endpoint-identification-enabled**</dt>
-<dd>A boolean value that, when set to true, causes clients to validate the server's hostname using the server's certificate.
+**ssl-endpoint-identification-enabled**
+:    A boolean value that, when set to true, causes clients to validate the server's hostname using the server's certificate.
 The default value is false.
-Enabling endpoint identification guards against DNS man-in-the-middle attacks when trusting certificates that are not self-signed.</dd>
+Enabling endpoint identification guards against DNS man-in-the-middle attacks when trusting certificates that are not self-signed.
 
-<dt>**ssl-use-default-context**</dt>
-<dd>A boolean value that, when set to true, allows <%=vars.product_name%> to use the default SSL context as returned by
+**ssl-use-default-context**
+:    A boolean value that, when set to true, allows <%=vars.product_name%> to use the default SSL context as returned by
 SSLContext.getInstance('Default') or set by using SSLContext.setDefault().
 When enabled, also causes ssl-endpoint-identification-enabled to be set to true.
-</dd>
 
-<dt>**ssl-require-authentication**</dt>
-<dd>Requires two-way authentication, applies to all components except web. Boolean - if true (the default), two-way authentication is required.</dd>
 
-<dt>**ssl-web-require-authentication**</dt>
-<dd>Requires two-way authentication for web component. Boolean - if true, two-way authentication is required. Default is false (one-way authentication only).</dd>
+**ssl-require-authentication**
+:    Requires two-way authentication, applies to all components except web. Boolean - if true (the default), two-way authentication is required.
 
-<dt>**ssl-default-alias**</dt>
-<dd>A server uses one key store to hold its SSL certificates. All components on that server can share a
+**ssl-web-require-authentication**
+:    Requires two-way authentication for web component. Boolean - if true, two-way authentication is required. Default is false (one-way authentication only).
+
+**ssl-default-alias**
+:    A server uses one key store to hold its SSL certificates. All components on that server can share a
 single certificate, designated by the ssl-default-alias property.  If ssl-default-alias
-is not specified, the first certificate in the key store acts as the default certificate.</dd>
+is not specified, the first certificate in the key store acts as the default certificate.
 
-<dt>**ssl-_component_-alias=string**</dt>
-<dd>You can configure a separate certificate for any component. All certificates reside in the same key
+**ssl-_component_-alias=string**
+:    You can configure a separate certificate for any component. All certificates reside in the same key
 store, but can be designated by separate aliases that incorporate the component name, using this syntax,
 where _component_ is the name of a component. When a component-specific alias is specified, it
 overrides the ssl-default-alias for the _component_ specified.
 
-For example, ssl-locator-alias would specify a name for the locator component's certificate in the system key store.</dd>
+For example, ssl-locator-alias would specify a name for the locator component's certificate in the system key store.
 
-<dt>**ssl-ciphers**</dt>
-<dd>A comma-separated list of the valid ciphers for TCP/IP connections with TLS encryption enabled. A setting of 'any'
-allows the JSSE provider to select an appropriate cipher that it supports.</dd>
+**ssl-ciphers**
+:    A comma-separated list of the valid ciphers for TCP/IP connections with TLS encryption enabled. A setting of 'any'
+allows the JSSE provider to select an appropriate cipher that it supports.
 
-<dt>**ssl-protocols**</dt>
-<dd>A comma-separated list of the valid protocol versions for TCP/IP connections with TLS encryption enabled.
-A setting of 'any' attempts to use your JSSE provider's TLSv1.3, or TLSv1.2 if v1.3 is not available.</dd>
+**ssl-protocols**
+:    A comma-separated list of the valid protocol versions for TCP/IP connections with TLS encryption enabled.
+A setting of 'any' attempts to use your JSSE provider's TLSv1.3, or TLSv1.2 if v1.3 is not available.
 
-<dt>**ssl-keystore, ssl-keystore-password**</dt>
-<dd>The path to the key store and the key store password, specified as strings</dd>
+**ssl-keystore, ssl-keystore-password**
+:    The path to the key store and the key store password, specified as strings
 
-<dt>**ssl-truststore, ssl-truststore-password**</dt>
-<dd>The path to the trust store and the trust store password, specified as strings</dd>
+**ssl-truststore, ssl-truststore-password**
+:    The path to the trust store and the trust store password, specified as strings
 
-<dt>**ssl-keystore-type, ssl-truststore-type**</dt>
-<dd>The types of the key store and trust store, specified as strings. The default for both is "JKS", indicating a Java key store or trust store.</dd>
+**ssl-keystore-type, ssl-truststore-type**
+:    The types of the key store and trust store, specified as strings. The default for both is "JKS", indicating a Java key store or trust store.
 
 ### Example: secure communications throughout
 
@@ -218,7 +218,7 @@ The following table lists the properties you can use to configure SSL on your <%
 | ssl-protocols                      | list of SSL protocols                      | comma-separated list (default "any") |
 | ssl-keystore                       | path to key store                           | string |
 | ssl-keystore-password              | key store password                          | string |
-| ssl-keystore-type                  | trust store type.                           | string |
+| ssl-keystore-type                  | trust store type                            | string |
 | ssl-truststore                     | path to trust store                         | string |
 | ssl-truststore-password            | trust store password                        | string |
 | ssl-truststore-type                | trust store type                            | string |


### PR DESCRIPTION
Doc format fixes. Back port to 1.15 ASAP.