### PR TITLE
GEODE-10401: Configurable .drf recovery HashMap overflow threshold 

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/DiskStoreImpl.java
@@ -184,11 +184,22 @@ public class DiskStoreImpl implements DiskStore {
       GeodeGlossary.GEMFIRE_PREFIX + "disk.recoverValuesSync";
 
   /**
+   * When configured threshold value is reached, then server will overflow to
+   * the new hashmap during the recovery of .drf files
+   */
+  public static final String DRF_HASHMAP_OVERFLOW_THRESHOLD_NAME =
+      GeodeGlossary.GEMFIRE_PREFIX + "disk.drfHashMapOverflowThreshold";
+
+  /**
    * Allows recovering values for LRU regions. By default values are not recovered for LRU regions
    * during recovery.
    */
   public static final String RECOVER_LRU_VALUES_PROPERTY_NAME =
       GeodeGlossary.GEMFIRE_PREFIX + "disk.recoverLruValues";
+
+  static final long DRF_HASHMAP_OVERFLOW_THRESHOLD_DEFAULT = 805306368;
+  static final long DRF_HASHMAP_OVERFLOW_THRESHOLD =
+      Long.getLong(DRF_HASHMAP_OVERFLOW_THRESHOLD_NAME, DRF_HASHMAP_OVERFLOW_THRESHOLD_DEFAULT);
 
   boolean RECOVER_VALUES = getBoolean(DiskStoreImpl.RECOVER_VALUE_PROPERTY_NAME, true);
 
@@ -3546,31 +3557,49 @@ public class DiskStoreImpl implements DiskStore {
       }
 
       try {
-        if (id > 0 && id <= 0x00000000FFFFFFFFL) {
-          currentInts.get().add((int) id);
+        if (shouldOverflow(id)) {
+          overflowToNewHashMap(id);
         } else {
-          currentLongs.get().add(id);
+          if (id > 0 && id <= 0x00000000FFFFFFFFL) {
+            this.currentInts.get().add((int) id);
+          } else {
+            this.currentLongs.get().add(id);
+          }
         }
       } catch (IllegalArgumentException illegalArgumentException) {
         // See GEODE-8029.
-        // Too many entries on the accumulated drf files, overflow and continue.
+        // Too many entries on the accumulated drf files, overflow next [Int|Long]OpenHashSet and
+        // continue.
+        overflowToNewHashMap(id);
+      }
+    }
+
+    boolean shouldOverflow(final long id) {
+      if (id > 0 && id <= 0x00000000FFFFFFFFL) {
+        return currentInts.get().size() == DRF_HASHMAP_OVERFLOW_THRESHOLD;
+      } else {
+        return currentLongs.get().size() == DRF_HASHMAP_OVERFLOW_THRESHOLD;
+      }
+    }
+
+    void overflowToNewHashMap(final long id) {
+      if (DRF_HASHMAP_OVERFLOW_THRESHOLD == DRF_HASHMAP_OVERFLOW_THRESHOLD_DEFAULT) {
         logger.warn(
             "There is a large number of deleted entries within the disk-store, please execute an offline compaction.");
+      }
 
-        // Overflow to the next [Int|Long]OpenHashSet and continue.
-        if (id > 0 && id <= 0x00000000FFFFFFFFL) {
-          IntOpenHashSet overflownHashSet = new IntOpenHashSet((int) INVALID_ID);
-          allInts.add(overflownHashSet);
-          currentInts.set(overflownHashSet);
+      if (id > 0 && id <= 0x00000000FFFFFFFFL) {
+        IntOpenHashSet overflownHashSet = new IntOpenHashSet((int) INVALID_ID);
+        allInts.add(overflownHashSet);
+        currentInts.set(overflownHashSet);
 
-          currentInts.get().add((int) id);
-        } else {
-          LongOpenHashSet overflownHashSet = new LongOpenHashSet((int) INVALID_ID);
-          allLongs.add(overflownHashSet);
-          currentLongs.set(overflownHashSet);
+        currentInts.get().add((int) id);
+      } else {
+        LongOpenHashSet overflownHashSet = new LongOpenHashSet((int) INVALID_ID);
+        allLongs.add(overflownHashSet);
+        currentLongs.set(overflownHashSet);
 
-          currentLongs.get().add(id);
-        }
+        currentLongs.get().add(id);
       }
     }
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/OplogEntryIdSetDrfHashSetThresholdTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/OplogEntryIdSetDrfHashSetThresholdTest.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetSystemProperty;
+
+import org.apache.geode.internal.cache.DiskStoreImpl.OplogEntryIdSet;
+
+/**
+ * Tests DiskStoreImpl.OplogEntryIdSet
+ */
+public class OplogEntryIdSetDrfHashSetThresholdTest {
+  @Test
+  @SetSystemProperty(key = "gemfire.disk.drfHashMapOverflowThreshold", value = "10")
+  public void addMethodOverflowBasedOnDrfOverflowThresholdParameters() {
+
+    int testEntries = 41;
+    IntOpenHashSet intOpenHashSet = new IntOpenHashSet();
+    LongOpenHashSet longOpenHashSet = new LongOpenHashSet();
+
+    List<IntOpenHashSet> intOpenHashSets =
+        new ArrayList<>(Collections.singletonList(intOpenHashSet));
+    List<LongOpenHashSet> longOpenHashSets =
+        new ArrayList<>(Collections.singletonList(longOpenHashSet));
+
+    OplogEntryIdSet oplogEntryIdSet = new OplogEntryIdSet(intOpenHashSets, longOpenHashSets);
+    IntStream.range(1, testEntries).forEach(oplogEntryIdSet::add);
+    LongStream.range(0x00000000FFFFFFFFL + 1, 0x00000000FFFFFFFFL + testEntries)
+        .forEach(oplogEntryIdSet::add);
+
+    assertThat(intOpenHashSets).hasSize(4);
+    assertThat(longOpenHashSets).hasSize(4);
+
+    IntStream.range(1, testEntries).forEach(i -> assertThat(oplogEntryIdSet.contains(i)).isTrue());
+    LongStream.range(0x00000000FFFFFFFFL + 1, 0x00000000FFFFFFFFL + testEntries)
+        .forEach(i -> assertThat(oplogEntryIdSet.contains(i)).isTrue());
+
+  }
+}


### PR DESCRIPTION
Configurable with the jvm parameter:

gemfire.disk.drfHashMapOverflowThreshold

Default value: 805306368

When configured threshold value is reached, then server will overflow to
the new hashmap during the recovery of .drf files. Warning: If you set
threshold parameter over 805306368, then uneeded delay will happen due
to bug in fastutil dependency.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
