### PR TITLE
GEODE-10570: Replace 2.0.0 with 2.0.1 as old version

### DIFF
--- a/ci/pipelines/shared/jinja.variables.yml
+++ b/ci/pipelines/shared/jinja.variables.yml
@@ -17,7 +17,7 @@
 
 benchmarks:
   baseline_branch_default: ''
-  baseline_version_default: '1.15.1'
+  baseline_version_default: '2.0.1'
   benchmark_branch: ((geode-build-branch))
   flavors:
   - title: 'base'


### PR DESCRIPTION
Replace 2.0.0 with 2.0.1 in old versions and set as default Benchmarks baseline on develop to enable rolling upgrade tests from 2.0.1

The serialization version has not changed between 2.0.0 and 2.0.1, so there should be no need to keep both

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [ ] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [ ] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [ ] Is your initial contribution a single, squashed commit?
- [ ] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
