### PR TITLE
GEODE-10573: RC script failure during rc prep

### DIFF
--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -277,7 +277,7 @@ BMDIR=apache-geode-benchmarks-${VERSION}-src
 BMTAR=${BMDIR}.tgz
 git clean -dxf
 mkdir ../${BMDIR}
-cp -r .travis.yml * ../${BMDIR}
+[ -f .travis.yml ] && cp -r .travis.yml * ../${BMDIR} || cp -r * ../${BMDIR}
 tar czf ${BMTAR} -C .. ${BMDIR}
 rm -Rf ../${BMDIR}
 gpg --armor -u ${SIGNING_KEY} -b ${BMTAR}

--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -277,7 +277,7 @@ BMDIR=apache-geode-benchmarks-${VERSION}-src
 BMTAR=${BMDIR}.tgz
 git clean -dxf
 mkdir ../${BMDIR}
-[ -f .travis.yml ] && cp -r .travis.yml * ../${BMDIR} || cp -r * ../${BMDIR}
+cp -r * ../${BMDIR}
 tar czf ${BMTAR} -C .. ${BMDIR}
 rm -Rf ../${BMDIR}
 gpg --armor -u ${SIGNING_KEY} -b ${BMTAR}


### PR DESCRIPTION
cp: .travis.yml: No such file or directory during rc prep

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
