### PR TITLE
[GEODE-10630] The source distribution does not complete ./gradlew build

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -438,6 +438,9 @@ distributions {
     contents {
       from rootProject.tasks.writeBuildInfo
       from (rootDir) {
+        // Provided by the writeBuildInfo task above; the root copy is present only when
+        // building from an unpacked source distribution.
+        exclude '.buildinfo'
         exclude 'KEYS'
         exclude '**/gradlew'
         exclude '**/gradlew.bat'


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

### Cause

The `src` distribution in `geode-assembly/build.gradle` picks up `.buildinfo` twice:

1. `from rootProject.tasks.writeBuildInfo`, which places the generated file at the archive root.
2. `from (rootDir)`, which sweeps the whole tree.

In a git checkout there is no `$rootDir/.buildinfo`, so only the first source contributes and the build passes. An unpacked source distribution already carries `.buildinfo` at its root, so the second source picks it up as well and Gradle 7 fails on the duplicate entry. The existing `build`/`out` directory exclusion covers `build/.buildinfo` but not the root copy.

### Fix

Exclude `.buildinfo` from the `rootDir` sweep, leaving the `writeBuildInfo` output as the single authoritative entry. Contents are unchanged, so the source distribution stays reproducible: rebuilding from an unpacked tarball emits the same `.buildinfo` it shipped with.

### Testing

With a `.buildinfo` placed at the repo root to reproduce the source-distribution layout:

- Before: `srcDistTar` fails with the duplicate-entry error above.
- After: `BUILD SUCCESSFUL`, and the archive contains exactly one `.buildinfo`, holding the real SCM values rather than the root copy.

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
