### PR TITLE
GEODE-10401: Replace 1.15.0 with 1.15.1 as old version

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -17,7 +17,7 @@
 
 benchmarks:
   baseline_branch_default: ''
-  baseline_version_default: '1.14.4'
+  baseline_version_default: '1.15.1'
   benchmark_branch: ((geode-build-branch))
   flavors:
   - title: 'base'


### PR DESCRIPTION
Replace 1.15.0 with 1.15.1 in old versions and set as default Benchmarks baseline on develop to enable rolling upgrade tests from 1.15.1

The serialization version has not changed between 1.15.0 and 1.15.1, so there should be no need to keep both
