### PR TITLE
GEODE-10393: Add generic type on return type

### DIFF
--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClearDuringGiiOplogWithMissingCreateRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/ClearDuringGiiOplogWithMissingCreateRegressionTest.java
@@ -212,7 +212,7 @@ public class ClearDuringGiiOplogWithMissingCreateRegressionTest extends CacheTes
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       return TestableDiskRegionEntry.class;
     }
 

--- a/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GiiDiskAccessExceptionRegressionTest.java
+++ b/geode-core/src/distributedTest/java/org/apache/geode/internal/cache/GiiDiskAccessExceptionRegressionTest.java
@@ -191,7 +191,7 @@ public class GiiDiskAccessExceptionRegressionTest extends CacheTestCase {
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       return getClass();
     }
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEntryFactory.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/RegionEntryFactory.java
@@ -34,7 +34,7 @@ public interface RegionEntryFactory {
   /**
    * @return the Class that each entry, of this factory, is an instance of
    */
-  Class getEntryClass();
+  Class<?> getEntryClass();
 
   /**
    * @return return the versioned equivalent of this RegionEntryFactory

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryHeap.java
@@ -64,7 +64,7 @@ public abstract class VMStatsDiskLRURegionEntryHeap extends VMStatsDiskLRURegion
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMStatsDiskLRURegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskLRURegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VMStatsDiskLRURegionEntryOffHeap extends VMStatsDiskLRUReg
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMStatsDiskLRURegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryHeap.java
@@ -64,7 +64,7 @@ public abstract class VMStatsDiskRegionEntryHeap extends VMStatsDiskRegionEntry 
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMStatsDiskRegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsDiskRegionEntryOffHeap.java
@@ -65,7 +65,7 @@ public abstract class VMStatsDiskRegionEntryOffHeap extends VMStatsDiskRegionEnt
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMStatsDiskRegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryHeap.java
@@ -64,7 +64,7 @@ public abstract class VMStatsLRURegionEntryHeap extends VMStatsLRURegionEntry {
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMStatsLRURegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsLRURegionEntryOffHeap.java
@@ -65,7 +65,7 @@ public abstract class VMStatsLRURegionEntryOffHeap extends VMStatsLRURegionEntry
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMStatsLRURegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryHeap.java
@@ -63,7 +63,7 @@ public abstract class VMStatsRegionEntryHeap extends VMStatsRegionEntry {
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMStatsRegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMStatsRegionEntryOffHeap.java
@@ -65,7 +65,7 @@ public abstract class VMStatsRegionEntryOffHeap extends VMStatsRegionEntry
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMStatsRegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryHeap.java
@@ -64,7 +64,7 @@ public abstract class VMThinDiskLRURegionEntryHeap extends VMThinDiskLRURegionEn
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMThinDiskLRURegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskLRURegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VMThinDiskLRURegionEntryOffHeap extends VMThinDiskLRURegio
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMThinDiskLRURegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryHeap.java
@@ -64,7 +64,7 @@ public abstract class VMThinDiskRegionEntryHeap extends VMThinDiskRegionEntry {
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMThinDiskRegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinDiskRegionEntryOffHeap.java
@@ -65,7 +65,7 @@ public abstract class VMThinDiskRegionEntryOffHeap extends VMThinDiskRegionEntry
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMThinDiskRegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryHeap.java
@@ -64,7 +64,7 @@ public abstract class VMThinLRURegionEntryHeap extends VMThinLRURegionEntry {
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMThinLRURegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinLRURegionEntryOffHeap.java
@@ -65,7 +65,7 @@ public abstract class VMThinLRURegionEntryOffHeap extends VMThinLRURegionEntry
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMThinLRURegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryHeap.java
@@ -63,7 +63,7 @@ public abstract class VMThinRegionEntryHeap extends VMThinRegionEntry {
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMThinRegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VMThinRegionEntryOffHeap.java
@@ -65,7 +65,7 @@ public abstract class VMThinRegionEntryOffHeap extends VMThinRegionEntry
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VMThinRegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryHeap.java
@@ -67,7 +67,7 @@ public abstract class VersionedStatsDiskLRURegionEntryHeap
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedStatsDiskLRURegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskLRURegionEntryOffHeap.java
@@ -68,7 +68,7 @@ public abstract class VersionedStatsDiskLRURegionEntryOffHeap
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedStatsDiskLRURegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryHeap.java
@@ -66,7 +66,7 @@ public abstract class VersionedStatsDiskRegionEntryHeap extends VersionedStatsDi
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedStatsDiskRegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsDiskRegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VersionedStatsDiskRegionEntryOffHeap extends VersionedStat
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedStatsDiskRegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryHeap.java
@@ -66,7 +66,7 @@ public abstract class VersionedStatsLRURegionEntryHeap extends VersionedStatsLRU
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedStatsLRURegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsLRURegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VersionedStatsLRURegionEntryOffHeap extends VersionedStats
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedStatsLRURegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryHeap.java
@@ -64,7 +64,7 @@ public abstract class VersionedStatsRegionEntryHeap extends VersionedStatsRegion
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedStatsRegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedStatsRegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VersionedStatsRegionEntryOffHeap extends VersionedStatsReg
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedStatsRegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryHeap.java
@@ -66,7 +66,7 @@ public abstract class VersionedThinDiskLRURegionEntryHeap extends VersionedThinD
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedThinDiskLRURegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskLRURegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VersionedThinDiskLRURegionEntryOffHeap extends VersionedTh
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedThinDiskLRURegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryHeap.java
@@ -66,7 +66,7 @@ public abstract class VersionedThinDiskRegionEntryHeap extends VersionedThinDisk
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedThinDiskRegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinDiskRegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VersionedThinDiskRegionEntryOffHeap extends VersionedThinD
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedThinDiskRegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryHeap.java
@@ -66,7 +66,7 @@ public abstract class VersionedThinLRURegionEntryHeap extends VersionedThinLRURe
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedThinLRURegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinLRURegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VersionedThinLRURegionEntryOffHeap extends VersionedThinLR
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedThinLRURegionEntryOffHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryHeap.java
@@ -64,7 +64,7 @@ public abstract class VersionedThinRegionEntryHeap extends VersionedThinRegionEn
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedThinRegionEntryHeapObjectKey.class;

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeap.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/entries/VersionedThinRegionEntryOffHeap.java
@@ -67,7 +67,7 @@ public abstract class VersionedThinRegionEntryOffHeap extends VersionedThinRegio
     }
 
     @Override
-    public Class getEntryClass() {
+    public Class<?> getEntryClass() {
       // The class returned from this method is used to estimate the memory size.
       // This estimate will not take into account the memory saved by inlining the keys.
       return VersionedThinRegionEntryOffHeapObjectKey.class;


### PR DESCRIPTION
- For RegionEntryFactory.getEntryClass

This is to reduce compiler warnings in this interface and implementing classes.