### PR TITLE
GEODE-10639: Remove the geode-native build image steps from promote_rc.sh

### DIFF
--- a/dev-tools/release/promote_rc.sh
+++ b/dev-tools/release/promote_rc.sh
@@ -293,10 +293,6 @@ set -x
 cd ${GEODE_NATIVE}
 git pull -r
 set +x
-if [ -r .travis.yml ] ; then
-  sed -e "s/geode-native-build:[latest0-9.]*/geode-native-build:${VERSION}/" \
-      -i.bak .travis.yml
-fi
 sed -e "s/GEODE_VERSION=.*/GEODE_VERSION=${VERSION}/" \
     -e "s/^ENV GEODE_VERSION.*/ENV GEODE_VERSION ${VERSION}/" \
     -i.bak $(git grep -l GEODE_VERSION= ; git grep -l 'ENV GEODE_VERSION')
@@ -344,22 +340,6 @@ set +x
 
 echo ""
 echo "============================================================"
-echo "Building Native docker image"
-echo "============================================================"
-if [ -f ${GEODE_NATIVE}/docker/Dockerfile ] ; then
-  set -x
-  cd ${GEODE_NATIVE}/docker
-  docker build . || docker build . || docker build .
-  docker build -t apachegeode/geode-native-build:${VERSION} .
-  [ -n "$LATER" ] || docker build -t apachegeode/geode-native-build:latest .
-  set +x
-else
-  echo "geode-native has no docker/Dockerfile on this branch; skipping the native image build"
-fi
-
-
-echo ""
-echo "============================================================"
 echo "Publishing Geode docker image"
 echo "============================================================"
 set -x
@@ -368,21 +348,6 @@ docker login
 docker push apachegeode/geode:${VERSION}
 [ -n "$LATER" ] || docker push apachegeode/geode:latest
 set +x
-
-
-echo ""
-echo "============================================================"
-echo "Publishing Native docker image"
-echo "============================================================"
-if [ -f ${GEODE_NATIVE}/docker/Dockerfile ] ; then
-  set -x
-  cd ${GEODE_NATIVE}/docker
-  docker push apachegeode/geode-native-build:${VERSION}
-  [ -n "$LATER" ] || docker push apachegeode/geode-native-build:latest
-  set +x
-else
-  echo "geode-native has no docker/Dockerfile on this branch; skipping the native image push"
-fi
 
 
 if [ -z "$LATER" ] ; then


### PR DESCRIPTION
geode-native removed its root docker/Dockerfile and .travis.yml in 2021, so the build environment image these steps produced has had no source since then and was last published in 2022.

<!-- Thank you for submitting a contribution to Apache Geode. -->

<!-- In order to streamline review of your contribution we ask that you
ensure you've taken the following steps. -->

### For all changes, please confirm:
- [x] Is there a JIRA ticket associated with this PR? Is it referenced in the commit message?
- [x] Has your PR been rebased against the latest commit within the target branch (typically `develop`)?
- [x] Is your initial contribution a single, squashed commit?
- [x] Does `gradlew build` run cleanly?
- [ ] Have you written or updated unit tests to verify your changes?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](http://www.apache.org/legal/resolved.html#category-a)?
