### PR TITLE
Update LICENSE: SLF4J API version and copyright notice

### DIFF
--- a/geode-assembly/src/main/dist/LICENSE
+++ b/geode-assembly/src/main/dist/LICENSE
@@ -1097,7 +1097,7 @@ Apache Geode bundles the following files under the MIT License:
   - Normalize.css v2.1.0 (https://necolas.github.io/normalize.css/),
     Copyright (c) Nicolas Gallagher and Jonathan Neal
   - Sizzle.js (http://sizzlejs.com/), Copyright (c) 2011, The Dojo Foundation
-  - SLF4J API v1.7.32 (http://www.slf4j.org), Copyright (c) 2004-2017 QOS.ch
+  - SLF4J API v1.7.36 (http://www.slf4j.org), Copyright (c) 2004-2025 QOS.ch
   - Split.js (https://github.com/nathancahill/Split.js), Copyright (c)
     2015 Nathan Cahill
   - TableDnD v0.5 (https://github.com/isocra/TableDnD), Copyright (c) 2012


### PR DESCRIPTION
### Summary
Updates the SLF4J API version and copyright attribution in the assembled distribution LICENSE file:
- Previous: SLF4J API v1.7.32, Copyright (c) 2004–2017 QOS.ch
- Updated: SLF4J API v1.7.36, Copyright (c) 2004–2025 QOS.ch
### Rationale
- Reflects the actual SLF4J version now bundled and aligns copyright years with upstream project notice. 
- Ensures compliance and accuracy of third‑party attributions.
### Scope
- Documentation/license metadata only.
- No functional or dependency changes introduced in this PR (dependency was already at 1.7.36, license text lagged behind).
### Validation
- Confirmed build includes slf4j-api 1.7.36.
- Verified upstream LICENSE/COPYRIGHT years (2025 appears in current SLF4J distribution).
### Impact
- None to runtime, packaging only. Improves legal clarity.

Checklist
- [x] LICENSE updated
- [x]  Matches currently resolved dependency version
- [x]  No other attributions modified
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [ ] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
