### PR TITLE
GEODE-10409: Fix rebalance load model missing collocated regions at s…

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
@@ -89,7 +89,7 @@ public class PartitionedRegionRebalanceOp {
   private final boolean replaceOfflineData;
   private final PartitionedRegion leaderRegion;
   private final PartitionedRegion targetRegion;
-  protected Collection<PartitionedRegion> colocatedRegions;
+  private Collection<PartitionedRegion> colocatedRegions;
   private final AtomicBoolean cancelled;
   private final ResourceManagerStats stats;
   private final boolean isRebalance; // true indicates a rebalance instead of recovery
@@ -397,7 +397,7 @@ public class PartitionedRegionRebalanceOp {
     }
   }
 
-  protected Map<PartitionedRegion, InternalPRInfo> fetchDetails(InternalCache cache) {
+  private Map<PartitionedRegion, InternalPRInfo> fetchDetails(InternalCache cache) {
     LoadProbe probe = cache.getInternalResourceManager().getLoadProbe();
     Map<PartitionedRegion, InternalPRInfo> detailsMap =
         new LinkedHashMap<>(colocatedRegions.size());
@@ -430,7 +430,7 @@ public class PartitionedRegionRebalanceOp {
    * etc.
    *
    */
-  protected PartitionedRegionLoadModel buildModel(BucketOperator operator,
+  private PartitionedRegionLoadModel buildModel(BucketOperator operator,
       Map<PartitionedRegion, InternalPRInfo> detailsMap, InternalResourceManager resourceManager) {
     PartitionedRegionLoadModel model;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
@@ -89,7 +89,7 @@ public class PartitionedRegionRebalanceOp {
   private final boolean replaceOfflineData;
   private final PartitionedRegion leaderRegion;
   private final PartitionedRegion targetRegion;
-  private Collection<PartitionedRegion> colocatedRegions;
+  protected Collection<PartitionedRegion> colocatedRegions;
   private final AtomicBoolean cancelled;
   private final ResourceManagerStats stats;
   private final boolean isRebalance; // true indicates a rebalance instead of recovery
@@ -397,7 +397,7 @@ public class PartitionedRegionRebalanceOp {
     }
   }
 
-  private Map<PartitionedRegion, InternalPRInfo> fetchDetails(InternalCache cache) {
+  protected Map<PartitionedRegion, InternalPRInfo> fetchDetails(InternalCache cache) {
     LoadProbe probe = cache.getInternalResourceManager().getLoadProbe();
     Map<PartitionedRegion, InternalPRInfo> detailsMap =
         new LinkedHashMap<>(colocatedRegions.size());
@@ -430,7 +430,7 @@ public class PartitionedRegionRebalanceOp {
    * etc.
    *
    */
-  private PartitionedRegionLoadModel buildModel(BucketOperator operator,
+  protected PartitionedRegionLoadModel buildModel(BucketOperator operator,
       Map<PartitionedRegion, InternalPRInfo> detailsMap, InternalResourceManager resourceManager) {
     PartitionedRegionLoadModel model;
 

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOp.java
@@ -302,8 +302,8 @@ public class PartitionedRegionRebalanceOp {
     // anywhere I think. We need to make sure we don't do a rebalance unless we have
     // all of the colocated regions others do.
     Map<String, PartitionedRegion> colocatedRegionsMap =
-        ColocationHelper.getAllColocationRegions(targetRegion);
-    colocatedRegionsMap.put(targetRegion.getFullPath(), targetRegion);
+        ColocationHelper.getAllColocationRegions(leaderRegion);
+    colocatedRegionsMap.put(leaderRegion.getFullPath(), leaderRegion);
     final LinkedList<PartitionedRegion> colocatedRegions = new LinkedList<>();
     for (PartitionedRegion colocatedRegion : colocatedRegionsMap.values()) {
 

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOpTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOpTest.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to You under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package org.apache.geode.internal.cache.partitioned;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+
+import org.junit.Test;
+
+import org.apache.geode.cache.PartitionAttributes;
+import org.apache.geode.cache.PartitionAttributesFactory;
+import org.apache.geode.internal.cache.InternalCache;
+import org.apache.geode.internal.cache.PartitionedRegion;
+import org.apache.geode.internal.cache.PartitionedRegionTestHelper;
+import org.apache.geode.internal.cache.control.InternalResourceManager;
+import org.apache.geode.internal.cache.partitioned.rebalance.model.Member;
+import org.apache.geode.internal.cache.partitioned.rebalance.model.PartitionedRegionLoadModel;
+
+
+public class PartitionedRegionRebalanceOpTest {
+  private PartitionedRegion leaderRegion;
+  private PartitionedRegion colocRegion1;
+  private PartitionedRegion colocRegion2;
+  private static final long MB = 1024 * 1024;
+
+  @Test
+  public void testAllCollocatedRegionsSetWhenRebalanceTargetIsLeaderRegion() {
+    leaderRegion = (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("leader");
+    PartitionAttributesFactory paf = new PartitionAttributesFactory();
+    PartitionAttributes pa = paf.setColocatedWith("/leader").create();
+    colocRegion1 =
+        (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("colo1", pa);
+    colocRegion2 =
+        (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("colo2", pa);
+
+    try {
+      PartitionedRegionRebalanceOp part_op =
+          new PartitionedRegionRebalanceOp(leaderRegion, false, null, false, false, null, null);
+      part_op.checkAndSetColocatedRegions();
+      assertEquals(3, part_op.colocatedRegions.size());
+    } finally {
+      colocRegion1.destroyRegion();
+      colocRegion2.destroyRegion();
+      leaderRegion.destroyRegion();
+    }
+  }
+
+  @Test
+  public void testAllCollocatedRegionsSetWhenRebalanceTargetIsCollocatedRegion() {
+    leaderRegion = (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("leader");
+    PartitionAttributesFactory paf = new PartitionAttributesFactory();
+    PartitionAttributes pa = paf.setColocatedWith("/leader").create();
+    colocRegion1 =
+        (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("colo1", pa);
+    colocRegion2 =
+        (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("colo2", pa);
+
+    try {
+      PartitionedRegionRebalanceOp part_op =
+          new PartitionedRegionRebalanceOp(colocRegion1, false, null, false, false, null, null);
+      part_op.checkAndSetColocatedRegions();
+      assertEquals(3, part_op.colocatedRegions.size());
+    } finally {
+      colocRegion1.destroyRegion();
+      colocRegion2.destroyRegion();
+      leaderRegion.destroyRegion();
+    }
+  }
+
+  @Test
+  public void testRebalanceModelWhenRebalanceTargetIsCollocatedRegion() {
+    PartitionAttributesFactory paf = new PartitionAttributesFactory();
+    PartitionAttributes pa = paf.setLocalMaxMemory(4).create();
+    leaderRegion =
+        (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("leader", pa);
+    paf = new PartitionAttributesFactory();
+    pa = paf.setColocatedWith("/leader").setLocalMaxMemory(4).create();
+    colocRegion1 =
+        (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("colo1", pa);
+    colocRegion2 =
+        (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("colo2", pa);
+
+    try {
+      PartitionedRegionRebalanceOp part_op =
+          new PartitionedRegionRebalanceOp(colocRegion1, false, null, false, false, null, null);
+      part_op.checkAndSetColocatedRegions();
+      InternalCache cache = leaderRegion.getCache();
+      Map<PartitionedRegion, InternalPRInfo> detailsMap = part_op.fetchDetails(cache);
+      InternalResourceManager resourceMgr =
+          InternalResourceManager.getInternalResourceManager(cache);
+      PartitionedRegionLoadModel model = part_op.buildModel(null, detailsMap, resourceMgr);
+      System.out.println(model.toString());
+      Member member = model.getMember(leaderRegion.getDistributionManager().getId());
+      assertEquals(member.getConfiguredMaxMemory() / MB, 12);
+    } finally {
+      colocRegion1.destroyRegion();
+      colocRegion2.destroyRegion();
+      leaderRegion.destroyRegion();
+    }
+  }
+}

--- a/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOpTest.java
+++ b/geode-core/src/test/java/org/apache/geode/internal/cache/partitioned/PartitionedRegionRebalanceOpTest.java
@@ -46,11 +46,11 @@ public class PartitionedRegionRebalanceOpTest {
     colocRegion2 =
         (PartitionedRegion) PartitionedRegionTestHelper.createPartionedRegion("colo2", pa);
     RebalanceDirector director = new MoveBuckets();
-    PartitionedRegionRebalanceOp part_op =
+    PartitionedRegionRebalanceOp rebalanceOp =
         new PartitionedRegionRebalanceOp(colocRegion1, false, director, false, true,
             new AtomicBoolean(false), null);
-    Set<PartitionRebalanceInfo> rebalanceInfo = part_op.execute();
+    Set<PartitionRebalanceInfo> rebalanceInfo = rebalanceOp.execute();
     // 3 regions include the leader region and 2 colocated regions.
-    assertThat(rebalanceInfo.size()).isEqualTo(3);
+    assertThat(rebalanceInfo).hasSize(3);
   }
 }


### PR DESCRIPTION
…erver startup

Assume region A collocated with A1 and A2, and a is the leader region, when rebalance at startup,
rebalance will happened after the 3 region collocation completed, generally this happened in region A2.
And when calculate rebalance load model from view of region A2, only leader region A and A2 itself will
be added to the model, this commit fix the issue and make A1 also be added to the model.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [x] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
