### PR TITLE
GEODE-10459: Fix for docker compose using shim

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -212,6 +212,12 @@ jobs:
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}
+      - name: Setup Docker Compose
+        run: |
+          sudo install -m 0755 /dev/stdin /usr/local/bin/docker-compose <<'EOF'
+          #!/usr/bin/env bash
+          exec docker compose "$@"
+          EOF
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
       - name: Run acceptance tests


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->
This attempts to fix the acceptance test docker-compose issue by adding a shim to make a call to `docker-compose` (docker compose v1) and make it use `docker compose` (space included) docker compose v2 version. 

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
