### PR TITLE
[GEODE-10529] Update prepare_rc.sh to support Java 17

### DIFF
--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -90,12 +90,12 @@ echo "============================================================"
 echo "Checking java..."
 echo "============================================================"
 [ -z "$JAVA_HOME" ] && JAVA=java || JAVA=$JAVA_HOME/bin/java
-if ! $JAVA -XshowSettings:properties -version 2>&1 | grep 'java.specification.version = 1.8' ; then
-  echo "Please set JAVA_HOME to use JDK 8 to compile Geode for release"
+if ! $JAVA -XshowSettings:properties -version 2>&1 | grep 'java.specification.version = 17' ; then
+  echo "Please set JAVA_HOME to use JDK 17 to compile Geode for release"
   exit 1
 fi
 if $JAVA -XshowSettings:properties -version 2>&1 | grep 'java.vm.vendor = Oracle' ; then
-  echo "Please set JAVA_HOME to use an Open JDK 8 such as from https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=hotspot to compile Geode for release"
+  echo "Please set JAVA_HOME to use an Open JDK 17 such as from https://adoptium.net to compile Geode for release"
   exit 1
 else
   $JAVA -XshowSettings:properties -version 2>&1 | grep 'java.vm.vendor = '
@@ -277,7 +277,8 @@ BMDIR=apache-geode-benchmarks-${VERSION}-src
 BMTAR=${BMDIR}.tgz
 git clean -dxf
 mkdir ../${BMDIR}
-cp -r .travis.yml * ../${BMDIR}
+cp -r * ../${BMDIR} 2>/dev/null || true
+[ -f .travis.yml ] && cp .travis.yml ../${BMDIR}
 tar czf ${BMTAR} -C .. ${BMDIR}
 rm -Rf ../${BMDIR}
 gpg --armor -u ${SIGNING_KEY} -b ${BMTAR}


### PR DESCRIPTION
## Summary
Updates `prepare_rc.sh` to support Java 17 for building Apache Geode 2.0.0 release candidates.


## Changes

- **Java Version Check**: Updated from Java 8 (1.8) to Java 17
- **Error Messages**: Updated to reference JDK 17 and adoptium.net
- **File Copying**: Fixed geode-benchmarks to gracefully handle missing `.travis.yml`

## Testing

Verified that the script correctly:
- Detects Java 17
- Rejects non-Java 17 versions
- Handles missing `.travis.yml` without failing

## Related Issue

GEODE-10529


<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [ x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
