### PR TITLE
Fix compile error in jdk11 due to toArray confusion

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesSet.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/EntriesSet.java
@@ -242,7 +242,7 @@ public class EntriesSet extends AbstractSet implements LogWithToString {
 
   @Override
   public Object[] toArray() {
-    return toArray(null);
+    return toArray((Object[]) null);
   }
 
   @Override

--- a/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
+++ b/geode-core/src/main/java/org/apache/geode/internal/cache/PartitionedRegion.java
@@ -6213,7 +6213,7 @@ public class PartitionedRegion extends LocalRegion
 
     @Override
     public Object[] toArray() {
-      return toArray(null);
+      return toArray((Object[]) null);
     }
 
     @Override


### PR DESCRIPTION
### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

When I compile with jdk11, I got an error below:
<img width="1382" alt="image" src="https://user-images.githubusercontent.com/22415594/201882997-2f20030f-132d-44c7-b81e-83f0f671af09.png">

This is caused by we have two `toArray` in `PartitionedRegion`, 
one is  
```
public Object[] toArray(Object[] array)
```

other is from `Collection` which is introduced in jdk 11. 
```java
default <T> T[] toArray(IntFunction<T[]> generator) {
        return toArray(generator.apply(0));
    }
```

This PR aims to fix this.

