### PR TITLE
GEODE-10579: Remediate CVE-2026-34478 - Improper Output Neutralization for Logs

### DIFF
--- a/boms/geode-all-bom/src/test/resources/expected-pom.xml
+++ b/boms/geode-all-bom/src/test/resources/expected-pom.xml
@@ -530,27 +530,27 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-api</artifactId>
-        <version>2.25.3</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-core</artifactId>
-        <version>2.25.3</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jcl</artifactId>
-        <version>2.25.3</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jul</artifactId>
-        <version>2.25.3</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.25.3</version>
+        <version>2.25.4</version>
       </dependency>
       <dependency>
         <groupId>org.apache.lucene</groupId>

--- a/build-tools/geode-dependency-management/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/build-tools/geode-dependency-management/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -46,7 +46,7 @@ class DependencyConstraints {
     deps.put("jakarta.annotation.version", "2.1.1")
     deps.put("jakarta.ejb.version", "4.0.1")
     deps.put("jgroups.version", "3.6.20.Final")
-    deps.put("log4j.version", "2.25.3")
+    deps.put("log4j.version", "2.25.4")
     deps.put("log4j-slf4j2-impl.version", "2.23.1")
     deps.put("micrometer.version", "1.14.0")
     deps.put("shiro.version", "2.1.0")

--- a/geode-assembly/src/acceptanceTest/resources/gradle-test-projects/management/build.gradle
+++ b/geode-assembly/src/acceptanceTest/resources/gradle-test-projects/management/build.gradle
@@ -25,7 +25,7 @@ repositories {
 
 dependencies {
   implementation("${project.group}:geode-core:${project.version}")
-  runtimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.25.3')
+  runtimeOnly('org.apache.logging.log4j:log4j-slf4j-impl:2.25.4')
 }
 
 application {

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -1012,11 +1012,11 @@ lib/jna-platform-5.11.0.jar
 lib/joda-time-2.12.7.jar
 lib/jopt-simple-5.0.4.jar
 lib/jul-to-slf4j-2.0.17.jar
-lib/log4j-api-2.25.3.jar
-lib/log4j-core-2.25.3.jar
-lib/log4j-jcl-2.25.3.jar
-lib/log4j-jul-2.25.3.jar
-lib/log4j-slf4j-impl-2.25.3.jar
+lib/log4j-api-2.25.4.jar
+lib/log4j-core-2.25.4.jar
+lib/log4j-jcl-2.25.4.jar
+lib/log4j-jul-2.25.4.jar
+lib/log4j-slf4j-impl-2.25.4.jar
 lib/lucene-analysis-common-9.12.3.jar
 lib/lucene-analysis-phonetic-9.12.3.jar
 lib/lucene-core-9.12.3.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -32,11 +32,11 @@ jaxb-runtime-4.0.2.jar
 jaxb-core-4.0.2.jar
 jakarta.xml.bind-api-4.0.2.jar
 jopt-simple-5.0.4.jar
-log4j-slf4j-impl-2.25.3.jar
-log4j-core-2.25.3.jar
-log4j-jcl-2.25.3.jar
-log4j-jul-2.25.3.jar
-log4j-api-2.25.3.jar
+log4j-slf4j-impl-2.25.4.jar
+log4j-core-2.25.4.jar
+log4j-jcl-2.25.4.jar
+log4j-jul-2.25.4.jar
+log4j-api-2.25.4.jar
 spring-aop-6.1.21.jar
 spring-shell-autoconfigure-3.3.3.jar
 spring-shell-standard-commands-3.3.3.jar

--- a/geode-docs/managing/logging/configuring_log4j2.html.md.erb
+++ b/geode-docs/managing/logging/configuring_log4j2.html.md.erb
@@ -36,16 +36,16 @@ You can also configure Log4j 2 to work with various popular and commonly used lo
 
 For example, if you are using:
 
--   **Commons Logging**, download "Commons Logging Bridge" (`log4j-jcl-2.25.3.jar`)
--   **SLF4J**, download "SLFJ4 Binding" (`log4j-slf4j-impl-2.25.3.jar`)
--   **java.util.logging**, download the "JUL adapter" (`log4j-jul-2.25.3.jar`)
+-   **Commons Logging**, download "Commons Logging Bridge" (`log4j-jcl-2.25.4.jar`)
+-   **SLF4J**, download "SLFJ4 Binding" (`log4j-slf4j-impl-2.25.4.jar`)
+-   **java.util.logging**, download the "JUL adapter" (`log4j-jul-2.25.4.jar`)
 
 See [http://logging.apache.org/log4j/2.x/faq.html](http://logging.apache.org/log4j/2.x/faq.html) for more examples.
 
-All three of the above JAR files are in the full distribution of Log4J 2.25.3 which can be downloaded at [http://logging.apache.org/log4j/2.x/download.html](http://logging.apache.org/log4j/2.x/download.html). Download the appropriate bridge, adapter, or binding JARs to ensure that <%=vars.product_name%> logging is integrated with every logging API used in various third-party libraries or in your own applications.
+All three of the above JAR files are in the full distribution of Log4J 2.25.4 which can be downloaded at [http://logging.apache.org/log4j/2.x/download.html](http://logging.apache.org/log4j/2.x/download.html). Download the appropriate bridge, adapter, or binding JARs to ensure that <%=vars.product_name%> logging is integrated with every logging API used in various third-party libraries or in your own applications.
 
 **Note:**
-<%=vars.product_name_long%> has been tested with Log4j 2.25.3. As newer versions of Log4j 2 come out, you can find 2.25.3 under Previous Releases on that page.
+<%=vars.product_name_long%> has been tested with Log4j 2.25.4. As newer versions of Log4j 2 come out, you can find 2.25.4 under Previous Releases on that page.
 
 ## Customizing Your Own log4j2.xml File
 

--- a/geode-docs/managing/logging/how_logging_works.html.md.erb
+++ b/geode-docs/managing/logging/how_logging_works.html.md.erb
@@ -21,9 +21,9 @@ limitations under the License.
 
 <%=vars.product_name%> uses [Apache Log4j 2](http://logging.apache.org/log4j/2.x/) API and Core libraries as the basis for its logging system. Log4j 2 API is a popular and powerful front-end logging API used by all the <%=vars.product_name%> classes to generate log statements. Log4j 2 Core is a backend implementation for logging; you can route any of the front-end logging API libraries to log to this backend. <%=vars.product_name%> uses the Core backend to run three custom Log4j 2 Appenders: **GeodeConsole**, **GeodeLogWriter**, and **GeodeAlert**.
 
-<%=vars.product_name%> has been tested with Log4j 2.25.3.
+<%=vars.product_name%> has been tested with Log4j 2.25.4.
 <%=vars.product_name%> requires the 
-`log4j-api-2.25.3.jar` and `log4j-core-2.25.3.jar`
+`log4j-api-2.25.4.jar` and `log4j-core-2.25.4.jar`
 JAR files to be in the classpath.
 Both of these JARs are distributed in the `<path-to-product>/lib` directory and included in the appropriate `*-dependencies.jar` convenience libraries.
 

--- a/geode-docs/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.html.md.erb
+++ b/geode-docs/tools_modules/http_session_mgmt/weblogic_setting_up_the_module.html.md.erb
@@ -108,9 +108,9 @@ If you are deploying an ear file:
     lib/geode-serialization-2.0.0.jar
     lib/jakarta.transaction-api-2.0.1.jar
     lib/jgroups-3.6.20.Final.jar
-    lib/log4j-api-2.25.3.jar
-    lib/log4j-core-2.25.3.jar
-    lib/log4j-jul-2.25.3.jar
+    lib/log4j-api-2.25.4.jar
+    lib/log4j-core-2.25.4.jar
+    lib/log4j-jul-2.25.4.jar
     ```
 
 ## <a id="weblogic_setting_up_the_module__section_20294A39368D4402AEFB3D074E8D5887" class="no-quick-link"></a>Peer-to-Peer Setup

--- a/geode-log4j/build.gradle
+++ b/geode-log4j/build.gradle
@@ -84,7 +84,7 @@ dependencies {
   // Log4j 2.20.0+ moved test utilities to log4j-core-test with new package names:
   // org.apache.logging.log4j.junit → org.apache.logging.log4j.core.test.junit
   // org.apache.logging.log4j.test → org.apache.logging.log4j.core.test
-  // log4j-core-test 2.25.3 transitively depends on assertj-core 3.27.3, but Geode's
+  // log4j-core-test 2.25.4 transitively depends on assertj-core 3.27.3, but Geode's
   // custom AssertJ assertions were built against 3.22.0. Force 3.22.0 to avoid
   // NoSuchMethodError: CommonValidations.failIfEmptySinceActualIsNotEmpty
   integrationTestImplementation('org.apache.logging.log4j:log4j-core-test') {

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -33,11 +33,11 @@ commons-lang3-3.18.0.jar
 jaxb-runtime-4.0.2.jar
 jaxb-core-4.0.2.jar
 jakarta.xml.bind-api-4.0.2.jar
-log4j-slf4j-impl-2.25.3.jar
-log4j-core-2.25.3.jar
-log4j-jcl-2.25.3.jar
-log4j-jul-2.25.3.jar
-log4j-api-2.25.3.jar
+log4j-slf4j-impl-2.25.4.jar
+log4j-core-2.25.4.jar
+log4j-jcl-2.25.4.jar
+log4j-jul-2.25.4.jar
+log4j-api-2.25.4.jar
 spring-shell-starter-3.3.3.jar
 rmiio-2.1.2.jar
 antlr-2.7.7.jar


### PR DESCRIPTION
## Summary

Upgrade Apache Log4j from **2.25.3** to **2.25.4** to remediate [CVE-2026-34478](https://nvd.nist.gov/vuln/detail/CVE-2026-34478).

## Security Vulnerability

| Field | Detail |
|-------|--------|
| **CVE** | [CVE-2026-34478](https://nvd.nist.gov/vuln/detail/CVE-2026-34478) |
| **CVSS** | 6.9 MEDIUM (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:L/SA:N) |
| **CWE** | [CWE-117](https://cwe.mitre.org/data/definitions/117.html) Improper Output Neutralization for Logs, [CWE-684](https://cwe.mitre.org/data/definitions/684.html) Incorrect Provision of Specified Functionality |
| **Affected versions** | Log4j Core 2.21.0 through 2.25.3 |
| **Fixed in** | Log4j Core 2.25.4 |
| **Published** | 2026-04-10 |

### Description

Log4j Core's `Rfc5424Layout` (versions 2.21.0 through 2.25.3) is vulnerable to **log injection via CRLF sequences** due to undocumented renames of security-relevant configuration attributes. Two distinct issues affect users of stream-based syslog services who configure `Rfc5424Layout` directly:

1. **`newLineEscape` attribute silently renamed** — Newline escaping stopped working for users of TCP framing (RFC 6587), exposing them to CRLF injection in log output.
2. **`useTlsMessageFormat` attribute silently renamed** — Users of TLS framing (RFC 5425) were silently downgraded to unframed TCP (RFC 6587) without newline escaping.

> Users of the `SyslogAppender` are not affected, as its configuration attributes were not modified.

## Changes

Pure version string replacement of `2.25.3` → `2.25.4` across **10 files** (33 insertions, 33 deletions):

| File | What changed |
|------|-------------|
| `build-tools/geode-dependency-management/.../DependencyConstraints.groovy` | Central managed version definition |
| `geode-assembly/.../management/build.gradle` | Hardcoded `log4j-slf4j-impl` dependency |
| `boms/geode-all-bom/.../expected-pom.xml` | 5 `<version>` entries in expected POM |
| `geode-assembly/.../assembly_content.txt` | 5 jar filename references |
| `geode-assembly/.../gfsh_dependency_classpath.txt` | 5 jar filename references |
| `geode-server-all/.../dependency_classpath.txt` | 5 jar filename references |
| `geode-docs/.../configuring_log4j2.html.md.erb` | Documentation references |
| `geode-docs/.../how_logging_works.html.md.erb` | Documentation references |
| `geode-docs/.../weblogic_setting_up_the_module.html.md.erb` | Documentation references |

No code logic changes — this is a dependency version bump only.

## Verification

- [x] `./gradlew test` — **BUILD SUCCESSFUL** 
- [x] No remaining references to `2.25.3` in the codebase
- [x] Rebased cleanly onto latest `origin/develop` with no merge conflicts

## References

- **NVD**: https://nvd.nist.gov/vuln/detail/CVE-2026-34478
- **Apache advisory**: https://logging.apache.org/security.html#CVE-2026-34478
- **Upstream fix**: https://github.com/apache/logging-log4j2/pull/4074
- **Log4j 2.25.4 release notes**: https://logging.apache.org/log4j/2.x/release-notes.html#2.25.4
- **Prior Geode Log4j upgrade PR**: https://github.com/apache/geode/pull/7975 (GEODE-10543)


<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
