### PR TITLE
[GEODE-10602] Remove ServerSerializableObjectHttpMessageConverter from mbean query

### DIFF
--- a/geode-gfsh/src/main/java/org/apache/geode/management/internal/web/shell/HttpOperationInvoker.java
+++ b/geode-gfsh/src/main/java/org/apache/geode/management/internal/web/shell/HttpOperationInvoker.java
@@ -17,6 +17,7 @@ package org.apache.geode.management.internal.web.shell;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.Base64;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -40,7 +41,6 @@ import org.apache.geode.management.internal.ManagementConstants;
 import org.apache.geode.management.internal.cli.CommandRequest;
 import org.apache.geode.management.internal.cli.shell.Gfsh;
 import org.apache.geode.management.internal.cli.shell.OperationInvoker;
-import org.apache.geode.management.internal.web.domain.QueryParameterSource;
 import org.apache.geode.management.internal.web.http.support.HttpRequester;
 import org.apache.geode.management.internal.web.shell.support.HttpMBeanProxyFactory;
 
@@ -376,8 +376,13 @@ public class HttpOperationInvoker implements OperationInvoker {
   public Set<ObjectName> queryNames(final ObjectName objectName, final QueryExp queryExpression) {
     final URI link = HttpRequester.createURI(baseUrl, "/mbean/query");
 
-    Object content = new QueryParameterSource(objectName, queryExpression);
     try {
+      final MultiValueMap<String, Object> content = new LinkedMultiValueMap<String, Object>();
+      content.add("objectName", objectName.toString());
+      if (queryExpression != null) {
+        content.add("queryExpression",
+            Base64.getEncoder().encodeToString(IOUtils.serializeObject(queryExpression)));
+      }
       return (Set<ObjectName>) IOUtils
           .deserializeObject(httpRequester.post(link, content, byte[].class));
     } catch (Exception e) {

--- a/geode-web/src/main/java/org/apache/geode/management/internal/web/controllers/ShellCommandsController.java
+++ b/geode-web/src/main/java/org/apache/geode/management/internal/web/controllers/ShellCommandsController.java
@@ -20,6 +20,7 @@ import static org.apache.geode.management.internal.web.util.UriUtils.decode;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Optional;
 import java.util.Set;
 
@@ -29,6 +30,7 @@ import javax.management.MBeanException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
+import javax.management.QueryExp;
 import javax.management.ReflectionException;
 
 import org.apache.commons.io.FileUtils;
@@ -39,7 +41,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -55,7 +56,6 @@ import org.apache.geode.management.cli.Result;
 import org.apache.geode.management.internal.cli.result.model.ResultModel;
 import org.apache.geode.management.internal.cli.util.CommandStringBuilder;
 import org.apache.geode.management.internal.i18n.CliStrings;
-import org.apache.geode.management.internal.web.domain.QueryParameterSource;
 import org.apache.geode.util.internal.GeodeConverter;
 
 /**
@@ -162,11 +162,17 @@ public class ShellCommandsController extends AbstractCommandsController {
   }
 
   @RequestMapping(method = RequestMethod.POST, value = "/mbean/query")
-  public ResponseEntity<?> queryNames(@RequestBody final QueryParameterSource query)
-      throws IOException {
+  public ResponseEntity<?> queryNames(@RequestParam("objectName") final String objectName,
+      @RequestParam(value = "queryExpression", required = false) final String queryExpressionBase64)
+      throws Exception {
     // Exceptions are caught by the @ExceptionHandler AbstractCommandsController.handleAppException
-    final Set<ObjectName> objectNames =
-        getMBeanServer().queryNames(query.getObjectName(), query.getQueryExpression());
+    ObjectName name = ObjectName.getInstance(decode(objectName));
+    QueryExp query = null;
+    if (queryExpressionBase64 != null) {
+      query =
+          (QueryExp) IOUtils.deserializeObject(Base64.getDecoder().decode(queryExpressionBase64));
+    }
+    final Set<ObjectName> objectNames = getMBeanServer().queryNames(name, query);
     return new ResponseEntity<>(IOUtils.serializeObject(objectNames), HttpStatus.OK);
   }
 

--- a/geode-web/src/main/webapp/WEB-INF/geode-mgmt-servlet.xml
+++ b/geode-web/src/main/webapp/WEB-INF/geode-mgmt-servlet.xml
@@ -48,7 +48,6 @@ limitations under the License.
       <bean class="org.springframework.http.converter.xml.Jaxb2RootElementHttpMessageConverter"/>
       <bean class="org.springframework.http.converter.xml.SourceHttpMessageConverter"/>
       <bean class="org.springframework.http.converter.support.AllEncompassingFormHttpMessageConverter"/>
-      <bean class="org.apache.geode.management.internal.web.http.converter.ServerSerializableObjectHttpMessageConverter"/>
     </mvc:message-converters>
   </mvc:annotation-driven>
 


### PR DESCRIPTION
Remove ServerSerializableObjectHttpMessageConverter from mbean query
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
