### PR TITLE
GEODE-10588:Replace deprecated-for-removal primitive-wrapper constructors in geode-cq distributed tests with equivalent valueOf calls.

### DIFF
--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataDUnitTest.java
@@ -910,7 +910,7 @@ public class CqDataDUnitTest extends JUnit4CacheTestCase {
             // Check if the events from CqListener are in order.
             int oldId = 0;
             for (Object cqEvent : cqListener.events.toArray()) {
-              int newId = new Integer(cqEvent.toString());
+              int newId = Integer.valueOf(cqEvent.toString());
               if (oldId > newId) {
                 fail("Queued events for CQ Listener during execution with "
                     + "Initial results is not in the order in which they are created.");
@@ -1067,7 +1067,7 @@ public class CqDataDUnitTest extends JUnit4CacheTestCase {
             // Check if the events from CqListener are in order.
             int oldId = 0;
             for (Object cqEvent : cqListener.events.toArray()) {
-              int newId = new Integer(cqEvent.toString());
+              int newId = Integer.valueOf(cqEvent.toString());
               if (oldId > newId) {
                 fail("Queued events for CQ Listener during execution with "
                     + "Initial results is not in the order in which they are created.");

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataUsingPoolDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqDataUsingPoolDUnitTest.java
@@ -785,7 +785,7 @@ public class CqDataUsingPoolDUnitTest extends JUnit4CacheTestCase {
             // Check if the events from CqListener are in order.
             int oldId = 0;
             for (Object cqEvent : cqListener.events.toArray()) {
-              int newId = new Integer(cqEvent.toString());
+              int newId = Integer.valueOf(cqEvent.toString());
               if (oldId > newId) {
                 fail("Queued events for CQ Listener during execution with "
                     + "Initial results is not in the order in which they are created.");

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/CqQueryDUnitTest.java
@@ -473,7 +473,7 @@ public class CqQueryDUnitTest extends JUnit4CacheTestCase {
         Region region1 = getRootRegion().getSubregion(regionName);
         for (int i = 1; i <= size; i++) {
           Portfolio portfolio = new Portfolio(i);
-          portfolio.shortID = new Short("" + i);
+          portfolio.shortID = Short.valueOf("" + i);
           region1.put(KEY + i, portfolio);
         }
         logger.info("### Number of Entries in Region :" + region1.keySet().size());

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionCqQueryDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PartitionedRegionCqQueryDUnitTest.java
@@ -1124,7 +1124,7 @@ public class PartitionedRegionCqQueryDUnitTest extends JUnit4CacheTestCase {
         // Check if the events from CqListener are in order.
         int oldId = 0;
         for (Object cqEvent : cqListener.events.toArray()) {
-          int newId = new Integer(cqEvent.toString());
+          int newId = Integer.valueOf(cqEvent.toString());
           if (oldId > newId) {
             fail("Queued events for CQ Listener during execution with "
                 + "Initial results is not in the order in which they are created.");

--- a/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PrCqUsingPoolDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/cache/query/cq/dunit/PrCqUsingPoolDUnitTest.java
@@ -1160,7 +1160,7 @@ public class PrCqUsingPoolDUnitTest extends JUnit4CacheTestCase {
         // Check if the events from CqListener are in order.
         int oldId = 0;
         for (Object cqEvent : cqListener.events.toArray()) {
-          int newId = new Integer(cqEvent.toString());
+          int newId = Integer.valueOf(cqEvent.toString());
           if (oldId > newId) {
             fail("Queued events for CQ Listener during execution with "
                 + "Initial results is not in the order in which they are created.");

--- a/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientToServerDeltaDUnitTest.java
+++ b/geode-cq/src/distributedTest/java/org/apache/geode/internal/cache/tier/sockets/ClientToServerDeltaDUnitTest.java
@@ -172,11 +172,11 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
         .createServerCache(Boolean.TRUE, Boolean.FALSE, clone, enableDelta));
 
     client.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server.getHost()), new Integer(PORT1), Boolean.FALSE,
+        NetworkUtils.getServerHostName(server.getHost()), Integer.valueOf(PORT1), Boolean.FALSE,
         Boolean.FALSE, Boolean.FALSE));
 
     client2.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server2.getHost()), new Integer(PORT2), Boolean.TRUE,
+        NetworkUtils.getServerHostName(server2.getHost()), Integer.valueOf(PORT2), Boolean.TRUE,
         Boolean.FALSE, cq, queries, RI));
   }
 
@@ -190,11 +190,11 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
         .createServerCache(Boolean.FALSE, Boolean.FALSE, clone, enableDelta));
 
     client.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server.getHost()), new Integer(PORT1), Boolean.FALSE,
+        NetworkUtils.getServerHostName(server.getHost()), Integer.valueOf(PORT1), Boolean.FALSE,
         Boolean.FALSE, Boolean.FALSE));
 
     client2.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server2.getHost()), new Integer(PORT2), Boolean.TRUE,
+        NetworkUtils.getServerHostName(server2.getHost()), Integer.valueOf(PORT2), Boolean.TRUE,
         Boolean.FALSE, cq, queries, RI));
   }
 
@@ -301,7 +301,7 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
         .createServerCache(Boolean.TRUE, Boolean.FALSE, Boolean.TRUE, Boolean.TRUE));
 
     ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server.getHost()), new Integer(PORT1), Boolean.FALSE,
+        NetworkUtils.getServerHostName(server.getHost()), Integer.valueOf(PORT1), Boolean.FALSE,
         Boolean.FALSE, Boolean.FALSE, null, Boolean.FALSE);
     Region r = cache.getRegion(REGION_NAME);
     DeltaTestImpl val = new DeltaTestImpl(0, "0", (double) 0, new byte[0],
@@ -835,7 +835,7 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
         .invoke(() -> ClientToServerDeltaDUnitTest.createServerCache(Boolean.FALSE, Boolean.FALSE));
 
     client.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server.getHost()), new Integer(PORT1), Boolean.FALSE,
+        NetworkUtils.getServerHostName(server.getHost()), Integer.valueOf(PORT1), Boolean.FALSE,
         Boolean.TRUE, Boolean.FALSE));
 
     /*
@@ -866,7 +866,7 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
         .invoke(() -> ClientToServerDeltaDUnitTest.createServerCache(Boolean.FALSE, Boolean.FALSE));
 
     client.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server.getHost()), new Integer(PORT1), Boolean.FALSE,
+        NetworkUtils.getServerHostName(server.getHost()), Integer.valueOf(PORT1), Boolean.FALSE,
         Boolean.TRUE, Boolean.FALSE));
 
     client.invoke(() -> ClientToServerDeltaDUnitTest.putDelta(KEY1));
@@ -892,11 +892,11 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
         .invoke(() -> ClientToServerDeltaDUnitTest.createServerCache(Boolean.FALSE, Boolean.FALSE));
 
     client.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server.getHost()), new Integer(PORT1), Boolean.TRUE,
+        NetworkUtils.getServerHostName(server.getHost()), Integer.valueOf(PORT1), Boolean.TRUE,
         Boolean.TRUE, Boolean.FALSE));
 
     client2.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server.getHost()), new Integer(PORT1), Boolean.TRUE,
+        NetworkUtils.getServerHostName(server.getHost()), Integer.valueOf(PORT1), Boolean.TRUE,
         Boolean.FALSE, Boolean.FALSE));
 
     int deltaSent =
@@ -922,7 +922,7 @@ public class ClientToServerDeltaDUnitTest extends JUnit4DistributedTestCase {
         .invoke(() -> ClientToServerDeltaDUnitTest.createServerCache(Boolean.FALSE, Boolean.FALSE));
 
     client.invoke(() -> ClientToServerDeltaDUnitTest.createClientCache(
-        NetworkUtils.getServerHostName(server.getHost()), new Integer(PORT1), Boolean.FALSE,
+        NetworkUtils.getServerHostName(server.getHost()), Integer.valueOf(PORT1), Boolean.FALSE,
         Boolean.FALSE, Boolean.FALSE));
 
     client.invoke(() -> ClientToServerDeltaDUnitTest.putDelta(KEY1));


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [x] Have you written or updated unit tests to verify your changes?
- [x] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
