### PR TITLE
Update Dockerfile for 1.15.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,16 +22,17 @@ RUN apk add --no-cache \
 		bash \
 		ncurses
 
-ENV GEODE_GPG 1A3694A1448840FC3B1137B2CAE347D5AE2E5C93
+# https://github.com/apache/geode/blob/develop/KEYS
+ENV GEODE_GPG 62F7DA41B7D8F26C
 
 ENV GEODE_HOME /geode
 ENV PATH $PATH:$GEODE_HOME/bin
 
 # https://geode.apache.org/releases/
-ENV GEODE_VERSION 1.15.1
+ENV GEODE_VERSION 1.15.2
 # Binaries TGZ SHA-256
 # https://dist.apache.org/repos/dist/release/geode/VERSION/apache-geode-VERSION.tgz.sha256
-ENV GEODE_SHA256 2668970982d373ef42cff5076e7073b03e82c8e2fcd7757d5799b2506e265d57
+ENV GEODE_SHA256 60d190b07b4dabd83a86bfa21acab7ed38d2eccaabe4bc5baabab0981cf7910a
 
 # http://apache.org/dyn/closer.cgi/geode/1.3.0/apache-geode-1.3.0.tgz
 


### PR DESCRIPTION
I have checked the build succeeds. Running the image produces:

```
$ docker run sha256:c70ba6627cde737c1cb56e8a858a
    _________________________     __
   / _____/ ______/ ______/ /____/ /
  / /  __/ /___  /_____  / _____  / 
 / /__/ / ____/  _____/ / /    / /  
/______/_/      /______/_/    /_/    1.15.2

Monitor and Manage Apache Geode
gfsh>
Exiting... 
$
```

That looks OK to my untrained eye.

### For all changes:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?

- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?

- [x] Is your initial contribution a single, squashed commit?

- [ ] Does `gradlew build` run cleanly?

- [ ] Have you written or updated unit tests to verify your changes?

- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?

<!-- Note:
Please ensure that once the PR is submitted, check Concourse for build issues and
submit an update to your PR as soon as possible. If you need help, please send an
email to dev@geode.apache.org.
-->
