### PR TITLE
[GEODE-10637] Skip the native image when the branch has no Dockerfile

### DIFF
--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -346,12 +346,16 @@ echo ""
 echo "============================================================"
 echo "Building Native docker image"
 echo "============================================================"
-set -x
-cd ${GEODE_NATIVE}/docker
-docker build . || docker build . || docker build .
-docker build -t apachegeode/geode-native-build:${VERSION} .
-[ -n "$LATER" ] || docker build -t apachegeode/geode-native-build:latest .
-set +x
+if [ -f ${GEODE_NATIVE}/docker/Dockerfile ] ; then
+  set -x
+  cd ${GEODE_NATIVE}/docker
+  docker build . || docker build . || docker build .
+  docker build -t apachegeode/geode-native-build:${VERSION} .
+  [ -n "$LATER" ] || docker build -t apachegeode/geode-native-build:latest .
+  set +x
+else
+  echo "geode-native has no docker/Dockerfile on this branch; skipping the native image build"
+fi
 
 
 echo ""
@@ -370,11 +374,15 @@ echo ""
 echo "============================================================"
 echo "Publishing Native docker image"
 echo "============================================================"
-set -x
-cd ${GEODE_NATIVE}/docker
-docker push apachegeode/geode-native-build:${VERSION}
-[ -n "$LATER" ] || docker push apachegeode/geode-native-build:latest
-set +x
+if [ -f ${GEODE_NATIVE}/docker/Dockerfile ] ; then
+  set -x
+  cd ${GEODE_NATIVE}/docker
+  docker push apachegeode/geode-native-build:${VERSION}
+  [ -n "$LATER" ] || docker push apachegeode/geode-native-build:latest
+  set +x
+else
+  echo "geode-native has no docker/Dockerfile on this branch; skipping the native image push"
+fi
 
 
 if [ -z "$LATER" ] ; then


### PR DESCRIPTION
geode-native moved its Dockerfiles into per-distro subdirectories (docker/ubuntu-20.04/, docker/rhel-8/ and so on) and removed docker/Dockerfile in February 2021. It is absent on every current branch and release tag.

promote_rc.sh still does cd ${GEODE_NATIVE}/docker and docker build ., which fails with no Dockerfile in that directory. The retry chain docker build . || docker build . || docker build . fails as a whole, and under set -e this aborts the promotion at the native image build, before the Geode image is pushed.

Run the native image build and push only when docker/Dockerfile is present, and print a message when it is skipped.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
