### PR TITLE
GEODE-10388: create better output filter for srcDist task

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -442,14 +442,8 @@ distributions {
         exclude 'wrapper'
 
         // These exclude the 'build' and 'out' artifact directories from Gradle and IntelliJ for each project
-        exclude 'buildSrc/build'
-        exclude 'buildSrc/out'
-        rootProject.allprojects.each {
-          def relPath = Paths.get(rootDir.getPath()).relativize(Paths.get(it.projectDir.getPath()))
-          def relOut = relPath.resolve("out").toString()
-          def relBuild = relPath.resolve("build").toString()
-          exclude relOut
-          exclude relBuild
+        exclude { FileTreeElement details ->
+          details.directory && (details.name == "build" || details.name == "out")
         }
       }
     }


### PR DESCRIPTION
Replace the brittle exclude list for `build` and `out` directories with
a closure containing comparison logic for file-type and name. Makes sure
that regular files named `out` are still archived.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [n/a] Have you written or updated unit tests to verify your changes?

- [n/a] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
