### PR TITLE
GEODE-10633: Publish release images to the apache organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     
 [![Apache Geode logo](https://geode.apache.org/img/Apache_Geode_logo.png)](http://geode.apache.org)
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) [![homebrew](https://img.shields.io/homebrew/v/apache-geode.svg)](https://formulae.brew.sh/formula/apache-geode) [![Docker Pulls](https://img.shields.io/docker/pulls/apachegeode/geode.svg)](https://hub.docker.com/r/apachegeode/geode/) 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0) [![homebrew](https://img.shields.io/homebrew/v/apache-geode.svg)](https://formulae.brew.sh/formula/apache-geode) [![Docker Pulls](https://img.shields.io/docker/pulls/apache/geode.svg)](https://hub.docker.com/r/apache/geode/) 
 
 </div>
 
@@ -44,7 +44,7 @@ latency and 24x7 availability requirements.
 
 You can download Apache Geode from the
 [website](https://geode.apache.org/releases/), run a Docker
-[image](https://hub.docker.com/r/apachegeode/geode/), or install with
+[image](https://hub.docker.com/r/apache/geode/), or install with
 [Homebrew](https://formulae.brew.sh/formula/apache-geode) on OSX. Application developers
 can load dependencies from [Maven
 Central](https://search.maven.org/#search%7Cga%7C1%7Cg%3A%22org.apache.geode%22).

--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -337,8 +337,8 @@ if ! docker build . ; then
   fi
 fi
 mv Dockerfile.backup Dockerfile
-docker build -t apachegeode/geode:${VERSION} .
-[ -n "$LATER" ] || docker build -t apachegeode/geode:latest .
+docker build -t apache/geode:${VERSION} .
+[ -n "$LATER" ] || docker build -t apache/geode:latest .
 set +x
 
 
@@ -350,8 +350,8 @@ if [ -f ${GEODE_NATIVE}/docker/Dockerfile ] ; then
   set -x
   cd ${GEODE_NATIVE}/docker
   docker build . || docker build . || docker build .
-  docker build -t apachegeode/geode-native-build:${VERSION} .
-  [ -n "$LATER" ] || docker build -t apachegeode/geode-native-build:latest .
+  docker build -t apache/geode-native-build:${VERSION} .
+  [ -n "$LATER" ] || docker build -t apache/geode-native-build:latest .
   set +x
 else
   echo "geode-native has no docker/Dockerfile on this branch; skipping the native image build"
@@ -365,8 +365,8 @@ echo "============================================================"
 set -x
 cd ${GEODE}/docker
 docker login
-docker push apachegeode/geode:${VERSION}
-[ -n "$LATER" ] || docker push apachegeode/geode:latest
+docker push apache/geode:${VERSION}
+[ -n "$LATER" ] || docker push apache/geode:latest
 set +x
 
 
@@ -377,8 +377,8 @@ echo "============================================================"
 if [ -f ${GEODE_NATIVE}/docker/Dockerfile ] ; then
   set -x
   cd ${GEODE_NATIVE}/docker
-  docker push apachegeode/geode-native-build:${VERSION}
-  [ -n "$LATER" ] || docker push apachegeode/geode-native-build:latest
+  docker push apache/geode-native-build:${VERSION}
+  [ -n "$LATER" ] || docker push apache/geode-native-build:latest
   set +x
 else
   echo "geode-native has no docker/Dockerfile on this branch; skipping the native image push"
@@ -685,7 +685,7 @@ echo "Final steps (some gaps in numbering is normal since not all steps apply to
 [ -z "$DID_OLDVER" ] || echo "3. Go to https://github.com/${GITHUB_USER}/geode/pull/new/add-${VERSION}-to-old-versions and create the pull request"
 [ -n "$LATER" ] || echo "3b.Go to https://github.com/${GITHUB_USER}/geode-native/pull/new/update-to-geode-${VERSION} and create the pull request"
 [ -n "$LATER" ] && tag=":${VERSION}" || tag=""
-echo "4. Validate docker image: docker run -it apachegeode/geode${tag}"
+echo "4. Validate docker image: docker run -it apache/geode${tag}"
 [ -n "$LATER" ] && caveat=" (UNLESS they are still unreleased on a later patch branch)"
 echo "5. Mark ${VERSION} as Released in Jira and Bulk-transition JIRA issues fixed in this release to Closed${caveat}"
 echo "5b.Publish to GitHub ( https://github.com/apache/geode/tags then Create Release from the 2nd ... menu ), filling out the form as follows:"
@@ -703,7 +703,7 @@ echo "8. Check that ${VERSION} documentation has been published to https://geode
 echo "9. Check that ${VERSION} download info has been published to https://geode.apache.org/releases/${DID_REMOVE}"
 [ "${PATCH}" -ne 0 ] || echo "10. If 3rd-party dependencies haven't been bumped in awhile, ask on the dev list for a volunteer (details in dev-tools/dependencies/README.md)"
 [ "${PATCH}" -ne 0 ] || [ "${MINOR}" -lt 15 ] || echo "11. In accordance with Geode's N-2 support policy, propose on the dev list that the time has come to ${0%/*}/end_of_support.sh -v ${MAJOR}.$((MINOR - 3))"
-[ "${PATCH}" -ne 0 ] || [ -n "$LATER" ] || echo "12. Log in to https://hub.docker.com/repository/docker/apachegeode/geode and update the latest Dockerfile linktext and url to ${VERSION_MM}"
+[ "${PATCH}" -ne 0 ] || [ -n "$LATER" ] || echo "12. Log in to https://hub.docker.com/repository/docker/apache/geode and update the latest Dockerfile linktext and url to ${VERSION_MM}"
 [ -n "$LATER" ] || andnative=", geode-benchmarks, and geode-native"
 echo "If there are any support branches between ${VERSION_MM} and develop, manually cherry-pick '${VERSION}' bump from develop to those branches of geode${andnative}."
 echo "Bump support pipeline to ${VERSION_MM}.$(( PATCH + 1 )) by plussing BumpPatch in https://concourse.apachegeode-ci.info/teams/main/pipelines/apache-support-${VERSION_MM//./-}-main?group=semver-management"

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,17 +9,17 @@ docker build .
 If you're updating the image for a release, tag the build with the version:
 
 ```
-docker build -t apachegeode/geode:{version} .
-docker build -t apachegeode/geode:latest .
+docker build -t apache/geode:{version} .
+docker build -t apache/geode:latest .
 ```
 
 Once it's tagged, push to DockerHub:
 
 ```
-docker push apachegeode/geode:{version}
+docker push apache/geode:{version}
 ```
 
-* You need to be authenticated in DockerHub and be an administrator of the project.  Ask for permissions at *dev@geode.apache.org*.
+* You need to be authenticated in DockerHub and be a member of the `apache` organization with write access to this repository.  Ask for permissions at *private@geode.apache.org*.
 * This may take a while depending on your internet connection.
 
 # Starting a locator and gfsh
@@ -27,7 +27,7 @@ docker push apachegeode/geode:{version}
 1. Execute the following command to run the container and start `gfsh`:
 
 ```
-docker run -it -p 10334:10334 -p 7575:7575 -p 1099:1099  apachegeode/geode
+docker run -it -p 10334:10334 -p 7575:7575 -p 1099:1099  apache/geode
 ```
 
 From this point you can pretty much follow [Apache Geode in 5 minutes](https://cwiki.apache.org/confluence/display/GEODE/Index#Index-Geodein5minutes) for example:


### PR DESCRIPTION
The apachegeode organization on Docker Hub has no reachable administrator, so release images move to apache/geode, which Infra administers and where the PMC holds write access.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
