### PR TITLE
[GEODE-10630] The source distribution does not complete ./gradlew build

### DIFF
--- a/geode-assembly/build.gradle
+++ b/geode-assembly/build.gradle
@@ -419,6 +419,9 @@ distributions {
     contents {
       from rootProject.tasks.writeBuildInfo
       from (rootDir) {
+        // Provided by the writeBuildInfo task above; the root copy is present only when
+        // building from an unpacked source distribution.
+        exclude '.buildinfo'
         exclude 'KEYS'
         exclude '**/gradlew'
         exclude '**/gradlew.bat'


### PR DESCRIPTION
<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
