### PR TITLE
GEODE-10412: Clear expired tombstones during region destroy

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/TombstoneService.java
@@ -926,7 +926,11 @@ public class TombstoneService {
      * @return true if predicate ever returned true
      */
     private boolean removeIf(Predicate<Tombstone> predicate) {
-      return removeUnexpiredIf(predicate) || removeExpiredIf(predicate);
+      boolean isTombstoneRemoved = removeUnexpiredIf(predicate);
+      if (removeExpiredIf(predicate)) {
+        isTombstoneRemoved = true;
+      }
+      return isTombstoneRemoved;
     }
 
     synchronized void start() {

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/TombstoneServiceTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/TombstoneServiceTest.java
@@ -99,7 +99,7 @@ public class TombstoneServiceTest {
   }
 
   @Test
-  public void validateThatTheNoneExpiredTombstonesAreCleared() {
+  public void validateThatTheNonExpiredTombstonesAreCleared() {
     when(region.getRegionMap()).thenReturn(regionMap);
     replicateTombstoneSweeper.scheduleTombstone(tombstone1);
     assertThat(replicateTombstoneSweeper.getScheduledTombstoneCount()).isOne();
@@ -108,7 +108,7 @@ public class TombstoneServiceTest {
   }
 
   @Test
-  public void validateThatTheNoneExpiredAndExpiredTombstonesAreCleared() {
+  public void validateThatTheNonExpiredAndExpiredTombstonesAreCleared() {
     when(region.getRegionMap()).thenReturn(regionMap);
     replicateTombstoneSweeper.scheduleTombstone(tombstone1);
     replicateTombstoneSweeper.expireTombstone(tombstone2);
@@ -116,5 +116,4 @@ public class TombstoneServiceTest {
     replicateTombstoneSweeper.unscheduleTombstones(region);
     assertThat(replicateTombstoneSweeper.getScheduledTombstoneCount()).isZero();
   }
-
 }


### PR DESCRIPTION
The issue:
During region destroy operation, the expired tombstones aren't cleared
when non-expired ones are available. Later, these expired
tombstones prevent all other regions' tombstones from being cleared
from memory, causing many issues (memory and disk exhaustion).

The solution:
When a region is destroyed, it must clear all the related expired and
non-expired tombstones from memory.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
