### PR TITLE
GEODE-10557: geode-lucene:integrationTest fails with OutOfMemoryError

### DIFF
--- a/geode-lucene/build.gradle
+++ b/geode-lucene/build.gradle
@@ -87,6 +87,6 @@ integrationTest.forkEvery 5
 // Increase heap size for Lucene integration tests to prevent OutOfMemoryError
 // Jakarta migration introduced ByteBuffersDirectory which may have different memory characteristics
 integrationTest {
-  maxHeapSize = '12g'
+  maxHeapSize = '16g'
   jvmArgs '-XX:+UseG1GC', '-XX:MaxGCPauseMillis=500', '-XX:+HeapDumpOnOutOfMemoryError'
 }


### PR DESCRIPTION
### Problem
`geode-lucene:integrationTest` fails with `OutOfMemoryError: Java heap space` during classpath scanning in CI environments.

### Root Cause
Jakarta EE migration introduced `ByteBuffersDirectory` with different memory characteristics. The existing 12GB heap allocation is insufficient for the full integration test suite in resource-constrained CI environments.

### Solution
- Increased `integrationTest.maxHeapSize` from `12g` to `16g` in `geode-lucene/build.gradle`
- No production code changes

### Testing
- Tests pass locally
- Monitoring CI for successful completion

### Impact
**Low risk** - Only affects test execution environment, no runtime changes.

---

**Files Changed:**
- `geode-lucene/build.gradle`

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
