### PR TITLE
GEODE-10447: use getDeclaredConstructor() for supporting JDK11

### DIFF
--- a/geode-concurrency-test/src/main/java/org/apache/geode/test/concurrency/ConcurrentTestRunner.java
+++ b/geode-concurrency-test/src/main/java/org/apache/geode/test/concurrency/ConcurrentTestRunner.java
@@ -14,6 +14,7 @@
  */
 package org.apache.geode.test.concurrency;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 
@@ -81,8 +82,9 @@ public class ConcurrentTestRunner extends ParentRunner<FrameworkMethod> {
     }
 
     try {
-      runner = configuration.runner().newInstance();
-    } catch (InstantiationException | IllegalAccessException e) {
+      runner = configuration.runner().getDeclaredConstructor().newInstance();
+    } catch (InstantiationException | IllegalAccessException | InvocationTargetException
+        | NoSuchMethodException e) {
       throw new InitializationError(e);
     }
   }

--- a/geode-concurrency-test/src/main/java/org/apache/geode/test/concurrency/loop/LoopRunner.java
+++ b/geode-concurrency-test/src/main/java/org/apache/geode/test/concurrency/loop/LoopRunner.java
@@ -46,7 +46,7 @@ public class LoopRunner implements Runner {
       ParallelExecutor executor = new DelegatingExecutor(executorService);
       for (int i = 0; i < count; i++) {
         try {
-          Object test = child.getDeclaringClass().newInstance();
+          Object test = child.getDeclaringClass().getDeclaredConstructor().newInstance();
           child.invoke(test, executor);
         } catch (InvocationTargetException ex) {
           Throwable exceptionToReturn = ex.getCause();


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
