### PR TITLE
[GEODE-10634] Skip the old-version commit on develop when nothing changed

### DIFF
--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -525,12 +525,17 @@ if [ -z "$LATER" ] ; then
 fi
 set -x
 git add settings.gradle
-git diff --staged --color | cat
-git commit -m "$JIRA: ${action} ${VERSION} as old version
+if [ $(git diff --staged | wc -l) -gt 0 ] ; then
+  git diff --staged --color | cat
+  git commit -m "$JIRA: ${action} ${VERSION} as old version
 
 ${action} ${VERSION} in old versions${BENCHMSG} on develop
 to enable rolling upgrade tests from ${VERSION}${ser}"
-git push -u myfork
+  git push -u myfork
+  DID_OLDVER=true
+else
+  echo "develop does not track ${VERSION_MM} in old versions; nothing to commit"
+fi
 set +x
 
 
@@ -668,7 +673,7 @@ PATCH="${VERSION##*.}"
 cd ${GEODE}/../..
 echo "Final steps (some gaps in numbering is normal since not all steps apply to all releases):"
 [ -n "$LATER" ] || echo "2. Go to https://github.com/${GITHUB_USER}/homebrew-core/pull/new/apache-geode-${VERSION} and submit the pull request"
-echo "3. Go to https://github.com/${GITHUB_USER}/geode/pull/new/add-${VERSION}-to-old-versions and create the pull request"
+[ -z "$DID_OLDVER" ] || echo "3. Go to https://github.com/${GITHUB_USER}/geode/pull/new/add-${VERSION}-to-old-versions and create the pull request"
 [ -n "$LATER" ] || echo "3b.Go to https://github.com/${GITHUB_USER}/geode-native/pull/new/update-to-geode-${VERSION} and create the pull request"
 [ -n "$LATER" ] && tag=":${VERSION}" || tag=""
 echo "4. Validate docker image: docker run -it apachegeode/geode${tag}"


### PR DESCRIPTION
develop tracks old versions only up to 1.14.4, so a 1.15 patch finds no entry to extend, and the benchmarks baseline edit is skipped whenever a later release exists. Both together leave the index empty, and the unconditional commit then fails the promotion. Commit only when there is a staged change, and suppress the corresponding pull request step.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
