### PR TITLE
GEODE-10089: Add 1.15.0 as old version

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -17,7 +17,7 @@
 
 benchmarks:
   baseline_branch_default: ''
-  baseline_version_default: '1.14.4'
+  baseline_version_default: '1.15.0'
   benchmark_branch: ((geode-build-branch))
   flavors:
   - title: 'base'

--- a/settings.gradle
+++ b/settings.gradle
@@ -109,7 +109,8 @@ include 'geode-server-all'
  '1.13.1',
  '1.13.8',
  '1.14.0', // Include for SSL protocol configuration changes in 1.14.0
- '1.14.4'].each {
+ '1.14.4',
+ '1.15.0'].each {
   include 'geode-old-versions:'.concat(it)
 }
 


### PR DESCRIPTION
Add 1.15.0 in old versions and set as Benchmarks baseline on develop
to enable rolling upgrade tests from 1.15.0