### PR TITLE
GEODE-10586: Update Homebrew clone to use main branch

### DIFF
--- a/dev-tools/release/prepare_rc.sh
+++ b/dev-tools/release/prepare_rc.sh
@@ -171,7 +171,7 @@ git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/g
 git clone --single-branch --branch develop git@github.com:apache/geode-native.git geode-native-develop
 git clone --single-branch --branch support/${VERSION_MM} git@github.com:apache/geode-benchmarks.git
 git clone --single-branch --branch develop git@github.com:apache/geode-benchmarks.git geode-benchmarks-develop
-git clone --single-branch --branch master git@github.com:Homebrew/homebrew-core.git
+git clone --single-branch --branch main git@github.com:Homebrew/homebrew-core.git
 
 svn checkout https://dist.apache.org/repos/dist --depth empty
 svn update --set-depth immediates --parents dist/release/geode


### PR DESCRIPTION
## Changes

Updated `dev-tools/release/prepare_rc.sh` to clone the Homebrew/homebrew-core repository using the `main` branch instead of `master`.

Homebrew renamed their default branch from `master` to `main`, so the release preparation script needs to be updated accordingly.

## Modified Files

- `dev-tools/release/prepare_rc.sh`

## Details

```diff
-git clone --single-branch --branch master git@github.com:Homebrew/homebrew-core.git
+git clone --single-branch --branch main git@github.com:Homebrew/homebrew-core.git
```
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
