### PR TITLE
Fix promote_rc.sh: Update Homebrew formula path for apache-geode

### DIFF
--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -231,7 +231,7 @@ else
   echo "Updating brew"
   echo "============================================================"
   set -x
-  cd ${BREW_DIR}/Formula
+  cd ${BREW_DIR}/Formula/a
   git pull
   git remote add myfork git@github.com:${GITHUB_USER}/homebrew-core.git || true
   if ! git fetch myfork ; then


### PR DESCRIPTION
In December 2021, Homebrew reorganized the homebrew-core repository structure to improve performance as the number of formulas grew. The flat Formula/ directory was split into alphabetically organized subdirectories (Formula/a/, Formula/b/, etc.).

Since apache-geode starts with 'a', the formula file moved from:
  Formula/apache-geode.rb
to:
  Formula/a/apache-geode.rb

This change updates promote_rc.sh to cd into Formula/a/ instead of Formula/, which has been the correct structure for over 3 years.

Without this fix, the script fails with 'No such file or directory' when attempting to update the apache-geode formula during the release promotion process.

Reference: Homebrew/homebrew-core#91469

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [ ] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
