### PR TITLE
GEODE-10453 - in case of REMOVE_DUE_TO_GII_TOMBSTONE_CLEANUP and for …

### DIFF
--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/CompactRangeIndex.java
@@ -167,10 +167,10 @@ public class CompactRangeIndex extends AbstractIndex {
         if (oldKeyValue.get() == null) {
           return;
         }
-        indexStore.removeMapping(oldKeyValue.get().getOldKey(), entry);
+        indexStore.removeMappingGII(oldKeyValue.get().getOldKey(), entry);
       } else {
         // rely on reverse map in the index store to figure out the real key
-        indexStore.removeMapping(IndexManager.NULL, entry);
+        indexStore.removeMappingGII(IndexManager.NULL, entry);
       }
     } else if (opCode == CLEAN_UP_THREAD_LOCALS) {
       if (oldKeyValue != null) {

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/IndexStore.java
@@ -39,6 +39,13 @@ public interface IndexStore {
   void removeMapping(Object indexKey, RegionEntry re) throws IMQException;
 
   /**
+   * Remove a mapping from the index store If entry at indexKey is not found, we must crawl the
+   * index to be sure the region entry does not exist
+   *
+   */
+  void removeMappingGII(Object indexKey, RegionEntry re) throws IMQException;
+
+  /**
    * Update a mapping in the index store. This method adds a new mapping and removes the old mapping
    *
    */

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MapIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MapIndexStore.java
@@ -59,6 +59,11 @@ public class MapIndexStore implements IndexStore {
   }
 
   @Override
+  public void removeMappingGII(Object indexKey, RegionEntry re) {
+    removeMapping(indexKey, re);
+  }
+
+  @Override
   public void removeMapping(Object indexKey, RegionEntry re) {
     indexMap.remove(indexKey, re.getKey());
   }

--- a/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
+++ b/geode-core/src/main/java/org/apache/geode/cache/query/internal/index/MemoryIndexStore.java
@@ -14,8 +14,6 @@
  */
 package org.apache.geode.cache.query.internal.index;
 
-import static java.util.Objects.hash;
-
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -46,7 +44,6 @@ import org.apache.geode.internal.cache.NonTXEntry;
 import org.apache.geode.internal.cache.RegionEntry;
 import org.apache.geode.internal.cache.Token;
 import org.apache.geode.internal.cache.persistence.query.CloseableIterator;
-import org.apache.geode.pdx.internal.PdxInstanceImpl;
 
 /**
  * The in-memory index storage
@@ -296,9 +293,18 @@ public class MemoryIndexStore implements IndexStore {
   }
 
   @Override
+  public void removeMappingGII(Object indexKey, RegionEntry re) throws IMQException {
+    doRemoveMapping(indexKey, re, false);
+  }
+
+  @Override
   public void removeMapping(Object indexKey, RegionEntry re) throws IMQException {
+    doRemoveMapping(indexKey, re, true);
+  }
+
+  private void doRemoveMapping(Object indexKey, RegionEntry re, boolean findOldKey) throws IMQException {
     // Remove from forward map
-    boolean found = basicRemoveMapping(indexKey, re, true);
+    boolean found = basicRemoveMapping(indexKey, re, findOldKey);
     // Remove from reverse map.
     // We do NOT need to synchronize here as different RegionEntries will be
     // operating concurrently i.e. different keys in entryToValuesMap which
@@ -870,48 +876,6 @@ public class MemoryIndexStore implements IndexStore {
           + Integer.toHexString(System.identityHashCode(this)) + ' ' + key
           + ' ' + value;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (!(obj instanceof CachedEntryWrapper)) {
-        return false;
-      }
-      CachedEntryWrapper object = (CachedEntryWrapper) obj;
-      if (!getKey().equals(object.getKey())) {
-        if (!(getKey() instanceof PdxInstanceImpl)) {
-          return false;
-        }
-        if (!(object.getKey() instanceof PdxInstanceImpl)) {
-          return false;
-        }
-        PdxInstanceImpl pdxkey1 = (PdxInstanceImpl) getKey();
-        PdxInstanceImpl pdxkey2 = (PdxInstanceImpl) object.getKey();
-        if (!pdxkey1.equals(pdxkey2)) {
-          return false;
-        }
-      }
-      if (!getValue().equals(object.getValue())) {
-        if (!(getValue() instanceof PdxInstanceImpl)) {
-          return false;
-        }
-        if (!(object.getValue() instanceof PdxInstanceImpl)) {
-          return false;
-        }
-        PdxInstanceImpl pdxvalue1 = (PdxInstanceImpl) getValue();
-        PdxInstanceImpl pdxvalue2 = (PdxInstanceImpl) object.getValue();
-        if (!pdxvalue1.equals(pdxvalue2)) {
-          return false;
-        }
-      }
-
-      return true;
-    }
-
-    @Override
-    public int hashCode() {
-      return hash(key, value);
-    }
-
   }
 
 }


### PR DESCRIPTION
…CompactRangeIndex, bypass very expensive old key lookup which is not needed for GII case

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
