### PR TITLE
update the path to the 'default' geode-native Dockerfile

### DIFF
--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -347,7 +347,7 @@ echo "============================================================"
 echo "Building Native docker image"
 echo "============================================================"
 set -x
-cd ${GEODE_NATIVE}/docker
+cd ${GEODE_NATIVE}/docker/ubuntu-20.04
 docker build . || docker build . || docker build .
 docker build -t apachegeode/geode-native-build:${VERSION} .
 [ -n "$LATER" ] || docker build -t apachegeode/geode-native-build:latest .


### PR DESCRIPTION
During the course of the 1.15.0 release, this small fix was identified due to a reorganization of geode-native.

If you're interested in volunteering as Release Manager for Geode 1.15.1, you'll want to have this fix present in your local checkout of develop.

Full instructions for doing a release can be found at https://cwiki.apache.org/confluence/display/GEODE/Releasing+Apache+Geode

Please email dev@geode.apache.org for any specific questions about the process or scripts.