### PR TITLE
[GEODE-10464] Fix Build Failures with Gradle Network Timeout and Retry Configuration

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,13 @@ distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+# --- Gradle network tuning ---
+# Connection timeout (default ~30s)
+systemProp.org.gradle.internal.http.connectionTimeout=60000
+
+# Socket timeout (read timeout, default ~30s)
+systemProp.org.gradle.internal.http.socketTimeout=120000
+
+# Retry failed requests 
+systemProp.org.gradle.internal.repository.max.retries=5
+systemProp.org.gradle.internal.repository.retry.delay=5000


### PR DESCRIPTION
## Problem
Builds are failing intermittently due to network connectivity issues when resolving dependencies from external repositories. The specific error encountered includes:

> `Read timed out` and other transient HTTP errors during dependency resolution.

> Could not determine the dependencies of task ':geode-assembly:acceptanceTest'.
   > Could not resolve all task dependencies for configuration ':geode-assembly:acceptanceTestRuntimeClasspath'.
      > Could not resolve org.gradle:gradle-tooling-api:5.1.1.
        > Could not get resource 'https://repo.spring.io/release/org/gradle/gradle-tooling-api/5.1.1/gradle-tooling-api-5.1.1.pom'.
           > Read timed out

---

## Solution

Added network tuning configuration to `gradle-wrapper.properties` to improve build reliability:

- **Connection Timeout**: Increased from default ~30s to 60s  
  `systemProp.org.gradle.internal.http.connectionTimeout=60000`
- **Socket Read Timeout**: Extended from default ~30s to 120s  
  `systemProp.org.gradle.internal.http.socketTimeout=120000`
- **Retry Mechanism**: Added automatic retry logic with 5 attempts and 5-second delays  
  `systemProp.org.gradle.internal.repository.max.retries=5`
  `systemProp.org.gradle.internal.repository.retry.delay=5000`

---

## Benefits

✅ Resolves "Read timed out" errors during dependency resolution  
✅ Handles transient HTTP errors (401, timeouts) from external repositories automatically  
✅ Improves CI/CD build reliability without requiring manual re-runs  
✅ Better handling of slow network connections and repository response times

---

## Testing

- Verify builds work normally under good network conditions  
- Confirm `:geode-assembly:acceptanceTest` task executes successfully  
- Monitor CI pipeline for reduced timeout-related failures
---

## Risk Assessment
**Low risk** – These are timeout and retry configurations that don't change build logic.  
The only potential downside is slightly longer wait times when repositories are genuinely unavailable.


<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline the review of the contribution we ask you
to ensure the following steps have been taken: 
-->

### For all changes:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [x] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
