### PR TITLE
GEODE-10423: Document the system property “ON_DISCONNECT_CLEAR_PDXTYP…

### DIFF
--- a/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
+++ b/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
@@ -32,15 +32,17 @@ When you serialize an object using PDX, <%=vars.product_name%> stores the object
 This centralization of object type information is advantageous for client/server installations in which clients and servers are written in different languages. Clients pass registry information to servers automatically when they store a PDX serialized object. Clients can run queries and functions against the data in the servers without compatibility between server and the stored objects. One client can store data on the server to be retrieved by another client, with no requirements on the part of the server.
 
 **Note:**
-In some cases pdx registry may be lost, the cases include but not limited to the following:
+There are situations where some of the information in the central registry of the PDX domain object metadata is lost, e.g. when restoring an old backup with an outdated central registry.
 
--   A backup was restored, and such backup is missing pdx registry.
--   PDX registry is not persistent, and the cluster goes down.
--   Disk store on which PDX types are stored gets corrupted and the cluster restarts.
+When that happens, new clients connecting to the cluster for the first time will get outdated PDX type information from the central registry, but, since information in the central registry is cached by clients, old clients may have fresher information about PDX types than the central registry does. That will result into inconsistent information about PDX types spread across the system:
 
-Once pdx registry is lost and the cluster restart, but client still running with the previous pdx type info, if cluster start again, the pdx registry between client and server will be inconsistent, hence this client still use old pdx type to write entries, now if other clients read these entries, they will see Unknown pdx type error, this error indicate that each entry using the missing PDX will be corrupted, hence this leads to data corruption in the cluster.
+-   old clients have fresh information
+-   the central registry has outdated information
+-   new clients have outdated information
 
-In order to avoid this issue, a system property in below table is used to clear the pdx type on client side when client disconnects from cluster, with this property set to true, if client disconnects from cluster then client will clear pdx registry, this could avoid pdx type inconsistency between client and server, client will write entry with new pdx type, this new pdx type is regenerated and passed among the clusters, hence other clients could read entries successfully.
+If old clients write entries of a PDX type they know but the central registry doesn't, new clients will get "Unknown PDX type" errors when they read those objects.
+
+To avoid this problem, clients may be configured with the system property in the table below to clear their PDX type cache when they disconnect from the cluster. After clearing their cache, old clients will re-generate type information for all PDX types, including the types the central registry "forgot". Since new PDX type information will be written in the central registry before entries of that type are written in the cluster, the central registry and all clients, old and new, will store consistent PDX type information.
 
 | Name                                      | Description                                             | Default |
 |-------------------------------------------|---------------------------------------------------------|---------|

--- a/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
+++ b/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
@@ -32,9 +32,15 @@ When you serialize an object using PDX, <%=vars.product_name%> stores the object
 This centralization of object type information is advantageous for client/server installations in which clients and servers are written in different languages. Clients pass registry information to servers automatically when they store a PDX serialized object. Clients can run queries and functions against the data in the servers without compatibility between server and the stored objects. One client can store data on the server to be retrieved by another client, with no requirements on the part of the server.
 
 **Note:**
-When pdx registry is not persistent or persistent pdx registry is removed, if all the servers are stopped/crashed with clients still running, then the client with previous pdx type info connects to cluster with servers that are re-started, the client will see Unknown pdx type error.
+In some cases pdx registry may be lost, the cases include but not limited to the following:
 
-To fix this currently a system property is used to clear the pdx type on client side when client disconnects from servers.
+-   A backup was restored, and such backup is missing pdx registry.
+-   PDX registry is not persistent, and the cluster goes down.
+-   Disk store on which PDX types are stored gets corrupted and the cluster restarts.
+
+Once pdx registry is lost and the cluster restart, but client still running with the previous pdx type info, if cluster start again, the pdx registry between client and server will be inconsistent, hence this client still use old pdx type to write entries, now if other clients read these entries, they will see Unknown pdx type error, this error indicate that each entry using the missing PDX will be corrupted, hence this leads to data corruption in the cluster.
+
+In order to avoid this issue, a system property in below table is used to clear the pdx type on client side when client disconnects from cluster, with this property set to true, if client disconnects from cluster then client will clear pdx registry, this could avoid pdx type inconsistency between client and server, client will write entry with new pdx type, this new pdx type is regenerated and passed among the clusters, hence other clients could read entries successfully.
 
 | Name                                      | Description                                             | Default |
 |-------------------------------------------|---------------------------------------------------------|---------|

--- a/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
+++ b/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
@@ -31,6 +31,25 @@ When you serialize an object using PDX, <%=vars.product_name%> stores the object
 
 This centralization of object type information is advantageous for client/server installations in which clients and servers are written in different languages. Clients pass registry information to servers automatically when they store a PDX serialized object. Clients can run queries and functions against the data in the servers without compatibility between server and the stored objects. One client can store data on the server to be retrieved by another client, with no requirements on the part of the server.
 
+**Note:**
+When pdx registry is not persistent or persistent pdx registry is removed, if all the servers are stopped/crashed with clients still running, then the client with previous pdx type info connects to cluster with servers that are re-started, the client will see Unknown pdx type error.
+
+To fix this currently a system property is used to clear the pdx type on client side when client disconnects from servers.
+
+| Name                                      | Description                                             | Default |
+|-------------------------------------------|---------------------------------------------------------|---------|
+| `gemfire.ON_DISCONNECT_CLEAR_PDXTYPEIDS`  | Clear pdxType ids when client disconnects from servers. | `false` |
+-   In the API, set the System properties before the cache creation call. Example:
+
+    ``` pre
+    System.setProperty(PoolImpl.ON_DISCONNECT_CLEAR_PDXTYPEIDS, "true");
+    ```
+-   At the java command line, pass in System properties using the -D switch. Example:
+
+    ``` pre
+    java -Dgemfire.ON_DISCONNECT_CLEAR_PDXTYPEIDS=true
+    ```
+
 ## <a id="concept_F02E40517C4B42F2A75B133BB507C626__section_08C901A3CF3E438C8778F09D482B9A63" class="no-quick-link"></a>Reduced Deserialization of Serialized Objects
 
 The access methods of PDX serialized objects allow you to examine specific fields of your domain object without deserializing the entire object. Depending on your object usage, you can reduce serialization and deserialization costs significantly.

--- a/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
+++ b/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
@@ -45,10 +45,10 @@ If old clients write entries of a PDX type they know but the central registry do
 
 To avoid this problem, clients may be configured with the system property in the table below to clear their PDX type cache when they disconnect from the cluster. After clearing their cache, old clients will re-generate type information for all PDX types, including the types the central registry "forgot". Since new PDX type information will be written in the central registry before entries of that type are written in the cluster, the central registry and all clients, old and new, will store consistent PDX type information.
 
-| Name                                      | Default | Applies to (Java Client, Native Client)|
-|-------------------------------------------|---------|----------------------------------------|
-| `gemfire.ON_DISCONNECT_CLEAR_PDXTYPEIDS`  | `false` | Java Client                            |
-| `on-client-disconnect-clear-pdxType-Ids`  | `false` | Native Client                          |
+| Name                                      | Default | Client type   |
+|-------------------------------------------|---------|---------------|
+| `gemfire.ON_DISCONNECT_CLEAR_PDXTYPEIDS`  | `false` | Java Client   |
+| `on-client-disconnect-clear-pdxType-Ids`  | `false` | Native Client |
 
 ## <a id="concept_F02E40517C4B42F2A75B133BB507C626__section_08C901A3CF3E438C8778F09D482B9A63" class="no-quick-link"></a>Reduced Deserialization of Serialized Objects
 

--- a/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
+++ b/geode-docs/developing/data_serialization/PDX_Serialization_Features.html.md.erb
@@ -32,6 +32,7 @@ When you serialize an object using PDX, <%=vars.product_name%> stores the object
 This centralization of object type information is advantageous for client/server installations in which clients and servers are written in different languages. Clients pass registry information to servers automatically when they store a PDX serialized object. Clients can run queries and functions against the data in the servers without compatibility between server and the stored objects. One client can store data on the server to be retrieved by another client, with no requirements on the part of the server.
 
 **Note:**
+
 There are situations where some of the information in the central registry of the PDX domain object metadata is lost, e.g. when restoring an old backup with an outdated central registry.
 
 When that happens, new clients connecting to the cluster for the first time will get outdated PDX type information from the central registry, but, since information in the central registry is cached by clients, old clients may have fresher information about PDX types than the central registry does. That will result into inconsistent information about PDX types spread across the system:
@@ -44,19 +45,10 @@ If old clients write entries of a PDX type they know but the central registry do
 
 To avoid this problem, clients may be configured with the system property in the table below to clear their PDX type cache when they disconnect from the cluster. After clearing their cache, old clients will re-generate type information for all PDX types, including the types the central registry "forgot". Since new PDX type information will be written in the central registry before entries of that type are written in the cluster, the central registry and all clients, old and new, will store consistent PDX type information.
 
-| Name                                      | Description                                             | Default |
-|-------------------------------------------|---------------------------------------------------------|---------|
-| `gemfire.ON_DISCONNECT_CLEAR_PDXTYPEIDS`  | Clear pdxType ids when client disconnects from servers. | `false` |
--   In the API, set the System properties before the cache creation call. Example:
-
-    ``` pre
-    System.setProperty(PoolImpl.ON_DISCONNECT_CLEAR_PDXTYPEIDS, "true");
-    ```
--   At the java command line, pass in System properties using the -D switch. Example:
-
-    ``` pre
-    java -Dgemfire.ON_DISCONNECT_CLEAR_PDXTYPEIDS=true
-    ```
+| Name                                      | Default | Applies to (Java Client, Native Client)|
+|-------------------------------------------|---------|----------------------------------------|
+| `gemfire.ON_DISCONNECT_CLEAR_PDXTYPEIDS`  | `false` | Java Client                            |
+| `on-client-disconnect-clear-pdxType-Ids`  | `false` | Native Client                          |
 
 ## <a id="concept_F02E40517C4B42F2A75B133BB507C626__section_08C901A3CF3E438C8778F09D482B9A63" class="no-quick-link"></a>Reduced Deserialization of Serialized Objects
 


### PR DESCRIPTION
…EIDS“

Document the java system property “ON_DISCONNECT_CLEAR_PDXTYPEIDS“. This property is used by Java client, add instructions for using this property.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
