### PR TITLE
GEODE-10454 - Migrate from Gradle Enterprise Gradle Plugin to Develocity Gradle Plugin

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,7 +42,7 @@ jobs:
     name: Analyze
     runs-on: ubuntu-latest
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 8
@@ -53,7 +53,7 @@ jobs:
          java: ['11']
      runs-on: ${{ matrix.os }}
      env:
-       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+       DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
      steps:
      - uses: actions/checkout@v3
      - name: Set up JDK (include all 3 JDKs in the env)
@@ -96,7 +96,7 @@ jobs:
        java: ['8', '11', '17']
    runs-on: ${{ matrix.os }}
    env:
-     GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+     DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
    steps:
    - uses: actions/checkout@v3
    - name: Set up JDK (include all 3 JDKs in env)
@@ -155,7 +155,7 @@ jobs:
          java: ['8']
      runs-on: ${{ matrix.os }}
      env:
-       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+       DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
      steps:
      - uses: actions/checkout@v3
      - name: Set up JDK
@@ -204,7 +204,7 @@ jobs:
         java: ['8']
     runs-on: ${{ matrix.os }}
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -246,7 +246,7 @@ jobs:
         java: ['8']
     runs-on: ${{ matrix.os }}
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -290,7 +290,7 @@ jobs:
         java: ['8']
     runs-on: ${{ matrix.os }}
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -334,7 +334,7 @@ jobs:
         java: ['8']
     runs-on: ${{ matrix.os }}
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -378,7 +378,7 @@ jobs:
         java: ['8']
     runs-on: ${{ matrix.os }}
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK
@@ -424,7 +424,7 @@ jobs:
         java: [ '8' ]
     runs-on: ${{ matrix.os }}
     env:
-      GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
+      DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,21 +39,21 @@ pluginManagement {
 }
 
 plugins {
-  id 'com.gradle.enterprise' version '3.13.2'
-  id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.10'
+  id 'com.gradle.develocity' version '3.17.6'
+  id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
 def isGithubActions = System.getenv('GITHUB_ACTIONS') != null
 def isJenkins = System.getenv('JENKINS_URL') != null
 def isCI = isGithubActions || isJenkins
 
-gradleEnterprise {
+develocity {
   server = "https://ge.apache.org"
+  projectId = "geode"
+
   buildScan {
-    capture { taskInputFiles = true }
     uploadInBackground = !isCI
-    publishAlways()
-    publishIfAuthenticated()
+    publishing.onlyIf { it.authenticated }
     obfuscation {
       // This obfuscates the IP addresses of the build machine in the build scan.
       // Alternatively, the build scan will provide the hostname for troubleshooting host-specific issues.
@@ -146,7 +146,7 @@ buildCache {
     enabled = !isCI
   }
 
-  remote(gradleEnterprise.buildCache) {
+  remote(develocity.buildCache) {
     enabled = false
   }
 }


### PR DESCRIPTION
This change migrates Geode to use the Develocity Gradle Plugin. The existing Gradle Enterprise Gradle Plugin will no longer be supported when ge.apache.org is updated to 2024.3.

These changes will not functionally change how build scans are published to ge.apache.org.

https://issues.apache.org/jira/browse/GEODE-10454

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
