### PR TITLE
GEODE-10583: Remediation of Bouncy Castle security vulnerabilities (CVE-2026-0636, CVE-2026-5598, CVE-2025-14813)

### DIFF
--- a/build-tools/geode-dependency-management/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
+++ b/build-tools/geode-dependency-management/src/main/groovy/org/apache/geode/gradle/plugins/DependencyConstraints.groovy
@@ -50,6 +50,8 @@ class DependencyConstraints {
     deps.put("log4j-slf4j2-impl.version", "2.23.1")
     deps.put("micrometer.version", "1.14.0")
     deps.put("shiro.version", "2.1.0")
+    // GEODE-10583: Pin Bouncy Castle (transitive via shiro-crypto-hash) to a fixed version
+    deps.put("bouncycastle.version", "1.84")
     deps.put("slf4j-api.version", "2.0.17")
     deps.put("jakarta.transaction-api.version", "2.0.1")
     deps.put("jboss-modules.version", "1.11.0.Final")
@@ -179,6 +181,8 @@ class DependencyConstraints {
         api(group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13')
         api(group: 'org.apache.httpcomponents', name: 'httpcore', version: '4.4.15')
         api(group: 'org.apache.shiro', name: 'shiro-core', version: get('shiro.version'))
+        // GEODE-10583: Pin Bouncy Castle provider (pulled in via shiro-crypto-hash) to 1.84
+        api(group: 'org.bouncycastle', name: 'bcprov-jdk18on', version: get('bouncycastle.version'))
         api(group: 'org.assertj', name: 'assertj-core', version: '3.22.0')
         api(group: 'org.awaitility', name: 'awaitility', version: '4.2.0')
         api(group: 'org.buildobjects', name: 'jproc', version: '2.8.0')

--- a/geode-assembly/src/integrationTest/resources/assembly_content.txt
+++ b/geode-assembly/src/integrationTest/resources/assembly_content.txt
@@ -923,7 +923,7 @@ lib/antlr-runtime-3.5.2.jar
 lib/asm-9.9.1.jar
 lib/asm-commons-9.9.1.jar
 lib/asm-tree-9.9.1.jar
-lib/bcprov-jdk18on-1.82.jar
+lib/bcprov-jdk18on-1.84.jar
 lib/classgraph-4.8.147.jar
 lib/classmate-1.5.1.jar
 lib/commons-beanutils-1.11.0.jar

--- a/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
+++ b/geode-assembly/src/integrationTest/resources/gfsh_dependency_classpath.txt
@@ -142,4 +142,4 @@ jboss-logging-3.4.3.Final.jar
 classmate-1.5.1.jar
 jakarta.el-api-5.0.0.jar
 jakarta.inject-api-2.0.1.jar
-bcprov-jdk18on-1.82.jar
+bcprov-jdk18on-1.84.jar

--- a/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
+++ b/geode-server-all/src/integrationTest/resources/dependency_classpath.txt
@@ -124,7 +124,7 @@ asm-commons-9.9.1.jar
 asm-tree-9.9.1.jar
 asm-9.9.1.jar
 txw2-4.0.2.jar
-bcprov-jdk18on-1.82.jar
+bcprov-jdk18on-1.84.jar
 reactor-core-3.6.10.jar
 jline-console-3.26.3.jar
 jline-builtins-3.26.3.jar


### PR DESCRIPTION
Remediation of Bouncy Castle security vulnerabilities (CVE-2026-0636, CVE-2026-5598, CVE-2025-14813)

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
